### PR TITLE
Hide creating witness apis for Shasta

### DIFF
--- a/src/main/java/org/tron/core/config/args/Args.java
+++ b/src/main/java/org/tron/core/config/args/Args.java
@@ -956,9 +956,8 @@ public class Args {
             : Runtime.getRuntime().availableProcessors();
 
     INSTANCE.isOneWitness =
-            config.hasPath("node.isOneWitness") ? config
-                    .getBoolean("node.isOneWitness")
-                    : false;
+            config.hasPath("node.isOneWitness") && config
+                    .getBoolean("node.isOneWitness");
 
     initBackupProperty(config);
     if ("ROCKSDB".equals(Args.getInstance().getStorage().getDbEngine().toUpperCase())) {

--- a/src/main/java/org/tron/core/config/args/Args.java
+++ b/src/main/java/org/tron/core/config/args/Args.java
@@ -470,6 +470,10 @@ public class Args {
   @Setter
   private int validContractProtoThreadNum;
 
+  @Getter
+  @Setter
+  private boolean isOneWitness;
+
   public static void clearParam() {
     INSTANCE.outputDirectory = "output-directory";
     INSTANCE.help = false;
@@ -950,6 +954,11 @@ public class Args {
         config.hasPath("node.validContractProto.threads") ? config
             .getInt("node.validContractProto.threads")
             : Runtime.getRuntime().availableProcessors();
+
+    INSTANCE.isOneWitness =
+            config.hasPath("node.isOneWitness") ? config
+                    .getBoolean("node.isOneWitness")
+                    : false;
 
     initBackupProperty(config);
     if ("ROCKSDB".equals(Args.getInstance().getStorage().getDbEngine().toUpperCase())) {

--- a/src/main/java/org/tron/core/db/KhaosDatabase.java
+++ b/src/main/java/org/tron/core/db/KhaosDatabase.java
@@ -14,6 +14,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javafx.util.Pair;
 import lombok.Getter;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -26,8 +28,10 @@ import org.tron.core.exception.NonCommonBlockException;
 import org.tron.core.exception.UnLinkedBlockException;
 
 @Component
+@Slf4j(topic = "DB")
 public class KhaosDatabase extends TronDatabase {
 
+  @ToString
   public static class KhaosBlock {
 
     public Sha256Hash getParentHash() {
@@ -74,6 +78,7 @@ public class KhaosDatabase extends TronDatabase {
     }
   }
 
+  @ToString
   public class KhaosStore {
 
     private HashMap<BlockId, KhaosBlock> hashKblkMap = new HashMap<>();
@@ -233,6 +238,7 @@ public class KhaosDatabase extends TronDatabase {
         }
         block.setParent(kblock);
       } else {
+        logger.error("debug khaos head:{}, block:{}, miniStore:{}", head, blk, miniStore);
         miniUnlinkedStore.insert(block);
         throw new UnLinkedBlockException();
       }

--- a/src/main/java/org/tron/core/db/Manager.java
+++ b/src/main/java/org/tron/core/db/Manager.java
@@ -981,7 +981,20 @@ public class Manager {
         witnessService.checkDupWitness(block);
       }
 
-      BlockCapsule newBlock = this.khaosDb.push(block);
+      BlockCapsule newBlock = null;
+      try {
+        newBlock = this.khaosDb.push(block);
+      } catch (UnLinkedBlockException e) {
+        logger.error("debug khaos block:{}, dy head num:{}, dy head hash:{}, dy head ts:{}, khaosdb head:{}, khaosdb ministore size:{}",
+                block,
+                dynamicPropertiesStore.getLatestBlockHeaderNumber(),
+                dynamicPropertiesStore.getLatestBlockHeaderHash(),
+                dynamicPropertiesStore.getLatestBlockHeaderTimestamp(),
+                khaosDb.getHead(),
+                khaosDb.getMiniStore().size()
+        );
+        throw e;
+      }
 
       // DB don't need lower block
       if (getDynamicPropertiesStore().getLatestBlockHeaderHash() == null) {

--- a/src/main/java/org/tron/core/services/RpcApiService.java
+++ b/src/main/java/org/tron/core/services/RpcApiService.java
@@ -969,6 +969,7 @@ public class RpcApiService implements Service {
           logger.debug("ContractValidateException: {}", e.getMessage());
         }
       } else {
+        logger.info("Not Allow to create witness (Grpc): " + isOneWitness);
         responseObserver.onNext(null);
       }
       responseObserver.onCompleted();
@@ -979,6 +980,10 @@ public class RpcApiService implements Service {
         StreamObserver<TransactionExtention> responseObserver) {
       if (!isOneWitness) {
         createTransactionExtention(request, ContractType.WitnessCreateContract, responseObserver);
+      } else {
+        logger.info("Not Allow to create witness2 (Grpc): " + isOneWitness);
+        responseObserver.onNext(null);
+        responseObserver.onCompleted();
       }
     }
 

--- a/src/main/java/org/tron/core/services/RpcApiService.java
+++ b/src/main/java/org/tron/core/services/RpcApiService.java
@@ -107,6 +107,7 @@ import org.tron.protos.Protocol.TransactionSign;
 public class RpcApiService implements Service {
 
   private int port = Args.getInstance().getRpcPort();
+  private boolean isOneWitness = Args.getInstance().isOneWitness();
   private Server apiServer;
 
   @Autowired
@@ -958,13 +959,17 @@ public class RpcApiService implements Service {
     @Override
     public void createWitness(WitnessCreateContract request,
         StreamObserver<Transaction> responseObserver) {
-      try {
-        responseObserver.onNext(
-            createTransactionCapsule(request, ContractType.WitnessCreateContract).getInstance());
-      } catch (ContractValidateException e) {
-        responseObserver
-            .onNext(null);
-        logger.debug("ContractValidateException: {}", e.getMessage());
+      if (!isOneWitness) {
+        try {
+          responseObserver.onNext(
+                  createTransactionCapsule(request, ContractType.WitnessCreateContract).getInstance());
+        } catch (ContractValidateException e) {
+          responseObserver
+                  .onNext(null);
+          logger.debug("ContractValidateException: {}", e.getMessage());
+        }
+      } else {
+        responseObserver.onNext(null);
       }
       responseObserver.onCompleted();
     }
@@ -972,7 +977,9 @@ public class RpcApiService implements Service {
     @Override
     public void createWitness2(WitnessCreateContract request,
         StreamObserver<TransactionExtention> responseObserver) {
-      createTransactionExtention(request, ContractType.WitnessCreateContract, responseObserver);
+      if (!isOneWitness) {
+        createTransactionExtention(request, ContractType.WitnessCreateContract, responseObserver);
+      }
     }
 
     @Override

--- a/src/main/java/org/tron/core/services/http/FullNodeHttpApiService.java
+++ b/src/main/java/org/tron/core/services/http/FullNodeHttpApiService.java
@@ -185,6 +185,9 @@ public class FullNodeHttpApiService implements Service {
       context.setContextPath("/wallet/");
       server.setHandler(context);
 
+      boolean isOneWitness = Args.getInstance().isOneWitness();
+      logger.info("useOneWitness", isOneWitness);
+
       context.addServlet(new ServletHolder(getAccountServlet), "/getaccount");
       context.addServlet(new ServletHolder(transferServlet), "/createtransaction");
       context.addServlet(new ServletHolder(broadcastServlet), "/broadcasttransaction");
@@ -194,7 +197,6 @@ public class FullNodeHttpApiService implements Service {
       context.addServlet(new ServletHolder(createAssetIssueServlet), "/createassetissue");
       context.addServlet(new ServletHolder(updateWitnessServlet), "/updatewitness");
       context.addServlet(new ServletHolder(createAccountServlet), "/createaccount");
-      context.addServlet(new ServletHolder(createWitnessServlet), "/createwitness");
       context.addServlet(new ServletHolder(transferAssetServlet), "/transferasset");
       context.addServlet(new ServletHolder(participateAssetIssueServlet), "/participateassetissue");
       context.addServlet(new ServletHolder(freezeBalanceServlet), "/freezebalance");
@@ -274,6 +276,11 @@ public class FullNodeHttpApiService implements Service {
           "/getdelegatedresourceaccountindex");
       context.addServlet(new ServletHolder(setAccountServlet), "/setaccountid");
       context.addServlet(new ServletHolder(getAccountByIdServlet), "/getaccountbyid");
+
+      if (!isOneWitness) {
+        logger.info("here is witness", isOneWitness);
+        context.addServlet(new ServletHolder(createWitnessServlet), "/createwitness");
+      }
 
       int maxHttpConnectNumber = Args.getInstance().getMaxHttpConnectNumber();
       if (maxHttpConnectNumber > 0) {

--- a/src/main/java/org/tron/core/services/http/FullNodeHttpApiService.java
+++ b/src/main/java/org/tron/core/services/http/FullNodeHttpApiService.java
@@ -186,7 +186,6 @@ public class FullNodeHttpApiService implements Service {
       server.setHandler(context);
 
       boolean isOneWitness = Args.getInstance().isOneWitness();
-      logger.info("useOneWitness", isOneWitness);
 
       context.addServlet(new ServletHolder(getAccountServlet), "/getaccount");
       context.addServlet(new ServletHolder(transferServlet), "/createtransaction");
@@ -278,7 +277,7 @@ public class FullNodeHttpApiService implements Service {
       context.addServlet(new ServletHolder(getAccountByIdServlet), "/getaccountbyid");
 
       if (!isOneWitness) {
-        logger.info("here is witness", isOneWitness);
+        logger.info("Allow to create witness: ", isOneWitness);
         context.addServlet(new ServletHolder(createWitnessServlet), "/createwitness");
       }
 

--- a/src/main/java/org/tron/core/services/http/FullNodeHttpApiService.java
+++ b/src/main/java/org/tron/core/services/http/FullNodeHttpApiService.java
@@ -277,8 +277,9 @@ public class FullNodeHttpApiService implements Service {
       context.addServlet(new ServletHolder(getAccountByIdServlet), "/getaccountbyid");
 
       if (!isOneWitness) {
-        logger.info("Allow to create witness: ", isOneWitness);
         context.addServlet(new ServletHolder(createWitnessServlet), "/createwitness");
+      } else {
+        logger.info("Not Allow to create witness (Http): " + isOneWitness);
       }
 
       int maxHttpConnectNumber = Args.getInstance().getMaxHttpConnectNumber();

--- a/src/main/java/org/tron/program/Version.java
+++ b/src/main/java/org/tron/program/Version.java
@@ -2,8 +2,8 @@ package org.tron.program;
 
 public class Version {
   private static final String version = "3.6.0";
-  public static final String versionName = "Odyssey-v3.5.1-890-gd39973cbb";
-  public static final String versionCode = "10803";
+  public static final String versionName = "Odyssey-v3.5.1-900-g7fe0ed20d";
+  public static final String versionCode = "10813";
 
   public static String getVersion() {
     return version;


### PR DESCRIPTION
**What does this PR do?**
Use isOneWitness in the config.conf to control if user can create witness for shasta network.

**Why are these changes required?**
Since shasta won't allow user to create SR, we should hide those create witness api.

**This PR has been tested by:**
- Unit Tests
No
- Manual Testing
Test Env: Private Net

Http API (Postman)
Scenario1: When isOneWitness = true
Expected Result: Should return 405 http code and write log info.
Actual Result: Return 405 (Method is not supported by this URL) and write log info.

Scenario2: When isOneWitness = false || isOneWitness is empty
Expected Result: Should execute original Java-Tron create witness logic.
Actual Result: Can execute witness original logic.

Grpc API (Grpcc client tool)
Scenario1: When isOneWitness = true
Expected Result: Should return null transaction.
Actual Result: Return null transaction.

Scenario2: When isOneWitness = false || isOneWitness is empty
Expected Result: Should execute original Java-Tron create witness logic.
Actual Result: Can execute witness original logic.

**Follow up**

**Extra details**

