### PR TITLE
Change method name 'build' to 'createApplication', 'size' to 'getStreamCount'

### DIFF
--- a/src/main/java/org/tron/common/application/ApplicationFactory.java
+++ b/src/main/java/org/tron/common/application/ApplicationFactory.java
@@ -22,7 +22,7 @@ public class ApplicationFactory {
   /**
    * Build a new application.
    */
-  public Application build() {
+  public Application createApplication() {
     return new ApplicationImpl();
   }
 

--- a/src/main/java/org/tron/core/db/Manager.java
+++ b/src/main/java/org/tron/core/db/Manager.java
@@ -632,7 +632,7 @@ public class Manager {
     }
     long start = System.currentTimeMillis();
     long headNum = dynamicPropertiesStore.getLatestBlockHeaderNumber();
-    long recentBlockCount = recentBlockStore.size();
+    long recentBlockCount = recentBlockStore.getStreamCount();
     ListeningExecutorService service = MoreExecutors
         .listeningDecorator(Executors.newFixedThreadPool(50));
     List<ListenableFuture<?>> futures = new ArrayList<>();
@@ -668,7 +668,7 @@ public class Manager {
     }
 
     logger.info("end to init txs cache. trxids:{}, block count:{}, empty block count:{}, cost:{}",
-        transactionCache.size(),
+        transactionCache.getStreamCount(),
         blockCount.get(),
         emptyBlockCount.get(),
         System.currentTimeMillis() - start

--- a/src/main/java/org/tron/core/db/TronStoreWithRevoking.java
+++ b/src/main/java/org/tron/core/db/TronStoreWithRevoking.java
@@ -151,7 +151,7 @@ public abstract class TronStoreWithRevoking<T extends ProtoCapsule> implements I
     });
   }
 
-  public long size() {
+  public long getStreamCount() {
     return Streams.stream(revokingDB.iterator()).count();
   }
 

--- a/src/main/java/org/tron/core/db/accountstate/storetrie/AccountStateStoreTrie.java
+++ b/src/main/java/org/tron/core/db/accountstate/storetrie/AccountStateStoreTrie.java
@@ -48,7 +48,7 @@ public class AccountStateStoreTrie extends TronStoreWithRevoking<BytesCapsule> i
 
   @Override
   public boolean isEmpty() {
-    return super.size() <= 0;
+    return super.getStreamCount() <= 0;
   }
 
   @Override

--- a/src/test/java/org/tron/core/db/ManagerTest.java
+++ b/src/test/java/org/tron/core/db/ManagerTest.java
@@ -223,7 +223,7 @@ public class ManagerTest {
       TransactionExpirationException, TooBigTransactionException, DupTransactionException,
       BadBlockException, TaposException, BadNumberBlockException, NonCommonBlockException, ReceiptCheckErrException, VMIllegalException, TooBigTransactionResultException, ZksnarkException {
     Args.setParam(new String[]{"--witness"}, Constant.TEST_CONF);
-    long size = dbManager.getBlockStore().size();
+    long size = dbManager.getBlockStore().getStreamCount();
     System.out.print("block store size:" + size + "\n");
     String key = "f31db24bfbd1a2ef19beddca0a0fa37632eded9ac666a05d3bd925f01dde1f62";
     byte[] privateKey = ByteArray.fromHexString(key);
@@ -269,7 +269,7 @@ public class ManagerTest {
         dbManager.getBlockStore().get(blockCapsule2.getBlockId().getBytes()).getParentHash(),
         blockCapsule1.getBlockId());
 
-    Assert.assertEquals(dbManager.getBlockStore().size(), size + 3);
+    Assert.assertEquals(dbManager.getBlockStore().getStreamCount(), size + 3);
 
     Assert.assertEquals(
         dbManager.getBlockIdByNum(dbManager.getHead().getNum() - 1),
@@ -296,7 +296,7 @@ public class ManagerTest {
       TaposException, BadNumberBlockException, NonCommonBlockException,
       ReceiptCheckErrException, VMIllegalException, TooBigTransactionResultException, ZksnarkException {
     Args.setParam(new String[]{"--witness"}, Constant.TEST_CONF);
-    long size = dbManager.getBlockStore().size();
+    long size = dbManager.getBlockStore().getStreamCount();
     System.out.print("block store size:" + size + "\n");
     String key = "f31db24bfbd1a2ef19beddca0a0fa37632eded9ac666a05d3bd925f01dde1f62";
     byte[] privateKey = ByteArray.fromHexString(key);
@@ -397,7 +397,7 @@ public class ManagerTest {
       ReceiptCheckErrException, VMIllegalException,
       TooBigTransactionResultException {
     Args.setParam(new String[]{"--witness"}, Constant.TEST_CONF);
-    long size = dbManager.getBlockStore().size();
+    long size = dbManager.getBlockStore().getStreamCount();
     System.out.print("block store size:" + size + "\n");
     String key = "f31db24bfbd1a2ef19beddca0a0fa37632eded9ac666a05d3bd925f01dde1f62";
     byte[] privateKey = ByteArray.fromHexString(key);
@@ -423,7 +423,7 @@ public class ManagerTest {
       TransactionExpirationException, TooBigTransactionException, DupTransactionException,
       BadBlockException, TaposException, BadNumberBlockException, NonCommonBlockException, ReceiptCheckErrException, VMIllegalException, TooBigTransactionResultException, ZksnarkException {
     Args.setParam(new String[]{"--witness"}, Constant.TEST_CONF);
-    long size = dbManager.getBlockStore().size();
+    long size = dbManager.getBlockStore().getStreamCount();
     System.out.print("block store size:" + size + "\n");
     String key = "f31db24bfbd1a2ef19beddca0a0fa37632eded9ac666a05d3bd925f01dde1f62";
     byte[] privateKey = ByteArray.fromHexString(key);


### PR DESCRIPTION
The class ApplicationFactory is used to represent ApplicationFactory.  This method named 'build' is to create an instance of the application. Thus, the method name 'createApplication' is more intuitive than 'build'.

The class TronStoreWithRevoking is used to represent TronStoreWithRevoking.  This method named 'size' is to count number of streams. Thus, the method name 'getStreamCount' is more intuitive than 'size'.