### PR TITLE
Add Raw Data Hex

### DIFF
--- a/src/main/java/org/tron/core/services/http/Util.java
+++ b/src/main/java/org/tron/core/services/http/Util.java
@@ -324,6 +324,8 @@ public class Util {
     JSONObject rawData = JSONObject.parseObject(jsonTransaction.get("raw_data").toString());
     rawData.put("contract", contracts);
     jsonTransaction.put("raw_data", rawData);
+    String rawDataHex = ByteArray.toHexString(transaction.getRawData().toByteArray());
+    jsonTransaction.put("raw_data_hex", rawDataHex);
     String txID = ByteArray.toHexString(Sha256Hash.hash(transaction.getRawData().toByteArray()));
     jsonTransaction.put("txID", txID);
     return jsonTransaction;


### PR DESCRIPTION
For hardware wallet integration the `raw_data_hex` is required, this can be send to the hardware wallet where it can be decoded and the transaction information can be read which then will be presented to the user