### PR TITLE
Use a mock for UTXOSet in Blockchain test

### DIFF
--- a/src/test/java/org/tron/core/BlockchainTest.java
+++ b/src/test/java/org/tron/core/BlockchainTest.java
@@ -19,6 +19,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.tron.protos.core.TronBlock.Block;
@@ -104,11 +105,19 @@ public class BlockchainTest {
 
     @Test
     public void testFindUTXO() {
+        long testAmount = 10;
         Wallet wallet = new Wallet();
         wallet.init();
-        UTXOSet utxoSet = new UTXOSet();
+        SpendableOutputs spendableOutputs = new SpendableOutputs();
+        spendableOutputs.setAmount(testAmount + 1);
+        spendableOutputs.setUnspentOutputs(new HashMap<>());
+        UTXOSet mockUtxoSet = Mockito.mock(UTXOSet.class);
+        Mockito.when(mockUtxoSet.findSpendableOutputs(wallet.getEcKey().getPubKey(), testAmount)
+        ).thenReturn(spendableOutputs);
+        Mockito.when(mockUtxoSet.getBlockchain()).thenReturn(blockchain);
+
         Transaction transaction = TransactionUtils.newTransaction(wallet,
-                "fd0f3c8ab4877f0fd96cd156b0ad42ea7aa82c31", 10, utxoSet);
+                "fd0f3c8ab4877f0fd96cd156b0ad42ea7aa82c31", testAmount, mockUtxoSet);
         List<Transaction> transactions = new ArrayList<>();
         transactions.add(transaction);
         blockchain.addBlock(BlockUtils.newBlock(transactions, ByteString


### PR DESCRIPTION
**What does this PR do?**

Swaps the UTXOSet in BlockchainTest for a mock

**Why are these changes required?**

Builds on Travis are failing when attempting to run UTXOStoreTest with a org.fusesource.leveldbjni.internal.NativeDB$DBException

The reason is both UTXOStore and UTXOSet create a lock on the TransactionDB. Using a mock for UTXOSet removes the need for a lock to be set on the TransactionDB to run BlockchainTest suite

**This PR has been tested by:**
- Unit Tests

**Follow up**

UTXOStore and UTXOSet classes both initialize and set a lock on the TransactionDB.

Blockchain and BlockStores classes both initialize and set a lock on the BlockDB.

In all cases these initialization on the DB are done in the constructor of the class.

It seems like these DBs could be initialized outside of the class, perhaps in the Peer class and then the database dependency injected into Blockchain, BlockStores, UTXOStore and UTXOSet in the constructor.

This way, we can ensure the DB connections are created and locked only once during the runtime lifecycle and avoid the NativeDB$DBException.

This would also allow using a mock for TransactionDB and BlockDB, which would allow for easier state management of the data in the unit tests and so better test coverage.

A wrapper class could be created around the initialization of the database so that the type system can make sure the correct DB is injected into correct class. For example, the Blockchain constructor could look like:

`public Blockchain(BlockDB blockDb)`