### PR TITLE
feat: switch to computeIfAbsent/findFirst/return constructor & add to clean advObjSpreadToUs and advObjWeSpread

### DIFF
--- a/src/main/java/org/tron/core/db/KhaosDatabase.java
+++ b/src/main/java/org/tron/core/db/KhaosDatabase.java
@@ -6,6 +6,8 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Stream;
 import javafx.util.Pair;
 import org.tron.common.utils.Sha256Hash;
 import org.tron.core.capsule.BlockCapsule;
@@ -59,13 +61,8 @@ public class KhaosDatabase extends TronDatabase {
 
     public void insert(KhaosBlock block) {
       hashKblkMap.put(block.id, block);
-      //parentHashKblkMap.put(block.getParentHash(), block);
-      ArrayList<KhaosBlock> listBlk = numKblkMap.get(block.num);
-      if (listBlk == null) {
-        listBlk = new ArrayList<KhaosBlock>();
-      }
-      listBlk.add(block);
-      numKblkMap.put(block.num, listBlk);
+      numKblkMap.computeIfAbsent(block.num, listBlk -> new ArrayList<>())
+                .add(block);
     }
 
     public boolean remove(Sha256Hash hash) {
@@ -143,27 +140,18 @@ public class KhaosDatabase extends TronDatabase {
    * check if the id is contained in the KhoasDB.
    */
   public Boolean containBlock(Sha256Hash hash) {
-    if (miniStore.getByHash(hash) != null) {
-      return true;
-    }
-    return miniUnlinkedStore.getByHash(hash) != null;
+    return miniStore.getByHash(hash) != null || miniUnlinkedStore.getByHash(hash) != null;
   }
 
   /**
    * Get the Block form KhoasDB, if it doesn't exist ,return null.
    */
   public BlockCapsule getBlock(Sha256Hash hash) {
-    KhaosBlock block = miniStore.getByHash(hash);
-    if (block != null) {
-      return block.blk;
-    } else {
-      KhaosBlock blockUnlinked = miniUnlinkedStore.getByHash(hash);
-      if (blockUnlinked != null) {
-        return blockUnlinked.blk;
-      } else {
-        return null;
-      }
-    }
+    return Stream.of(miniStore.getByHash(hash), miniUnlinkedStore.getByHash(hash))
+            .filter(Objects::nonNull)
+            .map(block -> block.blk)
+            .findFirst()
+            .orElse(null);
   }
 
   /**
@@ -213,7 +201,6 @@ public class KhaosDatabase extends TronDatabase {
       BlockId block2) {
     LinkedList<BlockCapsule> list1 = new LinkedList<>();
     LinkedList<BlockCapsule> list2 = new LinkedList<>();
-    Pair<LinkedList<BlockCapsule>, LinkedList<BlockCapsule>> ret = new Pair<>(list1, list2);
     KhaosBlock kblk1 = miniStore.getByHash(block1);
     KhaosBlock kblk2 = miniStore.getByHash(block2);
 
@@ -236,7 +223,7 @@ public class KhaosDatabase extends TronDatabase {
         kblk2 = kblk2.parent;
       } while (kblk1 != kblk2);
     }
-    return ret;
+    return new Pair<>(list1, list2);
   }
 
   public boolean hasData() {

--- a/src/main/java/org/tron/core/net/peer/PeerConnection.java
+++ b/src/main/java/org/tron/core/net/peer/PeerConnection.java
@@ -132,6 +132,8 @@ public class PeerConnection {
 
   public void cleanInvGarbage() {
     //TODO: clean advObjSpreadToUs and advObjWeSpread.
+    advObjSpreadToUs.clear();
+    advObjWeSpread.clear();
   }
 
   public boolean isBanned() {

--- a/src/main/java/org/tron/core/net/peer/PeerConnection.java
+++ b/src/main/java/org/tron/core/net/peer/PeerConnection.java
@@ -131,9 +131,8 @@ public class PeerConnection {
 
 
   public void cleanInvGarbage() {
-    //TODO: clean advObjSpreadToUs and advObjWeSpread.
-    advObjSpreadToUs.clear();
-    advObjWeSpread.clear();
+    //TODO: clean advObjSpreadToUs and advObjWeSpread accroding cleaning strategy 
+
   }
 
   public boolean isBanned() {


### PR DESCRIPTION
**What does this PR do?**
**KhaosDatabase.java**
- feat: switch to computeIfAbsent/findFirst/return constructor

**PeerConnection.java**
- feat: add to clean advObjSpreadToUs and advObjWeSpread

**Why are these changes required?**
- feat: switch to computeIfAbsent/findFirst/return constructor
- feat: add to clean advObjSpreadToUs and advObjWeSpread

**This PR has been tested by:**
- Unit Tests
- Manual Testing