### PR TITLE
modify generate block timeout value

### DIFF
--- a/src/main/java/org/tron/core/services/WitnessService.java
+++ b/src/main/java/org/tron/core/services/WitnessService.java
@@ -253,11 +253,10 @@ public class WitnessService implements Service {
 
         int blockProducedTimeOut = Args.getInstance().getBlockProducedTimeOut();
 
-        if (DateTime.now().getMillis() - now
-            > ChainConstant.BLOCK_PRODUCED_INTERVAL * blockProducedTimeOut / 100) {
-          logger.warn("Task timeout ( > {}ms)，startTime:{},endTime:{}",
-              ChainConstant.BLOCK_PRODUCED_INTERVAL * blockProducedTimeOut / 100,
-              new DateTime(now), DateTime.now());
+        long timeout = Math.min(ChainConstant.BLOCK_PRODUCED_INTERVAL * blockProducedTimeOut / 100 + 500,
+            ChainConstant.BLOCK_PRODUCED_INTERVAL);
+        if (DateTime.now().getMillis() - now > timeout) {
+          logger.warn("Task timeout ( > {}ms)，startTime:{},endTime:{}", timeout, new DateTime(now), DateTime.now());
           tronApp.getDbManager().eraseBlock();
           return BlockProductionCondition.TIME_OUT;
         }

--- a/src/test/java/org/tron/core/net/node/override/HandshakeHandlerTest.java
+++ b/src/test/java/org/tron/core/net/node/override/HandshakeHandlerTest.java
@@ -27,7 +27,7 @@ public class HandshakeHandlerTest extends HandshakeHandler {
         manager.getGenesisBlockId(), manager.getSolidBlockId(), manager.getHeadBlockId());
     ctx.writeAndFlush(message.getSendData());
     channel.getNodeStatistics().messageStatistics.addTcpOutMessage(message);
-    logger.info("Handshake Send to {}, {} ", ctx.channel().remoteAddress(), message);
+    logger.info("Handshake Send to {}, {}", ctx.channel().remoteAddress(), message);
   }
 
   public void close() {


### PR DESCRIPTION
**What does this PR do?**
Avoiding block overtime by increasing timeout time of 500 ms

**Why are these changes required?**
can reduce block miss

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

