### PR TITLE
fix the bug when call value is null

### DIFF
--- a/src/main/java/org/tron/common/runtime/Runtime.java
+++ b/src/main/java/org/tron/common/runtime/Runtime.java
@@ -176,7 +176,7 @@ public class Runtime {
       InternalTransaction internalTransaction = new InternalTransaction(trx,
           contract.getOwnerAddress().toByteArray(),
           contract.getContractAddress().toByteArray(),
-          contract.getCallValue().toByteArray()[0]);
+          contract.getCallValue().size()==0 ? new Byte("0") : contract.getCallValue().toByteArray()[0]);
       this.program = new Program(null, code, programInvoke,internalTransaction, config);
     }
 
@@ -225,7 +225,7 @@ public class Runtime {
       InternalTransaction internalTransaction = new InternalTransaction(trx,
           contract.getOwnerAddress().toByteArray(),
           contract.getContractAddress().toByteArray(),
-          contract.getCallValue().toByteArray()[0]);
+          contract.getCallValue().size()==0 ? new Byte("0") : contract.getCallValue().toByteArray()[0]);
       ProgramInvoke programInvoke = programInvokeFactory
           .createProgramInvoke(TRX_CONTRACT_CREATION_TYPE, executerType, trx,
               block, deposit);


### PR DESCRIPTION
When call a function return  constant value, we need to avoid call value to be null, so that we can  get generate a temp signature.

**What does this PR do?**

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

