### PR TITLE
Don't refer to singleton instance in blockchain

### DIFF
--- a/src/main/java/org/tron/core/Blockchain.java
+++ b/src/main/java/org/tron/core/Blockchain.java
@@ -303,7 +303,7 @@ public class Blockchain {
         byte[] lastHash = blockDB.getData(LAST_HASH);
         ByteString parentHash = ByteString.copyFrom(lastHash);
         // getData number
-        long number = BlockUtils.getIncreaseNumber(Tron.getPeer().getBlockchain());
+        long number = BlockUtils.getIncreaseNumber(this);
         // getData difficulty
         ByteString difficulty = ByteString.copyFromUtf8(Constant.DIFFICULTY);
         Block block = BlockUtils.newBlock(transactions, parentHash, difficulty,
@@ -322,8 +322,7 @@ public class Blockchain {
         byte[] lastHash = blockDB.getData(LAST_HASH);
         ByteString parentHash = ByteString.copyFrom(lastHash);
         // get number
-        long number = BlockUtils.getIncreaseNumber(Tron.getPeer()
-                .getBlockchain());
+        long number = BlockUtils.getIncreaseNumber(this);
         // get difficulty
         ByteString difficulty = ByteString.copyFromUtf8(Constant.DIFFICULTY);
         Block block = BlockUtils.newBlock(transactions, parentHash, difficulty,


### PR DESCRIPTION
**What does this PR do?**

The code references the singleton instance when it should be refering to his own instance

**Why are these changes required?**

When there are multiple blockchain instances then it should be refering to his own instance

**This PR has been tested by:**
- Unit Tests
- Manual Testing
