### PR TITLE
remove invalid maven repo causing build break

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,5 @@
 buildscript {
     repositories {
-        maven { url 'http://mvnrepository.com' }
         mavenCentral()
         jcenter()
     }
@@ -46,7 +45,6 @@ task sourceJar(type: Jar, dependsOn: classes) {
 }
 
 repositories {
-    maven { url 'http://mvnrepository.com' }
     mavenLocal()
     mavenCentral()
 }


### PR DESCRIPTION
**What does this PR do?**
Remove an invalid maven repository causing a build failure

**Why are these changes required?**
Run build normaly when running "gradlew build"

**This PR has been tested by:**

- Manual Testing

**Follow up**

**Extra details**

