### PR TITLE
Fix unit tests by refactoring Blockchain initialization and using Mockito.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ buildscript {
 
 dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
+    testCompile group: 'org.mockito', name: 'mockito-all', version: '1.9.5'
 
     compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
     compile group: 'org.slf4j', name: 'jcl-over-slf4j', version: '1.7.25'

--- a/src/main/java/org/tron/core/BlockUtils.java
+++ b/src/main/java/org/tron/core/BlockUtils.java
@@ -30,6 +30,7 @@ import java.sql.Timestamp;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.List;
+import java.util.Optional;
 
 import static org.tron.core.Constant.LAST_HASH;
 import static org.tron.crypto.Hash.sha3;
@@ -49,8 +50,10 @@ public class BlockUtils {
         Block.Builder block = Block.newBuilder();
 
         for (int i = 0; transactions != null && i < transactions.size(); i++) {
-            Transaction transaction = transactions.get(i);
-            block.addTransactions(i, transaction);
+            final int index = i;
+            Optional.ofNullable(transactions.get(index)).ifPresent((transaction) ->
+                    block.addTransactions(index, transaction)
+            );
         }
 
         //Chain programming

--- a/src/main/java/org/tron/peer/Peer.java
+++ b/src/main/java/org/tron/peer/Peer.java
@@ -106,11 +106,7 @@ public class Peer {
     }
 
     private void initBlockchain() {
-        if (Blockchain.dbExists()) {
-            blockchain = new Blockchain();
-        } else {
-            blockchain = new Blockchain(ByteArray.toHexString(wallet.getAddress()));
-        }
+       blockchain = new Blockchain(ByteArray.toHexString(wallet.getAddress()));
     }
 
     private void initUTXOSet() {

--- a/src/main/java/org/tron/protos/core/TronTXInput.java
+++ b/src/main/java/org/tron/protos/core/TronTXInput.java
@@ -676,7 +676,7 @@ public final class TronTXInput {
   static {
     java.lang.String[] descriptorData = {
       "\n\026core/TronTXInput.proto\022\006protos\"H\n\007TXIn" +
-      "putData\022\014\n\004txID\030\001 \001(\014\022\014\n\004vout\030\002 \001(\003\022\021\n\tsigna" +
+      "put\022\014\n\004txID\030\001 \001(\014\022\014\n\004vout\030\002 \001(\003\022\021\n\tsigna" +
       "ture\030\003 \001(\014\022\016\n\006pubKey\030\004 \001(\014B#\n\024org.tron.p" +
       "rotos.coreB\013TronTXInputb\006proto3"
     };

--- a/src/test/java/org/tron/core/BlockUtilsTest.java
+++ b/src/test/java/org/tron/core/BlockUtilsTest.java
@@ -98,6 +98,6 @@ public class BlockUtilsTest {
     @Test
     public void testGetIncreaseNumber() {
         logger.info("test getData increase number: {}", BlockUtils
-                .getIncreaseNumber(new Blockchain()));
+                .getIncreaseNumber(new Blockchain("0304f784e4e7bae517bcab94c3e0c9214fb4ac7ff9d7d5a937d1f40031f87b85")));
     }
 }

--- a/src/test/java/org/tron/core/BlockUtilsTest.java
+++ b/src/test/java/org/tron/core/BlockUtilsTest.java
@@ -16,10 +16,12 @@ package org.tron.core;
 
 import com.google.protobuf.ByteString;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.tron.protos.core.TronBlock.Block;
 import org.tron.protos.core.TronTransaction.Transaction;
+import org.tron.storage.leveldb.LevelDbDataSourceImpl;
 import org.tron.utils.ByteArray;
 
 import static org.tron.core.Blockchain.GENESIS_COINBASE_DATA;
@@ -97,7 +99,12 @@ public class BlockUtilsTest {
 
     @Test
     public void testGetIncreaseNumber() {
+        LevelDbDataSourceImpl mockDb = Mockito.mock(LevelDbDataSourceImpl.class);
+
+        Blockchain mockBlockchain = Mockito.mock(Blockchain.class);
+        Mockito.when(mockBlockchain.getBlockDB()).thenReturn(mockDb);
+
         logger.info("test getData increase number: {}", BlockUtils
-                .getIncreaseNumber(new Blockchain("0304f784e4e7bae517bcab94c3e0c9214fb4ac7ff9d7d5a937d1f40031f87b85")));
+                .getIncreaseNumber(mockBlockchain));
     }
 }

--- a/src/test/java/org/tron/core/BlockchainTest.java
+++ b/src/test/java/org/tron/core/BlockchainTest.java
@@ -16,13 +16,14 @@ package org.tron.core;
 
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.tron.storage.leveldb.LevelDbDataSourceImpl;
 import org.tron.protos.core.TronBlock.Block;
 import org.tron.protos.core.TronTXOutputs;
 import org.tron.protos.core.TronTransaction.Transaction;
+import org.tron.storage.leveldb.LevelDbDataSourceImpl;
 import org.tron.utils.ByteArray;
 import org.tron.wallet.Wallet;
 
@@ -36,12 +37,15 @@ import static org.tron.utils.ByteArray.toHexString;
 
 public class BlockchainTest {
     private static final Logger logger = LoggerFactory.getLogger("Test");
+    private static Blockchain blockchain;
+
+    @BeforeClass
+    public static void init() {
+       blockchain = new Blockchain("0304f784e4e7bae517bcab94c3e0c9214fb4ac7ff9d7d5a937d1f40031f87b85");
+    }
 
     @Test
     public void testBlockchain() {
-        Blockchain blockchain = new Blockchain
-                ("0304f784e4e7bae517bcab94c3e0c9214fb4ac7ff9d7d5a937d1f40031f87b85");
-
         logger.info("test blockchain: lashHash = {}, currentHash = {}",
                 ByteArray.toHexString(blockchain.getLastHash()), ByteArray
                         .toHexString(blockchain.getCurrentHash()));
@@ -49,8 +53,6 @@ public class BlockchainTest {
 
     @Test
     public void testBlockchainNew() {
-        Blockchain blockchain = new Blockchain();
-
         logger.info("test blockchain new: lastHash = {}", ByteArray
                 .toHexString(blockchain.getLastHash()));
 
@@ -70,7 +72,6 @@ public class BlockchainTest {
 
     @Test
     public void testIterator() {
-        Blockchain blockchain = new Blockchain("");
         Block info = null;
         BlockchainIterator bi = new BlockchainIterator(blockchain);
         while (bi.hasNext()) {
@@ -84,10 +85,6 @@ public class BlockchainTest {
 
     @Test
     public void testFindTransaction() {
-        Blockchain blockchain = new Blockchain();
-        LevelDbDataSourceImpl db = new LevelDbDataSourceImpl("test");
-        db.initDB();
-        blockchain.setBlockDB(db);
         Transaction transaction = blockchain.findTransaction(ByteString
                 .copyFrom(ByteArray.fromHexString
                         ("15f3988aa8d56eab3bfca45144bad77fc60acce50437a0a9d794a03a83c15c5e")));
@@ -101,12 +98,11 @@ public class BlockchainTest {
 
     @Test
     public void testFindUTXO() {
-        Blockchain blockchain = new Blockchain
-                ("fd0f3c8ab4877f0fd96cd156b0ad42ea7aa82c31");
         Wallet wallet = new Wallet();
         wallet.init();
+        UTXOSet utxoSet = new UTXOSet();
         Transaction transaction = TransactionUtils.newTransaction(wallet,
-                "fd0f3c8ab4877f0fd96cd156b0ad42ea7aa82c31", 10, null);
+                "fd0f3c8ab4877f0fd96cd156b0ad42ea7aa82c31", 10, utxoSet);
         List<Transaction> transactions = new ArrayList<>();
         transactions.add(transaction);
         blockchain.addBlock(BlockUtils.newBlock(transactions, ByteString
@@ -122,14 +118,11 @@ public class BlockchainTest {
         ByteString difficulty = ByteString.copyFrom(ByteArray.fromHexString
                 ("2001"));
 
-        //Blockchain blockchain = new Blockchain();
         Wallet wallet = new Wallet();
         wallet.init();
 
         Block block = BlockUtils.newBlock(null, parentHash,
                 difficulty, 0);
-        //TronBlockChainImpl tronBlockChain = new TronBlockChainImpl();
-        //tronBlockChain.addBlockToChain(block);
         LevelDbDataSourceImpl levelDbDataSource = new LevelDbDataSourceImpl
                 ("blockStore_test");
         levelDbDataSource.initDB();
@@ -139,8 +132,6 @@ public class BlockchainTest {
         byte[] values = value.getBytes();
         levelDbDataSource.putData(key, values);
 
-        Blockchain blockchain = new Blockchain();
         blockchain.addBlock(block);
-
     }
 }

--- a/src/test/java/org/tron/core/BlockchainTest.java
+++ b/src/test/java/org/tron/core/BlockchainTest.java
@@ -16,6 +16,7 @@ package org.tron.core;
 
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -42,6 +43,11 @@ public class BlockchainTest {
     @BeforeClass
     public static void init() {
        blockchain = new Blockchain("0304f784e4e7bae517bcab94c3e0c9214fb4ac7ff9d7d5a937d1f40031f87b85");
+    }
+
+    @AfterClass
+    public static void teardown() {
+        blockchain.getBlockDB().closeDB();
     }
 
     @Test


### PR DESCRIPTION
**What does this PR do?**

Refactor the constructor on Blockchain so there is only a single constructor and the constructor decides whether to initialize a new DB or not. This removes the need for the usage of System.exit(0)

Refactors BlockchainTest so all tests can share the same instance of Blockchain avoiding the issue attempting to initialize Blockchain, when a previous instance had locked access to LevelDB

Uses Mockito to mock the Blockchain in BlockUtilsTest to avoid tests locking access to LevelDB before BlockchainTest runs on a gradle build. Currently only BlockchainTest needs an actual instance of the Blockchain class.

**Why are these changes required?**

System.exit(0) was causing test processes to terminate which meant the full test suite was not running on the gradle build. Avoiding stopping the entire running process in this way is recommended (as tests were being ignored and so there was a risk of failures not being found when developing).

Previous tests locking access to LevelDB was preventing tests from running together when running a test suite or attempting to run the gradle test task.

**This PR has been tested by:**
- Unit Tests

**Follow up**
This was the fastest way of removing these issues I found. However, it may be desirable to change the constructor on Blockchain from Blockchain(String address) to something like Blockchain(LevelDbDataSourceImpl db)

This would allow passing a mocked LevelDB into Blockchain, which would make DB states much easier to configure for testing the Blockchain functionality.

To allow this initialising the DB could become a responsibility of Peer or maybe Wallet.
