### PR TITLE
use trx.getSerializedSize for estimate block size

### DIFF
--- a/src/main/java/org/tron/core/capsule/TransactionCapsule.java
+++ b/src/main/java/org/tron/core/capsule/TransactionCapsule.java
@@ -360,6 +360,10 @@ public class TransactionCapsule implements ProtoCapsule<Transaction> {
     return this.transaction.toByteArray();
   }
 
+  public long getSerializedSize() {
+    return this.transaction.getSerializedSize();
+  }
+
   @Override
   public Transaction getInstance() {
     return this.transaction;

--- a/src/main/java/org/tron/core/db/Manager.java
+++ b/src/main/java/org/tron/core/db/Manager.java
@@ -861,7 +861,7 @@ public class Manager {
     Iterator iterator = pendingTransactions.iterator();
     while (iterator.hasNext()) {
       TransactionCapsule trx = (TransactionCapsule) iterator.next();
-      currentTrxSize += RamUsageEstimator.sizeOf(trx);
+      currentTrxSize += trx.getSerializedSize();
       // judge block size
       if (currentTrxSize > ChainConstant.TRXS_SIZE) {
         postponedTrxCount++;


### PR DESCRIPTION
**What does this PR do?**
use trx.getSerializedSize for estimate block size

**Why are these changes required?**
use trx.getSerializedSize for estimate block size

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

