### PR TITLE
Fix BlockchainIterator#next and add tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,8 @@ configurations.getByName('checkstyleConfig') {
 
 dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
-    testCompile group: 'org.mockito', name: 'mockito-all', version: '1.9.5'
+    testCompile group: 'org.mockito', name: 'mockito-core', version: '2.13.0'
+    testCompile group: 'org.hamcrest', name: 'hamcrest-junit', version: '1.0.0.1'
 
     compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
     compile group: 'org.slf4j', name: 'jcl-over-slf4j', version: '1.7.25'

--- a/src/main/java/org/tron/command/PrintBlockchainCommand.java
+++ b/src/main/java/org/tron/command/PrintBlockchainCommand.java
@@ -28,16 +28,16 @@ public class PrintBlockchainCommand extends Command {
   public PrintBlockchainCommand() {
   }
 
-  @Override
-  public void execute(CliApplication app, String[] parameters) {
-    Peer peer = app.getPeer();
-    Blockchain blockchain = peer.getUTXOSet().getBlockchain();
-    BlockchainIterator bi = new BlockchainIterator(blockchain);
-    while (bi.hasNext()) {
-      TronBlock.Block block = (TronBlock.Block) bi.next();
-      System.out.println(BlockUtils.toPrintString(block));
+    @Override
+    public void execute(CliApplication app, String[] parameters) {
+        Peer peer = app.getPeer();
+        Blockchain blockchain = peer.getUTXOSet().getBlockchain();
+        BlockchainIterator bi = new BlockchainIterator(blockchain);
+        while (bi.hasNext()) {
+            TronBlock.Block block = bi.next();
+            System.out.println(BlockUtils.toPrintString(block));
+        }
     }
-  }
 
   @Override
   public void usage() {

--- a/src/main/java/org/tron/core/Blockchain.java
+++ b/src/main/java/org/tron/core/Blockchain.java
@@ -145,9 +145,9 @@ public class Blockchain {
   public Transaction findTransaction(ByteString id) {
     Transaction transaction = Transaction.newBuilder().build();
 
-    BlockchainIterator bi = new BlockchainIterator(this);
-    while (bi.hasNext()) {
-      Block block = (Block) bi.next();
+        BlockchainIterator bi = new BlockchainIterator(this);
+        while (bi.hasNext()) {
+            Block block = bi.next();
 
       for (Transaction tx : block.getTransactionsList()) {
         String txID = ByteArray.toHexString(tx.getId().toByteArray());
@@ -170,13 +170,12 @@ public class Blockchain {
     HashMap<String, TXOutputs> utxo = new HashMap<>();
     HashMap<String, long[]> spenttxos = new HashMap<>();
 
-    BlockchainIterator bi = new BlockchainIterator(this);
-    while (bi.hasNext()) {
-      Block block = (Block) bi.next();
+        BlockchainIterator bi = new BlockchainIterator(this);
+        while (bi.hasNext()) {
+            Block block = bi.next();
 
-      for (Transaction transaction : block.getTransactionsList()) {
-        String txid = ByteArray.toHexString(transaction.getId()
-            .toByteArray());
+            for (Transaction transaction : block.getTransactionsList()) {
+                String txid = ByteArray.toHexString(transaction.getId().toByteArray());
 
         output:
         for (int outIdx = 0; outIdx < transaction.getVoutList().size

--- a/src/test/java/org/tron/core/BlockchainIteratorTest.java
+++ b/src/test/java/org/tron/core/BlockchainIteratorTest.java
@@ -1,0 +1,127 @@
+package org.tron.core;
+
+import com.google.common.base.Charsets;
+import com.google.common.collect.ImmutableMap;
+import com.google.protobuf.ByteString;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.tron.protos.core.TronBlock.Block;
+import org.tron.protos.core.TronBlockHeader.BlockHeader;
+import org.tron.storage.leveldb.LevelDbDataSourceImpl;
+import org.tron.utils.ByteArray;
+
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
+import static org.tron.utils.ByteArray.toHexString;
+
+public class BlockchainIteratorTest {
+  private static final Logger LOGGER = LoggerFactory.getLogger("Test");
+
+  private Blockchain mockBlockchain;
+  private BlockchainIterator blockchainIterator;
+  private LevelDbDataSourceImpl mockDataSource;
+
+  @Before
+  public void setup() throws IOException {
+    mockDataSource = Mockito.mock(LevelDbDataSourceImpl.class);
+
+    mockBlockchain = Mockito.mock(Blockchain.class);
+    Mockito.when(mockBlockchain.getBlockDB()).thenReturn(mockDataSource);
+
+    final ByteString hash1 = ByteString.copyFrom("1", Charsets.UTF_8);
+    final ByteString hash2 = ByteString.copyFrom("2", Charsets.UTF_8);
+    final ByteString hash3 = ByteString.copyFrom("3", Charsets.UTF_8);
+    final ByteString hash4 = ByteString.copyFrom("4", Charsets.UTF_8);
+
+    Mockito.when(mockBlockchain.getCurrentHash()).thenReturn(ByteArray.fromString("4"));
+    ImmutableMap.of(
+        hash1.toByteArray(),
+        Block.newBuilder()
+            .setBlockHeader(
+                BlockHeader.newBuilder()
+                    .setNumber(1)
+                    .setHash(hash1)
+                    .setParentHash(ByteString.copyFrom("", Charsets.UTF_8))
+                    .build()
+            )
+            .build(),
+        hash2.toByteArray(),
+        Block.newBuilder()
+            .setBlockHeader(
+                BlockHeader.newBuilder()
+                    .setNumber(2)
+                    .setHash(hash2)
+                    .setParentHash(hash1)
+                    .build()
+            )
+            .build(),
+        hash3.toByteArray(),
+        Block.newBuilder()
+            .setBlockHeader(
+                BlockHeader.newBuilder()
+                    .setNumber(3)
+                    .setHash(hash3)
+                    .setParentHash(hash2)
+                    .build()
+            )
+            .build(),
+        hash4.toByteArray(),
+        Block.newBuilder()
+            .setBlockHeader(
+                BlockHeader.newBuilder()
+                    .setNumber(4)
+                    .setHash(hash4)
+                    .setParentHash(hash3)
+                    .build()
+            )
+            .build())
+        .forEach((key, value) -> Mockito.when(mockDataSource.getData(key)).thenReturn(value.toByteArray()));
+
+    blockchainIterator = new BlockchainIterator(mockBlockchain);
+  }
+
+  @Test
+  public void testIteration() {
+    final LinkedList<Block> blocks = new LinkedList<>();
+    while (blockchainIterator.hasNext()) {
+      Block block = blockchainIterator.next();
+      LOGGER.info("block[parentHash={},number={}]",
+          toHexString(block.getBlockHeader().getParentHash().toByteArray()),
+          block.getBlockHeader().getNumber());
+
+      blocks.add(block);
+    }
+
+    assertThat(blocks, hasSize(4));
+
+    final LinkedList<Long> blockNumbers = blocks.stream()
+        .map(Block::getBlockHeader)
+        .map(BlockHeader::getNumber)
+        .collect(Collectors.toCollection(LinkedList::new));
+
+    assertThat(blockNumbers, contains(4L, 3L, 2L, 1L));
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void testRemoveIsNotSupported() {
+    blockchainIterator.remove();
+  }
+
+  @Test(expected = NoSuchElementException.class)
+  public void testIteratorThrowsNoSuchElementExceptionAfterEnd() {
+    while (blockchainIterator.hasNext()) {
+      blockchainIterator.next();
+    }
+
+    blockchainIterator.next();
+  }
+}

--- a/src/test/java/org/tron/core/BlockchainTest.java
+++ b/src/test/java/org/tron/core/BlockchainTest.java
@@ -79,26 +79,13 @@ public class BlockchainTest {
     }
   }
 
-  @Test
-  public void testIterator() {
-    Block info = null;
-    BlockchainIterator bi = new BlockchainIterator(blockchain);
-    while (bi.hasNext()) {
-      info = (Block) bi.next();
-      logger.info("blockParentHash:{},number:{}", toHexString(info
-          .getBlockHeader()
-          .getParentHash().toByteArray()), info.getBlockHeader()
-          .getNumber());
+    @Test
+    public void testFindTransaction() {
+        Transaction transaction = blockchain.findTransaction(ByteString
+                .copyFrom(ByteArray.fromHexString
+                        ("15f3988aa8d56eab3bfca45144bad77fc60acce50437a0a9d794a03a83c15c5e")));
+        logger.info("{}", TransactionUtils.toPrintString(transaction));
     }
-  }
-
-  @Test
-  public void testFindTransaction() {
-    Transaction transaction = blockchain.findTransaction(ByteString
-        .copyFrom(ByteArray.fromHexString
-            ("15f3988aa8d56eab3bfca45144bad77fc60acce50437a0a9d794a03a83c15c5e")));
-    logger.info("{}", TransactionUtils.toPrintString(transaction));
-  }
 
   @Test
   public void testFindUTXO() {


### PR DESCRIPTION
**What does this PR do?**
* Fix the `BlockchainIterator#next()` method to adhere to the defined java contract. next() should return `NoSuchElementException` instead of null when surpassing values.
* Tests added for `BlockchainIterator`
* Define type to generic Iterator to prevent the need for casting

**Why are these changes required?**
* Currently `BlockchainIterator#next()` returns null instead of throwing an exception as expected based on java docs. 
* Tests are always good 😄 

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

