### PR TITLE
Add services init to constructor when running with injector

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ TRON is a product of Web 4.0 and the decentralized internet of next generation.
 
 IDEA: 
 - [Edit Configurations...] -> [Add New Configuration] -> [Application]
-- [Edit Configurations...] -> [Main Class]: `org.tron.example.Tron`
+- [Edit Configurations...] -> [Main Class]: `org.tron.program.example.Tron`
 - [Edit Configurations...] -> [Use classpath of module]: `java-tron_main`
 - [Edit Configurations...] -> [Program arguments]: `--type server`
 - Run

--- a/src/main/java/org/tron/common/application/Application.java
+++ b/src/main/java/org/tron/common/application/Application.java
@@ -32,7 +32,8 @@ public class Application {
 
   public Application(Injector injector) {
     this.injector = injector;
-
+    this.services = new ServiceContainer();
+    p2pnode = new NodeImpl();
   }
 
   public Application() {


### PR DESCRIPTION
**What does this PR do?**
When running the demo app as described in the README, I get a new Nullpointer when trying to execute the app (it fails at `public void addService(Service service)` in `Application.java`.

This is because the constructor calls to initialize `this.services` and `p2pnode` is not called when running the Application with `new Application(buildGuice())`.

In this PR I added the init calls to the constructor so that the project can be started as described in the README.

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**
I changed the readme to point to `org.tron.program.example.Tron` for the Main Class. The gif needs to be updated as well (though I haven't done so).
