### PR TITLE
NodeImpl improvements

### DIFF
--- a/src/main/java/org/tron/common/utils/ExecutorLoop.java
+++ b/src/main/java/org/tron/common/utils/ExecutorLoop.java
@@ -13,19 +13,29 @@ public class ExecutorLoop<In> {
 
   private BlockingQueue<Runnable> queue;
   private ThreadPoolExecutor exec;
-  private Function<In, Void> consumer;
+  private Consumer<In> consumer;
   private Consumer<Throwable> exceptionHandler;
   private String threadPoolName;
 
   private static AtomicInteger loopNum = new AtomicInteger(1);
   private AtomicInteger threadNumber = new AtomicInteger(1);
 
-  public ExecutorLoop(int threads, int queueSize, Function<In, Void> consumer,
+  public ExecutorLoop(
+      int threads,
+      int queueSize,
+      Consumer<In> consumer,
       Consumer<Throwable> exceptionHandler) {
-    queue = new LimitedQueue<>(queueSize);
-    exec = new ThreadPoolExecutor(threads, threads, 0L, TimeUnit.MILLISECONDS, queue, r ->
-        new Thread(r, threadPoolName + "-" + threadNumber.getAndIncrement())
+
+    this.queue = new LimitedQueue<>(queueSize);
+    this.exec = new ThreadPoolExecutor(
+      threads,
+      threads,
+      0L,
+      TimeUnit.MILLISECONDS,
+      queue,
+      r -> new Thread(r, threadPoolName + "-" + threadNumber.getAndIncrement())
     );
+
     this.consumer = consumer;
     this.exceptionHandler = exceptionHandler;
     this.threadPoolName = "loop-" + loopNum.getAndIncrement();
@@ -34,7 +44,7 @@ public class ExecutorLoop<In> {
   public void push(final In in) {
     exec.execute(() -> {
       try {
-        consumer.apply(in);
+        consumer.accept(in);
       } catch (Throwable e) {
         exceptionHandler.accept(e);
       }

--- a/src/main/java/org/tron/core/net/node/NodeImpl.java
+++ b/src/main/java/org/tron/core/net/node/NodeImpl.java
@@ -114,34 +114,30 @@ public class NodeImpl extends PeerConnectionDelegate implements Node {
   @Override
   public void connectToP2PNetWork() {
 
-    //broadcast inv
+    // broadcast inv
     loopAdvertiseInv = new ExecutorLoop<>(2, 10, b -> {
       logger.info("loop advertise inv");
-      for (PeerConnection peer :
-          gossipNode.listPeer.values()) {
+      for (PeerConnection peer : gossipNode.listPeer.values()) {
         if (!peer.needSyncFrom) {
           peer.sendMessage(b);
         }
       }
-      return null;
     }, throwable -> logger.error("Unhandled exception: ", throwable));
 
-    //fetch blocks
+    // fetch blocks
     loopFetchBlocks = new ExecutorLoop<>(2, 10, c -> {
       logger.info("loop fetch blocks");
       if (fetchMap.containsKey(c.sha256Hash())) {
         fetchMap.get(c.sha256Hash()).sendMessage(c);
       }
-      return null;
     }, throwable -> logger.error("Unhandled exception: ", throwable));
 
-    //sync block chain
+    // sync block chain
     loopSyncBlockChain = new ExecutorLoop<>(2, 10, d -> {
       logger.info("loop sync block chain");
       if (syncMap.containsKey(d.sha256Hash())) {
         syncMap.get(d.sha256Hash()).sendMessage(d);
       }
-      return null;
     }, throwable -> logger.error("Unhandled exception: ", throwable));
 
     advertiseLoopThread = new Thread(() -> {
@@ -178,8 +174,7 @@ public class NodeImpl extends PeerConnectionDelegate implements Node {
     Protocal.Inventory.Builder invBuild = Protocal.Inventory.newBuilder();
     invBuild.setType(Protocal.Inventory.InventoryType.BLOCK);
     int i = 0;
-    for (Sha256Hash hash :
-        hashList) {
+    for (Sha256Hash hash : hashList) {
       invBuild.setIds(i++, hash.getByteString());
     }
 
@@ -225,8 +220,7 @@ public class NodeImpl extends PeerConnectionDelegate implements Node {
   private void onHandleFetchDataMessage(PeerConnection peer, FetchInvDataMessage fetchInvDataMsg) {
     logger.info("on handle fetch block message");
     Protocal.Inventory inv = fetchInvDataMsg.getInventory();
-    MessageTypes type =
-        inv.getType() == InventoryType.BLOCK ? MessageTypes.BLOCK : MessageTypes.TRX;
+    MessageTypes type = inv.getType() == InventoryType.BLOCK ? MessageTypes.BLOCK : MessageTypes.TRX;
 
     for (ByteString hash : inv.getIdsList()) {
       peer.sendMessage(del.getData(Sha256Hash.wrap(hash.toByteArray()), type));

--- a/src/main/java/org/tron/core/net/node/NodeImpl.java
+++ b/src/main/java/org/tron/core/net/node/NodeImpl.java
@@ -106,7 +106,6 @@ public class NodeImpl extends PeerConnectionDelegate implements Node {
     gossipNode.stop();
     loopFetchBlocks.join();
     loopSyncBlockChain.join();
-    loopFetchBlocks.join();
     loopAdvertiseInv.join();
     isAdvertiseCancle = false;
   }

--- a/src/main/java/org/tron/core/net/node/NodeImpl.java
+++ b/src/main/java/org/tron/core/net/node/NodeImpl.java
@@ -19,9 +19,9 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public class NodeImpl extends PeerConnectionDelegate implements Node {
 
-  private List<Sha256Hash> trxToAdvertise = new ArrayList<>();
+  private final List<Sha256Hash> trxToAdvertise = new ArrayList<>();
 
-  private List<Sha256Hash> blockToAdvertise = new ArrayList<>();
+  private final List<Sha256Hash> blockToAdvertise = new ArrayList<>();
 
   private static final Logger logger = LoggerFactory.getLogger("Node");
 
@@ -35,7 +35,7 @@ public class NodeImpl extends PeerConnectionDelegate implements Node {
 
   private GossipLocalNode gossipNode;
 
-  private boolean isAdvertiseActive = true;
+  private volatile boolean isAdvertiseActive = true;
 
   private Thread advertiseLoopThread;
 

--- a/src/main/java/org/tron/core/net/node/NodeImpl.java
+++ b/src/main/java/org/tron/core/net/node/NodeImpl.java
@@ -35,9 +35,9 @@ public class NodeImpl extends PeerConnectionDelegate implements Node {
 
   private GossipLocalNode gossipNode;
 
-  private boolean isAdvertiseCancle = true;
+  private boolean isAdvertiseActive = true;
 
-  //loop
+  private Thread advertiseLoopThread;
 
   ExecutorLoop<SyncBlockChainMessage> loopSyncBlockChain;
 
@@ -107,7 +107,8 @@ public class NodeImpl extends PeerConnectionDelegate implements Node {
     loopFetchBlocks.join();
     loopSyncBlockChain.join();
     loopAdvertiseInv.join();
-    isAdvertiseCancle = false;
+    isAdvertiseActive = false;
+    advertiseLoopThread.join();
   }
 
   @Override
@@ -143,8 +144,8 @@ public class NodeImpl extends PeerConnectionDelegate implements Node {
       return null;
     }, throwable -> logger.error("Unhandled exception: ", throwable));
 
-    Thread advertiseloop = new Thread(() -> {
-      while (isAdvertiseCancle) {
+    advertiseLoopThread = new Thread(() -> {
+      while (isAdvertiseActive) {
         if (blockToAdvertise.isEmpty() && trxToAdvertise.isEmpty()) {
           try {
             Thread.sleep(1000);
@@ -168,9 +169,7 @@ public class NodeImpl extends PeerConnectionDelegate implements Node {
       }
     });
 
-    advertiseloop.start();
-
-
+    advertiseLoopThread.start();
   }
 
   @Override


### PR DESCRIPTION
* Remove duplicate `loopFetchBlocks.join()`
* Await advertise thread when closing node
* Mark `isAdvertiseActive` as volatile to prevent potential variable caching problems
* Replace `Function` in `ExecutorLoop` with `Consumer` because it was never returning a result
* Marked `trxToAdvertise` and `blockToAdvertise` `final` because they are being `synchronized`