### PR TITLE
Http/add data field

### DIFF
--- a/framework/src/main/java/org/tron/core/services/http/TransferAssetServlet.java
+++ b/framework/src/main/java/org/tron/core/services/http/TransferAssetServlet.java
@@ -38,6 +38,7 @@ public class TransferAssetServlet extends RateLimiterServlet {
           .getInstance();
       JSONObject jsonObject = JSONObject.parseObject(contract);
       tx = Util.setTransactionPermissionId(jsonObject, tx);
+      tx = Util.setTransactionExtraData(jsonObject, tx);
       response.getWriter().println(Util.printCreateTransaction(tx, visible));
     } catch (Exception e) {
       logger.debug("Exception: {}", e.getMessage());

--- a/framework/src/main/java/org/tron/core/services/http/TransferServlet.java
+++ b/framework/src/main/java/org/tron/core/services/http/TransferServlet.java
@@ -37,6 +37,7 @@ public class TransferServlet extends RateLimiterServlet {
           .getInstance();
       JSONObject jsonObject = JSONObject.parseObject(contract);
       tx = Util.setTransactionPermissionId(jsonObject, tx);
+      tx = Util.setTransactionExtraData(jsonObject, tx);
       response.getWriter().println(Util.printCreateTransaction(tx, visible));
     } catch (Exception e) {
       logger.debug("Exception: {}", e.getMessage());

--- a/framework/src/main/java/org/tron/core/services/http/TriggerConstantContractServlet.java
+++ b/framework/src/main/java/org/tron/core/services/http/TriggerConstantContractServlet.java
@@ -84,6 +84,7 @@ public class TriggerConstantContractServlet extends RateLimiterServlet {
               trxExtBuilder,
               retBuilder);
       trx = Util.setTransactionPermissionId(jsonObject, trx);
+      trx = Util.setTransactionExtraData(jsonObject, trx);
       trxExtBuilder.setTransaction(trx);
       retBuilder.setResult(true).setCode(response_code.SUCCESS);
     } catch (ContractValidateException e) {

--- a/framework/src/main/java/org/tron/core/services/http/Util.java
+++ b/framework/src/main/java/org/tron/core/services/http/Util.java
@@ -15,6 +15,7 @@ import java.security.InvalidParameterException;
 import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
+import org.spongycastle.util.encoders.Base64;
 import org.eclipse.jetty.util.StringUtil;
 import org.pf4j.util.StringUtils;
 import org.spongycastle.util.encoders.Hex;
@@ -46,6 +47,7 @@ public class Util {
   public static final String TRANSACTION = "transaction";
   public static final String VALUE = "value";
   public static final String CONTRACT_TYPE = "contractType";
+  public static final String EXTRA_DATA = "extra_data";
 
   public static String printErrorMsg(Exception e) {
     JSONObject jsonObject = new JSONObject();
@@ -326,6 +328,19 @@ public class Util {
             .setPermissionId(permissionId);
         raw.clearContract();
         raw.addContract(contract);
+        return transaction.toBuilder().setRawData(raw).build();
+      }
+    }
+    return transaction;
+  }
+
+  public static Transaction setTransactionExtraData(JSONObject jsonObject,
+      Transaction transaction) {
+    if (jsonObject.containsKey(EXTRA_DATA)) {
+      String data = jsonObject.getString(EXTRA_DATA);
+      if (data.length() > 0) {
+        Transaction.raw.Builder raw = transaction.getRawData().toBuilder();
+        raw.setData(ByteString.copyFrom(Base64.decode(data)));
         return transaction.toBuilder().setRawData(raw).build();
       }
     }

--- a/framework/src/test/java/stest/tron/wallet/common/client/utils/HttpMethed.java
+++ b/framework/src/test/java/stest/tron/wallet/common/client/utils/HttpMethed.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
+import org.spongycastle.util.encoders.Base64;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpPost;
@@ -282,6 +283,31 @@ public class HttpMethed {
       return null;
     }
     return response;
+  }
+
+  /**
+   * constructor.
+   */
+  public static String sendCoin(String httpNode, byte[] fromAddress, byte[] toAddress,
+      Long amount, String notes, String fromKey) {
+    try {
+      final String requestUrl = "http://" + httpNode + "/wallet/createtransaction";
+      JsonObject userBaseObj2 = new JsonObject();
+      userBaseObj2.addProperty("to_address", ByteArray.toHexString(toAddress));
+      userBaseObj2.addProperty("owner_address", ByteArray.toHexString(fromAddress));
+      userBaseObj2.addProperty("amount", amount);
+      userBaseObj2.addProperty("extra_data", Base64.toBase64String(notes.getBytes()));
+      response = createConnect(requestUrl, userBaseObj2);
+      transactionString = EntityUtils.toString(response.getEntity());
+      transactionSignString = gettransactionsign(httpNode, transactionString, fromKey);
+      response = broadcastTransaction(httpNode, transactionSignString);
+    } catch (Exception e) {
+      e.printStackTrace();
+      httppost.releaseConnection();
+      return null;
+    }
+    responseContent = HttpMethed.parseStringContent(transactionString);
+    return responseContent.getString("txID");
   }
 
   /**

--- a/framework/src/test/java/stest/tron/wallet/dailybuild/http/HttpTestAccount005.java
+++ b/framework/src/test/java/stest/tron/wallet/dailybuild/http/HttpTestAccount005.java
@@ -1,0 +1,62 @@
+package stest.tron.wallet.dailybuild.http;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONObject;
+import org.spongycastle.util.encoders.Base64;
+import org.tron.common.utils.ByteUtil;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.http.HttpResponse;
+import org.junit.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+import org.tron.common.crypto.ECKey;
+import org.tron.common.utils.ByteArray;
+import org.tron.common.utils.Utils;
+import stest.tron.wallet.common.client.Configuration;
+import stest.tron.wallet.common.client.utils.HttpMethed;
+import stest.tron.wallet.common.client.utils.PublicMethed;
+
+@Slf4j
+public class HttpTestAccount005 {
+
+  private final String testKey002 = Configuration.getByPath("testng.conf")
+      .getString("foundationAccount.key1");
+  private final byte[] fromAddress = PublicMethed.getFinalAddress(testKey002);
+  ECKey ecKey1 = new ECKey(Utils.getRandom());
+  byte[] toAddress = ecKey1.getAddress();
+  String toAddressKey = ByteArray.toHexString(ecKey1.getPrivKeyBytes());
+  Long amount = 1L;
+  String sendText = "Decentralize the WEB!";
+  private JSONObject responseContent;
+  private String httpnode = Configuration.getByPath("testng.conf").getStringList("httpnode.ip.list")
+      .get(0);
+
+  /**
+   * constructor.
+   */
+  @Test(enabled = true, description = "Test transfer with notes by http")
+  public void test01TransferWithNotes() {
+    PublicMethed.printAddress(toAddressKey);
+    //Send trx to test account
+    String txid = HttpMethed.sendCoin(httpnode, fromAddress, toAddress, amount, sendText, testKey002);
+    HttpMethed.waitToProduceOneBlock(httpnode);
+    HttpResponse response = HttpMethed.getTransactionById(httpnode, txid);
+    responseContent = HttpMethed.parseResponseContent(response);
+    HttpMethed.printJsonContent(responseContent);
+    String rawData = responseContent.getString("raw_data");
+    JSONObject rawDataObject = JSON.parseObject(rawData);
+    Assert.assertTrue(rawDataObject.containsKey("data"));
+    String hexData = rawDataObject.getString("data");
+    String recoveredString  = new String(ByteUtil.hexToBytes(hexData));
+    Assert.assertEquals(sendText,recoveredString);
+  }
+
+  /**
+   * constructor.
+   */
+  @AfterClass
+  public void shutdown() throws InterruptedException {
+    HttpMethed.freedResource(httpnode, toAddress, fromAddress, toAddressKey);
+    HttpMethed.disConnect();
+  }
+}


### PR DESCRIPTION
**What does this PR do?**
Add data (optional) field on http api transactions (transfer/transfer assets/triggersmartcontract)

**Why are these changes required?**
We are using tronweb with http API and we want to add extra data to transactions.
Transaction DATA field is not available on HTTP API transaction builder.

**This PR has been tested by:**
- Unit Tests (Yes)
- Manual Testing (Yes)

**Follow up**
telegran: @fbsobreia

**Extra details**
We have a new feature to be release in our product that makes use of the data field.
Our MVP works already works with local build transactions but the use of tronweb/http api transaction builder will speed up release

Several other developer have been asking for this feature in discord channel.


