### PR TITLE
add test coverage for Wallet

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.5-rc-2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.3-bin.zip

--- a/src/test/java/org/tron/wallet/WalletTest.java
+++ b/src/test/java/org/tron/wallet/WalletTest.java
@@ -12,13 +12,16 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.tron.core;
+package org.tron.wallet;
 
 import org.junit.Test;
+import static org.junit.Assert.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.tron.utils.ByteArray;
 import org.tron.wallet.Wallet;
+import org.tron.crypto.ECKey;
+import org.tron.utils.Utils;
 
 public class WalletTest {
     private static final Logger logger = LoggerFactory.getLogger("Test");
@@ -26,8 +29,24 @@ public class WalletTest {
     @Test
     public void testWallet() {
         Wallet wallet = new Wallet();
-
+        Wallet wallet2 = new Wallet();
         logger.info("wallet address = {}", ByteArray.toHexString(wallet
                 .getAddress()));
+        assertFalse(wallet.getAddress().equals(wallet2.getAddress()));
+    }
+
+    @Test
+    public void testGetAddress() {
+        ECKey ecKey = new ECKey(Utils.getRandom());
+        Wallet wallet = new Wallet(ecKey);
+        assertArrayEquals(wallet.getAddress(), ecKey.getAddress());
+    }
+
+    @Test
+    public void testGetECKey() {
+        ECKey ecKey = new ECKey(Utils.getRandom());
+        ECKey ecKey2 = new ECKey(Utils.getRandom());
+        Wallet wallet = new Wallet(ecKey);
+        assertEquals("Wallet ECKey should match provided ECKey", wallet.getEcKey(), ecKey);
     }
 }


### PR DESCRIPTION
**What does this PR do?**

- Upgrades gradle version
- Moves wallet test to proper package
- Adds test coverage for wallet class

**Why are these changes required?**

- Adds asserts to test instead of just logging (see issue https://github.com/tronprotocol/java-tron/issues/38)
- Fixes command line errors when running gradle tests from a fresh fork
- Wallet test was in incorrect core package and had no test coverage

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

