### PR TITLE
fix unfreezeDelegate error

### DIFF
--- a/src/main/java/org/tron/core/actuator/FreezeBalanceActuator.java
+++ b/src/main/java/org/tron/core/actuator/FreezeBalanceActuator.java
@@ -18,6 +18,7 @@ import org.tron.core.db.Manager;
 import org.tron.core.exception.ContractExeException;
 import org.tron.core.exception.ContractValidateException;
 import org.tron.protos.Contract.FreezeBalanceContract;
+import org.tron.protos.Protocol.AccountType;
 import org.tron.protos.Protocol.Transaction.Result.code;
 
 @Slf4j(topic = "actuator")
@@ -187,6 +188,13 @@ public class FreezeBalanceActuator extends AbstractActuator {
         String readableOwnerAddress = StringUtil.createReadableString(receiverAddress);
         throw new ContractValidateException(
             "Account[" + readableOwnerAddress + "] not exists");
+      }
+
+      if (dbManager.getDynamicPropertiesStore().getAllowTvmConstantinople() == 1
+          && receiverCapsule.getType() == AccountType.Contract) {
+        throw new ContractValidateException(
+            "Do not allow delegate resources to contract addresses");
+
       }
 
     }

--- a/src/test/java/org/tron/core/actuator/UnfreezeBalanceActuatorTest.java
+++ b/src/test/java/org/tron/core/actuator/UnfreezeBalanceActuatorTest.java
@@ -313,6 +313,108 @@ public class UnfreezeBalanceActuatorTest {
     }
   }
 
