### PR TITLE
git ignore all /output_*_test/ directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,8 +45,8 @@ src/main/resources/META-INF/
 /.apt_generated/
 
 # output directory
+/output_*_test/
 /output-directory/
-
 /output_manager/
 /output_witness/
 


### PR DESCRIPTION
git ignore all /output_*_test/ directories

that build produces

![image](https://user-images.githubusercontent.com/1614482/39557960-be69e0ec-4ebd-11e8-8512-7a3cef767e64.png)
