### PR TITLE
Fix blockchain test

### DIFF
--- a/src/main/java/org/tron/core/Blockchain.java
+++ b/src/main/java/org/tron/core/Blockchain.java
@@ -113,13 +113,13 @@ public class Blockchain {
             throw new Exception("Got as far as this");
 
             // put message to consensus
-            if (type.equals(PeerType.PEER_SERVER)) {
+/*            if (type.equals(PeerType.PEER_SERVER)) {
                 String value = ByteArray.toHexString(genesisBlock.toByteArray());
                 Message message = new Message(value, Type.BLOCK);
                 Client.putMessage1(message); // consensus: put message GenesisBlock
                 //Merely for the placeholders, no real meaning
                 Message time = new Message(value, Type.TRANSACTION);
-                Client.putMessage1(time);
+                Client.putMessage1(time);*/
 
             }
             logger.info("new blockchain");

--- a/src/main/java/org/tron/core/Blockchain.java
+++ b/src/main/java/org/tron/core/Blockchain.java
@@ -62,7 +62,7 @@ public class Blockchain {
      *
      * @param address wallet address
      */
-    public Blockchain(String address, String type) {
+    public Blockchain(String address, String type) throws Exception {
         if (dbExists()) {
             blockDB = new LevelDbDataSourceImpl(BLOCK_DB_NAME);
             blockDB.initDB();
@@ -109,6 +109,8 @@ public class Blockchain {
                     .getHash()
                     .toByteArray();
             blockDB.putData(LAST_HASH, lastHash);
+
+            throw new Exception("Got as far as this");
 
             // put message to consensus
             if (type.equals(PeerType.PEER_SERVER)) {

--- a/src/main/java/org/tron/core/Blockchain.java
+++ b/src/main/java/org/tron/core/Blockchain.java
@@ -62,7 +62,7 @@ public class Blockchain {
      *
      * @param address wallet address
      */
-    public Blockchain(String address, String type) throws Exception {
+    public Blockchain(String address, String type) {
         if (dbExists()) {
             blockDB = new LevelDbDataSourceImpl(BLOCK_DB_NAME);
             blockDB.initDB();
@@ -110,16 +110,14 @@ public class Blockchain {
                     .toByteArray();
             blockDB.putData(LAST_HASH, lastHash);
 
-            throw new Exception("Got as far as this");
-
             // put message to consensus
-/*            if (type.equals(PeerType.PEER_SERVER)) {
+            if (type.equals(PeerType.PEER_SERVER)) {
                 String value = ByteArray.toHexString(genesisBlock.toByteArray());
                 Message message = new Message(value, Type.BLOCK);
                 Client.putMessage1(message); // consensus: put message GenesisBlock
                 //Merely for the placeholders, no real meaning
                 Message time = new Message(value, Type.TRANSACTION);
-                Client.putMessage1(time);*/
+                Client.putMessage1(time);
 
             }
             logger.info("new blockchain");

--- a/src/test/java/org/tron/core/BlockchainTest.java
+++ b/src/test/java/org/tron/core/BlockchainTest.java
@@ -18,6 +18,7 @@ import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
@@ -36,6 +37,7 @@ import java.util.List;
 import static org.tron.core.Blockchain.dbExists;
 import static org.tron.utils.ByteArray.toHexString;
 
+@Ignore
 public class BlockchainTest {
     private static final Logger logger = LoggerFactory.getLogger("Test");
     private static Blockchain blockchain;

--- a/src/test/java/org/tron/core/BlockchainTest.java
+++ b/src/test/java/org/tron/core/BlockchainTest.java
@@ -41,7 +41,7 @@ public class BlockchainTest {
     @Before
     public void init() throws Exception {
         blockchain = new Blockchain
-               ("0304f784e4e7bae517bcab94c3e0c9214fb4ac7ff9d7d5a937d1f40031f87b85","server");
+               ("0304f784e4e7bae517bcab94c3e0c9214fb4ac7ff9d7d5a937d1f40031f87b85","normal");
     }
 
     @After

--- a/src/test/java/org/tron/core/BlockchainTest.java
+++ b/src/test/java/org/tron/core/BlockchainTest.java
@@ -56,7 +56,7 @@ public class BlockchainTest {
                         .toHexString(blockchain.getCurrentHash()));
     }
 
-    @Test
+/*    @Test
     public void testBlockchainNew() {
         logger.info("test blockchain new: lastHash = {}", ByteArray
                 .toHexString(blockchain.getLastHash()));
@@ -147,5 +147,5 @@ public class BlockchainTest {
 
         blockchain.addBlock(block);
         levelDbDataSource.closeDB();
-    }
+    }*/
 }

--- a/src/test/java/org/tron/core/BlockchainTest.java
+++ b/src/test/java/org/tron/core/BlockchainTest.java
@@ -18,7 +18,6 @@ import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
@@ -54,8 +53,6 @@ public class BlockchainTest {
 
     @Test
     public void testBlockchain() {
-        Blockchain blockchain = new Blockchain
-                ("0304f784e4e7bae517bcab94c3e0c9214fb4ac7ff9d7d5a937d1f40031f87b85","server");
         logger.info("test blockchain: lashHash = {}, currentHash = {}",
                 ByteArray.toHexString(blockchain.getLastHash()), ByteArray
                         .toHexString(blockchain.getCurrentHash()));
@@ -82,9 +79,7 @@ public class BlockchainTest {
 
     @Test
     public void testIterator() {
-
-        Blockchain blockchain = new Blockchain("","server");
-        Block info = null;
+        Block info;
         BlockchainIterator bi = new BlockchainIterator(blockchain);
         while (bi.hasNext()) {
             info = (Block) bi.next();
@@ -111,7 +106,6 @@ public class BlockchainTest {
     @Test
     public void testFindUTXO() {
         long testAmount = 10;
-        Blockchain blockchain = new Blockchain("fd0f3c8ab4877f0fd96cd156b0ad42ea7aa82c31","server");
         Wallet wallet = new Wallet();
         wallet.init();
         SpendableOutputs spendableOutputs = new SpendableOutputs();

--- a/src/test/java/org/tron/core/BlockchainTest.java
+++ b/src/test/java/org/tron/core/BlockchainTest.java
@@ -42,7 +42,6 @@ public class BlockchainTest {
     public void init() throws Exception {
         blockchain = new Blockchain
                ("0304f784e4e7bae517bcab94c3e0c9214fb4ac7ff9d7d5a937d1f40031f87b85","server");
-        throw new Exception("Got as far as this");
     }
 
     @After

--- a/src/test/java/org/tron/core/BlockchainTest.java
+++ b/src/test/java/org/tron/core/BlockchainTest.java
@@ -50,10 +50,13 @@ public class BlockchainTest {
     }
 
     @Test
-    public void testBlockchain() {
-        logger.info("test blockchain: lashHash = {}, currentHash = {}",
+    public void testBlockchain() throws Exception {
+        throw new Exception("Test execution got as far as this!");
+        /*
+       logger.info("test blockchain: lashHash = {}, currentHash = {}",
                 ByteArray.toHexString(blockchain.getLastHash()), ByteArray
                         .toHexString(blockchain.getCurrentHash()));
+                        */
     }
 
 /*    @Test

--- a/src/test/java/org/tron/core/BlockchainTest.java
+++ b/src/test/java/org/tron/core/BlockchainTest.java
@@ -37,7 +37,6 @@ import java.util.List;
 import static org.tron.core.Blockchain.dbExists;
 import static org.tron.utils.ByteArray.toHexString;
 
-@Ignore
 public class BlockchainTest {
     private static final Logger logger = LoggerFactory.getLogger("Test");
     private static Blockchain blockchain;

--- a/src/test/java/org/tron/core/BlockchainTest.java
+++ b/src/test/java/org/tron/core/BlockchainTest.java
@@ -40,9 +40,9 @@ public class BlockchainTest {
 
     @Before
     public void init() throws Exception {
+        blockchain = new Blockchain
+               ("0304f784e4e7bae517bcab94c3e0c9214fb4ac7ff9d7d5a937d1f40031f87b85","server");
         throw new Exception("Got as far as this");
-        //blockchain = new Blockchain
-        //       ("0304f784e4e7bae517bcab94c3e0c9214fb4ac7ff9d7d5a937d1f40031f87b85","server");
     }
 
     @After

--- a/src/test/java/org/tron/core/BlockchainTest.java
+++ b/src/test/java/org/tron/core/BlockchainTest.java
@@ -39,9 +39,10 @@ public class BlockchainTest {
     private static Blockchain blockchain;
 
     @Before
-    public void init() {
-        blockchain = new Blockchain
-               ("0304f784e4e7bae517bcab94c3e0c9214fb4ac7ff9d7d5a937d1f40031f87b85","server");
+    public void init() throws Exception {
+        throw new Exception("Got as far as this");
+        //blockchain = new Blockchain
+        //       ("0304f784e4e7bae517bcab94c3e0c9214fb4ac7ff9d7d5a937d1f40031f87b85","server");
     }
 
     @After
@@ -51,7 +52,6 @@ public class BlockchainTest {
 
     @Test
     public void testBlockchain() throws Exception {
-        throw new Exception("Test execution got as far as this!");
         /*
        logger.info("test blockchain: lashHash = {}, currentHash = {}",
                 ByteArray.toHexString(blockchain.getLastHash()), ByteArray

--- a/src/test/java/org/tron/core/BlockchainTest.java
+++ b/src/test/java/org/tron/core/BlockchainTest.java
@@ -51,14 +51,14 @@ public class BlockchainTest {
 
     @Test
     public void testBlockchain() throws Exception {
-        /*
+
        logger.info("test blockchain: lashHash = {}, currentHash = {}",
                 ByteArray.toHexString(blockchain.getLastHash()), ByteArray
                         .toHexString(blockchain.getCurrentHash()));
-                        */
+
     }
 
-/*    @Test
+    @Test
     public void testBlockchainNew() {
         logger.info("test blockchain new: lastHash = {}", ByteArray
                 .toHexString(blockchain.getLastHash()));
@@ -149,5 +149,5 @@ public class BlockchainTest {
 
         blockchain.addBlock(block);
         levelDbDataSource.closeDB();
-    }*/
+    }
 }

--- a/src/test/java/org/tron/core/BlockchainTest.java
+++ b/src/test/java/org/tron/core/BlockchainTest.java
@@ -16,10 +16,7 @@ package org.tron.core;
 
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.*;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,19 +34,18 @@ import java.util.List;
 import static org.tron.core.Blockchain.dbExists;
 import static org.tron.utils.ByteArray.toHexString;
 
-@Ignore
 public class BlockchainTest {
     private static final Logger logger = LoggerFactory.getLogger("Test");
     private static Blockchain blockchain;
 
-    @BeforeClass
-    public static void init() {
-       blockchain = new Blockchain
+    @Before
+    public void init() {
+        blockchain = new Blockchain
                ("0304f784e4e7bae517bcab94c3e0c9214fb4ac7ff9d7d5a937d1f40031f87b85","server");
     }
 
-    @AfterClass
-    public static void teardown() {
+    @After
+    public void teardown() {
         blockchain.getBlockDB().closeDB();
     }
 


### PR DESCRIPTION
**DO NOT MERGE** 

This passes locally for me but is hanging on the Travis build. I am currently using the PR to try to figure out why it is hanging. 

**What does this PR do?**

Refactors BlockchainTest to only initialize the Blockchain class once and re-use it. This removes the clash with the database lock and allows the tests to be run again.

**Why are these changes required?**

Because we like to be able to run out tests. Testing is good.

**This PR has been tested by:**
- Unit Tests

  