### PR TITLE
Change string comparison

### DIFF
--- a/src/main/java/org/tron/common/storage/leveldb/LevelDbDataSourceImpl.java
+++ b/src/main/java/org/tron/common/storage/leveldb/LevelDbDataSourceImpl.java
@@ -51,7 +51,7 @@ public class LevelDbDataSourceImpl implements DbSourceInter<byte[]> {
   public LevelDbDataSourceImpl() {}
 
   public LevelDbDataSourceImpl(String cfgType, String parentName, String name) {
-    if (Constant.NORMAL == cfgType) {
+    if (Constant.NORMAL.equals(cfgType)) {
       parentName += Configer.getConf(Constant.NORMAL_CONF).getString(Constant.DATABASE_DIR);
     } else {
       parentName += Configer.getConf(Constant.TEST_CONF).getString(Constant.DATABASE_DIR);


### PR DESCRIPTION
**What does this PR do?**
Change string comparison

**Why are these changes required?**
because the `==` operator not checks the actual contents of the string but whether the references to the objects are equal.