### PR TITLE
Decouple client from blockchain using events

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Jan 06 16:37:04 CST 2018
+#Wed Jan 10 22:50:54 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.5-rc-2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.5-rc-2-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Jan 10 22:50:54 CET 2018
+#Sat Jan 06 16:37:04 CST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.5-rc-2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.5-rc-2-bin.zip

--- a/src/main/java/org/tron/command/ConsensusCommand.java
+++ b/src/main/java/org/tron/command/ConsensusCommand.java
@@ -51,7 +51,7 @@ public class ConsensusCommand extends Command {
     }
 
     public void getClient(Peer peer) {
-        if (Tron.getPeer().getType().equals(PeerType.PEER_SERVER)) {
+        if (peer.getType().equals(PeerType.PEER_SERVER)) {
             client.getMessage(peer, MessageType.TRANSACTION);
             client.getMessage(peer, MessageType.BLOCK);
         } else {

--- a/src/main/java/org/tron/consensus/client/BlockchainClientListener.java
+++ b/src/main/java/org/tron/consensus/client/BlockchainClientListener.java
@@ -1,0 +1,53 @@
+package org.tron.consensus.client;
+
+import org.tron.core.events.BlockchainListener;
+import org.tron.overlay.Net;
+import org.tron.overlay.message.Message;
+import org.tron.overlay.message.Type;
+import org.tron.peer.Peer;
+import org.tron.peer.PeerType;
+import org.tron.protos.core.TronBlock;
+import org.tron.utils.ByteArray;
+
+public class BlockchainClientListener implements BlockchainListener {
+
+    private Client client;
+    private Peer peer;
+
+    public BlockchainClientListener(Client client, Peer peer) {
+        this.client = client;
+        this.peer = peer;
+    }
+
+    @Override
+    public void addBlock(TronBlock.Block block) {
+        String value = ByteArray.toHexString(block.toByteArray());
+
+        if (peer.getType().equals(PeerType.PEER_SERVER)) {
+            Message message = new Message(value, Type.BLOCK);
+            //net.broadcast(message);
+            client.putMessage1(message); // consensus: put message
+        }
+    }
+
+    @Override
+    public void addBlockNet(TronBlock.Block block, Net net) {
+        if (peer.getType().equals(PeerType.PEER_SERVER)) {
+            String value = ByteArray.toHexString(block.toByteArray());
+            Message message = new Message(value, Type.BLOCK);
+            net.broadcast(message);
+        }
+    }
+
+    @Override
+    public void addGenesisBlock(TronBlock.Block block) {
+        if (peer.getType().equals(PeerType.PEER_SERVER)) {
+            String value = ByteArray.toHexString(block.toByteArray());
+            Message message = new Message(value, Type.BLOCK);
+            client.putMessage1(message); // consensus: put message GenesisBlock
+            //Merely for the placeholders, no real meaning
+            Message time = new Message(value, Type.TRANSACTION);
+            client.putMessage1(time);
+        }
+    }
+}

--- a/src/main/java/org/tron/core/Blockchain.java
+++ b/src/main/java/org/tron/core/Blockchain.java
@@ -21,14 +21,10 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.tron.config.Configer;
-import org.tron.consensus.client.Client;
+import org.tron.core.events.BlockchainListener;
 import org.tron.crypto.ECKey;
-import org.tron.example.Tron;
 import org.tron.overlay.Net;
-import org.tron.overlay.message.Message;
-import org.tron.overlay.message.Type;
 import org.tron.peer.Peer;
-import org.tron.peer.PeerType;
 import org.tron.protos.core.TronBlock.Block;
 import org.tron.protos.core.TronTXInput.TXInput;
 import org.tron.protos.core.TronTXOutput.TXOutput;
@@ -60,7 +56,7 @@ public class Blockchain {
     private byte[] lastHash;
     private byte[] currentHash;
 
-    private Client client;
+    private List<BlockchainListener> listeners = new ArrayList<>();
 
     /**
      * create new blockchain
@@ -115,16 +111,10 @@ public class Blockchain {
                     .toByteArray();
             blockDB.putData(LAST_HASH, lastHash);
 
-            // put message to consensus
-            if (type.equals(PeerType.PEER_SERVER) && client != null) {
-                String value = ByteArray.toHexString(genesisBlock.toByteArray());
-                Message message = new Message(value, Type.BLOCK);
-                client.putMessage1(message); // consensus: put message GenesisBlock
-                //Merely for the placeholders, no real meaning
-                Message time = new Message(value, Type.TRANSACTION);
-                client.putMessage1(time);
-
+            for (BlockchainListener listener : listeners) {
+                listener.addGenesisBlock(genesisBlock);
             }
+
             logger.info("new blockchain");
         }
     }
@@ -309,11 +299,8 @@ public class Blockchain {
         Block block = BlockUtils.newBlock(transactions, parentHash, difficulty,
                 number);
 
-        String value = ByteArray.toHexString(block.toByteArray());
-
-        if (Tron.getPeer().getType().equals(PeerType.PEER_SERVER)) {
-            Message message = new Message(value, Type.BLOCK);
-            net.broadcast(message);
+        for (BlockchainListener listener : listeners) {
+            listener.addBlockNet(block, net);
         }
     }
 
@@ -325,17 +312,10 @@ public class Blockchain {
         long number = BlockUtils.getIncreaseNumber(this);
         // get difficulty
         ByteString difficulty = ByteString.copyFromUtf8(Constant.DIFFICULTY);
-        Block block = BlockUtils.newBlock(transactions, parentHash, difficulty,
-                number);
+        Block block = BlockUtils.newBlock(transactions, parentHash, difficulty, number);
 
-        String value = ByteArray.toHexString(block.toByteArray());
-        // View the type of peer
-        //System.out.println(Tron.getPeer().getType());
-
-        if (Tron.getPeer().getType().equals(PeerType.PEER_SERVER) && client != null) {
-            Message message = new Message(value, Type.BLOCK);
-            //net.broadcast(message);
-            client.putMessage1(message); // consensus: put message
+        for (BlockchainListener listener : listeners) {
+            listener.addBlock(block);
         }
     }
 
@@ -373,6 +353,10 @@ public class Blockchain {
         utxoSet.reindex();
     }
 
+    public void addListener(BlockchainListener listener) {
+        this.listeners.add(listener);
+    }
+
     public LevelDbDataSourceImpl getBlockDB() {
         return blockDB;
     }
@@ -403,9 +387,5 @@ public class Blockchain {
 
     public void setCurrentHash(byte[] currentHash) {
         this.currentHash = currentHash;
-    }
-
-    public void setClient(Client client) {
-        this.client = client;
     }
 }

--- a/src/main/java/org/tron/core/events/BlockchainListener.java
+++ b/src/main/java/org/tron/core/events/BlockchainListener.java
@@ -1,0 +1,23 @@
+package org.tron.core.events;
+
+import org.tron.overlay.Net;
+import org.tron.protos.core.TronBlock;
+
+public interface BlockchainListener {
+
+    /**
+     * New block added to blockchain
+     */
+    void addBlock(TronBlock.Block block);
+
+    /**
+     * New block added to blockchain
+     * includes net reference
+     */
+    void addBlockNet(TronBlock.Block block, Net net);
+
+    /**
+     * Genesis block added to blockchain
+     */
+    void addGenesisBlock(TronBlock.Block block);
+}

--- a/src/main/java/org/tron/example/Tron.java
+++ b/src/main/java/org/tron/example/Tron.java
@@ -31,9 +31,6 @@ public class Tron {
     @Parameter(names = {"--type", "-t"}, validateWith = PeerType.class)
     private String type = "normal";
 
-    private static Peer peer;
-
-
     public static void main(String[] args) {
         Tron tron = new Tron();
         JCommander.newBuilder()
@@ -51,7 +48,7 @@ public class Tron {
         app.addService(new Server());
         app.run();
 
-        peer = app.getInjector().getInstance(PeerBuilder.class)
+        Peer peer = app.getInjector().getInstance(PeerBuilder.class)
                 .setKey(Configer.getMyKey())
                 .setType(type)
                 .build();
@@ -60,9 +57,5 @@ public class Tron {
 
         Cli cli = new Cli();
         cli.run(app);
-    }
-
-    public static Peer getPeer() {
-        return peer;
     }
 }

--- a/src/main/java/org/tron/peer/PeerBuilder.java
+++ b/src/main/java/org/tron/peer/PeerBuilder.java
@@ -1,6 +1,7 @@
 package org.tron.peer;
 
 import com.google.inject.Injector;
+import org.tron.consensus.client.BlockchainClientListener;
 import org.tron.consensus.client.Client;
 import org.tron.core.Blockchain;
 import org.tron.core.UTXOSet;
@@ -34,7 +35,6 @@ public class PeerBuilder {
         if (type == null) throw new IllegalStateException("Type must be set before building the blockchain");
 
         blockchain = new Blockchain(ByteArray.toHexString(wallet.getAddress()), this.type);
-        blockchain.setClient(injector.getInstance(Client.class));
     }
 
     private void buildUTXOSet() {
@@ -67,6 +67,7 @@ public class PeerBuilder {
         buildUTXOSet();
         Peer peer = new Peer(type, blockchain, utxoSet, wallet, key);
         peer.setClient(injector.getInstance(Client.class));
+        blockchain.addListener(new BlockchainClientListener(injector.getInstance(Client.class), peer));
         return peer;
     }
 }


### PR DESCRIPTION
**What does this PR do?**

* Decouples the Client from blockchain by using events
* Removes the Tron.getPeer singleton

**Why are these changes required?**

* Because the blockchain should not be dependent on the client
* There should not be any singleton reference to the peer, and other classes should not be dependent on the singleton

**This PR has been tested by:**
- [x] Unit Tests
- [x] Manual Testing