### PR TITLE
fix error when generating block without permission

### DIFF
--- a/src/main/java/org/tron/core/db/Manager.java
+++ b/src/main/java/org/tron/core/db/Manager.java
@@ -1285,6 +1285,11 @@ public class Manager {
     session.reset();
     session.setValue(revokingStore.buildSession());
 
+    if (!witnessService.validateWitnessPermission(witnessCapsule.getAddress())) {
+      logger.warn("Witness permission is wrong");
+      return null;
+    }
+
     Set<String> accountSet = new HashSet<>();
     Iterator<TransactionCapsule> iterator = pendingTransactions.iterator();
     while (iterator.hasNext() || repushTransactions.size() > 0) {

--- a/src/main/java/org/tron/core/db/Manager.java
+++ b/src/main/java/org/tron/core/db/Manager.java
@@ -1287,7 +1287,8 @@ public class Manager {
     session.reset();
     session.setValue(revokingStore.buildSession());
 
-    if (!witnessService.validateWitnessPermission(witnessCapsule.getAddress())) {
+    if (witnessService != null && !witnessService.
+        validateWitnessPermission(witnessCapsule.getAddress())) {
       logger.warn("Witness permission is wrong");
       return null;
     }

--- a/src/main/java/org/tron/core/db/Manager.java
+++ b/src/main/java/org/tron/core/db/Manager.java
@@ -1253,7 +1253,7 @@ public class Manager {
    */
   public synchronized BlockCapsule generateBlock(
       final WitnessCapsule witnessCapsule, final long when, final byte[] privateKey,
-      Boolean lastHeadBlockIsMaintenanceBefore)
+      Boolean lastHeadBlockIsMaintenanceBefore, Boolean needCheckWitnessPermission)
       throws ValidateSignatureException, ContractValidateException, ContractExeException,
       UnLinkedBlockException, ValidateScheduleException, AccountResourceInsufficientException {
 
@@ -1287,7 +1287,7 @@ public class Manager {
     session.reset();
     session.setValue(revokingStore.buildSession());
 
-    if (witnessService != null && !witnessService.
+    if (needCheckWitnessPermission && !witnessService.
         validateWitnessPermission(witnessCapsule.getAddress())) {
       logger.warn("Witness permission is wrong");
       return null;

--- a/src/main/java/org/tron/core/services/WitnessService.java
+++ b/src/main/java/org/tron/core/services/WitnessService.java
@@ -317,7 +317,7 @@ public class WitnessService implements Service {
       throws ValidateSignatureException, ContractValidateException, ContractExeException,
       UnLinkedBlockException, ValidateScheduleException, AccountResourceInsufficientException {
     return tronApp.getDbManager().generateBlock(this.localWitnessStateMap.get(witnessAddress), when,
-        this.privateKeyMap.get(witnessAddress), lastHeadBlockIsMaintenance);
+        this.privateKeyMap.get(witnessAddress), lastHeadBlockIsMaintenance, true);
   }
 
   private boolean dupWitnessCheck() {

--- a/src/main/java/org/tron/core/services/WitnessService.java
+++ b/src/main/java/org/tron/core/services/WitnessService.java
@@ -247,17 +247,6 @@ public class WitnessService implements Service {
           return BlockProductionCondition.NO_PRIVATE_KEY;
         }
 
-        //Verify that the private key corresponds to the witness permission
-        if (manager.getDynamicPropertiesStore().getAllowMultiSign() == 1) {
-          byte[] privateKey = privateKeyMap.get(scheduledWitness);
-          byte[] witnessPermissionAddress = privateKeyToAddressMap.get(privateKey);
-          AccountCapsule witnessAccount = manager.getAccountStore()
-              .get(scheduledWitness.toByteArray());
-          if (!Arrays.equals(witnessPermissionAddress, witnessAccount.getWitnessPermissionAddress())) {
-            return BlockProductionCondition.WITNESS_PERMISSION_ERROR;
-          }
-        }
-
         controller.getManager().lastHeadBlockIsMaintenance();
 
         controller.setGeneratingBlock(true);
@@ -299,6 +288,20 @@ public class WitnessService implements Service {
     } finally {
       controller.setGeneratingBlock(false);
     }
+  }
+
+  //Verify that the private key corresponds to the witness permission
+  public boolean validateWitnessPermission(ByteString scheduledWitness) {
+    if (manager.getDynamicPropertiesStore().getAllowMultiSign() == 1) {
+      byte[] privateKey = privateKeyMap.get(scheduledWitness);
+      byte[] witnessPermissionAddress = privateKeyToAddressMap.get(privateKey);
+      AccountCapsule witnessAccount = manager.getAccountStore()
+          .get(scheduledWitness.toByteArray());
+      if (!Arrays.equals(witnessPermissionAddress, witnessAccount.getWitnessPermissionAddress())) {
+        return false;
+      }
+    }
+    return true;
   }
 
   private void broadcastBlock(BlockCapsule block) {

--- a/src/test/java/org/tron/core/db/ManagerTest.java
+++ b/src/test/java/org/tron/core/db/ManagerTest.java
@@ -230,7 +230,7 @@ public class ManagerTest {
     byte[] address = ecKey.getAddress();
     WitnessCapsule witnessCapsule = new WitnessCapsule(ByteString.copyFrom(address));
     dbManager.addWitness(ByteString.copyFrom(address));
-    dbManager.generateBlock(witnessCapsule, 1533529947843L, privateKey, false);
+    dbManager.generateBlock(witnessCapsule, 1533529947843L, privateKey, false, false);
 
     Map<ByteString, String> addressToProvateKeys = addTestWitnessAndAccount();
 
@@ -299,7 +299,7 @@ public class ManagerTest {
     byte[] address = ecKey.getAddress();
     WitnessCapsule witnessCapsule = new WitnessCapsule(ByteString.copyFrom(address));
     dbManager.addWitness(ByteString.copyFrom(address));
-    dbManager.generateBlock(witnessCapsule, 1533529947843L, privateKey, false);
+    dbManager.generateBlock(witnessCapsule, 1533529947843L, privateKey, false, false);
 
     Map<ByteString, String> addressToProvateKeys = addTestWitnessAndAccount();
 
@@ -396,12 +396,12 @@ public class ManagerTest {
     WitnessCapsule witnessCapsule = new WitnessCapsule(ByteString.copyFrom(address));
     dbManager.addWitness(ByteString.copyFrom(address));
     BlockCapsule blockCapsule =
-        dbManager.generateBlock(witnessCapsule, 1533529947843L, privateKey, true);
+        dbManager.generateBlock(witnessCapsule, 1533529947843L, privateKey, true, false);
 
     //has processed the first block of the maintenance period before starting the block
     dbManager.getWitnessStore().reset();
     dbManager.getDynamicPropertiesStore().saveStateFlag(0);
-    blockCapsule = dbManager.generateBlock(witnessCapsule, 1533529947843L, privateKey, true);
+    blockCapsule = dbManager.generateBlock(witnessCapsule, 1533529947843L, privateKey, true, false);
     Assert.assertTrue(blockCapsule == null);
   }
 
@@ -421,7 +421,7 @@ public class ManagerTest {
     byte[] address = ecKey.getAddress();
     WitnessCapsule witnessCapsule = new WitnessCapsule(ByteString.copyFrom(address));
     dbManager.addWitness(ByteString.copyFrom(address));
-    dbManager.generateBlock(witnessCapsule, 1533529947843L, privateKey, false);
+    dbManager.generateBlock(witnessCapsule, 1533529947843L, privateKey, false, false);
 
     Map<ByteString, String> addressToProvateKeys = addTestWitnessAndAccount();
 


### PR DESCRIPTION
**What does this PR do?**
fix error when generating block without permission

**Why are these changes required?**
In the following scenario, a block with a wrong signature is generated. 
The witness node accepts the transaction that obtained the permission and plans to generate the block at this time. This block will not be accepted at other nodes.

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

