### PR TITLE
fix bugs in AccountPermissionUpdateActuator

### DIFF
--- a/src/main/java/org/tron/core/actuator/AccountPermissionUpdateActuator.java
+++ b/src/main/java/org/tron/core/actuator/AccountPermissionUpdateActuator.java
@@ -89,7 +89,7 @@ public class AccountPermissionUpdateActuator extends AbstractActuator {
     boolean containOwner = false;
     boolean containActive = false;
     for (Permission permission : accountPermissionUpdateContract.getPermissionsList()) {
-      if (permission.getKeysCount() >= dbManager.getDynamicPropertiesStore().getTotalSignNum()) {
+      if (permission.getKeysCount() > dbManager.getDynamicPropertiesStore().getTotalSignNum()) {
         throw new ContractValidateException("number of keys in permission should not be greater "
             + "than " + dbManager.getDynamicPropertiesStore().getTotalSignNum());
       }
@@ -99,6 +99,7 @@ public class AccountPermissionUpdateActuator extends AbstractActuator {
       if (permission.getThreshold() <= 0) {
         throw new ContractValidateException("permission's threshold should be greater than 0");
       }
+
       if (StringUtils.isEmpty(permission.getName())) {
         throw new ContractValidateException("permission's name should not be empty");
       }
@@ -134,9 +135,6 @@ public class AccountPermissionUpdateActuator extends AbstractActuator {
       for (Key key : permission.getKeysList()) {
         if (!Wallet.addressValid(key.getAddress().toByteArray())) {
           throw new ContractValidateException("key is not a validate address");
-        }
-        if (dbManager.getAccountStore().get(key.getAddress().toByteArray()) == null) {
-          throw new ContractValidateException("key address does not exist");
         }
         if (key.getWeight() <= 0) {
           throw new ContractValidateException("key's weight should be greater than 0");

--- a/src/test/java/org/tron/core/actuator/AccountPermissionUpdateActuatorTest.java
+++ b/src/test/java/org/tron/core/actuator/AccountPermissionUpdateActuatorTest.java
@@ -595,35 +595,35 @@ public class AccountPermissionUpdateActuatorTest {
         actuator, ret, "key is not a validate address", "key is not a validate address");
   }
 
-  @Test
-  public void notExistKeyAddress() {
-    ByteString address = ByteString.copyFrom(ByteArray.fromHexString(OWNER_ADDRESS));
-
-    Permission ownerPermission = TransactionCapsule.getDefaultPermission(address, "owner");
-    Permission activePermission =
-        Permission.newBuilder()
-            .setName("active")
-            .setParent("owner")
-            .setThreshold(1)
-            .addKeys(Key.newBuilder().setAddress(address).setWeight(1).build())
-            .addKeys(
-                Key.newBuilder()
-                    .setAddress(ByteString.copyFrom(ByteArray.fromHexString(KEY_ADDRESS)))
-                    .setWeight(1)
-                    .build())
-            .build();
-
-    List<Permission> initPermissions = new ArrayList<>();
-    initPermissions.add(ownerPermission);
-    initPermissions.add(activePermission);
-
-    AccountPermissionUpdateActuator actuator =
-        new AccountPermissionUpdateActuator(getContract(address, initPermissions), dbManager);
-    TransactionResultCapsule ret = new TransactionResultCapsule();
-
-    processAndCheckInvalid(
-        actuator, ret, "key address does not exist", "key address does not exist");
-  }
+//  @Test
+//  public void notExistKeyAddress() {
+//    ByteString address = ByteString.copyFrom(ByteArray.fromHexString(OWNER_ADDRESS));
+//
+//    Permission ownerPermission = TransactionCapsule.getDefaultPermission(address, "owner");
+//    Permission activePermission =
+//        Permission.newBuilder()
+//            .setName("active")
+//            .setParent("owner")
+//            .setThreshold(1)
+//            .addKeys(Key.newBuilder().setAddress(address).setWeight(1).build())
+//            .addKeys(
+//                Key.newBuilder()
+//                    .setAddress(ByteString.copyFrom(ByteArray.fromHexString(KEY_ADDRESS)))
+//                    .setWeight(1)
+//                    .build())
+//            .build();
+//
+//    List<Permission> initPermissions = new ArrayList<>();
+//    initPermissions.add(ownerPermission);
+//    initPermissions.add(activePermission);
+//
+//    AccountPermissionUpdateActuator actuator =
+//        new AccountPermissionUpdateActuator(getContract(address, initPermissions), dbManager);
+//    TransactionResultCapsule ret = new TransactionResultCapsule();
+//
+//    processAndCheckInvalid(
+//        actuator, ret, "key address does not exist", "key address does not exist");
+//  }
 
   @Test
   public void weighValueInvalid() {


### PR DESCRIPTION
**What does this PR do?**
fix bugs in AccountPermissionUpdateActuator:
1. If the count of keys in permission equals the TotalSignNum, it will not throw exception
2.The address in permission can be a none active account

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

