### PR TITLE
not charge bandwidth for cancel deferred transaction

### DIFF
--- a/src/main/java/org/tron/core/actuator/CancelDeferredTransactionContractActuator.java
+++ b/src/main/java/org/tron/core/actuator/CancelDeferredTransactionContractActuator.java
@@ -35,6 +35,7 @@ public class CancelDeferredTransactionContractActuator extends AbstractActuator 
       dbManager.cancelDeferredTransaction(cancelDeferredTransactionContract.getTransactionId());
       dbManager.adjustBalance(getOwnerAddress().toByteArray(), -fee);
       // Add to blackhole address
+      capsule.setStatus(fee, code.SUCESS);
       dbManager.adjustBalance(dbManager.getAccountStore().getBlackhole().createDbKey(), fee);
 
     } catch (BalanceInsufficientException

--- a/src/main/java/org/tron/core/db/BandwidthProcessor.java
+++ b/src/main/java/org/tron/core/db/BandwidthProcessor.java
@@ -1,5 +1,6 @@
 package org.tron.core.db;
 
+import static org.tron.protos.Protocol.Transaction.Contract.ContractType.CancelDeferredTransactionContract;
 import static org.tron.protos.Protocol.Transaction.Contract.ContractType.TransferAssetContract;
 
 import com.google.protobuf.ByteString;
@@ -85,6 +86,9 @@ public class BandwidthProcessor extends ResourceProcessor {
     // charged is true indicates that the deferred transaction is executed for the first time, false indicates that it is executed for the second time
     boolean charged = trx.getDeferredStage() == Constant.UNEXECUTEDDEFERREDTRANSACTION;
     for (Contract contract : contracts) {
+      if (contract.getType() == CancelDeferredTransactionContract) {
+        continue;
+      }
       if (dbManager.getDynamicPropertiesStore().supportVM()) {
         bytesSize += Constant.MAX_RESULT_SIZE_IN_TX;
       }


### PR DESCRIPTION
**What does this PR do?**
hotfix for cancel deferred transaction, not charge bandwidth
**Why are these changes required?**
fix bug for  cancel deferred transaction
