### PR TITLE
Added fix to typo in the Application interface

### DIFF
--- a/src/main/java/org/tron/common/application/Application.java
+++ b/src/main/java/org/tron/common/application/Application.java
@@ -32,7 +32,7 @@ public interface Application {
 
   void shutdown();
 
-  void startServies();
+  void startServices();
 
   void shutdownServices();
 

--- a/src/main/java/org/tron/common/application/ApplicationImpl.java
+++ b/src/main/java/org/tron/common/application/ApplicationImpl.java
@@ -205,7 +205,7 @@ public class ApplicationImpl implements Application, NodeDelegate {
   }
 
   @Override
-  public void startServies() {
+  public void startServices() {
     services.start();
   }
 

--- a/src/main/java/org/tron/common/application/CliApplication.java
+++ b/src/main/java/org/tron/common/application/CliApplication.java
@@ -48,7 +48,7 @@ public class CliApplication implements Application {
   }
 
   @Override
-  public void startServies() {
+  public void startServices() {
 
   }
 

--- a/src/main/java/org/tron/program/FullNode.java
+++ b/src/main/java/org/tron/program/FullNode.java
@@ -13,7 +13,7 @@ public class FullNode {
     RpcApiService rpcApiService = new RpcApiService(tApp);
     tApp.addService(rpcApiService);
     tApp.addService(new WitnessService(tApp));
-    tApp.startServies();
+    tApp.startServices();
     tApp.startup();
     rpcApiService.blockUntilShutdown();
   }

--- a/src/main/java/org/tron/program/example/Tron.java
+++ b/src/main/java/org/tron/program/example/Tron.java
@@ -49,7 +49,7 @@ public class Tron {
 //        .buildCli();
     Application app = new ApplicationImpl();
     app.initServices(new Args());
-    app.startServies();
+    app.startServices();
     app.startup();
 
 //    app.(new Server());


### PR DESCRIPTION
**What does this PR do?**
This PR just fixes what is assumed to be a type in the Application interface and all other classes that implement it. 

**Why are these changes required?**
These changes are not required unless you have a spelling OCD.

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**
I changed 
```java
startServies()
```
to 
```java
startServices()
```
