### PR TITLE
Switch to bitcoinj implementation of secp256k1 for better performance

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,6 +110,8 @@ dependencies {
     compile "com.madgag.spongycastle:core:1.58.0.0"
     compile "com.madgag.spongycastle:prov:1.58.0.0"
 
+    compile "org.bitcoinj:bitcoinj-core:0.14.7"
+
     compile group: 'com.google.guava', name: 'guava', version: '24.1-jre'
 
     compile group: 'com.google.protobuf', name: 'protobuf-java', version: '3.4.0'

--- a/build.gradle
+++ b/build.gradle
@@ -334,6 +334,8 @@ def binaryRelease(taskName, jarName, mainClass) {
         manifest {
             attributes "Main-Class": "${mainClass}"
         }
+
+        exclude 'META-INF/*.RSA', 'META-INF/*.SF', 'META-INF/*.DSA'
     }
 }
 

--- a/src/main/java/org/tron/common/crypto/ECKey.java
+++ b/src/main/java/org/tron/common/crypto/ECKey.java
@@ -467,8 +467,7 @@ public class ECKey implements Serializable {
    */
   public static byte[] signatureToAddress(byte[] messageHash, String
       signatureBase64) throws SignatureException {
-    return computeAddress(signatureToKeyBytes(messageHash,
-        signatureBase64));
+    return Secp256k1Helper.signatureToAddress(messageHash, signatureBase64);
   }
 
   /**

--- a/src/main/java/org/tron/common/crypto/Secp256k1Helper.java
+++ b/src/main/java/org/tron/common/crypto/Secp256k1Helper.java
@@ -1,0 +1,29 @@
+package org.tron.common.crypto;
+
+import org.bitcoinj.core.ECKey;
+import org.bitcoinj.core.Sha256Hash;
+import org.spongycastle.util.encoders.Base64;
+
+import java.math.BigInteger;
+import java.security.SignatureException;
+import java.util.Arrays;
+
+public class Secp256k1Helper {
+    public static byte[] signatureToAddress(byte[] hash, String signature) throws SignatureException {
+        final byte[] sigDecoded = Base64.decode(signature);
+        final ECKey.ECDSASignature sig = new ECKey.ECDSASignature(
+                new BigInteger(1, Arrays.copyOfRange(sigDecoded, 1, 33)),
+                new BigInteger(1, Arrays.copyOfRange(sigDecoded, 33, 65))
+        );
+        byte header = (byte) (sigDecoded[0] & 0xFF);
+        if (header < 27 || header > 34) {
+            throw new SignatureException("Header byte out of range: " + header);
+        } else if (header >= 31) {
+            header -= 4;
+        }
+        final int recId = header - 27;
+        final ECKey key = ECKey.recoverFromSignature(recId, sig, Sha256Hash.wrap(hash), false);
+        final byte[] pubBytes = key.getPubKey();
+        return org.tron.common.crypto.ECKey.computeAddress(pubBytes);
+    }
+}


### PR DESCRIPTION


**What does this PR do?**
Replaces existing implementation of `signatureToAddress` with `bitcoinj` implementation.

**Why are these changes required?**
`signatureToAddress` function was one of the hot-spots while profiling
full node sync. It seems that bitcoinj implementation of secp256k1 is
much faster. More functions can be ported to use bitcoinj implementation
if needed.


**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**
Benchark comparing `signatureToAddress` function implemented with
`bouncycastle`, `spongycastle` and `bitcoinj` is available at:
https://github.com/tzdybal/secp256k1-java-bench

Results excerpt:
```
Benchmark                                    Mode  Cnt  Score   Error Units
Secp256k1Benchmark.bouncyCastleSigToAddr    thrpt   25  0.621 ± 0.008 ops/ms
Secp256k1Benchmark.libsecp256k1KeyRecovery  thrpt   25  3.061 ± 0.022 ops/ms
Secp256k1Benchmark.spongyCastleSigToAddr    thrpt   25  0.619 ± 0.009 ops/ms
```
