### PR TITLE
Enable shadowJar for jitpack dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ apply plugin: "jacoco"
 apply plugin: 'maven-publish'
 
 jar.enabled = false
-shadowJar.enabled = false
+shadowJar.enabled = true
 
 sourceCompatibility = 1.8
 [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'


### PR DESCRIPTION
Enable shadowJar for jitpack dependency

**What does this PR do?**
Restore shadowJar build

**Why are these changes required?**
So that java-tron can be used as dependency with jitpack

**This PR has been tested by:**
Unit Tests
Manual Testing


