### PR TITLE
leveldb flush to disk per write operation

### DIFF
--- a/src/main/java/org/tron/common/storage/leveldb/LevelDbDataSourceImpl.java
+++ b/src/main/java/org/tron/common/storage/leveldb/LevelDbDataSourceImpl.java
@@ -35,6 +35,7 @@ import org.iq80.leveldb.DBException;
 import org.iq80.leveldb.DBIterator;
 import org.iq80.leveldb.Options;
 import org.iq80.leveldb.WriteBatch;
+import org.iq80.leveldb.WriteOptions;
 import org.tron.common.storage.DbSourceInter;
 import org.tron.common.utils.FileUtil;
 import org.tron.core.config.args.Args;
@@ -48,6 +49,7 @@ public class LevelDbDataSourceImpl implements DbSourceInter<byte[]> {
   boolean alive;
   private String parentName;
   private ReadWriteLock resetDbLock = new ReentrantReadWriteLock();
+  private WriteOptions writeOptions = new WriteOptions().sync(true);
 
   /**
    * constructor.
@@ -178,7 +180,7 @@ public class LevelDbDataSourceImpl implements DbSourceInter<byte[]> {
   public void putData(byte[] key, byte[] value) {
     resetDbLock.readLock().lock();
     try {
-      database.put(key, value);
+      database.put(key, value, writeOptions);
     } finally {
       resetDbLock.readLock().unlock();
     }
@@ -188,7 +190,7 @@ public class LevelDbDataSourceImpl implements DbSourceInter<byte[]> {
   public void deleteData(byte[] key) {
     resetDbLock.readLock().lock();
     try {
-      database.delete(key);
+      database.delete(key, writeOptions);
     } finally {
       resetDbLock.readLock().unlock();
     }


### PR DESCRIPTION
**What does this PR do?**
1. leveldb writeoptions sync set true

**Why are these changes required?**
1. should solve the problem that does not find block from blockStore by dynamicHeadNumber

