### PR TITLE
Feature/new excodehash

### DIFF
--- a/src/main/java/org/tron/common/runtime/vm/program/ContractState.java
+++ b/src/main/java/org/tron/common/runtime/vm/program/ContractState.java
@@ -111,13 +111,18 @@ public class ContractState implements Deposit, ProgramListenerAware {
   }
 
   @Override
-  public void saveCode(byte[] addr, byte[] code) {
-    deposit.saveCode(addr, code);
+  public void updateContract(byte[] address, ContractCapsule contractCapsule) {
+    deposit.updateContract(address, contractCapsule);
   }
 
   @Override
-  public byte[] getCode(byte[] addr) {
-    return deposit.getCode(addr);
+  public void saveCode(byte[] address, byte[] code) {
+    deposit.saveCode(address, code);
+  }
+
+  @Override
+  public byte[] getCode(byte[] address) {
+    return deposit.getCode(address);
   }
 
   @Override

--- a/src/main/java/org/tron/common/runtime/vm/program/Program.java
+++ b/src/main/java/org/tron/common/runtime/vm/program/Program.java
@@ -398,9 +398,6 @@ public class Program {
           balance);
     }
 
-    if (VMConfig.allowTvmConstantinople() && getContractState().getAccount(obtainer) == null) {
-      return;
-    }
     increaseNonce();
 
     addInternalTx(null, owner, obtainer, balance, null, "suicide", nonce,
@@ -665,14 +662,7 @@ public class Program {
           TransferActuator
               .validateForSmartContract(deposit, senderAddress, contextAddress, endowment);
         } catch (ContractValidateException e) {
-          if (VMConfig.allowTvmConstantinople()) {
-            stackPushZero();
-            refundEnergy(msg.getEnergy().longValue(), "refund energy from message call");
-            return;
-          }
-          else {
-            throw new BytecodeExecutionException(VALIDATE_FOR_SMART_CONTRACT_FAILURE);
-          }
+          throw new BytecodeExecutionException(VALIDATE_FOR_SMART_CONTRACT_FAILURE);
         }
         deposit.addBalance(senderAddress, -endowment);
         contextBalance = deposit.addBalance(contextAddress, endowment);
@@ -681,14 +671,7 @@ public class Program {
           TransferAssetActuator.validateForSmartContract(deposit, senderAddress, contextAddress,
               tokenId, endowment);
         } catch (ContractValidateException e) {
-          if (VMConfig.allowTvmConstantinople()) {
-            stackPushZero();
-            refundEnergy(msg.getEnergy().longValue(), "refund energy from message call");
-            return;
-          }
-          else {
-            throw new BytecodeExecutionException(VALIDATE_FOR_SMART_CONTRACT_FAILURE);
-          }
+          throw new BytecodeExecutionException(VALIDATE_FOR_SMART_CONTRACT_FAILURE);
         }
         deposit.addTokenBalance(senderAddress, tokenId, -endowment);
         deposit.addTokenBalance(contextAddress, tokenId, endowment);
@@ -1381,28 +1364,14 @@ public class Program {
           transfer(deposit, senderAddress, contextAddress,
               msg.getEndowment().value().longValueExact());
         } catch (ContractValidateException e) {
-          if (VMConfig.allowTvmConstantinople()) {
-            stackPushZero();
-            refundEnergy(msg.getEnergy().longValue(), "refund energy from message call");
-            return;
-          }
-          else {
-            throw new BytecodeExecutionException("transfer failure");
-          }
+          throw new BytecodeExecutionException("transfer failure");
         }
       } else {
         try {
           TransferAssetActuator
               .validateForSmartContract(deposit, senderAddress, contextAddress, tokenId, endowment);
         } catch (ContractValidateException e) {
-          if (VMConfig.allowTvmConstantinople()) {
-            stackPushZero();
-            refundEnergy(msg.getEnergy().longValue(), "refund energy from message call");
-            return;
-          }
-          else {
-            throw new BytecodeExecutionException(VALIDATE_FOR_SMART_CONTRACT_FAILURE);
-          }
+          throw new BytecodeExecutionException(VALIDATE_FOR_SMART_CONTRACT_FAILURE);
         }
         deposit.addTokenBalance(senderAddress, tokenId, -endowment);
         deposit.addTokenBalance(contextAddress, tokenId, endowment);

--- a/src/main/java/org/tron/common/runtime/vm/program/Program.java
+++ b/src/main/java/org/tron/common/runtime/vm/program/Program.java
@@ -398,6 +398,9 @@ public class Program {
           balance);
     }
 
+    if (VMConfig.allowTvmConstantinople() && getContractState().getAccount(obtainer) == null) {
+      return;
+    }
     increaseNonce();
 
     addInternalTx(null, owner, obtainer, balance, null, "suicide", nonce,
@@ -662,7 +665,14 @@ public class Program {
           TransferActuator
               .validateForSmartContract(deposit, senderAddress, contextAddress, endowment);
         } catch (ContractValidateException e) {
-          throw new BytecodeExecutionException(VALIDATE_FOR_SMART_CONTRACT_FAILURE);
+          if (VMConfig.allowTvmConstantinople()) {
+            stackPushZero();
+            refundEnergy(msg.getEnergy().longValue(), "refund energy from message call");
+            return;
+          }
+          else {
+            throw new BytecodeExecutionException(VALIDATE_FOR_SMART_CONTRACT_FAILURE);
+          }
         }
         deposit.addBalance(senderAddress, -endowment);
         contextBalance = deposit.addBalance(contextAddress, endowment);
@@ -671,7 +681,14 @@ public class Program {
           TransferAssetActuator.validateForSmartContract(deposit, senderAddress, contextAddress,
               tokenId, endowment);
         } catch (ContractValidateException e) {
-          throw new BytecodeExecutionException(VALIDATE_FOR_SMART_CONTRACT_FAILURE);
+          if (VMConfig.allowTvmConstantinople()) {
+            stackPushZero();
+            refundEnergy(msg.getEnergy().longValue(), "refund energy from message call");
+            return;
+          }
+          else {
+            throw new BytecodeExecutionException(VALIDATE_FOR_SMART_CONTRACT_FAILURE);
+          }
         }
         deposit.addTokenBalance(senderAddress, tokenId, -endowment);
         deposit.addTokenBalance(contextAddress, tokenId, endowment);
@@ -1364,14 +1381,28 @@ public class Program {
           transfer(deposit, senderAddress, contextAddress,
               msg.getEndowment().value().longValueExact());
         } catch (ContractValidateException e) {
-          throw new BytecodeExecutionException("transfer failure");
+          if (VMConfig.allowTvmConstantinople()) {
+            stackPushZero();
+            refundEnergy(msg.getEnergy().longValue(), "refund energy from message call");
+            return;
+          }
+          else {
+            throw new BytecodeExecutionException("transfer failure");
+          }
         }
       } else {
         try {
           TransferAssetActuator
               .validateForSmartContract(deposit, senderAddress, contextAddress, tokenId, endowment);
         } catch (ContractValidateException e) {
-          throw new BytecodeExecutionException(VALIDATE_FOR_SMART_CONTRACT_FAILURE);
+          if (VMConfig.allowTvmConstantinople()) {
+            stackPushZero();
+            refundEnergy(msg.getEnergy().longValue(), "refund energy from message call");
+            return;
+          }
+          else {
+            throw new BytecodeExecutionException(VALIDATE_FOR_SMART_CONTRACT_FAILURE);
+          }
         }
         deposit.addTokenBalance(senderAddress, tokenId, -endowment);
         deposit.addTokenBalance(contextAddress, tokenId, endowment);

--- a/src/main/java/org/tron/common/runtime/vm/program/invoke/ProgramInvokeMockImpl.java
+++ b/src/main/java/org/tron/common/runtime/vm/program/invoke/ProgramInvokeMockImpl.java
@@ -17,6 +17,7 @@
  */
 package org.tron.common.runtime.vm.program.invoke;
 
+import com.google.protobuf.ByteString;
 import org.spongycastle.util.Arrays;
 import org.spongycastle.util.encoders.Hex;
 import org.tron.common.crypto.ECKey;
@@ -59,7 +60,8 @@ public class ProgramInvokeMockImpl implements ProgramInvoke {
     this.deposit.createAccount(ownerAddress, Protocol.AccountType.Normal);
 
     this.deposit.createAccount(contractAddress, Protocol.AccountType.Contract);
-    this.deposit.createContract(contractAddress, new ContractCapsule(SmartContract.newBuilder().build()));
+    this.deposit.createContract(contractAddress, new ContractCapsule(SmartContract.newBuilder().setContractAddress(
+        ByteString.copyFrom(contractAddress)).build()));
     this.deposit.saveCode(contractAddress,
         Hex.decode("385E60076000396000605f556014600054601e60"
             + "205463abcddcba6040545b51602001600a525451"

--- a/src/main/java/org/tron/common/runtime/vm/program/invoke/ProgramInvokeMockImpl.java
+++ b/src/main/java/org/tron/common/runtime/vm/program/invoke/ProgramInvokeMockImpl.java
@@ -26,8 +26,10 @@ import org.tron.common.runtime.vm.program.Program.IllegalOperationException;
 import org.tron.common.storage.Deposit;
 import org.tron.common.storage.DepositImpl;
 import org.tron.core.capsule.BlockCapsule;
+import org.tron.core.capsule.ContractCapsule;
 import org.tron.core.exception.StoreException;
 import org.tron.protos.Protocol;
+import org.tron.protos.Protocol.SmartContract;
 
 
 /**
@@ -57,6 +59,7 @@ public class ProgramInvokeMockImpl implements ProgramInvoke {
     this.deposit.createAccount(ownerAddress, Protocol.AccountType.Normal);
 
     this.deposit.createAccount(contractAddress, Protocol.AccountType.Contract);
+    this.deposit.createContract(contractAddress, new ContractCapsule(SmartContract.newBuilder().build()));
     this.deposit.saveCode(contractAddress,
         Hex.decode("385E60076000396000605f556014600054601e60"
             + "205463abcddcba6040545b51602001600a525451"

--- a/src/main/java/org/tron/common/storage/Deposit.java
+++ b/src/main/java/org/tron/common/storage/Deposit.java
@@ -38,9 +38,11 @@ public interface Deposit {
 
   ContractCapsule getContract(byte[] address);
 
-  void saveCode(byte[] codeHash, byte[] code);
+  void updateContract(byte[] address, ContractCapsule contractCapsule);
 
-  byte[] getCode(byte[] codeHash);
+  void saveCode(byte[] address, byte[] code);
+
+  byte[] getCode(byte[] address);
 
   void putStorageValue(byte[] address, DataWord key, DataWord value);
 

--- a/src/main/java/org/tron/common/storage/DepositImpl.java
+++ b/src/main/java/org/tron/common/storage/DepositImpl.java
@@ -285,7 +285,7 @@ public class DepositImpl implements Deposit {
     Value value = Value.create(code, Type.VALUE_TYPE_CREATE);
     codeCache.put(key, value);
 
-    if (VMConfig.allowTvmConstantinople()) {
+    if (VMConfig.allowTvmConstantinople() ) {
       ContractCapsule contract = getContract(address);
       byte[] codeHash = Hash.sha3(code);
       contract.setCodeHash(codeHash);

--- a/src/main/java/org/tron/common/storage/DepositImpl.java
+++ b/src/main/java/org/tron/common/storage/DepositImpl.java
@@ -285,10 +285,12 @@ public class DepositImpl implements Deposit {
     Value value = Value.create(code, Type.VALUE_TYPE_CREATE);
     codeCache.put(key, value);
 
-    ContractCapsule contract = getContract(address);
-    byte[] codeHash = Hash.sha3(code);
-    contract.setCodeHash(codeHash);
-    updateContract(address, contract);
+    if (VMConfig.allowTvmConstantinople()) {
+      ContractCapsule contract = getContract(address);
+      byte[] codeHash = Hash.sha3(code);
+      contract.setCodeHash(codeHash);
+      updateContract(address, contract);
+    }
   }
 
   @Override

--- a/src/main/java/org/tron/common/storage/DepositImpl.java
+++ b/src/main/java/org/tron/common/storage/DepositImpl.java
@@ -285,7 +285,7 @@ public class DepositImpl implements Deposit {
     Value value = Value.create(code, Type.VALUE_TYPE_CREATE);
     codeCache.put(key, value);
 
-    if (VMConfig.allowTvmConstantinople() ) {
+    if (VMConfig.allowTvmConstantinople()) {
       ContractCapsule contract = getContract(address);
       byte[] codeHash = Hash.sha3(code);
       contract.setCodeHash(codeHash);

--- a/src/main/java/org/tron/core/capsule/ContractCapsule.java
+++ b/src/main/java/org/tron/core/capsule/ContractCapsule.java
@@ -16,9 +16,9 @@
 package org.tron.core.capsule;
 
 import com.google.protobuf.Any;
+import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import lombok.extern.slf4j.Slf4j;
-import org.tron.common.utils.Sha256Hash;
 import org.tron.core.Constant;
 import org.tron.protos.Contract.CreateSmartContract;
 import org.tron.protos.Contract.TriggerSmartContract;
@@ -69,14 +69,12 @@ public class ContractCapsule implements ProtoCapsule<SmartContract> {
     }
   }
 
-  public Sha256Hash getHash() {
-    byte[] transBytes = this.smartContract.toByteArray();
-    return Sha256Hash.of(transBytes);
+  public byte[] getCodeHash() {
+    return this.smartContract.getCodeHash().toByteArray();
   }
 
-  public Sha256Hash getCodeHash() {
-    byte[] bytecode = smartContract.getBytecode().toByteArray();
-    return Sha256Hash.of(bytecode);
+  public void setCodeHash(byte[] codeHash) {
+    this.smartContract = this.smartContract.toBuilder().setCodeHash(ByteString.copyFrom(codeHash)).build();
   }
 
   @Override

--- a/src/main/protos/core/Tron.proto
+++ b/src/main/protos/core/Tron.proto
@@ -559,7 +559,7 @@ message SmartContract {
   int64 consume_user_resource_percent = 6;
   string name = 7;
   int64 origin_energy_limit = 8;
-
+  bytes code_hash = 9;
 }
 
 message InternalTransaction {


### PR DESCRIPTION
**What does this PR do?**
save codehash when deploying a contract and query the codehash of contract without codehash firstly

**Why are these changes required?**
saving codehash can reduce time of getting codehash of a contract

**This PR has been tested by:**
- Unit Tests : ExtCodeHashTest.java
- Manual Testing

**Follow up**

**Extra details**
https://github.com/tronprotocol/TIPs/issues/30

