### PR TITLE
refactor: make wallet less complex to use

### DIFF
--- a/src/main/java/org/tron/peer/PeerBuilder.java
+++ b/src/main/java/org/tron/peer/PeerBuilder.java
@@ -2,7 +2,6 @@ package org.tron.peer;
 
 import com.google.inject.Injector;
 import org.tron.consensus.client.Client;
-import org.tron.consensus.server.Server;
 import org.tron.core.Blockchain;
 import org.tron.core.UTXOSet;
 import org.tron.crypto.ECKey;
@@ -49,8 +48,7 @@ public class PeerBuilder {
     private void buildWallet() {
         if (key == null) throw new IllegalStateException("Key must be set before building the wallet");
 
-        wallet = new Wallet();
-        wallet.init(key);
+        wallet = new Wallet(key);
     }
 
     public PeerBuilder setType(String type) {

--- a/src/main/java/org/tron/wallet/Wallet.java
+++ b/src/main/java/org/tron/wallet/Wallet.java
@@ -21,45 +21,34 @@ import org.tron.utils.ByteArray;
 import org.tron.utils.Utils;
 
 public class Wallet {
+
     private static final Logger logger = LoggerFactory.getLogger("Wallet");
 
-    private ECKey ecKey;
-    private byte[] address;
+    private final ECKey ecKey;
 
     /**
-     * getData a new wallet key
+     * Creates a new Wallet with a random ECKey
      */
-    public void init() {
+    public Wallet() {
         this.ecKey = new ECKey(Utils.getRandom());
-        address = this.ecKey.getAddress();
     }
 
     /**
-     * getData a wallet by the key
+     * Creates a Wallet with an existing ECKey
      *
-     * @param ecKey keypair
+     * @param ECKey ecKey Existing Key
      */
-    public void init(ECKey ecKey) {
+    public Wallet(final ECKey ecKey) {
         this.ecKey = ecKey;
-        address = this.ecKey.getAddress();
-
-        logger.info("wallet address: {}", ByteArray.toHexString(address));
+        logger.info("wallet address: {}", ByteArray.toHexString(this.ecKey.getAddress()));
     }
 
     public ECKey getEcKey() {
         return ecKey;
     }
 
-    public void setEcKey(ECKey ecKey) {
-        this.ecKey = ecKey;
-    }
-
     public byte[] getAddress() {
-        return address;
-    }
-
-    public void setAddress(byte[] address) {
-        this.address = address;
+        return ecKey.getAddress();
     }
 
 }

--- a/src/test/java/org/tron/core/BlockchainTest.java
+++ b/src/test/java/org/tron/core/BlockchainTest.java
@@ -107,7 +107,6 @@ public class BlockchainTest {
     public void testFindUTXO() {
         long testAmount = 10;
         Wallet wallet = new Wallet();
-        wallet.init();
         SpendableOutputs spendableOutputs = new SpendableOutputs();
         spendableOutputs.setAmount(testAmount + 1);
         spendableOutputs.setUnspentOutputs(new HashMap<>());
@@ -134,7 +133,6 @@ public class BlockchainTest {
                 ("2001"));
 
         Wallet wallet = new Wallet();
-        wallet.init();
 
         Block block = BlockUtils.newBlock(null, parentHash,
                 difficulty, 0);

--- a/src/test/java/org/tron/core/WalletTest.java
+++ b/src/test/java/org/tron/core/WalletTest.java
@@ -26,7 +26,6 @@ public class WalletTest {
     @Test
     public void testWallet() {
         Wallet wallet = new Wallet();
-        wallet.init();
 
         logger.info("wallet address = {}", ByteArray.toHexString(wallet
                 .getAddress()));


### PR DESCRIPTION
**What does this PR do?**

The Wallet class was unnecessary complex as one had to
call init() for no real reason as this could also happen
easily in the constructor.

**Why are these changes required?**

To make the Wallet class easy understandable 


**This PR has been tested by:**

- Manual Testing

**Follow up**

Do we even need a Wallet class? It only wraps ECKey.

**Extra details**

