### PR TITLE
Refactor blockchain dependency

### DIFF
--- a/src/main/java/org/tron/application/Module.java
+++ b/src/main/java/org/tron/application/Module.java
@@ -5,6 +5,7 @@ import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import org.tron.consensus.client.Client;
 import org.tron.consensus.server.Server;
+import org.tron.core.Blockchain;
 import org.tron.core.Constant;
 import org.tron.storage.leveldb.LevelDbDataSourceImpl;
 
@@ -49,4 +50,11 @@ public class Module extends AbstractModule {
         db.initDB();
         return db;
     }
+
+    @Provides
+    @Singleton
+    public Blockchain buildBlockchain(@Named("block") LevelDbDataSourceImpl blockDB) {
+        return new Blockchain(blockDB);
+    }
+
 }

--- a/src/main/java/org/tron/core/Blockchain.java
+++ b/src/main/java/org/tron/core/Blockchain.java
@@ -32,6 +32,8 @@ import org.tron.protos.core.TronTransaction.Transaction;
 import org.tron.storage.leveldb.LevelDbDataSourceImpl;
 import org.tron.utils.ByteArray;
 
+import javax.inject.Inject;
+import javax.inject.Named;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.*;
@@ -56,10 +58,8 @@ public class Blockchain {
      * create new blockchain
      *
      * @param blockDB block database
-     * @param address wallet address
-     * @param type    peer type
      */
-    public Blockchain(LevelDbDataSourceImpl blockDB, String address, String type) {
+    public Blockchain(@Named("block") LevelDbDataSourceImpl blockDB) {
         this.blockDB = blockDB;
         this.lastHash = blockDB.getData(LAST_HASH);
 

--- a/src/main/java/org/tron/core/UTXOSet.java
+++ b/src/main/java/org/tron/core/UTXOSet.java
@@ -35,16 +35,13 @@ public class UTXOSet {
     private LevelDbDataSourceImpl txDB;
 
     @Inject
-    public UTXOSet(@Named("transaction") LevelDbDataSourceImpl txDb) {
-        txDB = txDb;
+    public UTXOSet(@Named("transaction") LevelDbDataSourceImpl txDb, Blockchain blockchain) {
+        this.txDB = txDb;
+        this.blockchain = blockchain;
     }
 
     public Blockchain getBlockchain() {
         return blockchain;
-    }
-
-    public void setBlockchain(Blockchain blockchain) {
-        this.blockchain = blockchain;
     }
 
     public void reindex() {

--- a/src/main/java/org/tron/core/UTXOSet.java
+++ b/src/main/java/org/tron/core/UTXOSet.java
@@ -32,7 +32,7 @@ public class UTXOSet {
     private static final Logger logger = LoggerFactory.getLogger("UTXOSet");
 
     private Blockchain blockchain;
-    private LevelDbDataSourceImpl txDB = null;
+    private LevelDbDataSourceImpl txDB;
 
     @Inject
     public UTXOSet(@Named("transaction") LevelDbDataSourceImpl txDb) {

--- a/src/main/java/org/tron/core/UTXOSet.java
+++ b/src/main/java/org/tron/core/UTXOSet.java
@@ -62,7 +62,7 @@ public class UTXOSet {
             String key = entry.getKey();
             TXOutputs value = entry.getValue();
 
-            for (TronTXOutput.TXOutput txOutput : value.getOutputsList()) {
+            for (TronTXOutput.TXOutput ignored : value.getOutputsList()) {
                 txDB.putData(ByteArray.fromHexString(key), value.toByteArray());
             }
         }

--- a/src/main/java/org/tron/core/UTXOSet.java
+++ b/src/main/java/org/tron/core/UTXOSet.java
@@ -18,17 +18,15 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.tron.crypto.ECKey;
-import org.tron.storage.leveldb.LevelDbDataSourceImpl;
 import org.tron.protos.core.TronTXOutput;
 import org.tron.protos.core.TronTXOutputs;
 import org.tron.protos.core.TronTXOutputs.TXOutputs;
+import org.tron.storage.leveldb.LevelDbDataSourceImpl;
 import org.tron.utils.ByteArray;
 
 import javax.inject.Inject;
 import javax.inject.Named;
 import java.util.*;
-
-import static org.tron.core.Constant.TRANSACTION_DB_NAME;
 
 public class UTXOSet {
     private static final Logger logger = LoggerFactory.getLogger("UTXOSet");

--- a/src/main/java/org/tron/peer/PeerBuilder.java
+++ b/src/main/java/org/tron/peer/PeerBuilder.java
@@ -1,15 +1,10 @@
 package org.tron.peer;
 
-import com.google.inject.Injector;
-import com.google.inject.Key;
-import com.google.inject.name.Names;
 import org.tron.consensus.client.BlockchainClientListener;
 import org.tron.consensus.client.Client;
 import org.tron.core.Blockchain;
 import org.tron.core.UTXOSet;
 import org.tron.crypto.ECKey;
-import org.tron.storage.leveldb.LevelDbDataSourceImpl;
-import org.tron.utils.ByteArray;
 import org.tron.wallet.Wallet;
 
 import javax.inject.Inject;
@@ -26,30 +21,13 @@ public class PeerBuilder {
     private Wallet wallet;
     private ECKey key;
     private String type;
-    private Injector injector;
+    private Client client;
 
     @Inject
-    public PeerBuilder(Injector injector) {
-        this.injector = injector;
-    }
-
-    private void buildBlockchain() {
-        if (wallet == null) throw new IllegalStateException("Wallet must be set before building the blockchain");
-        if (type == null) throw new IllegalStateException("Type must be set before building the blockchain");
-
-        blockchain = new Blockchain(
-                injector.getInstance(Key.get(LevelDbDataSourceImpl.class, Names.named("block"))),
-                ByteArray.toHexString(wallet.getAddress()),
-                this.type
-        );
-    }
-
-    private void buildUTXOSet() {
-        if (blockchain == null) throw new IllegalStateException("Blockchain must be set before building the UTXOSet");
-
-        utxoSet = injector.getInstance(UTXOSet.class);
-        utxoSet.setBlockchain(blockchain);
-        utxoSet.reindex();
+    public PeerBuilder(Blockchain blockchain, UTXOSet utxoSet, Client client) {
+        this.blockchain = blockchain;
+        this.utxoSet = utxoSet;
+        this.client = client;
     }
 
     private void buildWallet() {
@@ -70,11 +48,11 @@ public class PeerBuilder {
 
     public Peer build() {
         buildWallet();
-        buildBlockchain();
-        buildUTXOSet();
+        utxoSet.reindex();
+
         Peer peer = new Peer(type, blockchain, utxoSet, wallet, key);
-        peer.setClient(injector.getInstance(Client.class));
-        blockchain.addListener(new BlockchainClientListener(injector.getInstance(Client.class), peer));
+        peer.setClient(client);
+        blockchain.addListener(new BlockchainClientListener(client, peer));
         return peer;
     }
 }

--- a/src/test/java/org/tron/core/BlockchainTest.java
+++ b/src/test/java/org/tron/core/BlockchainTest.java
@@ -49,9 +49,7 @@ public class BlockchainTest {
         Mockito.when(mockBlockDB.getData(eq(LAST_HASH))).thenReturn(null);
         Mockito.when(mockBlockDB.getData(any())).thenReturn(ByteArray.fromString(""));
         blockchain = new Blockchain(
-                mockBlockDB,
-                "0304f784e4e7bae517bcab94c3e0c9214fb4ac7ff9d7d5a937d1f40031f87b85",
-                "normal"
+                mockBlockDB
         );
     }
 

--- a/src/test/java/org/tron/core/UTXOSetTest.java
+++ b/src/test/java/org/tron/core/UTXOSetTest.java
@@ -2,16 +2,42 @@ package org.tron.core;
 
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.tron.protos.core.TronTXOutput;
+import org.tron.protos.core.TronTXOutputs;
 import org.tron.storage.leveldb.LevelDbDataSourceImpl;
+import org.tron.utils.ByteArray;
+
+import java.util.HashMap;
+import java.util.UUID;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
 
 public class UTXOSetTest {
     @Test
     public void testReindex() {
+        String key = "15f3988aa8d56eab3bfca45144bad77fc60acce50437a0a9d794a03a83c15c5e";
+        TronTXOutput.TXOutput testOutput = TronTXOutput.TXOutput.newBuilder().build();
+        TronTXOutputs.TXOutputs testOutputs = TronTXOutputs.TXOutputs.newBuilder()
+                .addOutputs(testOutput)
+                .build();
+
+        HashMap<String, TronTXOutputs.TXOutputs> testUTXO = new HashMap<>();
+        testUTXO.put(key, testOutputs);
+
         Blockchain mockBlockchain = Mockito.mock(Blockchain.class);
+        when(mockBlockchain.findUTXO()).thenReturn(testUTXO);
+
         LevelDbDataSourceImpl mockTransactionDb = Mockito.mock(LevelDbDataSourceImpl.class);
+
         UTXOSet utxoSet = new UTXOSet(mockTransactionDb);
         utxoSet.setBlockchain(mockBlockchain);
 
         utxoSet.reindex();
+        Mockito.verify(mockTransactionDb, times(1)).resetDB();
+        Mockito.verify(mockTransactionDb, times(1))
+                .putData(eq(ByteArray.fromHexString(key)), eq(testOutputs.toByteArray()));
     }
 }

--- a/src/test/java/org/tron/core/UTXOSetTest.java
+++ b/src/test/java/org/tron/core/UTXOSetTest.java
@@ -1,0 +1,17 @@
+package org.tron.core;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.tron.storage.leveldb.LevelDbDataSourceImpl;
+
+public class UTXOSetTest {
+    @Test
+    public void testReindex() {
+        Blockchain mockBlockchain = Mockito.mock(Blockchain.class);
+        LevelDbDataSourceImpl mockTransactionDb = Mockito.mock(LevelDbDataSourceImpl.class);
+        UTXOSet utxoSet = new UTXOSet(mockTransactionDb);
+        utxoSet.setBlockchain(mockBlockchain);
+
+        utxoSet.reindex();
+    }
+}

--- a/src/test/java/org/tron/core/UTXOSetTest.java
+++ b/src/test/java/org/tron/core/UTXOSetTest.java
@@ -8,7 +8,6 @@ import org.tron.storage.leveldb.LevelDbDataSourceImpl;
 import org.tron.utils.ByteArray;
 
 import java.util.HashMap;
-import java.util.UUID;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
@@ -32,8 +31,7 @@ public class UTXOSetTest {
 
         LevelDbDataSourceImpl mockTransactionDb = Mockito.mock(LevelDbDataSourceImpl.class);
 
-        UTXOSet utxoSet = new UTXOSet(mockTransactionDb);
-        utxoSet.setBlockchain(mockBlockchain);
+        UTXOSet utxoSet = new UTXOSet(mockTransactionDb, mockBlockchain);
 
         utxoSet.reindex();
         Mockito.verify(mockTransactionDb, times(1)).resetDB();


### PR DESCRIPTION
**What does this PR do?**

Uses Guice dependency injection to provide a Singleton instance of the Blockchain class. Blockchain no longer had a dependency on Wallet being created first, so can now be instantiated at the start of the system, and that really seems to make sense.

Injects the Blockchain dependency on the constructor of UTXOSet.

Injects individual dependencies into PeerBuilder instead of the whole injector, as the change to Blockchain makes this possible now.

**Why are these changes required?**

So much depends on the Blockchain and it feels natural to have this class launched as a single instance when the system launches.

UTXOSet has Blockchain as an absolute dependency (it'll NullPointer if reindex is called without Blockchain set), so it's nicer to inject on the UTXOSet constructor.

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Extra details**

I've put these changes in a separate PR, so they can be assessed independently from the added unit test coverage.

I'd suggest merging [https://github.com/tronprotocol/java-tron/pull/58](https://github.com/tronprotocol/java-tron/pull/58) before merging these changes.