### PR TITLE
Add jitpack configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ TRON Protocol and the TVM allow anyone to develop DAPPs for themselves or their 
 * JDK 1.8 (JDK 1.9+ are not supported yet)
 * On Linux Ubuntu system (e.g. Ubuntu 16.04.4 LTS), ensure that the machine has [__Oracle JDK 8__](https://www.digitalocean.com/community/tutorials/how-to-install-java-with-apt-get-on-ubuntu-16-04), instead of having __Open JDK 8__ in the system. If you are building the source code by using __Open JDK 8__, you will get [__Build Failed__](https://github.com/tronprotocol/java-tron/issues/337) result.
 
-## Getting the code
+## Getting the code with git
 
 * Use Git from the Terminal, see the [Setting up Git](https://help.github.com/articles/set-up-git/) and [Fork a Repo](https://help.github.com/articles/fork-a-repo/) articles.
 * develop branch: the newnest code 
@@ -77,6 +77,42 @@ git checkout -t origin/master
 * For Mac, you can also install **[GitHub for Mac](https://mac.github.com/)** then **[fork and clone our repository](https://guides.github.com/activities/forking/)**. 
 
 * If you'd rather not use Git, [Download the ZIP](https://github.com/tronprotocol/java-tron/archive/develop.zip)
+
+## Including java-tron as dependency
+
+* If you don't want to checkout the code and build the project, you can include it directly as a dependency
+
+**Using gradle:**
+
+```
+repositories {
+   maven { url 'https://jitpack.io' }
+}
+dependencies {
+   implementation 'com.github.tronprotocol:java-tron:develop-SNAPSHOT'
+}
+```
+  
+**Using maven:**
+
+```xml
+...
+<repositories>
+  <repository>
+      <id>jitpack.io</id>
+      <url>https://jitpack.io</url>
+  </repository>
+</repositories>
+...
+<dependency>
+    <groupId>com.github.tronprotocol</groupId>
+    <artifactId>java-tron</artifactId>
+    <version>develop-SNAPSHOT</version><!--You can use any of the tag/branch name available-->
+</dependency>
+```
+
+
+
 
 ## Building from source code
 

--- a/build.gradle
+++ b/build.gradle
@@ -22,10 +22,28 @@ apply plugin: 'application'
 apply plugin: 'checkstyle'
 apply plugin: 'com.github.johnrengelman.shadow'
 apply plugin: "jacoco"
+apply plugin: 'maven-publish'
 
 sourceCompatibility = 1.8
 [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
 mainClassName = 'org.tron.program.FullNode'
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
+            artifact sourceJar
+        }
+    }
+    repositories {
+        mavenLocal()
+    }
+}
+
+task sourceJar(type: Jar, dependsOn: classes) {
+    classifier 'sources'
+    from sourceSets.main.allSource
+}
 
 repositories {
     maven { url 'http://mvnrepository.com' }

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+install:
+   - ./gradlew build publishToMavenLocal -x test


### PR DESCRIPTION
**What does this PR do?**

Add the ability for developers to add java-tron directly as dependency with build tools like gradle, maven, sbt etc

**Why are these changes required?**

It should be more easy for developers to include java-tron into their project

**This PR has been tested by:**

- Manual Testing

**Follow up**

**Extra details**

