### PR TITLE
set max grpc idle timeout to 1 minute

### DIFF
--- a/src/main/java/org/tron/common/overlay/client/DatabaseGrpcClient.java
+++ b/src/main/java/org/tron/common/overlay/client/DatabaseGrpcClient.java
@@ -37,6 +37,10 @@ public class DatabaseGrpcClient {
     return databaseBlockingStub.getBlockByNum(builder.build());
   }
 
+  public void shutdown() {
+    channel.shutdown();
+  }
+
   public DynamicProperties getDynamicProperties() {
     return databaseBlockingStub.getDynamicProperties(EmptyMessage.newBuilder().build());
   }

--- a/src/main/java/org/tron/core/config/Parameter.java
+++ b/src/main/java/org/tron/core/config/Parameter.java
@@ -31,7 +31,7 @@ public interface Parameter {
   }
 
   interface NetConstants {
-
+    long GRPC_IDLE_TIME_OUT = 60000L;
     long ADV_TIME_OUT = 20000L;
     long SYNC_TIME_OUT = 5000L;
     long HEAD_NUM_MAX_DELTA = 1000L;
@@ -43,7 +43,7 @@ public interface Parameter {
     int MSG_CACHE_DURATION_IN_BLOCKS = 5;
   }
 
-  interface DataBaseConstants {
+  interface DatabaseConstants {
     int TRANSACTIONS_COUNT_LIMIT_MAX = 1000;
   }
 }

--- a/src/main/java/org/tron/core/db/api/StoreAPI.java
+++ b/src/main/java/org/tron/core/db/api/StoreAPI.java
@@ -14,7 +14,7 @@ import static com.googlecode.cqengine.query.QueryFactory.orderBy;
 import static com.googlecode.cqengine.query.QueryFactory.queryOptions;
 import static com.googlecode.cqengine.query.QueryFactory.threshold;
 import static com.googlecode.cqengine.query.option.EngineThresholds.INDEX_ORDERING_SELECTIVITY;
-import static org.tron.core.config.Parameter.DataBaseConstants.TRANSACTIONS_COUNT_LIMIT_MAX;
+import static org.tron.core.config.Parameter.DatabaseConstants.TRANSACTIONS_COUNT_LIMIT_MAX;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;

--- a/src/main/java/org/tron/core/services/RpcApiService.java
+++ b/src/main/java/org/tron/core/services/RpcApiService.java
@@ -3,7 +3,7 @@ package org.tron.core.services;
 import com.google.common.base.Preconditions;
 import com.google.protobuf.ByteString;
 import io.grpc.Server;
-import io.grpc.ServerBuilder;
+import io.grpc.netty.NettyServerBuilder;
 import io.grpc.stub.StreamObserver;
 import java.io.IOException;
 import java.util.HashMap;
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -48,6 +49,7 @@ import org.tron.core.capsule.AccountCapsule;
 import org.tron.core.capsule.BlockCapsule;
 import org.tron.core.capsule.TransactionCapsule;
 import org.tron.core.capsule.WitnessCapsule;
+import org.tron.core.config.Parameter.NetConstants;
 import org.tron.core.config.args.Args;
 import org.tron.core.db.Manager;
 import org.tron.core.exception.ContractValidateException;
@@ -97,7 +99,7 @@ public class RpcApiService implements Service {
   @Override
   public void start() {
     try {
-      ServerBuilder serverBuilder = ServerBuilder.forPort(port)
+      NettyServerBuilder serverBuilder = NettyServerBuilder.forPort(port)
           .addService(new DatabaseApi());
       Args args = Args.getInstance();
       if (args.getRpcThreadNum() > 0) {
@@ -109,6 +111,7 @@ public class RpcApiService implements Service {
       } else {
         serverBuilder = serverBuilder.addService(new WalletApi());
       }
+      serverBuilder.maxConnectionIdle(NetConstants.GRPC_IDLE_TIME_OUT, TimeUnit.MILLISECONDS);
       apiServer = serverBuilder.build().start();
     } catch (IOException e) {
       logger.debug(e.getMessage(), e);

--- a/src/main/java/org/tron/program/SolidityNode.java
+++ b/src/main/java/org/tron/program/SolidityNode.java
@@ -49,11 +49,18 @@ public class SolidityNode {
     }
   }
 
+  private void shutdownGrpcClient() {
+    if (databaseGrpcClient != null) {
+      databaseGrpcClient.shutdown();
+    }
+  }
+
   private void syncLoop(Args args) {
     while (true) {
       try {
         initGrpcClient(args.getTrustNodeAddr());
         syncSolidityBlock();
+        shutdownGrpcClient();
       } catch (Exception e) {
         logger.error("Error in sync solidity block " + e.getMessage(), e);
       }


### PR DESCRIPTION
**What does this PR do?**
set max grpc idle timeout to 1 minute
shutdown grpc for solidity after complete sync block

**Why are these changes required?**
avoid open too many port

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**
