### PR TITLE
fix unfreeze for delegate and to account had recreated

### DIFF
--- a/src/main/java/org/tron/core/actuator/UnfreezeBalanceActuator.java
+++ b/src/main/java/org/tron/core/actuator/UnfreezeBalanceActuator.java
@@ -50,7 +50,6 @@ public class UnfreezeBalanceActuator extends AbstractActuator {
     long oldBalance = accountCapsule.getBalance();
 
     long unfreezeBalance = 0L;
-    ;
 
     byte[] receiverAddress = unfreezeBalanceContract.getReceiverAddress().toByteArray();
     //If the receiver is not included in the contract, unfreeze frozen balance for this account.
@@ -83,10 +82,20 @@ public class UnfreezeBalanceActuator extends AbstractActuator {
           (receiverCapsule != null && receiverCapsule.getType() != AccountType.Contract)) {
         switch (unfreezeBalanceContract.getResource()) {
           case BANDWIDTH:
-            receiverCapsule.addAcquiredDelegatedFrozenBalanceForBandwidth(-unfreezeBalance);
+            if (dbManager.getDynamicPropertiesStore().supportShieldedTransaction()
+                    && receiverCapsule.getAcquiredDelegatedFrozenBalanceForBandwidth() < unfreezeBalance) {
+              receiverCapsule.setAcquiredDelegatedFrozenBalanceForBandwidth(0);
+            } else {
+              receiverCapsule.addAcquiredDelegatedFrozenBalanceForBandwidth(-unfreezeBalance);
+            }
             break;
           case ENERGY:
-            receiverCapsule.addAcquiredDelegatedFrozenBalanceForEnergy(-unfreezeBalance);
+            if (dbManager.getDynamicPropertiesStore().supportShieldedTransaction()
+                    && receiverCapsule.getAcquiredDelegatedFrozenBalanceForEnergy() < unfreezeBalance) {
+              receiverCapsule.setAcquiredDelegatedFrozenBalanceForEnergy(0);
+            } else {
+              receiverCapsule.addAcquiredDelegatedFrozenBalanceForEnergy(-unfreezeBalance);
+            }
             break;
           default:
             //this should never happen
@@ -175,11 +184,11 @@ public class UnfreezeBalanceActuator extends AbstractActuator {
     switch (unfreezeBalanceContract.getResource()) {
       case BANDWIDTH:
         dbManager.getDynamicPropertiesStore()
-            .addTotalNetWeight(-unfreezeBalance / 1000_000L);
+            .addTotalNetWeight(-unfreezeBalance / 1_000_000L);
         break;
       case ENERGY:
         dbManager.getDynamicPropertiesStore()
-            .addTotalEnergyWeight(-unfreezeBalance / 1000_000L);
+            .addTotalEnergyWeight(-unfreezeBalance / 1_000_000L);
         break;
       default:
         //this should never happen
@@ -285,15 +294,17 @@ public class UnfreezeBalanceActuator extends AbstractActuator {
                       + "]");
             }
           } else {
-            if (receiverCapsule != null && receiverCapsule.getType() != AccountType.Contract
-                && receiverCapsule.getAcquiredDelegatedFrozenBalanceForBandwidth()
-                < delegatedResourceCapsule.getFrozenBalanceForBandwidth()) {
-              throw new ContractValidateException(
-                  "AcquiredDelegatedFrozenBalanceForBandwidth[" + receiverCapsule
-                      .getAcquiredDelegatedFrozenBalanceForBandwidth() + "] < delegatedBandwidth["
-                      + delegatedResourceCapsule.getFrozenBalanceForBandwidth()
-                      + "]");
-            }
+              if (!dbManager.getDynamicPropertiesStore().supportShieldedTransaction()
+                  && receiverCapsule != null
+                  && receiverCapsule.getType() != AccountType.Contract
+                  && receiverCapsule.getAcquiredDelegatedFrozenBalanceForBandwidth()
+                      < delegatedResourceCapsule.getFrozenBalanceForBandwidth()) {
+                  throw new ContractValidateException(
+                          "AcquiredDelegatedFrozenBalanceForBandwidth[" + receiverCapsule
+                                  .getAcquiredDelegatedFrozenBalanceForBandwidth() + "] < delegatedBandwidth["
+                                  + delegatedResourceCapsule.getFrozenBalanceForBandwidth()
+                                  + "]");
+              }
           }
 
           if (delegatedResourceCapsule.getExpireTimeForBandwidth() > now) {
@@ -314,14 +325,16 @@ public class UnfreezeBalanceActuator extends AbstractActuator {
                       "]");
             }
           } else {
-            if (receiverCapsule != null && receiverCapsule.getType() != AccountType.Contract
+            if (!dbManager.getDynamicPropertiesStore().supportShieldedTransaction()
+                && receiverCapsule != null
+                && receiverCapsule.getType() != AccountType.Contract
                 && receiverCapsule.getAcquiredDelegatedFrozenBalanceForEnergy()
-                < delegatedResourceCapsule.getFrozenBalanceForEnergy()) {
-              throw new ContractValidateException(
-                  "AcquiredDelegatedFrozenBalanceForEnergy[" + receiverCapsule
-                      .getAcquiredDelegatedFrozenBalanceForEnergy() + "] < delegatedEnergy["
-                      + delegatedResourceCapsule.getFrozenBalanceForEnergy() +
-                      "]");
+                    < delegatedResourceCapsule.getFrozenBalanceForEnergy()) {
+                throw new ContractValidateException(
+                        "AcquiredDelegatedFrozenBalanceForEnergy[" + receiverCapsule
+                                .getAcquiredDelegatedFrozenBalanceForEnergy() + "] < delegatedEnergy["
+                                + delegatedResourceCapsule.getFrozenBalanceForEnergy() +
+                                "]");
             }
           }
 

--- a/src/main/java/org/tron/core/capsule/AccountCapsule.java
+++ b/src/main/java/org/tron/core/capsule/AccountCapsule.java
@@ -342,6 +342,15 @@ public class AccountCapsule implements ProtoCapsule<Account>, Comparable<Account
     return getAccountResource().getAcquiredDelegatedFrozenBalanceForEnergy();
   }
 
+  public void setAcquiredDelegatedFrozenBalanceForEnergy(long balance) {
+    AccountResource newAccountResource = getAccountResource().toBuilder()
+            .setAcquiredDelegatedFrozenBalanceForEnergy(balance).build();
+
+    this.account = this.account.toBuilder()
+            .setAccountResource(newAccountResource)
+            .build();
+  }
+
   public long getDelegatedFrozenBalanceForEnergy() {
     return getAccountResource().getDelegatedFrozenBalanceForEnergy();
   }


### PR DESCRIPTION
**What does this PR do?**
fix UnfreezeBalance for delegate. when to account had been deleted and recreated can't UnfreezeBalance.

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

