### PR TITLE
Inject block db to blockchain

### DIFF
--- a/src/main/java/org/tron/core/Blockchain.java
+++ b/src/main/java/org/tron/core/Blockchain.java
@@ -54,7 +54,7 @@ public class Blockchain {
     public static String parentName=Constant.NORMAL;
 
     public static final Logger logger = LoggerFactory.getLogger("BlockChain");
-    private LevelDbDataSourceImpl blockDB = null;
+    private LevelDbDataSourceImpl blockDB;
     private PendingState pendingState = new PendingStateImpl();
 
     private byte[] lastHash;
@@ -67,19 +67,11 @@ public class Blockchain {
      *
      * @param address wallet address
      */
-    public Blockchain(String address, String type) {
-        if (dbExists()) {
-            blockDB = new LevelDbDataSourceImpl(parentName,BLOCK_DB_NAME);
-            blockDB.initDB();
+    public Blockchain(LevelDbDataSourceImpl blockDB, String address, String type) {
+        this.blockDB = blockDB;
+        this.lastHash = blockDB.getData(LAST_HASH);
 
-            this.lastHash = blockDB.getData(LAST_HASH);
-            this.currentHash = this.lastHash;
-
-            logger.info("load blockchain");
-        } else {
-            blockDB = new LevelDbDataSourceImpl(Constant.NORMAL,BLOCK_DB_NAME);
-            blockDB.initDB();
-
+        if(this.lastHash == null) {
             InputStream is = getClass().getClassLoader().getResourceAsStream("genesis.json");
             String json = null;
             try {
@@ -126,6 +118,9 @@ public class Blockchain {
 
             }
             logger.info("new blockchain");
+        } else {
+            this.currentHash = this.lastHash;
+            logger.info("load blockchain");
         }
     }
 

--- a/src/main/java/org/tron/core/Blockchain.java
+++ b/src/main/java/org/tron/core/Blockchain.java
@@ -20,7 +20,6 @@ import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.tron.config.Configer;
 import org.tron.consensus.client.Client;
 import org.tron.crypto.ECKey;
 import org.tron.example.Tron;
@@ -37,15 +36,10 @@ import org.tron.protos.core.TronTransaction.Transaction;
 import org.tron.storage.leveldb.LevelDbDataSourceImpl;
 import org.tron.utils.ByteArray;
 
-import javax.inject.Inject;
-import javax.inject.Named;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.Paths;
 import java.util.*;
 
-import static org.tron.core.Constant.BLOCK_DB_NAME;
 import static org.tron.core.Constant.LAST_HASH;
 
 public class Blockchain {
@@ -65,7 +59,10 @@ public class Blockchain {
     /**
      * create new blockchain
      *
+     * @param blockDB block database
      * @param address wallet address
+     * @param type peer type
+     *
      */
     public Blockchain(LevelDbDataSourceImpl blockDB, String address, String type) {
         this.blockDB = blockDB;

--- a/src/main/java/org/tron/core/Blockchain.java
+++ b/src/main/java/org/tron/core/Blockchain.java
@@ -125,24 +125,6 @@ public class Blockchain {
     }
 
     /**
-     * create blockchain by db source
-     */
-    @Inject
-    public Blockchain(@Named("block") LevelDbDataSourceImpl blockDb) {
-        if (!dbExists()) {
-            logger.info("no existing blockchain found. please create one first");
-            throw new IllegalStateException("No existing blockchain found. please create one first");
-        }
-
-        blockDB = blockDb;
-
-        this.lastHash = blockDB.getData(LAST_HASH);
-        this.currentHash = this.lastHash;
-
-        logger.info("load blockchain");
-    }
-
-    /**
      * find transaction by id
      *
      * @param id ByteString id
@@ -228,23 +210,6 @@ public class Blockchain {
 
         return utxo;
     }
-
-    /**
-     * Checks if the database file exists
-     *
-     * @return boolean
-     */
-    public static boolean dbExists() {
-        if (Constant.NORMAL==parentName){
-            parentName= Configer.getConf(Constant.NORMAL_CONF).getString(Constant.DATABASE_DIR);
-        }else {
-            parentName=Configer.getConf(Constant.TEST_CONF).getString(Constant.DATABASE_DIR);
-
-        }
-        File file = new File(Paths.get(parentName, BLOCK_DB_NAME).toString());
-        return file.exists();
-    }
-
 
     /**
      * add a block into database

--- a/src/main/java/org/tron/peer/PeerBuilder.java
+++ b/src/main/java/org/tron/peer/PeerBuilder.java
@@ -1,10 +1,13 @@
 package org.tron.peer;
 
 import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.name.Names;
 import org.tron.consensus.client.Client;
 import org.tron.core.Blockchain;
 import org.tron.core.UTXOSet;
 import org.tron.crypto.ECKey;
+import org.tron.storage.leveldb.LevelDbDataSourceImpl;
 import org.tron.utils.ByteArray;
 import org.tron.wallet.Wallet;
 
@@ -33,7 +36,11 @@ public class PeerBuilder {
         if (wallet == null) throw new IllegalStateException("Wallet must be set before building the blockchain");
         if (type == null) throw new IllegalStateException("Type must be set before building the blockchain");
 
-        blockchain = new Blockchain(ByteArray.toHexString(wallet.getAddress()), this.type);
+        blockchain = new Blockchain(
+                injector.getInstance(Key.get(LevelDbDataSourceImpl.class, Names.named("block"))),
+                        ByteArray.toHexString(wallet.getAddress()),
+                        this.type
+                );
         blockchain.setClient(injector.getInstance(Client.class));
     }
 

--- a/src/test/java/org/tron/core/BlockchainTest.java
+++ b/src/test/java/org/tron/core/BlockchainTest.java
@@ -14,13 +14,9 @@
  */
 package org.tron.core;
 
-import com.alibaba.fastjson.JSON;
-import com.google.common.io.ByteStreams;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
-import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
@@ -33,13 +29,12 @@ import org.tron.utils.ByteArray;
 import org.tron.wallet.Wallet;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
-import static org.tron.core.Blockchain.GENESIS_COINBASE_DATA;
-import static org.tron.core.Blockchain.dbExists;
 import static org.tron.core.Constant.LAST_HASH;
 import static org.tron.utils.ByteArray.toHexString;
 
@@ -105,11 +100,6 @@ public class BlockchainTest {
                 .copyFrom(ByteArray.fromHexString
                         ("15f3988aa8d56eab3bfca45144bad77fc60acce50437a0a9d794a03a83c15c5e")));
         logger.info("{}", TransactionUtils.toPrintString(transaction));
-    }
-
-    @Test
-    public void testDBExists() {
-        logger.info("test dbStore exists: {}", dbExists());
     }
 
     @Test

--- a/src/test/java/org/tron/core/BlockchainTest.java
+++ b/src/test/java/org/tron/core/BlockchainTest.java
@@ -14,9 +14,12 @@
  */
 package org.tron.core;
 
+import com.alibaba.fastjson.JSON;
+import com.google.common.io.ByteStreams;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -29,26 +32,32 @@ import org.tron.storage.leveldb.LevelDbDataSourceImpl;
 import org.tron.utils.ByteArray;
 import org.tron.wallet.Wallet;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.*;
 
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.tron.core.Blockchain.GENESIS_COINBASE_DATA;
 import static org.tron.core.Blockchain.dbExists;
+import static org.tron.core.Constant.LAST_HASH;
 import static org.tron.utils.ByteArray.toHexString;
 
 public class BlockchainTest {
     private static final Logger logger = LoggerFactory.getLogger("Test");
     private static Blockchain blockchain;
+    private static LevelDbDataSourceImpl mockBlockDB;
 
-    @BeforeClass
-    public static void init() {
-       blockchain = new Blockchain
-               ("0304f784e4e7bae517bcab94c3e0c9214fb4ac7ff9d7d5a937d1f40031f87b85","normal");
-    }
-
-    @AfterClass
-    public static void teardown() {
-        blockchain.getBlockDB().closeDB();
+    @Before
+    public void setup() throws IOException {
+        mockBlockDB = Mockito.mock(LevelDbDataSourceImpl.class);
+        Mockito.when(mockBlockDB.getData(eq(LAST_HASH))).thenReturn(null);
+        Mockito.when(mockBlockDB.getData(any())).thenReturn(ByteArray.fromString(""));
+        blockchain = new Blockchain(
+                mockBlockDB,
+                "0304f784e4e7bae517bcab94c3e0c9214fb4ac7ff9d7d5a937d1f40031f87b85",
+                "normal"
+        );
     }
 
     @Test


### PR DESCRIPTION
**What does this PR do?**

1) Injects blockDB from Guice injector into the Blockchain constructor, from within PeerBuilder

2) Uses a mock for blockDB in BlockchainTest

3) Removes dbExists feature from Blockchain

**Why are these changes required?**
1) Should mean the instance of blockDB launched by Guice is the only instance needed. Abstracts Blockchain away from responsibility for maintaining database state.

2) Using a mock in BlockchainTest will make it easier to set up of various test conditions. This will make testing Blockchain class easier.

3) As Guice initializes the blockDB, relying on the database file existing no longer seems to be a reliable way to know if the blockchain has been created.
I encountered NullPointerExceptions where the blockDB existed but the LAST_HASH was null. 
In these changes, if LAST_HASH is null on initialization of Blockchain, the create Blockchain logic will run.

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Extra details**

Also removes constructor used by Guice to initialize a Blockchain. PeerBuilder has sole responsibility for initializing Blockchain.