+  @Test
+  public void testUnfreezeDelegatedBalanceForBandwidthWithDeletedReceiver() {
+
+    dbManager.getDynamicPropertiesStore().saveAllowDelegateResource(1);
+    long now = System.currentTimeMillis();
+    dbManager.getDynamicPropertiesStore().saveLatestBlockHeaderTimestamp(now);
+
+    AccountCapsule owner = dbManager.getAccountStore()
+        .get(ByteArray.fromHexString(OWNER_ADDRESS));
+    owner.setDelegatedFrozenBalanceForBandwidth(frozenBalance);
+    Assert.assertEquals(frozenBalance, owner.getTronPower());
+
+    AccountCapsule receiver = dbManager.getAccountStore()
+        .get(ByteArray.fromHexString(RECEIVER_ADDRESS));
+    receiver.setAcquiredDelegatedFrozenBalanceForBandwidth(frozenBalance);
+    Assert.assertEquals(0L, receiver.getTronPower());
+
+    dbManager.getAccountStore().put(owner.createDbKey(), owner);
+
+    //init DelegatedResourceCapsule
+    DelegatedResourceCapsule delegatedResourceCapsule = new DelegatedResourceCapsule(
+        owner.getAddress(),
+        receiver.getAddress()
+    );
+    delegatedResourceCapsule.setFrozenBalanceForBandwidth(
+        frozenBalance,
+        now - 100L);
+    dbManager.getDelegatedResourceStore().put(DelegatedResourceCapsule
+        .createDbKey(ByteArray.fromHexString(OWNER_ADDRESS),
+            ByteArray.fromHexString(RECEIVER_ADDRESS)), delegatedResourceCapsule);
+
+    //init DelegatedResourceAccountIndex
+    {
+      DelegatedResourceAccountIndexCapsule delegatedResourceAccountIndex = new DelegatedResourceAccountIndexCapsule(
+          owner.getAddress());
+      delegatedResourceAccountIndex
+          .addToAccount(ByteString.copyFrom(ByteArray.fromHexString(RECEIVER_ADDRESS)));
+      dbManager.getDelegatedResourceAccountIndexStore()
+          .put(ByteArray.fromHexString(OWNER_ADDRESS), delegatedResourceAccountIndex);
+    }
+
+    {
+      DelegatedResourceAccountIndexCapsule delegatedResourceAccountIndex = new DelegatedResourceAccountIndexCapsule(
+          receiver.getAddress());
+      delegatedResourceAccountIndex
+          .addFromAccount(ByteString.copyFrom(ByteArray.fromHexString(OWNER_ADDRESS)));
+      dbManager.getDelegatedResourceAccountIndexStore()
+          .put(ByteArray.fromHexString(RECEIVER_ADDRESS), delegatedResourceAccountIndex);
+    }
+
+    UnfreezeBalanceActuator actuator = new UnfreezeBalanceActuator(
+        getDelegatedContractForBandwidth(OWNER_ADDRESS, RECEIVER_ADDRESS), dbManager);
+    TransactionResultCapsule ret = new TransactionResultCapsule();
+
+
+
+    dbManager.getDynamicPropertiesStore().saveAllowTvmConstantinople(0);
+    dbManager.getAccountStore().delete(receiver.createDbKey());
+    try {
+      actuator.validate();
+      actuator.execute(ret);
+    } catch (ContractValidateException e) {
+      Assert.assertEquals(e.getMessage(),"Account[a0abd4b9367799eaa3197fecb144eb71de1e049150] not exists");
+    } catch (ContractExeException e) {
+      Assert.assertFalse(e instanceof ContractExeException);
+    }
+
+    dbManager.getDynamicPropertiesStore().saveAllowTvmConstantinople(1);
+    try {
+      actuator.validate();
+      actuator.execute(ret);
+      Assert.assertEquals(ret.getInstance().getRet(), code.SUCESS);
+      AccountCapsule ownerResult =
+          dbManager.getAccountStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
+
+      Assert.assertEquals(initBalance + frozenBalance, ownerResult.getBalance());
+      Assert.assertEquals(0L, ownerResult.getTronPower());
+      Assert.assertEquals(0L, ownerResult.getDelegatedFrozenBalanceForBandwidth());
+
+      //check DelegatedResourceAccountIndex
+      DelegatedResourceAccountIndexCapsule delegatedResourceAccountIndexCapsuleOwner = dbManager
+          .getDelegatedResourceAccountIndexStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
+      Assert
+          .assertEquals(0, delegatedResourceAccountIndexCapsuleOwner.getFromAccountsList().size());
+      Assert.assertEquals(0, delegatedResourceAccountIndexCapsuleOwner.getToAccountsList().size());
+
+      DelegatedResourceAccountIndexCapsule delegatedResourceAccountIndexCapsuleReceiver = dbManager
+          .getDelegatedResourceAccountIndexStore().get(ByteArray.fromHexString(RECEIVER_ADDRESS));
+      Assert
+          .assertEquals(0, delegatedResourceAccountIndexCapsuleReceiver.getToAccountsList().size());
+      Assert
+          .assertEquals(0,
+              delegatedResourceAccountIndexCapsuleReceiver.getFromAccountsList().size());
+
+    } catch (ContractValidateException e) {
+      logger.error("",e);
+      Assert.assertFalse(e instanceof ContractValidateException);
+    } catch (ContractExeException e) {
+      Assert.assertFalse(e instanceof ContractExeException);
+    }
+
+  }
 
   /**
    * when SameTokenName close,delegate balance frozen, unfreoze show error
@@ -384,7 +486,6 @@ public class UnfreezeBalanceActuatorTest {
     }
   }
 
-
   @Test
   public void testUnfreezeDelegatedBalanceForCpu() {
     dbManager.getDynamicPropertiesStore().saveAllowDelegateResource(1);
@@ -402,7 +503,7 @@ public class UnfreezeBalanceActuatorTest {
     Assert.assertEquals(0L, receiver.getTronPower());
 
     dbManager.getAccountStore().put(owner.createDbKey(), owner);
-    dbManager.getAccountStore().put(receiver.createDbKey(), receiver);
+    dbManager.getAccountStore().put(receiver.createDbKey(),receiver);
 
     DelegatedResourceCapsule delegatedResourceCapsule = new DelegatedResourceCapsule(
         owner.getAddress(),
@@ -433,6 +534,72 @@ public class UnfreezeBalanceActuatorTest {
       Assert.assertEquals(0L, ownerResult.getTronPower());
       Assert.assertEquals(0L, ownerResult.getDelegatedFrozenBalanceForEnergy());
       Assert.assertEquals(0L, receiverResult.getAllFrozenBalanceForEnergy());
+    } catch (ContractValidateException e) {
+      logger.error("",e);
+      Assert.assertFalse(e instanceof ContractValidateException);
+    } catch (ContractExeException e) {
+      Assert.assertFalse(e instanceof ContractExeException);
+    }
+  }
+
+  @Test
+  public void testUnfreezeDelegatedBalanceForCpuWithDeletedReceiver() {
+    dbManager.getDynamicPropertiesStore().saveAllowDelegateResource(1);
+    long now = System.currentTimeMillis();
+    dbManager.getDynamicPropertiesStore().saveLatestBlockHeaderTimestamp(now);
+
+    AccountCapsule owner = dbManager.getAccountStore()
+        .get(ByteArray.fromHexString(OWNER_ADDRESS));
+    owner.addDelegatedFrozenBalanceForEnergy(frozenBalance);
+    Assert.assertEquals(frozenBalance, owner.getTronPower());
+
+    AccountCapsule receiver = dbManager.getAccountStore()
+        .get(ByteArray.fromHexString(RECEIVER_ADDRESS));
+    receiver.addAcquiredDelegatedFrozenBalanceForEnergy(frozenBalance);
+    Assert.assertEquals(0L, receiver.getTronPower());
+
+    dbManager.getAccountStore().put(owner.createDbKey(), owner);
+
+    DelegatedResourceCapsule delegatedResourceCapsule = new DelegatedResourceCapsule(
+        owner.getAddress(),
+        receiver.getAddress()
+    );
+    delegatedResourceCapsule.setFrozenBalanceForEnergy(
+        frozenBalance,
+        now - 100L);
+    dbManager.getDelegatedResourceStore().put(DelegatedResourceCapsule
+        .createDbKey(ByteArray.fromHexString(OWNER_ADDRESS),
+            ByteArray.fromHexString(RECEIVER_ADDRESS)), delegatedResourceCapsule);
+
+    UnfreezeBalanceActuator actuator = new UnfreezeBalanceActuator(
+        getDelegatedContractForCpu(OWNER_ADDRESS, RECEIVER_ADDRESS), dbManager);
+    TransactionResultCapsule ret = new TransactionResultCapsule();
+
+
+    dbManager.getDynamicPropertiesStore().saveAllowTvmConstantinople(0);
+    dbManager.getAccountStore().delete(receiver.createDbKey());
+
+    try {
+      actuator.validate();
+      actuator.execute(ret);
+    } catch (ContractValidateException e) {
+      Assert.assertEquals(e.getMessage(),"Account[a0abd4b9367799eaa3197fecb144eb71de1e049150] not exists");
+    } catch (ContractExeException e) {
+      Assert.assertFalse(e instanceof ContractExeException);
+    }
+
+    dbManager.getDynamicPropertiesStore().saveAllowTvmConstantinople(1);
+
+    try {
+      actuator.validate();
+      actuator.execute(ret);
+      Assert.assertEquals(ret.getInstance().getRet(), code.SUCESS);
+      AccountCapsule ownerResult =
+          dbManager.getAccountStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
+
+      Assert.assertEquals(initBalance + frozenBalance, ownerResult.getBalance());
+      Assert.assertEquals(0L, ownerResult.getTronPower());
+      Assert.assertEquals(0L, ownerResult.getDelegatedFrozenBalanceForEnergy());
     } catch (ContractValidateException e) {
       Assert.assertFalse(e instanceof ContractValidateException);
     } catch (ContractExeException e) {


### PR DESCRIPTION
**What does this PR do?**
It is forbidden to delegate resources to contract accounts and to modify the verification when there is a system contract at the time of unfreezing resource.

**Why are these changes required?**
Fix the problem of delegating the resource to the contract account and the resource cannot be thawed after the contract account is suicided.

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

