### PR TITLE
Fix validation on AssetIssue abbr

### DIFF
--- a/src/main/java/org/tron/core/actuator/AssetIssueActuator.java
+++ b/src/main/java/org/tron/core/actuator/AssetIssueActuator.java
@@ -138,7 +138,7 @@ public class AssetIssueActuator extends AbstractActuator {
       throw new ContractValidateException("Invalid assetName");
     }
     if ((!assetIssueContract.getAbbr().isEmpty()) && !TransactionUtil
-        .validAssetName(assetIssueContract.getAbbr().toByteArray())) {
+    	.validTokenAbbrName(assetIssueContract.getAbbr().toByteArray())) {
       throw new ContractValidateException("Invalid abbreviation for token");
     }
     if (!TransactionUtil.validUrl(assetIssueContract.getUrl().toByteArray())) {


### PR DESCRIPTION
**What does this PR do?**
Fix validation on token abbreviation

**Why are these changes required?**
Validation on token abbr isn't done correctly exemples of tokens created with abbr > 5 on mainnet:
- SHALOM
- tronbook.io
- $JcSkyHighTreeService$

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

