### PR TITLE
add lastest solidfied block num

### DIFF
--- a/src/main/java/org/tron/common/logsfilter/capsule/ContractEventTriggerCapsule.java
+++ b/src/main/java/org/tron/common/logsfilter/capsule/ContractEventTriggerCapsule.java
@@ -28,6 +28,10 @@ public class ContractEventTriggerCapsule extends TriggerCapsule {
   @Setter
   private Entry abiEntry;
 
+  public void setLastestSolidifiedBlockNumber(long lastestSolidifiedBlockNumber) {
+    contractEventTrigger.setLastestSolidifiedBlockNumber(lastestSolidifiedBlockNumber);
+  }
+
   public ContractEventTriggerCapsule(LogEventWrapper log) {
     this.contractEventTrigger = new ContractEventTrigger();
 

--- a/src/main/java/org/tron/common/logsfilter/capsule/ContractLogTriggerCapsule.java
+++ b/src/main/java/org/tron/common/logsfilter/capsule/ContractLogTriggerCapsule.java
@@ -15,6 +15,10 @@ public class ContractLogTriggerCapsule extends TriggerCapsule {
     this.contractLogTrigger = contractLogTrigger;
   }
 
+  public void setLastestSolidifiedBlockNumber(long lastestSolidifiedBlockNumber) {
+    contractLogTrigger.setLastestSolidifiedBlockNumber(lastestSolidifiedBlockNumber);
+  }
+
   @Override
   public void processTrigger() {
     if (FilterQuery.matchFilter(contractLogTrigger)) {

--- a/src/main/java/org/tron/common/logsfilter/capsule/TransactionLogTriggerCapsule.java
+++ b/src/main/java/org/tron/common/logsfilter/capsule/TransactionLogTriggerCapsule.java
@@ -35,6 +35,10 @@ public class TransactionLogTriggerCapsule extends TriggerCapsule {
   @Setter
   TransactionLogTrigger transactionLogTrigger;
 
+  public void setLastestSolidifiedBlockNumber(long lastestSolidifiedBlockNumber) {
+    transactionLogTrigger.setLastestSolidifiedBlockNumber(lastestSolidifiedBlockNumber);
+  }
+
   public TransactionLogTriggerCapsule(TransactionCapsule trxCasule, BlockCapsule blockCapsule) {
     transactionLogTrigger = new TransactionLogTrigger();
     if (Objects.nonNull(blockCapsule)) {

--- a/src/main/java/org/tron/common/logsfilter/trigger/ContractTrigger.java
+++ b/src/main/java/org/tron/common/logsfilter/trigger/ContractTrigger.java
@@ -53,4 +53,8 @@ public class ContractTrigger extends Trigger {
   @Getter
   @Setter
   private boolean removed;
+
+  @Getter
+  @Setter
+  private long lastestSolidifiedBlockNumber;
 }

--- a/src/main/java/org/tron/common/logsfilter/trigger/TransactionLogTrigger.java
+++ b/src/main/java/org/tron/common/logsfilter/trigger/TransactionLogTrigger.java
@@ -90,6 +90,10 @@ public class TransactionLogTrigger extends Trigger {
   @Setter
   private long assetAmount;
 
+  @Getter
+  @Setter
+  private long lastestSolidifiedBlockNumber;
+
   //internal transaction
   @Getter
   @Setter

--- a/src/main/java/org/tron/core/db/Manager.java
+++ b/src/main/java/org/tron/core/db/Manager.java
@@ -1861,8 +1861,9 @@ public class Manager {
   private void postTransactionTrigger(final TransactionCapsule trxCap,
       final BlockCapsule blockCap) {
     if (eventPluginLoaded && EventPluginLoader.getInstance().isTransactionLogTriggerEnable()) {
-      boolean result = triggerCapsuleQueue
-          .offer(new TransactionLogTriggerCapsule(trxCap, blockCap));
+      TransactionLogTriggerCapsule trx = new TransactionLogTriggerCapsule(trxCap, blockCap);
+      trx.setLastestSolidifiedBlockNumber(latestSolidifiedBlockNumber);
+      boolean result = triggerCapsuleQueue.offer(trx);
       if (result == false) {
         logger.info("too many trigger, lost transaction trigger: {}", trxCap.getTransactionId());
       }
@@ -1901,12 +1902,14 @@ public class Manager {
           ContractEventTriggerCapsule contractEventTriggerCapsule = new ContractEventTriggerCapsule(
               (LogEventWrapper) trigger);
           contractEventTriggerCapsule.getContractEventTrigger().setRemoved(remove);
+          contractEventTriggerCapsule.setLastestSolidifiedBlockNumber(latestSolidifiedBlockNumber);
           result = triggerCapsuleQueue.offer(contractEventTriggerCapsule);
         } else if (trigger instanceof ContractLogTrigger && EventPluginLoader.getInstance()
             .isContractLogTriggerEnable()) {
           ContractLogTriggerCapsule contractLogTriggerCapsule = new ContractLogTriggerCapsule(
               (ContractLogTrigger) trigger);
           contractLogTriggerCapsule.getContractLogTrigger().setRemoved(remove);
+          contractLogTriggerCapsule.setLastestSolidifiedBlockNumber(latestSolidifiedBlockNumber);
           result = triggerCapsuleQueue.offer(contractLogTriggerCapsule);
         }
         if (result == false) {


### PR DESCRIPTION
What does this PR do?
add lastest block number in the transaction and contract event log, developers could verify whether the contract event is confirmed or not.
Why are these changes required?
requirement of trx market.

This PR has been tested by:

Unit Tests
Manual Testing
Follow up

Extra details