### PR TITLE
move checkcputime to the end of execute op

### DIFF
--- a/src/main/java/org/tron/common/runtime/vm/VM.java
+++ b/src/main/java/org/tron/common/runtime/vm/VM.java
@@ -274,7 +274,6 @@ public class VM {
       }
 
       program.spendEnergy(energyCost, op.name());
-      program.checkCPUTimeLimit(op.name());
 
       // Execute operation
       switch (op) {
@@ -1322,6 +1321,7 @@ public class VM {
           break;
       }
 
+      program.checkCPUTimeLimit(op.name());
       program.setPreviouslyExecutedOp(op.val());
     } catch (RuntimeException e) {
       logger.info("VM halted: [{}]", e.getMessage());


### PR DESCRIPTION
**What does this PR do?**

move checkcputime to the end of execute op

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

