### PR TITLE
extract message converter from startworker

### DIFF
--- a/src/main/java/org/tron/common/overlay/node/GossipLocalNode.java
+++ b/src/main/java/org/tron/common/overlay/node/GossipLocalNode.java
@@ -94,8 +94,9 @@ public class GossipLocalNode implements LocalNode {
     executors = new ThreadPoolExecutor(4, 4, 0L, TimeUnit.MILLISECONDS,
         new ArrayBlockingQueue<>(1000), new ThreadPoolExecutor.CallerRunsPolicy());
 
-    Subscription messageSubscription =
-            cluster.listen().subscribe(msg -> executors.submit(new StartWorker(msg, peerDel, cluster)));
+    Subscription messageSubscription = cluster
+            .listen()
+            .subscribe(msg -> executors.submit(new StartWorker(msg, peerDel)));
 
     subscriptions.add(membershipListener);
     subscriptions.add(messageSubscription);

--- a/src/main/java/org/tron/core/net/message/MessageRegistry.java
+++ b/src/main/java/org/tron/core/net/message/MessageRegistry.java
@@ -1,0 +1,26 @@
+package org.tron.core.net.message;
+
+public class MessageRegistry {
+
+  public static Message getMessageByKey(String key, byte[] content) {
+
+    switch (MessageTypes.valueOf(key)) {
+      case BLOCK:
+        return new BlockMessage(content);
+      case TRX:
+        return new TransactionMessage(content);
+      case SYNC_BLOCK_CHAIN:
+        return new SyncBlockChainMessage(content);
+      case FETCH_INV_DATA:
+        return new FetchInvDataMessage(content);
+      case BLOCK_INVENTORY:
+        return new BlockInventoryMessage(content);
+      case BLOCK_CHAIN_INVENTORY:
+        return new ChainInventoryMessage(content);
+      case INVENTORY:
+        return new InventoryMessage(content);
+    }
+
+    throw new IllegalArgumentException("Unknown message");
+  }
+}


### PR DESCRIPTION
Move `getMessageByKey` out of `StartWorker` for reusability