### PR TITLE
Add protobuf generated classes to .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ shareddata.*
 
 # svn
 .svn
+
+# protobuf generated classes
+src/main/gen


### PR DESCRIPTION
**What does this PR do?**

Adds protobuf generated classes to .gitignore file

**Why are these changes required?**

If someone working in the code base does a 'git add' after the Protobuf code has been generated, the generated code will get added and then possibly committed. 
I expect the repository only needs to keep track of the .proto files and not the generated code.

**This PR has been tested by:**
- Manual Testing