### PR TITLE
Evan rm hash.sha256

### DIFF
--- a/src/main/java/org/tron/common/crypto/Hash.java
+++ b/src/main/java/org/tron/common/crypto/Hash.java
@@ -36,28 +36,11 @@ public class Hash {
   private static final String HASH_256_ALGORITHM_NAME;
   private static final String HASH_512_ALGORITHM_NAME;
 
-  private static final MessageDigest sha256digest;
-
   static {
     Security.addProvider(TronCastleProvider.getInstance());
     CRYPTO_PROVIDER = Security.getProvider("SC");
     HASH_256_ALGORITHM_NAME = "TRON-KECCAK-256";
     HASH_512_ALGORITHM_NAME = "TRON-KECCAK-512";
-    try {
-      sha256digest = MessageDigest.getInstance("SHA-256");
-    } catch (NoSuchAlgorithmException e) {
-      logger.error("Can't initialize HashUtils", e);
-      throw new RuntimeException(e); // Can't happen.
-    }
-
-  }
-
-  /**
-   * @param input - data for hashing
-   * @return - sha256 hash of the data
-   */
-  public static byte[] sha256(byte[] input) {
-    return sha256digest.digest(input);
   }
 
   public static byte[] sha3(byte[] input) {

--- a/src/main/java/org/tron/core/Wallet.java
+++ b/src/main/java/org/tron/core/Wallet.java
@@ -140,8 +140,8 @@ public class Wallet {
   }
 
   public static String encode58Check(byte[] input) {
-    byte[] hash0 = Sha256Hash.of(input).getBytes();
-    byte[] hash1 = Sha256Hash.of(hash0).getBytes();
+    byte[] hash0 = Sha256Hash.hash(input);
+    byte[] hash1 = Sha256Hash.hash(hash0);
     byte[] inputCheck = new byte[input.length + 4];
     System.arraycopy(input, 0, inputCheck, 0, input.length);
     System.arraycopy(hash1, 0, inputCheck, input.length, 4);
@@ -155,8 +155,8 @@ public class Wallet {
     }
     byte[] decodeData = new byte[decodeCheck.length - 4];
     System.arraycopy(decodeCheck, 0, decodeData, 0, decodeData.length);
-    byte[] hash0 = Sha256Hash.of(decodeData).getBytes();
-    byte[] hash1 = Sha256Hash.of(hash0).getBytes();
+    byte[] hash0 = Sha256Hash.hash(decodeData);
+    byte[] hash1 = Sha256Hash.hash(hash0);
     if (hash1[0] == decodeCheck[decodeData.length] &&
         hash1[1] == decodeCheck[decodeData.length + 1] &&
         hash1[2] == decodeCheck[decodeData.length + 2] &&

--- a/src/main/java/org/tron/core/Wallet.java
+++ b/src/main/java/org/tron/core/Wallet.java
@@ -38,10 +38,10 @@ import org.tron.api.GrpcAPI.NumberMessage;
 import org.tron.api.GrpcAPI.Return.response_code;
 import org.tron.api.GrpcAPI.WitnessList;
 import org.tron.common.crypto.ECKey;
-import org.tron.common.crypto.Hash;
 import org.tron.common.overlay.message.Message;
 import org.tron.common.utils.Base58;
 import org.tron.common.utils.ByteArray;
+import org.tron.common.utils.Sha256Hash;
 import org.tron.common.utils.Utils;
 import org.tron.core.capsule.AccountCapsule;
 import org.tron.core.capsule.AssetIssueCapsule;
@@ -140,8 +140,8 @@ public class Wallet {
   }
 
   public static String encode58Check(byte[] input) {
-    byte[] hash0 = Hash.sha256(input);
-    byte[] hash1 = Hash.sha256(hash0);
+    byte[] hash0 = Sha256Hash.of(input).getBytes();
+    byte[] hash1 = Sha256Hash.of(hash0).getBytes();
     byte[] inputCheck = new byte[input.length + 4];
     System.arraycopy(input, 0, inputCheck, 0, input.length);
     System.arraycopy(hash1, 0, inputCheck, input.length, 4);
@@ -155,8 +155,8 @@ public class Wallet {
     }
     byte[] decodeData = new byte[decodeCheck.length - 4];
     System.arraycopy(decodeCheck, 0, decodeData, 0, decodeData.length);
-    byte[] hash0 = Hash.sha256(decodeData);
-    byte[] hash1 = Hash.sha256(hash0);
+    byte[] hash0 = Sha256Hash.of(decodeData).getBytes();
+    byte[] hash1 = Sha256Hash.of(hash0).getBytes();
     if (hash1[0] == decodeCheck[decodeData.length] &&
         hash1[1] == decodeCheck[decodeData.length + 1] &&
         hash1[2] == decodeCheck[decodeData.length + 2] &&
@@ -439,7 +439,8 @@ public class Wallet {
     try {
       transactionCapsule = dbManager.getTransactionStore()
           .get(transactionId.toByteArray());
-    } catch (BadItemException e) {}
+    } catch (BadItemException e) {
+    }
     if (transactionCapsule != null) {
       return transactionCapsule.getInstance();
     }

--- a/src/test/java/stest/tron/wallet/common/client/WalletClient.java
+++ b/src/test/java/stest/tron/wallet/common/client/WalletClient.java
@@ -17,20 +17,18 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.spongycastle.util.encoders.Hex;
-import org.tron.api.GrpcAPI;
 import org.tron.api.GrpcAPI.AssetIssueList;
 import org.tron.api.GrpcAPI.BlockList;
 import org.tron.api.GrpcAPI.NodeList;
 import org.tron.api.GrpcAPI.TransactionList;
 import org.tron.api.GrpcAPI.WitnessList;
 import org.tron.common.crypto.ECKey;
-import org.tron.common.crypto.Hash;
 import org.tron.common.crypto.SymmEncoder;
 import org.tron.common.utils.ByteArray;
 import org.tron.common.utils.FileUtil;
+import org.tron.common.utils.Sha256Hash;
 import org.tron.common.utils.Utils;
 import org.tron.protos.Contract;
-import org.tron.protos.Contract.AssetIssueContract;
 import org.tron.protos.Contract.FreezeBalanceContract;
 import org.tron.protos.Contract.UnfreezeBalanceContract;
 import org.tron.protos.Contract.WithdrawBalanceContract;
@@ -274,10 +272,6 @@ public class WalletClient {
             return false;
         }
         transaction = signTransaction(transaction);
-        System.out.println("--------------------------------");
-        System.out.println(
-                "txid = " + ByteArray.toHexString(Hash.sha256(transaction.getRawData().toByteArray())));
-        System.out.println("--------------------------------");
         return rpcCli.broadcastTransaction(transaction);
     }
 
@@ -562,8 +556,8 @@ public class WalletClient {
             return null;
         }
         byte[] pwd;
-        pwd = Hash.sha256(password.getBytes());
-        pwd = Hash.sha256(pwd);
+        pwd = Sha256Hash.hash(password.getBytes());
+        pwd = Sha256Hash.hash(pwd);
         pwd = Arrays.copyOfRange(pwd, 0, 16);
         return pwd;
     }
@@ -573,7 +567,7 @@ public class WalletClient {
             return null;
         }
         byte[] encKey;
-        encKey = Hash.sha256(password.getBytes());
+        encKey = Sha256Hash.hash(password.getBytes());
         encKey = Arrays.copyOfRange(encKey, 0, 16);
         return encKey;
     }
@@ -623,8 +617,8 @@ public class WalletClient {
     }
 
     public static String encode58Check(byte[] input) {
-        byte[] hash0 = Hash.sha256(input);
-        byte[] hash1 = Hash.sha256(hash0);
+        byte[] hash0 = Sha256Hash.hash(input);
+        byte[] hash1 = Sha256Hash.hash(hash0);
         byte[] inputCheck = new byte[input.length + 4];
         System.arraycopy(input, 0, inputCheck, 0, input.length);
         System.arraycopy(hash1, 0, inputCheck, input.length, 4);
@@ -638,8 +632,8 @@ public class WalletClient {
         }
         byte[] decodeData = new byte[decodeCheck.length - 4];
         System.arraycopy(decodeCheck, 0, decodeData, 0, decodeData.length);
-        byte[] hash0 = Hash.sha256(decodeData);
-        byte[] hash1 = Hash.sha256(hash0);
+        byte[] hash0 = Sha256Hash.hash(decodeData);
+        byte[] hash1 = Sha256Hash.hash(hash0);
         if (hash1[0] == decodeCheck[decodeData.length] &&
                 hash1[1] == decodeCheck[decodeData.length + 1] &&
                 hash1[2] == decodeCheck[decodeData.length + 2] &&

--- a/src/test/java/stest/tron/wallet/common/client/utils/Base58.java
+++ b/src/test/java/stest/tron/wallet/common/client/utils/Base58.java
@@ -3,7 +3,7 @@ package stest.tron.wallet.common.client.utils;
 
 import java.io.UnsupportedEncodingException;
 import java.math.BigInteger;
-import org.tron.common.crypto.Hash;
+import org.tron.common.utils.Sha256Hash;
 
 public class Base58 {
     private static final int BASE58CHECK_ADDRESS_SIZE = 35;
@@ -182,8 +182,8 @@ public class Base58 {
         }
         byte[] decodeData = new byte[decodeCheck.length - 4];
         System.arraycopy(decodeCheck, 0, decodeData, 0, decodeData.length);
-        byte[] hash0 = Hash.sha256(decodeData);
-        byte[] hash1 = Hash.sha256(hash0);
+        byte[] hash0 = Sha256Hash.hash(decodeData);
+        byte[] hash1 = Sha256Hash.hash(hash0);
         if (hash1[0] == decodeCheck[decodeData.length] &&
                 hash1[1] == decodeCheck[decodeData.length + 1] &&
                 hash1[2] == decodeCheck[decodeData.length + 2] &&
@@ -215,8 +215,8 @@ public class Base58 {
     }
 
     public static String encode58Check(byte[] input) {
-        byte[] hash0 = Hash.sha256(input);
-        byte[] hash1 = Hash.sha256(hash0);
+        byte[] hash0 = Sha256Hash.hash(input);
+        byte[] hash1 = Sha256Hash.hash(hash0);
         byte[] inputCheck = new byte[input.length + 4];
         System.arraycopy(input, 0, inputCheck, 0, input.length);
         System.arraycopy(hash1, 0, inputCheck, input.length, 4);

--- a/src/test/java/stest/tron/wallet/common/client/utils/TransactionUtils.java
+++ b/src/test/java/stest/tron/wallet/common/client/utils/TransactionUtils.java
@@ -15,21 +15,17 @@ package stest.tron.wallet.common.client.utils;
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import static org.tron.common.crypto.Hash.sha256;
-
 import com.google.protobuf.ByteString;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.spongycastle.util.encoders.Base64;
-import org.tron.common.crypto.ECKey;
-import org.tron.common.crypto.ECKey.ECDSASignature;
-import org.tron.protos.Protocol.TXInput;
-import org.tron.protos.Protocol.Transaction;
-import org.tron.protos.Protocol.Transaction.Contract;
-
 import java.security.SignatureException;
 import java.util.Arrays;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.tron.common.crypto.ECKey;
+import org.tron.common.crypto.ECKey.ECDSASignature;
+import org.tron.common.utils.Sha256Hash;
+import org.tron.protos.Protocol.Transaction;
+import org.tron.protos.Protocol.Transaction.Contract;
 
 public class TransactionUtils {
 
@@ -46,7 +42,7 @@ public class TransactionUtils {
         Transaction.Builder tmp = transaction.toBuilder();
         //tmp.clearId();
 
-        return sha256(tmp.build().toByteArray());
+        return Sha256Hash.hash(tmp.build().toByteArray());
     }
 
     public static byte[] getOwner(Transaction.Contract contract) {
@@ -121,7 +117,7 @@ public class TransactionUtils {
         assert (signedTransaction.getSignatureCount() ==
                 signedTransaction.getRawData().getContractCount());
         List<Transaction.Contract> listContract = signedTransaction.getRawData().getContractList();
-        byte[] hash = sha256(signedTransaction.getRawData().toByteArray());
+        byte[] hash = Sha256Hash.hash(signedTransaction.getRawData().toByteArray());
         int count = signedTransaction.getSignatureCount();
         if (count == 0) {
             return false;
@@ -147,7 +143,7 @@ public class TransactionUtils {
         ByteString lockSript = ByteString.copyFrom(myKey.getAddress());
         Transaction.Builder transactionBuilderSigned = transaction.toBuilder();
 
-        byte[] hash = sha256(transaction.getRawData().toByteArray());
+        byte[] hash = Sha256Hash.hash(transaction.getRawData().toByteArray());
         List<Contract> listContract = transaction.getRawData().getContractList();
         for (int i = 0; i < listContract.size(); i++) {
             ECDSASignature signature = myKey.sign(hash);


### PR DESCRIPTION
**What does this PR do?**
Remove Hash.sha256 instead of  Sha256Hash.hash

**Why are these changes required?**
Hash.sha256  is called by multiple threads then will cause some errors.

**This PR has been tested by:**
- Unit Tests
add Sha256HashTest.java 
The Function testHash prove Sha256Hash.hash is right.
The Function testMultiThreadingHash prove Sha256Hash.hash is right when called by multithread.

- Manual Testing

**Follow up**

**Extra details**
The function encode58Check, decode58Check of src/main/java/org/tron/core/Wallet.java
sendCoin, getAddressByStorage, getAddressByStorage, encode58Check,decode58Check of
src/test/java/stest/tron/wallet/common/client/WalletClient.java
decode58Check, encode58Check of src/test/java/stest/tron/wallet/common/client/utils/Base58.java
getHash, validTransaction, sign of  src/test/java/stest/tron/wallet/common/client/utils/TransactionUtils.java
have been modified。

