### PR TITLE
Feature/develop event subscribe

### DIFF
--- a/src/main/java/org/tron/common/logsfilter/ContractEventParser.java
+++ b/src/main/java/org/tron/common/logsfilter/ContractEventParser.java
@@ -69,7 +69,7 @@ public class ContractEventParser {
       }
     } else {
       for (int i = 1; i < topicList.size(); ++i) {
-        map.put("" + (i - 1), DataWord.shortHex(topicList.get(i)));
+        map.put("" + (i - 1), Hex.toHexString(topicList.get(i)));
       }
     }
     return map;
@@ -159,7 +159,7 @@ public class ContractEventParser {
         // this length is byte count. no need X 32
         int length = intValueExact(lengthBytes);
         byte[] realBytes = subBytes(data, start + DATAWORD_UNIT_SIZE, length);
-        return type == Type.STRING ? new String(realBytes) : DataWord.shortHex(realBytes);
+        return type == Type.STRING ? new String(realBytes) : Hex.toHexString(realBytes);
       }
     } catch (OutputLengthException | ArithmeticException e) {
       logger.debug("parseDataBytes ", e);
@@ -223,6 +223,6 @@ public class ContractEventParser {
       byte[] last20Bytes = Arrays.copyOfRange(bytes, 12, bytes.length);
       return Wallet.encode58Check(MUtil.convertToTronAddress(last20Bytes));
     }
-    return DataWord.shortHex(bytes);
+    return Hex.toHexString(bytes);
   }
 }

--- a/src/main/java/org/tron/common/runtime/RuntimeImpl.java
+++ b/src/main/java/org/tron/common/runtime/RuntimeImpl.java
@@ -452,7 +452,7 @@ public class RuntimeImpl implements Runtime {
           && isCheckTransaction()){
 
         logInfoTriggerParser = new LogInfoTriggerParser(newSmartContract.getAbi(),
-            blockCap.getNum(), blockCap.getTimeStamp(), txId,
+            blockCap.getNum(), trx.getRawData().getTimestamp(), txId,
             callerAddress, callerAddress, callerAddress, contractAddress);
 
       }
@@ -580,7 +580,7 @@ public class RuntimeImpl implements Runtime {
           && isCheckTransaction()){
 
         logInfoTriggerParser = new LogInfoTriggerParser(deployedContract.getInstance().getAbi(),
-            blockCap.getNum(), blockCap.getTimeStamp(), txId,
+            blockCap.getNum(), trx.getRawData().getTimestamp(), txId,
             callerAddress, creatorAddress, originAddress, contractAddress);
       }
     }


### PR DESCRIPTION
**What does this PR do?**
1. changed Dataword.shortHex to  Hex.toHexString  because it is different from the Gettransacitoninfobyid result.

2. changed blockCap.getTimeStamp() to trx.getRawData().getTimestamp() to get exact timestamp of a transaction execution.

**Why are these changes required?**


**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

