### PR TITLE
avoid broadcast some invalid trxs and one unnecessary disconnection

### DIFF
--- a/src/main/java/org/tron/core/db/Manager.java
+++ b/src/main/java/org/tron/core/db/Manager.java
@@ -60,6 +60,7 @@ import org.tron.core.exception.BadItemException;
 import org.tron.core.exception.BadNumberBlockException;
 import org.tron.core.exception.BalanceInsufficientException;
 import org.tron.core.exception.ContractExeException;
+import org.tron.core.exception.ContractSizeNotEqualToOneException;
 import org.tron.core.exception.ContractValidateException;
 import org.tron.core.exception.DupTransactionException;
 import org.tron.core.exception.HeaderNotFound;
@@ -866,7 +867,7 @@ public class Manager {
     validateCommon(trxCap);
 
     if (trxCap.getInstance().getRawData().getContractList().size() != 1) {
-      throw new ContractValidateException("act size greater than 1, this is extend feature");
+      throw new ContractSizeNotEqualToOneException("act size greater than 1, this is extend feature");
     }
 
     validateDup(trxCap);

--- a/src/main/java/org/tron/core/db/Manager.java
+++ b/src/main/java/org/tron/core/db/Manager.java
@@ -867,7 +867,7 @@ public class Manager {
     validateCommon(trxCap);
 
     if (trxCap.getInstance().getRawData().getContractList().size() != 1) {
-      throw new ContractSizeNotEqualToOneException("act size greater than 1, this is extend feature");
+      throw new ContractSizeNotEqualToOneException("act size should be exactly 1, this is extend feature");
     }
 
     validateDup(trxCap);

--- a/src/main/java/org/tron/core/exception/ContractSizeNotEqualToOneException.java
+++ b/src/main/java/org/tron/core/exception/ContractSizeNotEqualToOneException.java
@@ -1,7 +1,6 @@
 package org.tron.core.exception;
 
 public class ContractSizeNotEqualToOneException extends ContractValidateException{
-
   public ContractSizeNotEqualToOneException() {
     super();
   }

--- a/src/main/java/org/tron/core/exception/ContractSizeNotEqualToOneException.java
+++ b/src/main/java/org/tron/core/exception/ContractSizeNotEqualToOneException.java
@@ -1,0 +1,12 @@
+package org.tron.core.exception;
+
+public class ContractSizeNotEqualToOneException extends ContractValidateException{
+
+  public ContractSizeNotEqualToOneException() {
+    super();
+  }
+
+  public ContractSizeNotEqualToOneException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/org/tron/core/net/node/NodeDelegate.java
+++ b/src/main/java/org/tron/core/net/node/NodeDelegate.java
@@ -20,7 +20,7 @@ public interface NodeDelegate {
   LinkedList<Sha256Hash> handleBlock(BlockCapsule block, boolean syncMode)
       throws BadBlockException, UnLinkedBlockException, InterruptedException;
 
-  void handleTransaction(TransactionCapsule trx) throws BadTransactionException;
+  boolean handleTransaction(TransactionCapsule trx) throws BadTransactionException;
 
   LinkedList<BlockId> getLostBlockIds(List<BlockId> blockChainSummary) throws StoreException;
 

--- a/src/main/java/org/tron/core/net/node/NodeDelegateImpl.java
+++ b/src/main/java/org/tron/core/net/node/NodeDelegateImpl.java
@@ -101,11 +101,11 @@ public class NodeDelegateImpl implements NodeDelegate {
 
 
   @Override
-  public void handleTransaction(TransactionCapsule trx) throws BadTransactionException {
+  public boolean handleTransaction(TransactionCapsule trx) throws BadTransactionException {
     logger.debug("handle transaction");
     if (dbManager.getTransactionIdCache().getIfPresent(trx.getTransactionId()) != null) {
       logger.warn("This transaction has been processed");
-      return;
+      return false;
     } else {
       dbManager.getTransactionIdCache().put(trx.getTransactionId(), true);
     }
@@ -113,7 +113,8 @@ public class NodeDelegateImpl implements NodeDelegate {
       dbManager.pushTransactions(trx);
     } catch (ContractValidateException e) {
       logger.info("Contract validate failed" + e.getMessage());
-      throw new BadTransactionException();
+      //throw new BadTransactionException();
+      return false;
     } catch (ContractExeException e) {
       logger.info("Contract execute failed" + e.getMessage());
       throw new BadTransactionException();
@@ -122,15 +123,21 @@ public class NodeDelegateImpl implements NodeDelegate {
       throw new BadTransactionException();
     } catch (AccountResourceInsufficientException e) {
       logger.info("AccountResourceInsufficientException" + e.getMessage());
+      return false;
     } catch (DupTransactionException e) {
       logger.info("dup trans" + e.getMessage());
+      return false;
     } catch (TaposException e) {
       logger.info("tapos error" + e.getMessage());
+      return false;
     } catch (TooBigTransactionException e) {
       logger.info("too big transaction" + e.getMessage());
+      return false;
     } catch (TransactionExpirationException e) {
       logger.info("expiration transaction" + e.getMessage());
+      return false;
     }
+    return true;
   }
 
   @Override

--- a/src/main/java/org/tron/core/net/node/NodeDelegateImpl.java
+++ b/src/main/java/org/tron/core/net/node/NodeDelegateImpl.java
@@ -25,6 +25,7 @@ import org.tron.core.exception.BadItemException;
 import org.tron.core.exception.BadNumberBlockException;
 import org.tron.core.exception.BadTransactionException;
 import org.tron.core.exception.ContractExeException;
+import org.tron.core.exception.ContractSizeNotEqualToOneException;
 import org.tron.core.exception.ContractValidateException;
 import org.tron.core.exception.DupTransactionException;
 import org.tron.core.exception.ItemNotFoundException;
@@ -111,13 +112,17 @@ public class NodeDelegateImpl implements NodeDelegate {
     }
     try {
       dbManager.pushTransactions(trx);
+    } catch (ContractSizeNotEqualToOneException e){
+      logger.info("Contract validate failed" + e.getMessage());
+      throw new BadTransactionException();
     } catch (ContractValidateException e) {
       logger.info("Contract validate failed" + e.getMessage());
       //throw new BadTransactionException();
       return false;
     } catch (ContractExeException e) {
       logger.info("Contract execute failed" + e.getMessage());
-      throw new BadTransactionException();
+      //throw new BadTransactionException();
+      return false;
     } catch (ValidateSignatureException e) {
       logger.info("ValidateSignatureException" + e.getMessage());
       throw new BadTransactionException();

--- a/src/main/java/org/tron/core/net/node/NodeImpl.java
+++ b/src/main/java/org/tron/core/net/node/NodeImpl.java
@@ -886,8 +886,9 @@ public class NodeImpl extends PeerConnectionDelegate implements Node {
             peer.getNode().getHost());
         return;
       }
-      del.handleTransaction(trxMsg.getTransactionCapsule());
-      broadcast(trxMsg);
+      if(del.handleTransaction(trxMsg.getTransactionCapsule())){
+        broadcast(trxMsg);
+      }
     } catch (TraitorPeerException e) {
       logger.error(e.getMessage());
       banTraitorPeer(peer, ReasonCode.BAD_PROTOCOL);


### PR DESCRIPTION
**What does this PR do?**
1.  When getting a ContractValidateException in handleTransaction, it could be a fake false for the validation due to didn't receive an block with an Asset, but validate it first. So, we need to avoid ban the connection in this way.
2. In onHandleTransactionMessage we need to avoid to broadcast transactions those are invalid. This can avoid invalid transactions being broadcast in whole network. 

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

