### PR TITLE
Feature/trigger constant contract

### DIFF
--- a/src/main/java/org/tron/core/capsule/TransactionCapsule.java
+++ b/src/main/java/org/tron/core/capsule/TransactionCapsule.java
@@ -67,6 +67,7 @@ import org.tron.protos.Contract.AccountCreateContract;
 import org.tron.protos.Contract.AccountPermissionUpdateContract;
 import org.tron.protos.Contract.AccountUpdateContract;
 import org.tron.protos.Contract.CancelDeferredTransactionContract;
+import org.tron.protos.Contract.ClearABIContract;
 import org.tron.protos.Contract.CreateSmartContract;
 import org.tron.protos.Contract.ExchangeCreateContract;
 import org.tron.protos.Contract.ExchangeInjectContract;
@@ -86,7 +87,6 @@ import org.tron.protos.Contract.UnfreezeBalanceContract;
 import org.tron.protos.Contract.UpdateAssetContract;
 import org.tron.protos.Contract.UpdateEnergyLimitContract;
 import org.tron.protos.Contract.UpdateSettingContract;
-import org.tron.protos.Contract.ClearABIContract;
 import org.tron.protos.Contract.WithdrawBalanceContract;
 import org.tron.protos.Protocol.DeferredStage;
 import org.tron.protos.Protocol.Key;
@@ -568,6 +568,9 @@ public class TransactionCapsule implements ProtoCapsule<Transaction> {
         break;
       case UpdateEnergyLimitContract:
         clazz = UpdateEnergyLimitContract.class;
+        break;
+      case ClearABIContract:
+        clazz = ClearABIContract.class;
         break;
       case ExchangeCreateContract:
         clazz = ExchangeCreateContract.class;


### PR DESCRIPTION
**What does this PR do?**
1. Provide clearContractABI API
2. Provide triggerConstantContract API

**Why are these changes required?**

1. Some developers want to clear the ABI of their contract.
2. Tron network can't know if the function is a constant when the contract's abi had cleared. So provide triggerConstantContract API for call constant contract.

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**
[tronprotocol/TIPs#31](https://github.com/tronprotocol/TIPs/issues/31)
[tronprotocol/TIPs#32](https://github.com/tronprotocol/TIPs/issues/32)