### PR TITLE
fix spelling for comments, add FIXME for spelling errors

### DIFF
--- a/src/main/protos/core/Tron.proto
+++ b/src/main/protos/core/Tron.proto
@@ -41,7 +41,7 @@ message Account {
 
   bytes account_name = 1;
   AccountType type = 2;
-  // the create adress
+  // the create address
   bytes address = 3;
   // the trx balance
   int64 balance = 4;
@@ -55,7 +55,7 @@ message Account {
   int64 bandwidth = 8;
   // this account create time
   int64 create_time = 9;
-  // this last opration time, including transfer, voting and so on.
+  // this last operation time, including transfer, voting and so on. //FIXME fix grammar
   int64 latest_opration_time = 10;
 
   // witness block producing allowance
@@ -66,13 +66,14 @@ message Account {
   bytes code = 13;
 }
 
+//FIXME authority?
 message acuthrity {
   AccountId account = 1;
   bytes permission_name = 2;
 
 }
 
-
+//FIXME permission
 message permision {
   AccountId account = 1;
 }
@@ -90,7 +91,7 @@ message Witness {
   bool isJobs = 9;
 }
 
-// Transcation
+// Transaction
 
 message TXOutput {
   int64 value = 1;
@@ -113,7 +114,7 @@ message TXOutputs {
 
 
 message Transaction {
-  // transcation type, utxo is desprated.
+  // transaction type, utxo is desprecated.
   enum TransactionType {
     UtxoType = 0;
     ContractType = 1;
@@ -158,7 +159,7 @@ message Transaction {
     int64 ref_block_num = 3;
     bytes ref_block_hash = 4;
     int64 expiration = 8;
-    repeated acuthrity auths = 9;
+    repeated acuthrity auths = 9; //FIXME authority
     // data not used
     bytes data = 10;
     repeated Contract contract = 11;


### PR DESCRIPTION
fix English spelling for comments, add FIXME for English spelling errors.




In short check dictionary and use spell check tools

![image](https://user-images.githubusercontent.com/1614482/39557467-77e5e1d2-4eba-11e8-8c31-9bb082136922.png)

