### PR TITLE
let the multivalidatesign return byte32

### DIFF
--- a/src/main/java/org/tron/common/runtime/utils/MUtil.java
+++ b/src/main/java/org/tron/common/runtime/utils/MUtil.java
@@ -1,15 +1,10 @@
 package org.tron.common.runtime.utils;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
 import org.tron.common.storage.Deposit;
 import org.tron.core.Wallet;
 import org.tron.core.actuator.TransferActuator;
 import org.tron.core.actuator.TransferAssetActuator;
 import org.tron.core.capsule.AccountCapsule;
-import org.tron.core.config.args.Account;
 import org.tron.core.exception.ContractValidateException;
 import org.tron.protos.Protocol;
 
@@ -63,4 +58,13 @@ public class MUtil {
     }
     return address;
   }
+
+  public static byte[] allZero32TronAddress() {
+    byte[] newAddress = new byte[32];
+    byte[] temp = new byte[]{Wallet.getAddressPreFixByte()};
+    System.arraycopy(temp, 0, newAddress, 11, temp.length);
+
+    return newAddress;
+  }
+
 }

--- a/src/main/java/org/tron/common/runtime/vm/DataWord.java
+++ b/src/main/java/org/tron/common/runtime/vm/DataWord.java
@@ -45,7 +45,7 @@ public class DataWord implements Comparable<DataWord> {
   public static final BigInteger _2_256 = BigInteger.valueOf(2).pow(256);
   public static final BigInteger MAX_VALUE = _2_256.subtract(BigInteger.ONE);
   // TODO not safe
-  public static final DataWord ZERO = new DataWord(new byte[32]);      // don't push it in to the stack
+  public static final DataWord ZERO = new DataWord(new byte[WORD_SIZE]);      // don't push it in to the stack
 
   public static DataWord ONE() {
     return DataWord.of((byte)1);

--- a/src/main/java/org/tron/common/runtime/vm/PrecompiledContracts.java
+++ b/src/main/java/org/tron/common/runtime/vm/PrecompiledContracts.java
@@ -1384,8 +1384,8 @@ public class PrecompiledContracts {
         }
       } else {
         // add check
-        CountDownLatch countDownLatch = new CountDownLatch(cnt);
-        List<Future<ValidateSignResult>> futures = new ArrayList<>(cnt);
+        CountDownLatch countDownLatch = new CountDownLatch(min);
+        List<Future<ValidateSignResult>> futures = new ArrayList<>(min);
 
         for (int i = 0; i < min; i++) {
           Future<ValidateSignResult> future = workers
@@ -1408,6 +1408,9 @@ public class PrecompiledContracts {
       byte[] r;
       byte[] s;
       DataWord out = null;
+      if (sign.length < 65) {
+        return false;
+      }
       try {
         r = Arrays.copyOfRange(sign, 0, 32);
         s = Arrays.copyOfRange(sign, 32, 64);
@@ -1422,7 +1425,7 @@ public class PrecompiledContracts {
           }
         }
       } catch (Throwable any) {
-        logger.info("ECRecover error", any);
+        logger.info("ECRecover error", any.getMessage());
       }
       return out != null && Arrays.equals(new DataWord(address).getLast20Bytes(),
           out.getLast20Bytes());

--- a/src/main/java/org/tron/common/runtime/vm/PrecompiledContracts.java
+++ b/src/main/java/org/tron/common/runtime/vm/PrecompiledContracts.java
@@ -1332,7 +1332,7 @@ public class PrecompiledContracts {
     private static final ExecutorService workers;
     private static final int ENGERYPERSIGN = 1500;
     private static final byte[] ZEROADDR = MUtil.allZero32TronAddress();
-    private static final byte[] EMPTYADDR = new byte[32];
+    private static final byte[] EMPTYADDR = new byte[DataWord.WORD_SIZE];
 
     static {
       workers = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors() / 2);

--- a/src/main/java/org/tron/common/runtime/vm/PrecompiledContracts.java
+++ b/src/main/java/org/tron/common/runtime/vm/PrecompiledContracts.java
@@ -1371,7 +1371,7 @@ public class PrecompiledContracts {
       byte[][] addresses = extractBytes32Array(words, words[2].intValueSafe() / DataWord.WORD_SIZE);
       int cnt = signatures.length;
       if (cnt == 0 || signatures.length != addresses.length) {
-        return Pair.of(true, new DataWord(Longs.toByteArray(0)).getData());
+        return Pair.of(true, new byte[DataWord.WORD_SIZE]);
       }
       int min = Math.min(cnt, DataWord.WORD_SIZE);
       byte[] res = new byte[DataWord.WORD_SIZE];

--- a/src/main/java/org/tron/common/runtime/vm/program/Program.java
+++ b/src/main/java/org/tron/common/runtime/vm/program/Program.java
@@ -1451,6 +1451,7 @@ public class Program {
       contract.setDeposit(deposit);
       contract.setResult(this.result);
       contract.setStaticCall(isStaticCall());
+      contract.setVmShouldEndInUs(getVmShouldEndInUs());
       Pair<Boolean, byte[]> out = contract.execute(data);
 
       if (out.getLeft()) { // success

--- a/src/test/java/org/tron/common/runtime/vm/MultiValidateSignContractTest.java
+++ b/src/test/java/org/tron/common/runtime/vm/MultiValidateSignContractTest.java
@@ -58,6 +58,30 @@ public class MultiValidateSignContractTest {
         Assert.assertEquals(ret.getValue()[i], 1);
       }
     }
+    signatures = new ArrayList<>();
+    addresses = new ArrayList<>();
+
+    //test when length >= 32
+    for (int i = 0; i < 100; i++) {
+      ECKey key = new ECKey();
+      byte[] sign = key.sign(hash).toByteArray();
+      if (i == 30) {
+        signatures.add(Hex.toHexString(DataWord.ONE().getData()));
+      } else {
+        signatures.add(Hex.toHexString(sign));
+      }
+      addresses.add(Wallet.encode58Check(key.getAddress()));
+    }
+    ret = validateMultiSign(hash, signatures, addresses);
+    Assert.assertEquals(ret.getValue().length, 32);
+    for (int i = 0; i < 32; i++) {
+      if (i == 30) {
+        Assert.assertEquals(ret.getValue()[i], 0);
+      } else {
+        Assert.assertEquals(ret.getValue()[i], 1);
+      }
+    }
+
   }
 
   @Test
@@ -77,7 +101,7 @@ public class MultiValidateSignContractTest {
       }
       addresses.add(Wallet.encode58Check(key.getAddress()));
     }
-    Pair<Boolean, byte[]> ret;
+    Pair<Boolean, byte[]> ret = null;
     ret = validateMultiSign(hash, signatures, addresses);
     for (int i = 0; i < 27; i++) {
       if (i >= 27) {
@@ -88,6 +112,7 @@ public class MultiValidateSignContractTest {
         Assert.assertEquals(ret.getValue()[i], 1);
       }
     }
+
     // incorrect hash
     byte[] incorrectHash = DataWord.ONE().getData();
     ret = validateMultiSign(incorrectHash, signatures, addresses);
@@ -100,6 +125,29 @@ public class MultiValidateSignContractTest {
     incorrectSigns.remove(incorrectSigns.size() - 1);
     ret = validateMultiSign(hash, incorrectSigns, addresses);
     Assert.assertEquals(ret.getValue(), DataWord.ZERO().getData());
+
+    //test when length >= 32
+    signatures = new ArrayList<>();
+    addresses = new ArrayList<>();
+    for (int i = 0; i < 80; i++) {
+      ECKey key = new ECKey();
+      byte[] sign = key.sign(hash).toByteArray();
+      if (i == 13) {
+        signatures.add(Hex.toHexString(DataWord.ONE().getData()));
+      } else {
+        signatures.add(Hex.toHexString(sign));
+      }
+      addresses.add(Wallet.encode58Check(key.getAddress()));
+    }
+    ret = validateMultiSign(hash, signatures, addresses);
+    Assert.assertEquals(ret.getValue().length, 32);
+    for (int i = 0; i < 32; i++) {
+      if (i == 13) {
+        Assert.assertEquals(ret.getValue()[i], 0);
+      } else {
+        Assert.assertEquals(ret.getValue()[i], 1);
+      }
+    }
 
   }
 


### PR DESCRIPTION
let the multivalidatesign return byte32
static call multivalidatesign don't use thread pool
modify test

**What does this PR do?**

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

