### PR TITLE
Potential Deadlock fixed 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,12 @@ src/main/java/org/tron/core/bftconsensus
 src/test/java/org/tron/consensus2
 src/main/java/META-INF/
 src/main/resources/META-INF/
+/bin/
+
+# Eclipse IDE specific files and folders
+/.project
+/.classpath
+/.settings/
+
+# output directory
+/output-directory/

--- a/src/main/java/org/tron/common/storage/leveldb/LevelDbDataSourceImpl.java
+++ b/src/main/java/org/tron/common/storage/leveldb/LevelDbDataSourceImpl.java
@@ -1,25 +1,21 @@
 /*
- * Copyright (c) [2016] [ <ether.camp> ]
- * This file is part of the ethereumJ library.
+ * Copyright (c) [2016] [ <ether.camp> ] This file is part of the ethereumJ library.
  *
- * The ethereumJ library is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ * The ethereumJ library is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
  *
- * The ethereumJ library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
+ * The ethereumJ library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE. See the GNU Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
- * along with the ethereumJ library. If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU Lesser General Public License along with the ethereumJ
+ * library. If not, see <http://www.gnu.org/licenses/>.
  */
 
 package org.tron.common.storage.leveldb;
 
 import static org.fusesource.leveldbjni.JniDBFactory.factory;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -43,7 +39,6 @@ import org.tron.common.utils.FileUtil;
 import org.tron.core.Constant;
 import org.tron.core.config.Configer;
 
-
 public class LevelDbDataSourceImpl implements DbSourceInter<byte[]> {
 
   private static final Logger logger = LoggerFactory.getLogger("dbStore");
@@ -53,8 +48,7 @@ public class LevelDbDataSourceImpl implements DbSourceInter<byte[]> {
   private String parentName;
   private ReadWriteLock resetDbLock = new ReentrantReadWriteLock();
 
-  public LevelDbDataSourceImpl() {
-  }
+  public LevelDbDataSourceImpl() {}
 
   public LevelDbDataSourceImpl(String cfgType, String parentName, String name) {
     if (Constant.NORMAL == cfgType) {
@@ -240,10 +234,10 @@ public class LevelDbDataSourceImpl implements DbSourceInter<byte[]> {
   @Override
   public void closeDB() {
     resetDbLock.writeLock().lock();
-    if (!isAlive()) {
-      return;
-    }
     try {
+      if (!isAlive()) {
+        return;
+      }
       database.close();
       alive = false;
     } catch (IOException e) {

--- a/src/test/java/org/tron/common/storage/leveldb/LevelDbDataSourceImplTest.java
+++ b/src/test/java/org/tron/common/storage/leveldb/LevelDbDataSourceImplTest.java
@@ -1,38 +1,39 @@
 /*
- * Copyright (c) [2016] [ <ether.camp> ]
- * This file is part of the ethereumJ library.
+ * Copyright (c) [2016] [ <ether.camp> ] This file is part of the ethereumJ library.
  *
- * The ethereumJ library is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ * The ethereumJ library is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
  *
- * The ethereumJ library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
+ * The ethereumJ library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE. See the GNU Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
- * along with the ethereumJ library. If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU Lesser General Public License along with the ethereumJ
+ * library. If not, see <http://www.gnu.org/licenses/>.
  */
 
 package org.tron.common.storage.leveldb;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-
-import org.junit.Ignore;
+import org.junit.Before;
 import org.junit.Test;
 import org.tron.common.utils.ByteArray;
 import org.tron.core.Constant;
 
-@Ignore
 public class LevelDbDataSourceImplTest {
+
+  private LevelDbDataSourceImpl dataSource;
+
+  @Before
+  public void setup() {
+    dataSource = new LevelDbDataSourceImpl(Constant.TEST, Constant.OUTPUT_DIR, "test");
+  }
 
   @Test
   public void testGet() {
-    LevelDbDataSourceImpl dataSource = new LevelDbDataSourceImpl(Constant.TEST, Constant.OUTPUT_DIR,
-        "test");
     dataSource.initDB();
     String key1 = "000134yyyhy";
     byte[] key = key1.getBytes();
@@ -44,8 +45,6 @@ public class LevelDbDataSourceImplTest {
 
   @Test
   public void testPut() {
-    LevelDbDataSourceImpl dataSource = new LevelDbDataSourceImpl(Constant.TEST, Constant.OUTPUT_DIR,
-        "test");
     dataSource.initDB();
     String key1 = "000134yyyhy";
     byte[] key = key1.getBytes();
@@ -63,11 +62,21 @@ public class LevelDbDataSourceImplTest {
 
   @Test
   public void testRest() {
-
-    LevelDbDataSourceImpl dataSource = new LevelDbDataSourceImpl(Constant.TEST_CONF,
-        Constant.OUTPUT_DIR, "test");
     dataSource.resetDB();
     dataSource.closeDB();
+  }
+
+  @Test(timeout = 100)
+  public void testLockReleased() {
+    dataSource.initDB();
+    // normal close
+    dataSource.closeDB();
+    // closing already closed db.
+    dataSource.closeDB();
+    // closing again to make sure the lock is free. If not test will hang.
+    dataSource.closeDB();
+
+    assertFalse("Database is still alive after closing.", dataSource.isAlive());
   }
 
 }


### PR DESCRIPTION
**What does this PR do?**
Fixes a bug in LevelDbDataSourceImpl.closeDB, that can cause deadlock and memory leak when called multiple times.

**Why are these changes required?**
To avoid blocking threads and leaking memory. 

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

