### PR TITLE
Added info under `Prepared dependencies` section, to suggest Linux Ubuntu's users, using Oracle JDK 8, instead of OpenJDK 8, to avoid error build

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ git clone https://github.com/tronprotocol/java-tron.git
 ## Prepare dependencies
 
 * JDK 1.8 (JDK 1.9+ are not supported yet)
+* On Linux Ubuntu system (e.g. Ubuntu 16.04.4 LTS), ensure that the machine has [__Oracle JDK 8__](https://www.digitalocean.com/community/tutorials/how-to-install-java-with-apt-get-on-ubuntu-16-04), instead of having __Open JDK 8__ in the system. If you are building the source code by using __Open JDK 8__, you will get [__Build Failed__](https://github.com/tronprotocol/java-tron/issues/337) result.
 
 ## Building from source code
 


### PR DESCRIPTION
**What does this PR do?**
Changed `README.md` file by adding info under `Prepared dependencies` section, to suggest Linux Ubuntu's users, using Oracle JDK 8, instead of OpenJDK 8, to avoid error build.

**Why are these changes required?**
Some Linux Ubuntu users are using `OpenJDK 8` instead of using `Oracle JDK 8`. Before this PR, the `Prepared dependencies` section only mention `JDK` , not mentioning specific `JDK` flavor. Also, building the source code using `OpenJDK 8` will result in `BUILD FAILED` outcome (see: https://github.com/tronprotocol/java-tron/issues/337). By adding more info in `Prepared dependencies` section, we could help Linux Ubuntu user (whom use OpenJDK 8), avoiding this build error.

**This PR has been tested by:**
- Manual Testing

**Follow up**

**Extra details**
Machine environment:
- Ubuntu OS version 16.04.4 LTS.
- Oracle JDK 8
