### PR TITLE
use class.getName() instead of string

### DIFF
--- a/src/main/java/org/tron/common/crypto/jce/TronCastleProvider.java
+++ b/src/main/java/org/tron/common/crypto/jce/TronCastleProvider.java
@@ -21,6 +21,8 @@ package org.tron.common.crypto.jce;
 import java.security.Provider;
 import java.security.Security;
 import org.spongycastle.jce.provider.BouncyCastleProvider;
+import org.tron.common.crypto.cryptohash.Keccak256;
+import org.tron.common.crypto.cryptohash.Keccak512;
 
 public final class TronCastleProvider {
 
@@ -36,11 +38,8 @@ public final class TronCastleProvider {
       Provider p = Security.getProvider("SC");
 
       INSTANCE = (p != null) ? p : new BouncyCastleProvider();
-
-      INSTANCE.put("MessageDigest.TRON-KECCAK-256", "org.tron.common.crypto" +
-          ".cryptohash.Keccak256");
-      INSTANCE.put("MessageDigest.TRON-KECCAK-512", "org.tron.common.crypto" +
-          ".cryptohash.Keccak512");
+      INSTANCE.put("MessageDigest.TRON-KECCAK-256", Keccak256.class.getName());
+      INSTANCE.put("MessageDigest.TRON-KECCAK-512", Keccak512.class.getName());
     }
   }
 }


### PR DESCRIPTION
Minor improvement, use the `class.getName()` to retrieve the classname instead of a string