### PR TITLE
fix undo in disorder

### DIFF
--- a/src/main/java/org/tron/core/db/AbstractRevokingStore.java
+++ b/src/main/java/org/tron/core/db/AbstractRevokingStore.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
@@ -39,7 +40,7 @@ public abstract class AbstractRevokingStore implements RevokingDatabase {
 
     boolean disableOnExit = disabled && forceEnable;
     if (forceEnable) {
-      enable();
+      disabled = false;
     }
 
     while (stack.size() > DEFAULT_STACK_MAX_SIZE) {
@@ -178,7 +179,7 @@ public abstract class AbstractRevokingStore implements RevokingDatabase {
       state.removed.forEach((k, v) -> k.database.putData(k.key, v));
       stack.pollLast();
     } finally {
-      enable();
+      disabled = false;
     }
     --activeDialog;
   }
@@ -215,7 +216,7 @@ public abstract class AbstractRevokingStore implements RevokingDatabase {
       state.removed.forEach((k, v) -> k.database.putData(k.key, v));
       stack.pollLast();
     } finally {
-      enable();
+      disabled = false;
     }
   }
 
@@ -339,6 +340,7 @@ public abstract class AbstractRevokingStore implements RevokingDatabase {
   }
 
   @AllArgsConstructor
+  @EqualsAndHashCode
   public static class RevokingTuple {
 
     private SourceInter<byte[], byte[]> database;


### PR DESCRIPTION
**What does this PR do?**
1. RevokingTuple implement equals and hashcode

**Why are these changes required?**
1. e.g.
```
        byte[] a = "hello".getBytes();
        byte[] b = new byte[a.length];
        byte[] c = new byte[a.length];
        System.arraycopy(a,0,b,0,a.length);
        System.arraycopy(a,0,c,0,a.length);
```
**attention:** b.hashcode() != c.hashcode();
should use Arrays.hashcode(b) == Arrays.hashcode(c)

