### PR TITLE
restore voteCount values to repair synch

### DIFF
--- a/src/main/resources/config.conf
+++ b/src/main/resources/config.conf
@@ -108,57 +108,57 @@ genesis.block = {
     {
       address: 27cEZa99jVaDkujPwzZuHYgkYNqv6zzYLSP
       url = "http://Mercury.org",
-      voteCount = 0
+      voteCount = 105
     },
     {
       address: 27anh4TDZJGYpsn4BjXzb7uEArNALxwiZZW
       url = "http://Venus.org",
-      voteCount = 0
+      voteCount = 104
     },
     {
       address: 27Wkfa5iEJtsKAKdDzSmF1b2gDm5s49kvdZ
       url = "http://Earth.org",
-      voteCount = 0
+      voteCount = 103
     },
     {
       address: 27bqKYX9Bgv7dgTY7xBw5SUHZ8EGaPSikjx
       url = "http://Mars.org",
-      voteCount = 0
+      voteCount = 102
     },
     {
       address: 27fASUY6qKtsaAEPz6QxhZac2KYVz2ZRTXW
       url = "http://Jupiter.org",
-      voteCount = 0
+      voteCount = 101
     },
     {
       address: 27Q3RSbiqm59VXcF8shQWHKbyztfso5FwvP
       url = "http://Saturn.org",
-      voteCount = 0
+      voteCount = 100
     },
     {
       address: 27YkUVSuvCK3K84DbnFnxYUxozpi793PTqZ
       url = "http://Uranus.org",
-      voteCount = 0
+      voteCount = 99
     },
     {
       address: 27kdTBTDJ16hK3Xqr8PpCuQJmje1b94CDJU
       url = "http://Neptune.org",
-      voteCount = 0
+      voteCount = 98
     },
     {
       address: 27mw9UpRy7inTMQ5kUzsdTc2QZ6KvtCX4uB
       url = "http://Pluto.org",
-      voteCount = 0
+      voteCount = 97
     },
     {
       address: 27QzC4PeQZJ2kFMUXiCo4S8dx3VWN5U9xcg
       url = "http://Altair.org",
-      voteCount = 0
+      voteCount = 96
     },
     {
       address: 27VZHn9PFZwNh7o2EporxmLkpe157iWZVkh
       url = "http://AlphaLyrae.org",
-      voteCount = 0
+      voteCount = 95
     }
   ]
 


### PR DESCRIPTION
**What does this PR do?**
Restore values of voteCount for defaulet witnesses.

**Why are these changes required?**
After running in witness or full node synchronisations was hanging up. Described in details in issue #685 Block not sync in lastest develop (p2p.version = 64)

**This PR has been tested by:**
- Unit Tests
- Manual Testing

- Running build with changes 
- Running node in witness mode

**Follow up**

**Extra details**