### PR TITLE
remove initial active peers in config

### DIFF
--- a/src/main/resources/config.conf
+++ b/src/main/resources/config.conf
@@ -17,31 +17,17 @@ node.discovery = {
 
 node {
   # trust node for solidity node
-  trustNode = "47.254.16.55:50051"
+  # trustNode = "ip:port"
 
   listen.port = 18888
 
   connection.timeout = 2
 
   active = [
+    # Initial active peers
     # Sample entries:
-    # { url = "enode://<hex nodeID>@hostname.com:30303" }
-    # {
-    #    ip = hostname.com
-    #    port = 30303
-    #    nodeId = e437a4836b77ad9d9ffe73ee782ef2614e6d8370fcf62191a6e488276e23717147073a7ce0b444d485fff5a0c34c4577251a7a990cf80d8542e21b95aa8c5e6c
-    # }
-    "47.254.16.55:18888",
-    "47.254.18.49:18888",
-    "18.188.111.53:18888",
-    "54.219.41.56:18888",
-    "35.169.113.187:18888",
-    "34.214.241.188:18888",
-    "47.254.146.147:18888",
-    "47.254.144.25:18888",
-    "47.91.246.252:18888",
-    "47.91.216.69:18888",
-    "39.106.220.120:18888"
+    # "ip:port",
+    # "ip:port"
   ]
 
   maxActiveNodes = 30


### PR DESCRIPTION
**What does this PR do?**
remove initial active peers in config

**Why are these changes required?**
Active peer should init with p2p discovery

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**
