### PR TITLE
calc blockId using raw data to prevent malleability attack

### DIFF
--- a/src/main/java/org/tron/core/capsule/BlockCapsule.java
+++ b/src/main/java/org/tron/core/capsule/BlockCapsule.java
@@ -225,7 +225,7 @@ public class BlockCapsule implements ProtoCapsule<Block> {
 
   public BlockId getBlockId() {
     if (blockId.equals(Sha256Hash.ZERO_HASH)) {
-      blockId = new BlockId(Sha256Hash.of(this.block.getBlockHeader().toByteArray()), getNum());
+      blockId = new BlockId(Sha256Hash.of(this.block.getBlockHeader().getRawData().toByteArray()), getNum());
     }
     return blockId;
   }

--- a/src/main/java/org/tron/core/db/api/index/BlockIndex.java
+++ b/src/main/java/org/tron/core/db/api/index/BlockIndex.java
@@ -64,7 +64,7 @@ public class BlockIndex extends AbstractIndex<BlockCapsule, Block> {
         attribute("block id",
             bytes -> {
               Block block = getObject(bytes);
-              return Sha256Hash.of(block.getBlockHeader().toByteArray()).toString();
+              return Sha256Hash.of(block.getBlockHeader().getRawData().toByteArray()).toString();
             });
     Block_NUMBER =
         attribute("block number",

--- a/src/main/java/org/tron/core/db/api/index/BlockIndex.java
+++ b/src/main/java/org/tron/core/db/api/index/BlockIndex.java
@@ -64,7 +64,7 @@ public class BlockIndex extends AbstractIndex<BlockCapsule, Block> {
         attribute("block id",
             bytes -> {
               Block block = getObject(bytes);
-              return Sha256Hash.of(block.getBlockHeader().getRawData().toByteArray()).toString();
+              return new BlockCapsule(block).getBlockId().toString();
             });
     Block_NUMBER =
         attribute("block number",


### PR DESCRIPTION
**What does this PR do?**
calc blockId using raw data to prevent malleability attack

**Why are these changes required?**
calc blockId using raw data to prevent malleability attack

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

