### PR TITLE
typo: Fix function name

### DIFF
--- a/src/main/java/org/tron/peer/Peer.java
+++ b/src/main/java/org/tron/peer/Peer.java
@@ -93,7 +93,7 @@ public class Peer {
     private void init() {
         initWallet();
 
-        initBlockchian();
+        initBlockchain();
 
         initUTXOSet();
 
@@ -105,7 +105,7 @@ public class Peer {
         wallet.init(myKey);
     }
 
-    private void initBlockchian() {
+    private void initBlockchain() {
         if (Blockchain.dbExists()) {
             blockchain = new Blockchain();
         } else {


### PR DESCRIPTION
Minor typo fix.

`initBlockchian` => `initBlockchain`