### PR TITLE
Fix the NullPointerException when a static call throws OutOfTimeException 

### DIFF
--- a/src/main/java/org/tron/common/runtime/RuntimeImpl.java
+++ b/src/main/java/org/tron/common/runtime/RuntimeImpl.java
@@ -702,7 +702,9 @@ public class RuntimeImpl implements Runtime {
       }
       logger.info("runtime result is :{}", result.getException().getMessage());
     }
-    trace.setBill(result.getEnergyUsed());
+    if (!isStaticCall) {
+      trace.setBill(result.getEnergyUsed());
+    }
   }
 
   private static long getEnergyFee(long callerEnergyUsage, long callerEnergyFrozen,


### PR DESCRIPTION
**What does this PR do?**
check static before setBill function fix the NullPointerException when a static call throws OutOfTimeException 
**Why are these changes required?**
NullPointerException should not appear when static call
**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

