### PR TITLE
enable walletExtensionApi by default to getTransaction

### DIFF
--- a/src/main/resources/config.conf
+++ b/src/main/resources/config.conf
@@ -61,7 +61,7 @@ node {
   trustNode = "127.0.0.1:50051"
 
   # expose extension api to public or not
-  walletExtensionApi = false
+  walletExtensionApi = true
 
   listen.port = 18888
   rpc.port = 50051


### PR DESCRIPTION
**What does this PR do?**
enable walletExtensionApi by default to getTransaction

**Why are these changes required?**
enable walletExtensionApi by default to getTransaction

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**
