### PR TITLE
Improve stest case soliditynode query stability

### DIFF
--- a/src/test/java/stest/tron/wallet/account/WalletTestAccount014.java
+++ b/src/test/java/stest/tron/wallet/account/WalletTestAccount014.java
@@ -164,7 +164,7 @@ public class WalletTestAccount014 {
         3,1,ByteString.copyFrom(
         account014Address),account014SecondKey,blockingStubFull));
 
-
+    PublicMethed.waitSolidityNodeSynFullNodeData(blockingStubFull,blockingStubSoliInFull);
     Account account014 = PublicMethed.queryAccount(account014Address, blockingStubFull);
     final long lastCustomeTimeInFullnode = account014.getLatestConsumeTime();
     final long netUsageInFullnode = account014.getNetUsage();

--- a/src/test/java/stest/tron/wallet/exchangeandtoken/WalletExchange001.java
+++ b/src/test/java/stest/tron/wallet/exchangeandtoken/WalletExchange001.java
@@ -337,8 +337,8 @@ public class WalletExchange001 {
     ExchangeList exchangeList = blockingStubFull
         .getPaginatedExchangeList(pageMessageBuilder.build());
     Assert.assertTrue(exchangeList.getExchangesCount() >= 1);
+    PublicMethed.waitProduceNextBlock(blockingStubFull);
     PublicMethed.waitSolidityNodeSynFullNodeData(blockingStubFull,blockingStubSolidity);
-
     //Solidity support getExchangeId
     exchangeIdInfo = PublicMethed.getExchange(exchangeId.toString(),blockingStubSolidity);
     logger.info("createtime is" + exchangeIdInfo.get().getCreateTime());

--- a/src/test/java/stest/tron/wallet/exchangeandtoken/WalletTestAssetIssue017.java
+++ b/src/test/java/stest/tron/wallet/exchangeandtoken/WalletTestAssetIssue017.java
@@ -189,12 +189,12 @@ public class WalletTestAssetIssue017 {
     PaginatedMessage.Builder pageMessageBuilder = PaginatedMessage.newBuilder();
     pageMessageBuilder.setOffset(offset);
     pageMessageBuilder.setLimit(limit);
-
+    Assert.assertTrue(PublicMethed.waitSolidityNodeSynFullNodeData(blockingStubFull,
+        blockingStubSolidity));
     AssetIssueList assetIssueList = blockingStubSolidity
         .getPaginatedAssetIssueList(pageMessageBuilder.build());
     Optional<AssetIssueList> assetIssueListPaginated = Optional.ofNullable(assetIssueList);
-    Assert.assertTrue(PublicMethed.waitSolidityNodeSynFullNodeData(blockingStubFull,
-        blockingStubSolidity));
+
     logger.info(Long.toString(assetIssueListPaginated.get().getAssetIssueCount()));
     Assert.assertTrue(assetIssueListPaginated.get().getAssetIssueCount() >= 1);
     for (Integer i = 0; i < assetIssueListPaginated.get().getAssetIssueCount(); i++) {


### PR DESCRIPTION
**What does this PR do?**
To improve stest case of solidity node query stability
**Why are these changes required?**
Sometimes, stest case is not stability due to query solidity node too fast
**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**
