### PR TITLE
Fix test bytes to long

### DIFF
--- a/src/main/java/org/tron/common/utils/TypeConversion.java
+++ b/src/main/java/org/tron/common/utils/TypeConversion.java
@@ -25,11 +25,13 @@ public class TypeConversion {
   private static ByteBuffer buffer = ByteBuffer.allocate(8);
 
   public static byte[] longToBytes(long x) {
+    buffer.clear();
     buffer.putLong(0, x);
     return buffer.array();
   }
 
   public static long bytesToLong(byte[] bytes) {
+    buffer.clear();
     buffer.put(bytes, 0, bytes.length);
     buffer.flip();
     return buffer.getLong();

--- a/src/main/java/org/tron/common/utils/TypeConversion.java
+++ b/src/main/java/org/tron/common/utils/TypeConversion.java
@@ -21,73 +21,74 @@ package org.tron.common.utils;
 import java.nio.ByteBuffer;
 
 public class TypeConversion {
-    private static ByteBuffer buffer = ByteBuffer.allocate(8);
 
-    public static byte[] longToBytes(long x) {
-        buffer.putLong(0, x);
-        return buffer.array();
+  private static ByteBuffer buffer = ByteBuffer.allocate(8);
+
+  public static byte[] longToBytes(long x) {
+    buffer.putLong(0, x);
+    return buffer.array();
+  }
+
+  public static long bytesToLong(byte[] bytes) {
+    buffer.put(bytes, 0, bytes.length);
+    buffer.flip();
+    return buffer.getLong();
+  }
+
+  public static String bytesToHexString(byte[] src) {
+    StringBuilder stringBuilder = new StringBuilder("");
+
+    if (src == null || src.length <= 0) {
+      return null;
     }
 
-    public static long bytesToLong(byte[] bytes) {
-        buffer.put(bytes, 0, bytes.length);
-        buffer.flip();
-        return buffer.getLong();
+    for (int i = 0; i < src.length; i++) {
+      int v = src[i] & 0xFF;
+      String hv = Integer.toHexString(v);
+
+      if (hv.length() < 2) {
+        stringBuilder.append(0);
+      }
+
+      stringBuilder.append(hv);
     }
 
-    public static String bytesToHexString(byte[] src) {
-        StringBuilder stringBuilder = new StringBuilder("");
+    return stringBuilder.toString();
+  }
 
-        if (src == null || src.length <= 0) {
-            return null;
-        }
-
-        for (int i = 0; i < src.length; i++) {
-            int v = src[i] & 0xFF;
-            String hv = Integer.toHexString(v);
-
-            if (hv.length() < 2) {
-                stringBuilder.append(0);
-            }
-
-            stringBuilder.append(hv);
-        }
-
-        return stringBuilder.toString();
+  public static byte[] hexStringToBytes(String hexString) {
+    if (hexString == null || hexString.equals("")) {
+      return null;
     }
 
-    public static byte[] hexStringToBytes(String hexString) {
-        if (hexString == null || hexString.equals("")) {
-            return null;
-        }
+    hexString = hexString.toUpperCase();
+    int length = hexString.length() / 2;
+    char[] hexChars = hexString.toCharArray();
+    byte[] d = new byte[length];
 
-        hexString = hexString.toUpperCase();
-        int length = hexString.length() / 2;
-        char[] hexChars = hexString.toCharArray();
-        byte[] d = new byte[length];
-
-        for (int i = 0; i < length; i++) {
-            int pos = i * 2;
-            d[i] = (byte) (charToByte(hexChars[pos]) << 4 | charToByte
-                    (hexChars[pos + 1]));
-        }
-
-        return d;
+    for (int i = 0; i < length; i++) {
+      int pos = i * 2;
+      d[i] = (byte) (charToByte(hexChars[pos]) << 4 | charToByte
+          (hexChars[pos + 1]));
     }
 
-    private static byte charToByte(char c) {
-        return (byte) "0123456789ABCDEF".indexOf(c);
+    return d;
+  }
+
+  private static byte charToByte(char c) {
+    return (byte) "0123456789ABCDEF".indexOf(c);
+  }
+
+  public static boolean increment(byte[] bytes) {
+    final int startIndex = 0;
+    int i;
+    for (i = bytes.length - 1; i >= startIndex; i--) {
+      bytes[i]++;
+      if (bytes[i] != 0) {
+        break;
+      }
     }
 
-    public static boolean increment(byte[] bytes) {
-        final int startIndex = 0;
-        int i;
-        for (i = bytes.length - 1; i >= startIndex; i--) {
-            bytes[i]++;
-            if (bytes[i] != 0) {
-                break;
-            }
-        }
-
-        return (i >= startIndex || bytes[startIndex] != 0);
-    }
+    return (i >= startIndex || bytes[startIndex] != 0);
+  }
 }

--- a/src/test/java/org/tron/utils/TypeConversionTest.java
+++ b/src/test/java/org/tron/utils/TypeConversionTest.java
@@ -15,11 +15,13 @@
 
 package org.tron.utils;
 
+import static org.junit.Assert.assertTrue;
 import static org.tron.common.utils.TypeConversion.bytesToHexString;
 import static org.tron.common.utils.TypeConversion.bytesToLong;
 import static org.tron.common.utils.TypeConversion.hexStringToBytes;
 import static org.tron.common.utils.TypeConversion.longToBytes;
 
+import java.util.Arrays;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,6 +34,7 @@ public class TypeConversionTest {
   @Test
   public void testLongToBytes() {
     byte[] result = longToBytes(123L);
+    assertTrue(Arrays.equals(result, new byte[]{0, 0, 0, 0, 0, 0, 0, 123}));
     logger.info("long 123 to bytes is: {}", result);
   }
 

--- a/src/test/java/org/tron/utils/TypeConversionTest.java
+++ b/src/test/java/org/tron/utils/TypeConversionTest.java
@@ -15,6 +15,7 @@
 
 package org.tron.utils;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.tron.common.utils.TypeConversion.bytesToHexString;
 import static org.tron.common.utils.TypeConversion.bytesToLong;
@@ -34,25 +35,28 @@ public class TypeConversionTest {
   @Test
   public void testLongToBytes() {
     byte[] result = longToBytes(123L);
-    assertTrue(Arrays.equals(result, new byte[]{0, 0, 0, 0, 0, 0, 0, 123}));
+    assertTrue(Arrays.equals(new byte[]{0, 0, 0, 0, 0, 0, 0, 123}, result));
     logger.info("long 123 to bytes is: {}", result);
   }
 
   @Test
   public void testBytesToLong() {
     long result = bytesToLong(new byte[]{0, 0, 0, 0, 0, 0, 0, 124});
+    assertEquals(124L, result);
     logger.info("bytes 124 to long is: {}", result);
   }
 
   @Test
   public void testBytesToHexString() {
     String result = bytesToHexString(new byte[]{0, 0, 0, 0, 0, 0, 0, 125});
+    assertEquals("000000000000007d", result);
     logger.info("bytes 125 to hex string is: {}", result);
   }
 
   @Test
   public void testHexStringToBytes() {
     byte[] result = hexStringToBytes("7f");
+    assertTrue(Arrays.equals(new byte[]{127}, result));
     logger.info("hex string 7f to bytes is: {}", result);
   }
 }

--- a/src/test/java/org/tron/utils/TypeConversionTest.java
+++ b/src/test/java/org/tron/utils/TypeConversionTest.java
@@ -15,37 +15,41 @@
 
 package org.tron.utils;
 
+import static org.tron.common.utils.TypeConversion.bytesToHexString;
+import static org.tron.common.utils.TypeConversion.bytesToLong;
+import static org.tron.common.utils.TypeConversion.hexStringToBytes;
+import static org.tron.common.utils.TypeConversion.longToBytes;
+
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.tron.common.utils.TypeConversion.*;
-
 
 public class TypeConversionTest {
-    private static final Logger logger = LoggerFactory.getLogger("Test");
 
-    @Test
-    public void testLongToBytes() {
-        byte[] result = longToBytes(123L);
-        logger.info("long 123 to bytes is: {}", result);
-    }
+  private static final Logger logger = LoggerFactory.getLogger("Test");
 
-    @Test
-    public void testBytesToLong() {
-        long result = bytesToLong(new byte[]{0, 0, 0, 0, 0, 0, 0, 124});
-        logger.info("bytes 124 to long is: {}", result);
-    }
+  @Test
+  public void testLongToBytes() {
+    byte[] result = longToBytes(123L);
+    logger.info("long 123 to bytes is: {}", result);
+  }
 
-    @Test
-    public void testBytesToHexString() {
-        String result = bytesToHexString(new byte[]{0, 0, 0, 0, 0, 0, 0, 125});
-        logger.info("bytes 125 to hex string is: {}", result);
-    }
+  @Test
+  public void testBytesToLong() {
+    long result = bytesToLong(new byte[]{0, 0, 0, 0, 0, 0, 0, 124});
+    logger.info("bytes 124 to long is: {}", result);
+  }
 
-    @Test
-    public void testHexStringToBytes() {
-        byte[] result = hexStringToBytes("7f");
-        logger.info("hex string 7f to bytes is: {}", result);
-    }
+  @Test
+  public void testBytesToHexString() {
+    String result = bytesToHexString(new byte[]{0, 0, 0, 0, 0, 0, 0, 125});
+    logger.info("bytes 125 to hex string is: {}", result);
+  }
+
+  @Test
+  public void testHexStringToBytes() {
+    byte[] result = hexStringToBytes("7f");
+    logger.info("hex string 7f to bytes is: {}", result);
+  }
 }


### PR DESCRIPTION
**What does this PR do?**

1) Calls buffer.clear() before writing to the ByteBuffer in TypeConversion 
2) Adds assertions into the TypeConversionTest

**Why are these changes required?**
This test was failing in build runs from Gradle: 

org.tron.common.utils.TypeConversionTest > testBytesToLong FAILED
    java.nio.BufferOverflowException at TypeConversionTest.java:39

Was not failing when the same test is run in IntelliJ, but as it was being caused by the buffer containing bytes from a previous use of the TypeConversion class, may have also become an issue for the running application in the future.

**This PR has been tested by:**
- Unit Tests
