### PR TITLE
Replace Long.valueOf with Long.parseLong

### DIFF
--- a/src/main/java/org/tron/command/SendCommand.java
+++ b/src/main/java/org/tron/command/SendCommand.java
@@ -33,7 +33,7 @@ public class SendCommand extends Command {
     public void execute(Peer peer, String[] parameters) {
         if (check(parameters)) {
             String to = parameters[0];
-            long amount = Long.valueOf(parameters[1]);
+            long amount = Long.parseLong(parameters[1]);
             TronTransaction.Transaction transaction = TransactionUtils.newTransaction(peer.getWallet(), to, amount,
                     peer.getUTXOSet());
 
@@ -68,7 +68,7 @@ public class SendCommand extends Command {
 
         long amount = 0;
         try {
-            amount = Long.valueOf(parameters[1]);
+            amount = Long.parseLong(parameters[1]);
         } catch (NumberFormatException e) {
             LOGGER.error("amount invalid");
             return false;


### PR DESCRIPTION
**What does this PR do?**
Replaces function call to parse transaction amount from send parameters.

**Why are these changes required?**
To make code a little more efficient.

`Long.valueOf` calls `parseLong` and returns a `new Long` object.

```
 public static Long valueOf(String s) throws NumberFormatException {
   return new Long(parseLong(s, 10));
 }
```

A primitive `long` seems to be sufficient.

**This PR has been tested by:**




