### PR TITLE
fix a bug: transfer asset to a nonexistent account address will throw…

### DIFF
--- a/src/main/java/org/tron/core/actuator/TransferAssetActuator.java
+++ b/src/main/java/org/tron/core/actuator/TransferAssetActuator.java
@@ -86,8 +86,7 @@ public class TransferAssetActuator extends AbstractActuator {
       // if account with to_address is not existed,  create it.
       ByteString toAddress = transferAssetContract.getToAddress();
       if (!dbManager.getAccountStore().has(toAddress.toByteArray())) {
-        AccountCapsule account = new AccountCapsule(toAddress, null,
-            AccountType.Normal);
+        AccountCapsule account = new AccountCapsule(toAddress, AccountType.Normal);
         dbManager.getAccountStore().put(toAddress.toByteArray(), account);
       }
 


### PR DESCRIPTION
… a NullPoint Exception

**What does this PR do?**
change   AccountCapsule account = new AccountCapsule(toAddress, null,    AccountType.Normal);
to  AccountCapsule account = new AccountCapsule(toAddress, AccountType.Normal);
**Why are these changes required?**
throw a NullPoint Exception ，Caused a  logic error
**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

