### PR TITLE
Add eclipse support to the gradle file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,8 @@ apply plugin: 'com.google.protobuf'
 apply plugin: 'application'
 apply plugin: 'checkstyle'
 apply plugin: 'com.github.johnrengelman.shadow'
-apply plugin: "jacoco"
+apply plugin: 'jacoco'
+apply plugin: 'eclipse'
 
 sourceCompatibility = 1.8
 [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'


### PR DESCRIPTION
**What does this PR do?**
This adds eclipse support in the gradle file for the java-tron project

**Why are these changes required?**
This will allow people to use eclipse for their development ide

**This PR has been tested by:**
- Unit Tests
- Manual Testing
Yes

**Follow up**

**Extra details**

