### PR TITLE
fix bug: resolve config file in jar using getResourceAsStream

### DIFF
--- a/src/main/java/org/tron/core/config/Configuration.java
+++ b/src/main/java/org/tron/core/config/Configuration.java
@@ -59,13 +59,10 @@ public class Configuration {
   private static void resolveConfigFile(String fileName, File confFile) {
     if (confFile.exists()) {
       config = ConfigFactory.parseFile(confFile);
-    } else {
-      try {
-        ResourceUtils.getFile("classpath:" + fileName);
-      } catch (FileNotFoundException e) {
-        throw new IllegalArgumentException("Configuration path is required! No Such file " + fileName);
-      }
+    } else if (Thread.currentThread().getContextClassLoader().getResourceAsStream(fileName) != null) {
       config = ConfigFactory.load(fileName);
+    } else {
+      throw new IllegalArgumentException("Configuration path is required! No Such file " + fileName);
     }
   }
 }


### PR DESCRIPTION
**What does this PR do?**
fix bug: resolve config file in jar using getResourceAsStream

**Why are these changes required?**
could not resolve config file in jar with ResourceUtils 

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**
