### PR TITLE
Fix client consensus to use localhost address for cluster

### DIFF
--- a/src/main/java/org/tron/consensus/client/Client.java
+++ b/src/main/java/org/tron/consensus/client/Client.java
@@ -21,6 +21,8 @@ import io.atomix.copycat.client.CopycatClient;
 import org.tron.consensus.common.GetQuery;
 import org.tron.consensus.common.PutCommand;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
@@ -40,13 +42,18 @@ public class Client {
         client.serializer().register(PutCommand.class);
         client.serializer().register(GetQuery.class);
 
-        Collection<Address> cluster = Arrays.asList(
-                new Address("192.168.0.108", 5000)
+        InetAddress localhost = null;
+        try {
+            localhost = InetAddress.getLocalHost();
+            Collection<Address> cluster = Arrays.asList(
+                    new Address(localhost.getHostAddress(), 5000)
+            );
 
-        );
-
-        CompletableFuture<CopycatClient> future = client.connect(cluster);
-        future.join();
+            CompletableFuture<CopycatClient> future = client.connect(cluster);
+            future.join();
+        } catch (UnknownHostException e) {
+            e.printStackTrace();
+        }
     }
 
     public static CopycatClient getClient() {


### PR DESCRIPTION
**What does this PR do?**
It makes the `getmessage` and `putmessage` commands work. The consensus server was hardcoded to "192.168.0.108" and I changed it to the server address. 

**Why are these changes required?**

Without doing this, the message commands just say `Connecting to "192.168.0.108"`. I tried this by following the guide using IntelliJ Idea.

**This PR has been tested by:**

Tested by manually starting a consensus server then setting a message and getting it as you can see below
![image](https://user-images.githubusercontent.com/767013/34467706-0a89a328-ef5e-11e7-8ebf-468e2f96d43c.png)


**Follow up**
I'm a beginner to blockchain development so please let me know if I'm doing something wrong or there is a better way of doing it. 
I'm also not sure this is the best solution either but it seems to work :)


