### PR TITLE
Add binary release gradle script

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -227,3 +227,28 @@ task stest(type:Test){
         showStackTraces = "true"
     }
 }
+
+def binaryRelease(jarName,mainClass,jarVersion) {
+    return tasks.create("${jarName}", Jar) {
+        baseName = jarName
+        version = jarVersion
+        from(sourceSets.main.output) {
+            include "/**"
+        }
+
+        from {
+            configurations.compile.collect {
+                it.isDirectory() ? it : zipTree(it)
+            }
+        }
+
+        manifest {
+            attributes "Main-Class": "${mainClass}"
+        }
+    }
+}
+
+artifacts {
+    archives(binaryRelease('java-tron-SolidityNode','org.tron.program.SolidityNode','1.0.0'),
+            binaryRelease('java-tron-FullNode',"org.tron.program.FullNode",'1.0.0'))
+}

--- a/build.gradle
+++ b/build.gradle
@@ -228,10 +228,10 @@ task stest(type:Test){
     }
 }
 
-def binaryRelease(jarName,mainClass,jarVersion) {
-    return tasks.create("${jarName}", Jar) {
+def binaryRelease(taskName,jarName,mainClass) {
+    return tasks.create("${taskName}", Jar) {
         baseName = jarName
-        version = jarVersion
+        version = null
         from(sourceSets.main.output) {
             include "/**"
         }
@@ -249,6 +249,6 @@ def binaryRelease(jarName,mainClass,jarVersion) {
 }
 
 artifacts {
-    archives(binaryRelease('java-tron-SolidityNode','org.tron.program.SolidityNode','1.0.0'),
-            binaryRelease('java-tron-FullNode',"org.tron.program.FullNode",'1.0.0'))
+    archives(binaryRelease('buildSolidityNodeJar','SolidityNode','org.tron.program.SolidityNode'),
+            binaryRelease('buildFullNodeJar','FullNode','org.tron.program.FullNode'))
 }


### PR DESCRIPTION
**What does this PR do?**
Implement build binary release script

**Why are these changes required?**
create a gradle script so that we can get binary release for soliditynode and fullnode version in a convenient way.
 
**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**
run ./gradlew build
You should be able to find FullNode.jar and SolidityNode.jar in /build/libs/