### PR TITLE
Add a test relied on the TVM runtime with bytecodes

### DIFF
--- a/src/test/java/org/tron/common/runtime/vm/InterpreterTest.java
+++ b/src/test/java/org/tron/common/runtime/vm/InterpreterTest.java
@@ -1,0 +1,59 @@
+/*
+ * java-tron is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * java-tron is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.tron.common.runtime.vm;
+
+import static org.junit.Assert.assertTrue;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Test;
+import java.io.*;
+import org.tron.protos.Protocol.Transaction;
+import org.tron.common.runtime.vm.program.InternalTransaction;
+import org.tron.common.runtime.vm.VM;
+import org.tron.common.runtime.vm.program.Program;
+import org.tron.common.runtime.vm.program.invoke.ProgramInvokeMockImpl;
+
+@Slf4j
+public class InterpreterTest {
+
+  private ProgramInvokeMockImpl invoke;
+  private Program program;
+
+  @Test
+  public void testVMException() {
+    VM vm = new VM();
+    invoke = new ProgramInvokeMockImpl();
+    byte[] op = { 0x5b, 0x60, 0x00, 0x56 };
+    // 0x5b      - JUMPTEST
+    // 0x60 0x00 - PUSH 0x00
+    // 0x56      - JUMP to 0
+    Transaction trx = Transaction.getDefaultInstance();
+    InternalTransaction interTrx = new InternalTransaction(trx);
+    program = new Program(op, invoke, interTrx);
+
+    boolean result = false;
+
+    try {
+      while (!program.isStopped()) {
+        vm.step(program);
+      }
+    } catch (Exception e) {
+      result = true;
+    }
+
+    assertTrue(result);
+  }
+}


### PR DESCRIPTION
Signed-off-by: Hyunjune <hykim0777@gmail.com>

**What does this PR do?**
This patch is a unit test relied on the TVM runtime to run byte codes.
This test is to check JUMP OP code whether the exception do run or not.

Byte codes are above
// 0x5b      - JUMPTEST
// 0x60 0x00 - PUSH 0x00
// 0x56      - JUMP to 0


**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

