### PR TITLE
No witness shuffle

### DIFF
--- a/src/main/java/org/tron/core/db/DynamicPropertiesStore.java
+++ b/src/main/java/org/tron/core/db/DynamicPropertiesStore.java
@@ -29,11 +29,11 @@ public class DynamicPropertiesStore extends TronStoreWithRevoking<BytesCapsule> 
 
   private static final byte[] BLOCK_FILLED_SLOTS = "BLOCK_FILLED_SLOTS".getBytes();
 
+  private static final byte[] BLOCK_FILLED_SLOTS_INDEX = "BLOCK_FILLED_SLOTS_INDEX".getBytes();
+
   private static final byte[] NEXT_MAINTENANCE_TIME = "NEXT_MAINTENANCE_TIME".getBytes();
 
   private static final int BLOCK_FILLED_SLOTS_NUMBER = 128;
-
-  private int blockFilledSlotsIndex = 0;
 
 
   private DynamicPropertiesStore(String dbName) {
@@ -66,6 +66,12 @@ public class DynamicPropertiesStore extends TronStoreWithRevoking<BytesCapsule> 
       this.getLatestSolidifiedBlockNum();
     } catch (IllegalArgumentException e) {
       this.saveLatestSolidifiedBlockNum(0);
+    }
+
+    try {
+      this.getBlockFilledSlotsIndex();
+    } catch (IllegalArgumentException e) {
+      this.saveBlockFilledSlotsIndex(0);
     }
 
     try {
@@ -135,6 +141,19 @@ public class DynamicPropertiesStore extends TronStoreWithRevoking<BytesCapsule> 
     return result;
   }
 
+  public void saveBlockFilledSlotsIndex(int blockFilledSlotsIndex) {
+    logger.debug("blockFilledSlotsIndex:" + blockFilledSlotsIndex);
+    this.put(BLOCK_FILLED_SLOTS_INDEX,
+        new BytesCapsule(ByteArray.fromInt(blockFilledSlotsIndex)));
+  }
+
+  public int getBlockFilledSlotsIndex() {
+    return Optional.ofNullable(this.dbSource.getData(BLOCK_FILLED_SLOTS_INDEX))
+        .map(ByteArray::toInt)
+        .orElseThrow(
+            () -> new IllegalArgumentException("not found BLOCK_FILLED_SLOTS_INDEX"));
+  }
+
   public void saveBlockFilledSlots(int[] blockFilledSlots) {
     logger.debug("blockFilledSlots:" + intArrayToString(blockFilledSlots));
     this.put(BLOCK_FILLED_SLOTS,
@@ -147,13 +166,13 @@ public class DynamicPropertiesStore extends TronStoreWithRevoking<BytesCapsule> 
         .map(this::stringToIntArray)
         .orElseThrow(
             () -> new IllegalArgumentException("not found latest SOLIDIFIED_BLOCK_NUM timestamp"));
-    //return ByteArray.toLong(this.dbSource.getData(this.SOLIDIFIED_THRESHOLD));
   }
 
   public void applyBlock(boolean fillBlock) {
     int[] blockFilledSlots = getBlockFilledSlots();
+    int blockFilledSlotsIndex = getBlockFilledSlotsIndex();
     blockFilledSlots[blockFilledSlotsIndex] = fillBlock ? 1 : 0;
-    blockFilledSlotsIndex = (blockFilledSlotsIndex + 1) % BLOCK_FILLED_SLOTS_NUMBER;
+    saveBlockFilledSlotsIndex((blockFilledSlotsIndex + 1) % BLOCK_FILLED_SLOTS_NUMBER);
     saveBlockFilledSlots(blockFilledSlots);
   }
 

--- a/src/main/java/org/tron/core/db/Manager.java
+++ b/src/main/java/org/tron/core/db/Manager.java
@@ -425,7 +425,7 @@ public class Manager {
   /**
    * when switch fork need erase blocks on fork branch.
    */
-  private void eraseBlock() throws BadItemException, ItemNotFoundException {
+  public void eraseBlock() throws BadItemException, ItemNotFoundException {
     dialog.reset();
     BlockCapsule oldHeadBlock = getBlockStore()
         .get(getDynamicPropertiesStore().getLatestBlockHeaderHash().getBytes());

--- a/src/main/java/org/tron/core/db/Manager.java
+++ b/src/main/java/org/tron/core/db/Manager.java
@@ -207,6 +207,7 @@ public class Manager {
     return this.peersStore.get("neighbours".getBytes());
   }
 
+  // fot test only
   public void destory() {
     AccountStore.destroy();
     TransactionStore.destroy();
@@ -391,7 +392,7 @@ public class Manager {
     return true;
   }
 
-  void validateFreq(TransactionCapsule trx) throws HighFreqException {
+  private void validateFreq(TransactionCapsule trx) throws HighFreqException {
     List<org.tron.protos.Protocol.Transaction.Contract> contracts = trx.getInstance().getRawData()
         .getContractList();
     for (Transaction.Contract contract : contracts) {
@@ -399,18 +400,18 @@ public class Manager {
           || contract.getType() == TransferAssetContract) {
         byte[] address = TransactionCapsule.getOwner(contract);
         AccountCapsule accountCapsule = this.getAccountStore().get(address);
-        long balacne = accountCapsule.getBalance();
+        long balance = accountCapsule.getBalance();
         long latestOperationTime = accountCapsule.getLatestOperationTime();
         if (latestOperationTime != 0) {
-          doValidateFreq(balacne, 0, latestOperationTime);
-        } else {
-          accountCapsule.setLatestOperationTime(Time.getCurrentMillis());
+          doValidateFreq(balance, 0, latestOperationTime);
         }
+        accountCapsule.setLatestOperationTime(Time.getCurrentMillis());
+        this.getAccountStore().put(accountCapsule.createDbKey(),accountCapsule);
       }
     }
   }
 
-  void doValidateFreq(long balance, int transNumber, long latestOperationTime)
+  private void doValidateFreq(long balance, int transNumber, long latestOperationTime)
       throws HighFreqException {
     long now = Time.getCurrentMillis();
     // todo: avoid ddos, design more smoothly formula later.
@@ -424,7 +425,7 @@ public class Manager {
   /**
    * when switch fork need erase blocks on fork branch.
    */
-  public void eraseBlock() throws BadItemException, ItemNotFoundException {
+  private void eraseBlock() throws BadItemException, ItemNotFoundException {
     dialog.reset();
     BlockCapsule oldHeadBlock = getBlockStore()
         .get(getDynamicPropertiesStore().getLatestBlockHeaderHash().getBytes());


### PR DESCRIPTION
**What does this PR do?**
- fix validate Freq
- persistence BLOCK FILLED SLOTS INDEX

**Why are these changes required?**
- fix validate Freq problem that not store latest Operation Time of accounts
- BLOCK FILLED SLOTS INDEX need store in database when restart

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

