### PR TITLE
merge params of libsodium into one class

### DIFF
--- a/chainbase/src/main/java/org/tron/common/zksnark/JLibsodium.java
+++ b/chainbase/src/main/java/org/tron/common/zksnark/JLibsodium.java
@@ -1,80 +1,91 @@
 package org.tron.common.zksnark;
 
 import org.tron.common.utils.DBConfig;
-
+import org.tron.common.zksnark.JLibsodiumParam.Black2bSaltPersonalParams;
+import org.tron.common.zksnark.JLibsodiumParam.Blake2bFinalParams;
+import org.tron.common.zksnark.JLibsodiumParam.Blake2bInitSaltPersonalParams;
+import org.tron.common.zksnark.JLibsodiumParam.Blake2bUpdateParams;
+import org.tron.common.zksnark.JLibsodiumParam.Chacha20Poly1305IetfEncryptParams;
+import org.tron.common.zksnark.JLibsodiumParam.Chacha20poly1305IetfDecryptParams;
 
 public class JLibsodium {
-
-  public static final int crypto_generichash_blake2b_PERSONALBYTES = 16;
-  public static final int crypto_aead_chacha20poly1305_IETF_NPUBBYTES = 12;
+  
+  public static final int CRYPTO_GENERICHASH_BLAKE2B_PERSONALBYTES = 16;
+  public static final int CRYPTO_AEAD_CHACHA20POLY1305_IETF_NPUBBYTES = 12;
   private static Libsodium INSTANCE;
-
-  public static int cryptoGenerichashBlake2bInitSaltPersonal(
-      long state, byte[] key, int keylen, int outlen, byte[] salt, byte[] personal) {
+  
+  public static int cryptoGenerichashBlake2bInitSaltPersonal(Blake2bInitSaltPersonalParams params) {
     if (!isOpenZen()) {
       return 0;
     }
     return INSTANCE
-        .cryptoGenerichashBlake2BInitSaltPersonal(state, key, keylen, outlen, salt, personal);
+            .cryptoGenerichashBlake2BInitSaltPersonal(params.getState(), params.getKey(),
+                    params.getKeyLen(), params.getOutLen(), params.getSalt(), params.getPersonal());
   }
-
-  public static int cryptoGenerichashBlake2bUpdate(
-      long state, byte[] in, long inlen) {
-    if (!isOpenZen()) {
-      return 0;
-    }
-    return INSTANCE.cryptoGenerichashBlake2BUpdate(state, in, inlen);
-  }
-
-  public static int cryptoGenerichashBlake2bFinal(
-      long state, byte[] out, int outlen) {
-    if (!isOpenZen()) {
-      return 0;
-    }
-    return INSTANCE.cryptoGenerichashBlake2BFinal(state, out, outlen);
-  }
-
-  public static int cryptoGenerichashBlack2bSaltPersonal(byte[] out, int outlen, byte[] in,
-      long inlen, byte[] key, int keylen, byte[] salt, byte[] personal) {
-    if (!isOpenZen()) {
-      return 0;
-    }
-    return INSTANCE.cryptoGenerichashBlake2BSaltPersonal(out, outlen, in, inlen, key, keylen, salt,
-        personal);
-  }
-
-  public static int cryptoAeadChacha20poly1305IetfDecrypt(byte[] m, long[] mlen_p, byte[] nsec,
-      byte[] c, long clen, byte[] ad, long adlen, byte[] npub, byte[] k) {
+  
+  public static int cryptoGenerichashBlake2bUpdate(Blake2bUpdateParams params) {
     if (!isOpenZen()) {
       return 0;
     }
     return INSTANCE
-        .cryptoAeadChacha20Poly1305IetfDecrypt(m, mlen_p, nsec, c, clen, ad, adlen, npub, k);
+            .cryptoGenerichashBlake2BUpdate(params.getState(), params.getIn(), params.getInLen());
   }
-
-  public static int cryptoAeadChacha20Poly1305IetfEncrypt(byte[] c, long[] clen_p, byte[] m,
-      long mlen, byte[] ad, long adlen, byte[] nsec, byte[] npub, byte[] k) {
+  
+  public static int cryptoGenerichashBlake2bFinal(Blake2bFinalParams params) {
+    if (!isOpenZen()) {
+      return 0;
+    }
+    return INSTANCE.cryptoGenerichashBlake2BFinal(params.getState(),
+            params.getOut(), params.getOutLen());
+  }
+  
+  public static int cryptoGenerichashBlack2bSaltPersonal(Black2bSaltPersonalParams params) {
+    if (!isOpenZen()) {
+      return 0;
+    }
+    return INSTANCE.cryptoGenerichashBlake2BSaltPersonal(params.getOut(), params.getOutLen(),
+            params.getIn(), params.getInLen(), params.getKey(), params.getKeyLen(),
+            params.getSalt(),
+            params.getPersonal());
+  }
+  
+  public static int cryptoAeadChacha20poly1305IetfDecrypt(
+          Chacha20poly1305IetfDecryptParams params) {
     if (!isOpenZen()) {
       return 0;
     }
     return INSTANCE
-        .cryptoAeadChacha20Poly1305IetfEncrypt(c, clen_p, m, mlen, ad, adlen, nsec, npub, k);
+            .cryptoAeadChacha20Poly1305IetfDecrypt(params.getM(), params.getMLenP(),
+                    params.getNSec(),
+                    params.getC(), params.getCLen(), params.getAd(),
+                    params.getAdLen(), params.getNPub(), params.getK());
   }
-
+  
+  public static int cryptoAeadChacha20Poly1305IetfEncrypt(
+          Chacha20Poly1305IetfEncryptParams params) {
+    if (!isOpenZen()) {
+      return 0;
+    }
+    return INSTANCE
+            .cryptoAeadChacha20Poly1305IetfEncrypt(params.getC(), params.getCLenP(), params.getM(),
+                    params.getMLen(), params.getAd(), params.getAdLen(),
+                    params.getNSec(), params.getNPub(), params.getK());
+  }
+  
   public static long initState() {
     if (!isOpenZen()) {
       return 0;
     }
     return INSTANCE.cryptoGenerichashBlake2BStateInit();
   }
-
+  
   public static void freeState(long state) {
     if (!isOpenZen()) {
       return;
     }
     INSTANCE.cryptoGenerichashBlake2BStateFree(state);
   }
-
+  
   private static boolean isOpenZen() {
     boolean res = DBConfig.isFullNodeAllowShieldedTransaction();
     if (res) {

--- a/chainbase/src/main/java/org/tron/common/zksnark/JLibsodium.java
+++ b/chainbase/src/main/java/org/tron/common/zksnark/JLibsodium.java
@@ -9,83 +9,83 @@ import org.tron.common.zksnark.JLibsodiumParam.Chacha20Poly1305IetfEncryptParams
 import org.tron.common.zksnark.JLibsodiumParam.Chacha20poly1305IetfDecryptParams;
 
 public class JLibsodium {
-  
+
   public static final int CRYPTO_GENERICHASH_BLAKE2B_PERSONALBYTES = 16;
   public static final int CRYPTO_AEAD_CHACHA20POLY1305_IETF_NPUBBYTES = 12;
   private static Libsodium INSTANCE;
-  
+
   public static int cryptoGenerichashBlake2bInitSaltPersonal(Blake2bInitSaltPersonalParams params) {
     if (!isOpenZen()) {
       return 0;
     }
     return INSTANCE
-            .cryptoGenerichashBlake2BInitSaltPersonal(params.getState(), params.getKey(),
-                    params.getKeyLen(), params.getOutLen(), params.getSalt(), params.getPersonal());
+        .cryptoGenerichashBlake2BInitSaltPersonal(params.getState(), params.getKey(),
+            params.getKeyLen(), params.getOutLen(), params.getSalt(), params.getPersonal());
   }
-  
+
   public static int cryptoGenerichashBlake2bUpdate(Blake2bUpdateParams params) {
     if (!isOpenZen()) {
       return 0;
     }
     return INSTANCE
-            .cryptoGenerichashBlake2BUpdate(params.getState(), params.getIn(), params.getInLen());
+        .cryptoGenerichashBlake2BUpdate(params.getState(), params.getIn(), params.getInLen());
   }
-  
+
   public static int cryptoGenerichashBlake2bFinal(Blake2bFinalParams params) {
     if (!isOpenZen()) {
       return 0;
     }
     return INSTANCE.cryptoGenerichashBlake2BFinal(params.getState(),
-            params.getOut(), params.getOutLen());
+        params.getOut(), params.getOutLen());
   }
-  
+
   public static int cryptoGenerichashBlack2bSaltPersonal(Black2bSaltPersonalParams params) {
     if (!isOpenZen()) {
       return 0;
     }
     return INSTANCE.cryptoGenerichashBlake2BSaltPersonal(params.getOut(), params.getOutLen(),
-            params.getIn(), params.getInLen(), params.getKey(), params.getKeyLen(),
-            params.getSalt(),
-            params.getPersonal());
+        params.getIn(), params.getInLen(), params.getKey(), params.getKeyLen(),
+        params.getSalt(),
+        params.getPersonal());
   }
-  
+
   public static int cryptoAeadChacha20poly1305IetfDecrypt(
-          Chacha20poly1305IetfDecryptParams params) {
+      Chacha20poly1305IetfDecryptParams params) {
     if (!isOpenZen()) {
       return 0;
     }
     return INSTANCE
-            .cryptoAeadChacha20Poly1305IetfDecrypt(params.getM(), params.getMLenP(),
-                    params.getNSec(),
-                    params.getC(), params.getCLen(), params.getAd(),
-                    params.getAdLen(), params.getNPub(), params.getK());
+        .cryptoAeadChacha20Poly1305IetfDecrypt(params.getM(), params.getMLenP(),
+            params.getNSec(),
+            params.getC(), params.getCLen(), params.getAd(),
+            params.getAdLen(), params.getNPub(), params.getK());
   }
-  
+
   public static int cryptoAeadChacha20Poly1305IetfEncrypt(
-          Chacha20Poly1305IetfEncryptParams params) {
+      Chacha20Poly1305IetfEncryptParams params) {
     if (!isOpenZen()) {
       return 0;
     }
     return INSTANCE
-            .cryptoAeadChacha20Poly1305IetfEncrypt(params.getC(), params.getCLenP(), params.getM(),
-                    params.getMLen(), params.getAd(), params.getAdLen(),
-                    params.getNSec(), params.getNPub(), params.getK());
+        .cryptoAeadChacha20Poly1305IetfEncrypt(params.getC(), params.getCLenP(), params.getM(),
+            params.getMLen(), params.getAd(), params.getAdLen(),
+            params.getNSec(), params.getNPub(), params.getK());
   }
-  
+
   public static long initState() {
     if (!isOpenZen()) {
       return 0;
     }
     return INSTANCE.cryptoGenerichashBlake2BStateInit();
   }
-  
+
   public static void freeState(long state) {
     if (!isOpenZen()) {
       return;
     }
     INSTANCE.cryptoGenerichashBlake2BStateFree(state);
   }
-  
+
   private static boolean isOpenZen() {
     boolean res = DBConfig.isFullNodeAllowShieldedTransaction();
     if (res) {

--- a/chainbase/src/main/java/org/tron/common/zksnark/JLibsodiumParam.java
+++ b/chainbase/src/main/java/org/tron/common/zksnark/JLibsodiumParam.java
@@ -6,33 +6,33 @@ import org.tron.common.utils.ByteUtil;
 import org.tron.core.exception.ZksnarkException;
 
 public class JLibsodiumParam {
-  
+
   interface ValidParam {
-    
+
     void valid() throws ZksnarkException;
   }
-  
+
   public static void validNull(byte[] value) throws ZksnarkException {
     if (ByteUtil.isNullOrZeroArray(value)) {
       throw new ZksnarkException("param is null");
     }
   }
-  
+
   public static void validValueParams(long value) throws ZksnarkException {
     if (value < 0) {
       throw new ZksnarkException("Value should be non-negative.");
     }
   }
-  
+
   public static void validParamLength(byte[] value, int length) throws ZksnarkException {
     validNull(value);
     if (value.length != length) {
       throw new ZksnarkException("param length must be " + length);
     }
   }
-  
+
   public static class Blake2bInitSaltPersonalParams implements ValidParam {
-    
+
     @Setter
     @Getter
     private long state;
@@ -51,28 +51,28 @@ public class JLibsodiumParam {
     @Setter
     @Getter
     private byte[] personal;
-    
+
     public Blake2bInitSaltPersonalParams(long state, byte[] key, int keyLen, int outLen,
-            byte[] salt, byte[] personal) throws ZksnarkException {
+        byte[] salt, byte[] personal) throws ZksnarkException {
       this.state = state;
       this.key = key;
       this.keyLen = keyLen;
       this.outLen = outLen;
       this.salt = salt;
       this.personal = personal;
-      
+
       valid();
     }
-    
+
     @Override
     public void valid() throws ZksnarkException {
       validValueParams(state);
       validParamLength(personal, 16);
     }
   }
-  
+
   public static class Blake2bUpdateParams implements ValidParam {
-    
+
     @Setter
     @Getter
     private long state;
@@ -82,15 +82,15 @@ public class JLibsodiumParam {
     @Setter
     @Getter
     private long inLen;
-    
+
     public Blake2bUpdateParams(long state, byte[] in, long inLen) throws ZksnarkException {
       this.state = state;
       this.in = in;
       this.inLen = inLen;
-      
+
       valid();
     }
-    
+
     @Override
     public void valid() throws ZksnarkException {
       validValueParams(state);
@@ -99,9 +99,9 @@ public class JLibsodiumParam {
       }
     }
   }
-  
+
   public static class Blake2bFinalParams implements ValidParam {
-    
+
     @Setter
     @Getter
     private long state;
@@ -111,15 +111,15 @@ public class JLibsodiumParam {
     @Setter
     @Getter
     private int outLen;
-    
+
     public Blake2bFinalParams(long state, byte[] out, int outLen) throws ZksnarkException {
       this.state = state;
       this.out = out;
       this.outLen = outLen;
-      
+
       valid();
     }
-    
+
     @Override
     public void valid() throws ZksnarkException {
       validValueParams(state);
@@ -128,9 +128,9 @@ public class JLibsodiumParam {
       }
     }
   }
-  
+
   public static class Black2bSaltPersonalParams implements ValidParam {
-    
+
     @Setter
     @Getter
     private byte[] out;
@@ -155,10 +155,10 @@ public class JLibsodiumParam {
     @Setter
     @Getter
     private byte[] personal;
-    
-    
+
+
     public Black2bSaltPersonalParams(byte[] out, int outLen, byte[] in, long inLen, byte[] key,
-            int keyLen, byte[] salt, byte[] personal) throws ZksnarkException {
+        int keyLen, byte[] salt, byte[] personal) throws ZksnarkException {
       this.out = out;
       this.outLen = outLen;
       this.in = in;
@@ -167,23 +167,23 @@ public class JLibsodiumParam {
       this.keyLen = keyLen;
       this.salt = salt;
       this.personal = personal;
-      
+
       valid();
     }
-    
+
     @Override
     public void valid() throws ZksnarkException {
       if (out.length != outLen || in.length != inLen) {
         throw new ZksnarkException("out.length is not equal to outlen "
-                + "or in.length is not equal to inlen");
+            + "or in.length is not equal to inlen");
       }
       validParamLength(out, 32);
       validParamLength(personal, 16);
     }
   }
-  
+
   public static class Chacha20poly1305IetfDecryptParams implements ValidParam {
-    
+
     @Setter
     @Getter
     private byte[] m;
@@ -211,9 +211,9 @@ public class JLibsodiumParam {
     @Setter
     @Getter
     private byte[] k;
-    
+
     public Chacha20poly1305IetfDecryptParams(byte[] m, long[] mLenP, byte[] nSec, byte[] c,
-            long cLen, byte[] ad, long adLen, byte[] nPub, byte[] k) throws ZksnarkException {
+        long cLen, byte[] ad, long adLen, byte[] nPub, byte[] k) throws ZksnarkException {
       this.m = m;
       this.mLenP = mLenP;
       this.nSec = nSec;
@@ -223,19 +223,19 @@ public class JLibsodiumParam {
       this.adLen = adLen;
       this.nPub = nPub;
       this.k = k;
-      
+
       valid();
     }
-    
+
     @Override
     public void valid() throws ZksnarkException {
       validParamLength(nPub, 12);
       validParamLength(k, 32);
     }
   }
-  
+
   public static class Chacha20Poly1305IetfEncryptParams implements ValidParam {
-    
+
     @Setter
     @Getter
     private byte[] c;
@@ -263,9 +263,9 @@ public class JLibsodiumParam {
     @Setter
     @Getter
     private byte[] k;
-    
+
     public Chacha20Poly1305IetfEncryptParams(byte[] c, long[] cLenP, byte[] m, long mLen,
-            byte[] ad, long adLen, byte[] nSec, byte[] nPub, byte[] k) throws ZksnarkException {
+        byte[] ad, long adLen, byte[] nSec, byte[] nPub, byte[] k) throws ZksnarkException {
       this.c = c;
       this.cLenP = cLenP;
       this.m = m;
@@ -275,10 +275,10 @@ public class JLibsodiumParam {
       this.nSec = nSec;
       this.nPub = nPub;
       this.k = k;
-      
+
       valid();
     }
-    
+
     @Override
     public void valid() throws ZksnarkException {
       validParamLength(nPub, 12);

--- a/chainbase/src/main/java/org/tron/common/zksnark/JLibsodiumParam.java
+++ b/chainbase/src/main/java/org/tron/common/zksnark/JLibsodiumParam.java
@@ -1,0 +1,288 @@
+package org.tron.common.zksnark;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.tron.common.utils.ByteUtil;
+import org.tron.core.exception.ZksnarkException;
+
+public class JLibsodiumParam {
+  
+  interface ValidParam {
+    
+    void valid() throws ZksnarkException;
+  }
+  
+  public static void validNull(byte[] value) throws ZksnarkException {
+    if (ByteUtil.isNullOrZeroArray(value)) {
+      throw new ZksnarkException("param is null");
+    }
+  }
+  
+  public static void validValueParams(long value) throws ZksnarkException {
+    if (value < 0) {
+      throw new ZksnarkException("Value should be non-negative.");
+    }
+  }
+  
+  public static void validParamLength(byte[] value, int length) throws ZksnarkException {
+    validNull(value);
+    if (value.length != length) {
+      throw new ZksnarkException("param length must be " + length);
+    }
+  }
+  
+  public static class Blake2bInitSaltPersonalParams implements ValidParam {
+    
+    @Setter
+    @Getter
+    private long state;
+    @Setter
+    @Getter
+    private byte[] key;
+    @Setter
+    @Getter
+    private int keyLen;
+    @Setter
+    @Getter
+    private int outLen;
+    @Setter
+    @Getter
+    private byte[] salt;
+    @Setter
+    @Getter
+    private byte[] personal;
+    
+    public Blake2bInitSaltPersonalParams(long state, byte[] key, int keyLen, int outLen,
+            byte[] salt, byte[] personal) throws ZksnarkException {
+      this.state = state;
+      this.key = key;
+      this.keyLen = keyLen;
+      this.outLen = outLen;
+      this.salt = salt;
+      this.personal = personal;
+      
+      valid();
+    }
+    
+    @Override
+    public void valid() throws ZksnarkException {
+      validValueParams(state);
+      validParamLength(personal, 16);
+    }
+  }
+  
+  public static class Blake2bUpdateParams implements ValidParam {
+    
+    @Setter
+    @Getter
+    private long state;
+    @Setter
+    @Getter
+    private byte[] in;
+    @Setter
+    @Getter
+    private long inLen;
+    
+    public Blake2bUpdateParams(long state, byte[] in, long inLen) throws ZksnarkException {
+      this.state = state;
+      this.in = in;
+      this.inLen = inLen;
+      
+      valid();
+    }
+    
+    @Override
+    public void valid() throws ZksnarkException {
+      validValueParams(state);
+      if (in.length != inLen || (in.length != 33 && in.length != 34)) {
+        throw new ZksnarkException("param length must be 33 or 34");
+      }
+    }
+  }
+  
+  public static class Blake2bFinalParams implements ValidParam {
+    
+    @Setter
+    @Getter
+    private long state;
+    @Setter
+    @Getter
+    private byte[] out;
+    @Setter
+    @Getter
+    private int outLen;
+    
+    public Blake2bFinalParams(long state, byte[] out, int outLen) throws ZksnarkException {
+      this.state = state;
+      this.out = out;
+      this.outLen = outLen;
+      
+      valid();
+    }
+    
+    @Override
+    public void valid() throws ZksnarkException {
+      validValueParams(state);
+      if (out.length != outLen || (out.length != 11 && out.length != 64)) {
+        throw new ZksnarkException("param length must be 11 or 64");
+      }
+    }
+  }
+  
+  public static class Black2bSaltPersonalParams implements ValidParam {
+    
+    @Setter
+    @Getter
+    private byte[] out;
+    @Setter
+    @Getter
+    private int outLen;
+    @Setter
+    @Getter
+    private byte[] in;
+    @Setter
+    @Getter
+    private long inLen;
+    @Setter
+    @Getter
+    private byte[] key;
+    @Setter
+    @Getter
+    private int keyLen;
+    @Setter
+    @Getter
+    private byte[] salt;
+    @Setter
+    @Getter
+    private byte[] personal;
+    
+    
+    public Black2bSaltPersonalParams(byte[] out, int outLen, byte[] in, long inLen, byte[] key,
+            int keyLen, byte[] salt, byte[] personal) throws ZksnarkException {
+      this.out = out;
+      this.outLen = outLen;
+      this.in = in;
+      this.inLen = inLen;
+      this.key = key;
+      this.keyLen = keyLen;
+      this.salt = salt;
+      this.personal = personal;
+      
+      valid();
+    }
+    
+    @Override
+    public void valid() throws ZksnarkException {
+      if (out.length != outLen || in.length != inLen) {
+        throw new ZksnarkException("out.length is not equal to outlen "
+                + "or in.length is not equal to inlen");
+      }
+      validParamLength(out, 32);
+      validParamLength(personal, 16);
+    }
+  }
+  
+  public static class Chacha20poly1305IetfDecryptParams implements ValidParam {
+    
+    @Setter
+    @Getter
+    private byte[] m;
+    @Setter
+    @Getter
+    private long[] mLenP;
+    @Setter
+    @Getter
+    private byte[] nSec;
+    @Setter
+    @Getter
+    private byte[] c;
+    @Setter
+    @Getter
+    private long cLen;
+    @Setter
+    @Getter
+    private byte[] ad;
+    @Setter
+    @Getter
+    private long adLen;
+    @Setter
+    @Getter
+    private byte[] nPub;
+    @Setter
+    @Getter
+    private byte[] k;
+    
+    public Chacha20poly1305IetfDecryptParams(byte[] m, long[] mLenP, byte[] nSec, byte[] c,
+            long cLen, byte[] ad, long adLen, byte[] nPub, byte[] k) throws ZksnarkException {
+      this.m = m;
+      this.mLenP = mLenP;
+      this.nSec = nSec;
+      this.c = c;
+      this.cLen = cLen;
+      this.ad = ad;
+      this.adLen = adLen;
+      this.nPub = nPub;
+      this.k = k;
+      
+      valid();
+    }
+    
+    @Override
+    public void valid() throws ZksnarkException {
+      validParamLength(nPub, 12);
+      validParamLength(k, 32);
+    }
+  }
+  
+  public static class Chacha20Poly1305IetfEncryptParams implements ValidParam {
+    
+    @Setter
+    @Getter
+    private byte[] c;
+    @Setter
+    @Getter
+    private long[] cLenP;
+    @Setter
+    @Getter
+    private byte[] m;
+    @Setter
+    @Getter
+    private long mLen;
+    @Setter
+    @Getter
+    private byte[] ad;
+    @Setter
+    @Getter
+    private long adLen;
+    @Setter
+    @Getter
+    private byte[] nSec;
+    @Setter
+    @Getter
+    private byte[] nPub;
+    @Setter
+    @Getter
+    private byte[] k;
+    
+    public Chacha20Poly1305IetfEncryptParams(byte[] c, long[] cLenP, byte[] m, long mLen,
+            byte[] ad, long adLen, byte[] nSec, byte[] nPub, byte[] k) throws ZksnarkException {
+      this.c = c;
+      this.cLenP = cLenP;
+      this.m = m;
+      this.mLen = mLen;
+      this.ad = ad;
+      this.adLen = adLen;
+      this.nSec = nSec;
+      this.nPub = nPub;
+      this.k = k;
+      
+      valid();
+    }
+    
+    @Override
+    public void valid() throws ZksnarkException {
+      validParamLength(nPub, 12);
+      validParamLength(k, 32);
+    }
+  }
+}

--- a/framework/src/main/java/org/tron/core/zen/ZenTransactionBuilder.java
+++ b/framework/src/main/java/org/tron/core/zen/ZenTransactionBuilder.java
@@ -287,7 +287,7 @@ public class ZenTransactionBuilder {
       throw new ZksnarkException("Output proof failed");
     }
   
-    if(ArrayUtils.isEmpty(output.ovk) || output.ovk.length != 32){
+    if (ArrayUtils.isEmpty(output.ovk) || output.ovk.length != 32) {
       throw new ZksnarkException("ovk is null or invalid and ovk should be 32 bytes (256 bit)");
     }
     

--- a/framework/src/main/java/org/tron/core/zen/ZenTransactionBuilder.java
+++ b/framework/src/main/java/org/tron/core/zen/ZenTransactionBuilder.java
@@ -286,11 +286,11 @@ public class ZenTransactionBuilder {
             zkProof))) {
       throw new ZksnarkException("Output proof failed");
     }
-  
+
     if (ArrayUtils.isEmpty(output.ovk) || output.ovk.length != 32) {
       throw new ZksnarkException("ovk is null or invalid and ovk should be 32 bytes (256 bit)");
     }
-    
+
     ReceiveDescriptionCapsule receiveDescriptionCapsule = new ReceiveDescriptionCapsule();
     receiveDescriptionCapsule.setValueCommitment(cv);
     receiveDescriptionCapsule.setNoteCommitment(cm);

--- a/framework/src/main/java/org/tron/core/zen/ZenTransactionBuilder.java
+++ b/framework/src/main/java/org/tron/core/zen/ZenTransactionBuilder.java
@@ -22,7 +22,6 @@ import org.tron.core.capsule.ReceiveDescriptionCapsule;
 import org.tron.core.capsule.SpendDescriptionCapsule;
 import org.tron.core.capsule.TransactionCapsule;
 import org.tron.core.exception.ZksnarkException;
-import org.tron.core.utils.TransactionUtil;
 import org.tron.core.zen.address.DiversifierT;
 import org.tron.core.zen.address.ExpandedSpendingKey;
 import org.tron.core.zen.address.PaymentAddress;
@@ -287,7 +286,11 @@ public class ZenTransactionBuilder {
             zkProof))) {
       throw new ZksnarkException("Output proof failed");
     }
-
+  
+    if(ArrayUtils.isEmpty(output.ovk) || output.ovk.length != 32){
+      throw new ZksnarkException("ovk is null or invalid and ovk should be 32 bytes (256 bit)");
+    }
+    
     ReceiveDescriptionCapsule receiveDescriptionCapsule = new ReceiveDescriptionCapsule();
     receiveDescriptionCapsule.setValueCommitment(cv);
     receiveDescriptionCapsule.setNoteCommitment(cm);

--- a/framework/src/main/java/org/tron/core/zen/address/SpendingKey.java
+++ b/framework/src/main/java/org/tron/core/zen/address/SpendingKey.java
@@ -8,17 +8,20 @@ import lombok.Setter;
 import org.tron.common.utils.ByteArray;
 import org.tron.common.zksnark.JLibrustzcash;
 import org.tron.common.zksnark.JLibsodium;
+import org.tron.common.zksnark.JLibsodiumParam.Blake2bFinalParams;
+import org.tron.common.zksnark.JLibsodiumParam.Blake2bInitSaltPersonalParams;
+import org.tron.common.zksnark.JLibsodiumParam.Blake2bUpdateParams;
 import org.tron.core.Constant;
 import org.tron.core.exception.BadItemException;
 import org.tron.core.exception.ZksnarkException;
 
 @AllArgsConstructor
 public class SpendingKey {
-
+  
   @Setter
   @Getter
   public byte[] value;
-
+  
   public static SpendingKey random() throws ZksnarkException {
     while (true) {
       SpendingKey sk = new SpendingKey(randomUint256());
@@ -27,16 +30,16 @@ public class SpendingKey {
       }
     }
   }
-
+  
   public static SpendingKey decode(String hex) {
     SpendingKey sk = new SpendingKey(ByteArray.fromHexString(hex));
     return sk;
   }
-
+  
   private static byte[] randomUint256() {
     return generatePrivateKey(0L);
   }
-
+  
   public static byte[] generatePrivateKey(long seed) {
     byte[] result = new byte[32];
     if (seed != 0L) {
@@ -48,30 +51,30 @@ public class SpendingKey {
     result[0] = i.byteValue();
     return result;
   }
-
+  
   public String encode() {
     return ByteArray.toHexString(value);
   }
-
+  
   public ExpandedSpendingKey expandedSpendingKey() throws ZksnarkException {
     return new ExpandedSpendingKey(
-        PRF.prfAsk(this.value), PRF.prfNsk(this.value), PRF.prfOvk(this.value));
+            PRF.prfAsk(this.value), PRF.prfNsk(this.value), PRF.prfOvk(this.value));
   }
-
+  
   public FullViewingKey fullViewingKey() throws ZksnarkException {
     return expandedSpendingKey().fullViewingKey();
   }
-
+  
   public PaymentAddress defaultAddress() throws BadItemException, ZksnarkException {
     Optional<PaymentAddress> addrOpt =
-        fullViewingKey().inViewingKey().address(defaultDiversifier());
+            fullViewingKey().inViewingKey().address(defaultDiversifier());
     if (addrOpt.isPresent()) {
       return addrOpt.get();
     } else {
       return null;
     }
   }
-
+  
   public DiversifierT defaultDiversifier() throws BadItemException, ZksnarkException {
     byte[] res = new byte[Constant.ZC_DIVERSIFIER_SIZE];
     byte[] blob = new byte[34];
@@ -83,14 +86,15 @@ public class SpendingKey {
       long state = JLibsodium.initState();
       try {
         JLibsodium.cryptoGenerichashBlake2bInitSaltPersonal(
-            state, null, 0, 64, null, Constant.ZTRON_EXPANDSEED_PERSONALIZATION);
-        JLibsodium.cryptoGenerichashBlake2bUpdate(state, blob, 34);
-        JLibsodium.cryptoGenerichashBlake2bFinal(state, res, 11);
+                new Blake2bInitSaltPersonalParams(state, null, 0, 64, null,
+                        Constant.ZTRON_EXPANDSEED_PERSONALIZATION));
+        JLibsodium.cryptoGenerichashBlake2bUpdate(new Blake2bUpdateParams(state, blob, 34));
+        JLibsodium.cryptoGenerichashBlake2bFinal(new Blake2bFinalParams(state, res, 11));
         if (JLibrustzcash.librustzcashCheckDiversifier(res)) {
           break;
         } else if (blob[33] == (byte) 255) {
           throw new BadItemException(
-              "librustzcash_check_diversifier did not return valid diversifier");
+                  "librustzcash_check_diversifier did not return valid diversifier");
         }
         blob[33] += 1;
       } finally {
@@ -101,9 +105,9 @@ public class SpendingKey {
     diversifierT.setData(res);
     return diversifierT;
   }
-
+  
   private static class PRF {
-
+    
     public static byte[] prfAsk(byte[] sk) throws ZksnarkException {
       byte[] ask = new byte[32];
       byte t = 0x00;
@@ -111,7 +115,7 @@ public class SpendingKey {
       JLibrustzcash.librustzcashToScalar(tmp, ask);
       return ask;
     }
-
+    
     public static byte[] prfNsk(byte[] sk) throws ZksnarkException {
       byte[] nsk = new byte[32];
       byte t = 0x01;
@@ -119,26 +123,27 @@ public class SpendingKey {
       JLibrustzcash.librustzcashToScalar(tmp, nsk);
       return nsk;
     }
-
-    public static byte[] prfOvk(byte[] sk) {
+    
+    public static byte[] prfOvk(byte[] sk) throws ZksnarkException {
       byte[] ovk = new byte[32];
       byte t = 0x02;
       byte[] tmp = prfExpand(sk, t);
       System.arraycopy(tmp, 0, ovk, 0, 32);
       return ovk;
     }
-
-    private static byte[] prfExpand(byte[] sk, byte t) {
+    
+    private static byte[] prfExpand(byte[] sk, byte t) throws ZksnarkException {
       byte[] res = new byte[64];
       byte[] blob = new byte[33];
       System.arraycopy(sk, 0, blob, 0, 32);
       blob[32] = t;
       long state = JLibsodium.initState();
       try {
-        JLibsodium.cryptoGenerichashBlake2bInitSaltPersonal(
-            state, null, 0, 64, null, Constant.ZTRON_EXPANDSEED_PERSONALIZATION);
-        JLibsodium.cryptoGenerichashBlake2bUpdate(state, blob, 33);
-        JLibsodium.cryptoGenerichashBlake2bFinal(state, res, 64);
+        JLibsodium.cryptoGenerichashBlake2bInitSaltPersonal(new Blake2bInitSaltPersonalParams(
+                state, null, 0, 64, null,
+                Constant.ZTRON_EXPANDSEED_PERSONALIZATION));
+        JLibsodium.cryptoGenerichashBlake2bUpdate(new Blake2bUpdateParams(state, blob, 33));
+        JLibsodium.cryptoGenerichashBlake2bFinal(new Blake2bFinalParams(state, res, 64));
       } finally {
         JLibsodium.freeState(state);
       }

--- a/framework/src/main/java/org/tron/core/zen/note/NoteEncryption.java
+++ b/framework/src/main/java/org/tron/core/zen/note/NoteEncryption.java
@@ -1,6 +1,6 @@
 package org.tron.core.zen.note;
 
-import static org.tron.common.zksnark.JLibsodium.crypto_aead_chacha20poly1305_IETF_NPUBBYTES;
+import static org.tron.common.zksnark.JLibsodium.CRYPTO_AEAD_CHACHA20POLY1305_IETF_NPUBBYTES;
 import static org.tron.core.utils.ZenChainParams.ZC_ENCCIPHERTEXT_SIZE;
 import static org.tron.core.utils.ZenChainParams.ZC_ENCPLAINTEXT_SIZE;
 import static org.tron.core.utils.ZenChainParams.ZC_OUTCIPHERTEXT_SIZE;
@@ -13,9 +13,13 @@ import lombok.Getter;
 import lombok.Setter;
 import org.tron.common.zksnark.JLibrustzcash;
 import org.tron.common.zksnark.JLibsodium;
+import org.tron.common.zksnark.JLibsodiumParam.Black2bSaltPersonalParams;
+import org.tron.common.zksnark.JLibsodiumParam.Chacha20Poly1305IetfEncryptParams;
+import org.tron.common.zksnark.JLibsodiumParam.Chacha20poly1305IetfDecryptParams;
 import org.tron.common.zksnark.LibrustzcashParam.KaAgreeParams;
 import org.tron.common.zksnark.LibrustzcashParam.KaDerivepublicParams;
 import org.tron.core.exception.ZksnarkException;
+import org.tron.core.utils.ZenChainParams;
 import org.tron.core.zen.address.DiversifierT;
 import org.tron.core.zen.note.NoteEncryption.Encryption.EncCiphertext;
 import org.tron.core.zen.note.NoteEncryption.Encryption.EncPlaintext;
@@ -24,22 +28,22 @@ import org.tron.core.zen.note.NoteEncryption.Encryption.OutPlaintext;
 
 @AllArgsConstructor
 public class NoteEncryption {
-
+  
   // Ephemeral public key
   @Getter
   private byte[] epk;
   // Ephemeral secret key
   @Getter
   private byte[] esk;
-
+  
   private boolean alreadyEncryptedEnc;
   private boolean alreadyEncryptedOut;
-
+  
   public NoteEncryption(byte[] epk, byte[] esk) {
     this.epk = epk;
     this.esk = esk;
   }
-
+  
   /**
    * generate pair of (esk,epk). epk = esk * d
    */
@@ -48,113 +52,117 @@ public class NoteEncryption {
     byte[] esk = new byte[32];
     JLibrustzcash.librustzcashSaplingGenerateR(esk);
     if (!JLibrustzcash
-        .librustzcashSaplingKaDerivepublic(new KaDerivepublicParams(d.getData(), esk, epk))) {
+            .librustzcashSaplingKaDerivepublic(new KaDerivepublicParams(d.getData(), esk, epk))) {
       return Optional.empty();
     }
     return Optional.of(new NoteEncryption(epk, esk));
   }
-
+  
   /**
    * encrypt plain_enc by kEnc to cEnc with sharedsecret and epk, use this esk,epk kEnc can use in
    * encrypt also in decrypt，symmetric encryption.
    */
   public Optional<EncCiphertext> encryptToRecipient(byte[] pkD, EncPlaintext message)
-      throws ZksnarkException {
+          throws ZksnarkException {
     if (alreadyEncryptedEnc) {
       throw new ZksnarkException("already encrypted to the recipient using this key");
     }
-
+    
     byte[] dhsecret = new byte[32];
     if (!JLibrustzcash.librustzcashKaAgree(new KaAgreeParams(pkD, esk, dhsecret))) {
       return Optional.empty();
     }
-
+    
     byte[] kEnc = new byte[NOTEENCRYPTION_CIPHER_KEYSIZE];
     //generate kEnc by sharedsecret and epk
     Encryption.kdfSapling(kEnc, dhsecret, epk);
-    byte[] cipherNonce = new byte[crypto_aead_chacha20poly1305_IETF_NPUBBYTES];
+    byte[] cipherNonce = new byte[CRYPTO_AEAD_CHACHA20POLY1305_IETF_NPUBBYTES];
     EncCiphertext ciphertext = new EncCiphertext();
-    JLibsodium.cryptoAeadChacha20Poly1305IetfEncrypt(ciphertext.data, null, message.data,
-        ZC_ENCPLAINTEXT_SIZE, null, 0, null, cipherNonce, kEnc);
+    JLibsodium.cryptoAeadChacha20Poly1305IetfEncrypt(new Chacha20Poly1305IetfEncryptParams(
+            ciphertext.data, null, message.data,
+            ZenChainParams.ZC_ENCPLAINTEXT_SIZE, null, 0, null, cipherNonce, kEnc));
     alreadyEncryptedEnc = true;
     return Optional.of(ciphertext);
   }
-
+  
   /**
    * encrypt plain_out with ock to c_out, use this epk
    */
   public OutCiphertext encryptToOurselves(
-      byte[] ovk, byte[] cv, byte[] cm, OutPlaintext message) throws ZksnarkException {
+          byte[] ovk, byte[] cv, byte[] cm, OutPlaintext message) throws ZksnarkException {
     if (alreadyEncryptedOut) {
       throw new ZksnarkException("already encrypted to the recipient using this key");
     }
-
+    
     byte[] ock = new byte[NOTEENCRYPTION_CIPHER_KEYSIZE];
     Encryption.prfOck(ock, ovk, cv, cm, epk);
-
-    byte[] cipherNonce = new byte[crypto_aead_chacha20poly1305_IETF_NPUBBYTES];
+    
+    byte[] cipherNonce = new byte[CRYPTO_AEAD_CHACHA20POLY1305_IETF_NPUBBYTES];
     OutCiphertext ciphertext = new OutCiphertext();
-    JLibsodium.cryptoAeadChacha20Poly1305IetfEncrypt(ciphertext.data, null, message.data,
-        ZC_OUTPLAINTEXT_SIZE, null, 0, null, cipherNonce, ock);
+    JLibsodium.cryptoAeadChacha20Poly1305IetfEncrypt(new Chacha20Poly1305IetfEncryptParams(
+            ciphertext.data, null, message.data,
+            ZenChainParams.ZC_OUTPLAINTEXT_SIZE, null, 0, null, cipherNonce, ock));
     alreadyEncryptedOut = true;
     return ciphertext;
   }
-
+  
   public static class Encryption {
-
+    
     public static final int NOTEENCRYPTION_CIPHER_KEYSIZE = 32;
-
+    
     /**
      * generate ock by ovk, cv, cm, epk
      */
     public static void prfOck(byte[] ock, byte[] ovk, byte[] cv, byte[] cm, byte[] epk)
-        throws ZksnarkException {
+            throws ZksnarkException {
       byte[] block = new byte[128];
       System.arraycopy(ovk, 0, block, 0, 32);
       System.arraycopy(cv, 0, block, 32, 32);
       System.arraycopy(cm, 0, block, 64, 32);
       System.arraycopy(epk, 0, block, 96, 32);
-
-      byte[] personalization = new byte[JLibsodium.crypto_generichash_blake2b_PERSONALBYTES];
+      
+      byte[] personalization = new byte[JLibsodium.CRYPTO_GENERICHASH_BLAKE2B_PERSONALBYTES];
       byte[] temp = "Ztron_Derive_ock".getBytes();
       System.arraycopy(temp, 0, personalization, 0, temp.length);
-      if (JLibsodium.cryptoGenerichashBlack2bSaltPersonal(ock, NOTEENCRYPTION_CIPHER_KEYSIZE,
-          block, 128,
-          null, 0, // No key.
-          null,    // No salt.
-          personalization
+      if (JLibsodium.cryptoGenerichashBlack2bSaltPersonal(new Black2bSaltPersonalParams(
+              ock, NOTEENCRYPTION_CIPHER_KEYSIZE,
+              block, 128,
+              null, 0, // No key.
+              null,    // No salt.
+              personalization)
       ) != 0) {
         throw new ZksnarkException("hash function failure");
       }
     }
-
+    
     /**
      * generate kEnc by sharedsecret and epk
      */
     public static void kdfSapling(byte[] kEnc, byte[] sharedsecret, byte[] epk)
-        throws ZksnarkException {
+            throws ZksnarkException {
       byte[] block = new byte[64];
       System.arraycopy(sharedsecret, 0, block, 0, 32);
       System.arraycopy(epk, 0, block, 32, 32);
-      byte[] personalization = new byte[JLibsodium.crypto_generichash_blake2b_PERSONALBYTES];
+      byte[] personalization = new byte[JLibsodium.CRYPTO_GENERICHASH_BLAKE2B_PERSONALBYTES];
       byte[] temp = "Ztron_SaplingKDF".getBytes();
       System.arraycopy(temp, 0, personalization, 0, temp.length);
-      if (JLibsodium.cryptoGenerichashBlack2bSaltPersonal(kEnc, NOTEENCRYPTION_CIPHER_KEYSIZE,
-          block, 64,
-          null, 0, // No key.
-          null,    // No salt.
-          personalization
+      if (JLibsodium.cryptoGenerichashBlack2bSaltPersonal(new Black2bSaltPersonalParams(
+              kEnc, NOTEENCRYPTION_CIPHER_KEYSIZE,
+              block, 64,
+              null, 0, // No key.
+              null,    // No salt.
+              personalization)
       ) != 0) {
         throw new ZksnarkException(("hash function failure"));
       }
     }
-
+    
     /**
      * decrypt cEnc by kEnc to plain_enc generate with epk + ivk kEnc can use in encrypt also in
      * decrypt，symmetric encryption.
      */
     public static Optional<EncPlaintext> attemptEncDecryption(
-        byte[] ciphertext, byte[] ivk, byte[] epk) throws ZksnarkException {
+            byte[] ciphertext, byte[] ivk, byte[] epk) throws ZksnarkException {
       byte[] sharedsecret = new byte[32];
       //generate sharedsecret by epk and ivk
       if (!JLibrustzcash.librustzcashKaAgree(new KaAgreeParams(epk, ivk, sharedsecret))) {
@@ -163,28 +171,28 @@ public class NoteEncryption {
       byte[] kEnc = new byte[NOTEENCRYPTION_CIPHER_KEYSIZE];
       //generate kEnc by sharedsecret and epk
       kdfSapling(kEnc, sharedsecret, epk);
-      byte[] cipher_nonce = new byte[crypto_aead_chacha20poly1305_IETF_NPUBBYTES];
+      byte[] cipher_nonce = new byte[CRYPTO_AEAD_CHACHA20POLY1305_IETF_NPUBBYTES];
       EncPlaintext plaintext = new EncPlaintext();
       plaintext.data = new byte[ZC_ENCPLAINTEXT_SIZE];
       //decrypt cEnc by kEnc
-      if (JLibsodium.cryptoAeadChacha20poly1305IetfDecrypt(
-          plaintext.data, null,
-          null,
-          ciphertext, ZC_ENCCIPHERTEXT_SIZE,
-          null,
-          0,
-          cipher_nonce, kEnc) != 0) {
+      if (JLibsodium.cryptoAeadChacha20poly1305IetfDecrypt(new Chacha20poly1305IetfDecryptParams(
+              plaintext.data, null,
+              null,
+              ciphertext, ZC_ENCCIPHERTEXT_SIZE,
+              null,
+              0,
+              cipher_nonce, kEnc)) != 0) {
         return Optional.empty();
       }
       return Optional.of(plaintext);
     }
-
+    
     /**
      * decrypt cEnc by kEnc to plain_enc generate with esk + pkD kEnc can use in encrypt also in
      * decrypt，symmetric encryption.
      */
     public static Optional<EncPlaintext> attemptEncDecryption(
-        EncCiphertext ciphertext, byte[] epk, byte[] esk, byte[] pkD) throws ZksnarkException {
+            EncCiphertext ciphertext, byte[] epk, byte[] esk, byte[] pkD) throws ZksnarkException {
       byte[] sharedsecret = new byte[32];
       //generate sharedsecret by esk and pkD. esk + pkD = sharedsecret = epk + ivk
       if (!JLibrustzcash.librustzcashKaAgree(new KaAgreeParams(pkD, esk, sharedsecret))) {
@@ -193,70 +201,81 @@ public class NoteEncryption {
       byte[] kEnc = new byte[NOTEENCRYPTION_CIPHER_KEYSIZE];
       //generate kEnc by sharedsecret and epk
       kdfSapling(kEnc, sharedsecret, epk);
-      byte[] cipherNonce = new byte[crypto_aead_chacha20poly1305_IETF_NPUBBYTES];
+      byte[] cipherNonce = new byte[CRYPTO_AEAD_CHACHA20POLY1305_IETF_NPUBBYTES];
       EncPlaintext plaintext = new EncPlaintext();
       plaintext.data = new byte[ZC_ENCPLAINTEXT_SIZE];
       //decrypt cEnc by kEnc.
-      if (JLibsodium.cryptoAeadChacha20poly1305IetfDecrypt(
-          plaintext.data, null,
-          null,
-          ciphertext.data, ZC_ENCCIPHERTEXT_SIZE,
-          null,
-          0,
-          cipherNonce, kEnc) != 0) {
+//      if (JLibsodium.cryptoAeadChacha20poly1305IetfDecrypt(
+//          plaintext.data, null,
+//          null,
+//          ciphertext.data, ZC_ENCCIPHERTEXT_SIZE,
+//          null,
+//          0,
+//          cipherNonce, kEnc) != 0) {
+//        return Optional.empty();
+//      }
+      
+      if (JLibsodium.cryptoAeadChacha20poly1305IetfDecrypt(new Chacha20poly1305IetfDecryptParams(
+              plaintext.data, null,
+              null,
+              ciphertext.data, ZC_ENCCIPHERTEXT_SIZE,
+              null,
+              0,
+              cipherNonce, kEnc)) != 0) {
         return Optional.empty();
       }
-
+      
       return Optional.of(plaintext);
     }
-
+    
     /**
      * decrypt c_out to plain_out with ock generate ovk
      */
     public static Optional<OutPlaintext> attemptOutDecryption(
-        OutCiphertext ciphertext, byte[] ovk, byte[] cv, byte[] cm, byte[] epk)
-        throws ZksnarkException {
+            OutCiphertext ciphertext, byte[] ovk, byte[] cv, byte[] cm, byte[] epk)
+            throws ZksnarkException {
       byte[] ock = new byte[NOTEENCRYPTION_CIPHER_KEYSIZE];
       //generate ock by ovk, cv, cm, epk
       prfOck(ock, ovk, cv, cm, epk);
-      byte[] cipherNonce = new byte[crypto_aead_chacha20poly1305_IETF_NPUBBYTES];
+      byte[] cipherNonce = new byte[CRYPTO_AEAD_CHACHA20POLY1305_IETF_NPUBBYTES];
       OutPlaintext plaintext = new OutPlaintext();
       plaintext.data = new byte[ZC_OUTPLAINTEXT_SIZE];
       //decrypt out by ock, get esk, pkD
-      if (JLibsodium.cryptoAeadChacha20poly1305IetfDecrypt(plaintext.data, null,
-          null,
-          ciphertext.data, ZC_OUTCIPHERTEXT_SIZE,
-          null,
-          0,
-          cipherNonce, ock) != 0) {
+      if (JLibsodium.cryptoAeadChacha20poly1305IetfDecrypt(new Chacha20poly1305IetfDecryptParams(
+              plaintext.data, null,
+              null,
+              ciphertext.data, ZC_OUTCIPHERTEXT_SIZE,
+              null,
+              0,
+              cipherNonce, ock)) != 0) {
         return Optional.empty();
       }
       return Optional.of(plaintext);
     }
-
+    
     public static class EncCiphertext {
-
+      
       @Getter
       @Setter
       private byte[] data = new byte[ZC_ENCCIPHERTEXT_SIZE]; // ZC_ENCCIPHERTEXT_SIZE
     }
-
+    
     public static class EncPlaintext {
-
+      
       @Getter
       @Setter
       private byte[] data = new byte[ZC_ENCPLAINTEXT_SIZE]; // ZC_ENCPLAINTEXT_SIZE
     }
-
+    
     public static class OutCiphertext {
-
+      
       @Getter
       @Setter
       private byte[] data = new byte[ZC_OUTCIPHERTEXT_SIZE]; // ZC_OUTCIPHERTEXT_SIZE
     }
-
+    
     public static class OutPlaintext {
-
+      
       @Getter
       @Setter
       private byte[] data = new byte[ZC_OUTPLAINTEXT_SIZE]; // ZC_OUTPLAINTEXT_SIZE

--- a/framework/src/main/java/org/tron/core/zen/note/NoteEncryption.java
+++ b/framework/src/main/java/org/tron/core/zen/note/NoteEncryption.java
@@ -28,22 +28,22 @@ import org.tron.core.zen.note.NoteEncryption.Encryption.OutPlaintext;
 
 @AllArgsConstructor
 public class NoteEncryption {
-  
+
   // Ephemeral public key
   @Getter
   private byte[] epk;
   // Ephemeral secret key
   @Getter
   private byte[] esk;
-  
+
   private boolean alreadyEncryptedEnc;
   private boolean alreadyEncryptedOut;
-  
+
   public NoteEncryption(byte[] epk, byte[] esk) {
     this.epk = epk;
     this.esk = esk;
   }
-  
+
   /**
    * generate pair of (esk,epk). epk = esk * d
    */
@@ -52,94 +52,94 @@ public class NoteEncryption {
     byte[] esk = new byte[32];
     JLibrustzcash.librustzcashSaplingGenerateR(esk);
     if (!JLibrustzcash
-            .librustzcashSaplingKaDerivepublic(new KaDerivepublicParams(d.getData(), esk, epk))) {
+        .librustzcashSaplingKaDerivepublic(new KaDerivepublicParams(d.getData(), esk, epk))) {
       return Optional.empty();
     }
     return Optional.of(new NoteEncryption(epk, esk));
   }
-  
+
   /**
    * encrypt plain_enc by kEnc to cEnc with sharedsecret and epk, use this esk,epk kEnc can use in
    * encrypt also in decrypt，symmetric encryption.
    */
   public Optional<EncCiphertext> encryptToRecipient(byte[] pkD, EncPlaintext message)
-          throws ZksnarkException {
+      throws ZksnarkException {
     if (alreadyEncryptedEnc) {
       throw new ZksnarkException("already encrypted to the recipient using this key");
     }
-    
+
     byte[] dhsecret = new byte[32];
     if (!JLibrustzcash.librustzcashKaAgree(new KaAgreeParams(pkD, esk, dhsecret))) {
       return Optional.empty();
     }
-    
+
     byte[] kEnc = new byte[NOTEENCRYPTION_CIPHER_KEYSIZE];
     //generate kEnc by sharedsecret and epk
     Encryption.kdfSapling(kEnc, dhsecret, epk);
     byte[] cipherNonce = new byte[CRYPTO_AEAD_CHACHA20POLY1305_IETF_NPUBBYTES];
     EncCiphertext ciphertext = new EncCiphertext();
     JLibsodium.cryptoAeadChacha20Poly1305IetfEncrypt(new Chacha20Poly1305IetfEncryptParams(
-            ciphertext.data, null, message.data,
-            ZenChainParams.ZC_ENCPLAINTEXT_SIZE, null, 0, null, cipherNonce, kEnc));
+        ciphertext.data, null, message.data,
+        ZenChainParams.ZC_ENCPLAINTEXT_SIZE, null, 0, null, cipherNonce, kEnc));
     alreadyEncryptedEnc = true;
     return Optional.of(ciphertext);
   }
-  
+
   /**
    * encrypt plain_out with ock to c_out, use this epk
    */
   public OutCiphertext encryptToOurselves(
-          byte[] ovk, byte[] cv, byte[] cm, OutPlaintext message) throws ZksnarkException {
+      byte[] ovk, byte[] cv, byte[] cm, OutPlaintext message) throws ZksnarkException {
     if (alreadyEncryptedOut) {
       throw new ZksnarkException("already encrypted to the recipient using this key");
     }
-    
+
     byte[] ock = new byte[NOTEENCRYPTION_CIPHER_KEYSIZE];
     Encryption.prfOck(ock, ovk, cv, cm, epk);
-    
+
     byte[] cipherNonce = new byte[CRYPTO_AEAD_CHACHA20POLY1305_IETF_NPUBBYTES];
     OutCiphertext ciphertext = new OutCiphertext();
     JLibsodium.cryptoAeadChacha20Poly1305IetfEncrypt(new Chacha20Poly1305IetfEncryptParams(
-            ciphertext.data, null, message.data,
-            ZenChainParams.ZC_OUTPLAINTEXT_SIZE, null, 0, null, cipherNonce, ock));
+        ciphertext.data, null, message.data,
+        ZenChainParams.ZC_OUTPLAINTEXT_SIZE, null, 0, null, cipherNonce, ock));
     alreadyEncryptedOut = true;
     return ciphertext;
   }
-  
+
   public static class Encryption {
-    
+
     public static final int NOTEENCRYPTION_CIPHER_KEYSIZE = 32;
-    
+
     /**
      * generate ock by ovk, cv, cm, epk
      */
     public static void prfOck(byte[] ock, byte[] ovk, byte[] cv, byte[] cm, byte[] epk)
-            throws ZksnarkException {
+        throws ZksnarkException {
       byte[] block = new byte[128];
       System.arraycopy(ovk, 0, block, 0, 32);
       System.arraycopy(cv, 0, block, 32, 32);
       System.arraycopy(cm, 0, block, 64, 32);
       System.arraycopy(epk, 0, block, 96, 32);
-      
+
       byte[] personalization = new byte[JLibsodium.CRYPTO_GENERICHASH_BLAKE2B_PERSONALBYTES];
       byte[] temp = "Ztron_Derive_ock".getBytes();
       System.arraycopy(temp, 0, personalization, 0, temp.length);
       if (JLibsodium.cryptoGenerichashBlack2bSaltPersonal(new Black2bSaltPersonalParams(
-              ock, NOTEENCRYPTION_CIPHER_KEYSIZE,
-              block, 128,
-              null, 0, // No key.
-              null,    // No salt.
-              personalization)
+          ock, NOTEENCRYPTION_CIPHER_KEYSIZE,
+          block, 128,
+          null, 0, // No key.
+          null,    // No salt.
+          personalization)
       ) != 0) {
         throw new ZksnarkException("hash function failure");
       }
     }
-    
+
     /**
      * generate kEnc by sharedsecret and epk
      */
     public static void kdfSapling(byte[] kEnc, byte[] sharedsecret, byte[] epk)
-            throws ZksnarkException {
+        throws ZksnarkException {
       byte[] block = new byte[64];
       System.arraycopy(sharedsecret, 0, block, 0, 32);
       System.arraycopy(epk, 0, block, 32, 32);
@@ -147,22 +147,22 @@ public class NoteEncryption {
       byte[] temp = "Ztron_SaplingKDF".getBytes();
       System.arraycopy(temp, 0, personalization, 0, temp.length);
       if (JLibsodium.cryptoGenerichashBlack2bSaltPersonal(new Black2bSaltPersonalParams(
-              kEnc, NOTEENCRYPTION_CIPHER_KEYSIZE,
-              block, 64,
-              null, 0, // No key.
-              null,    // No salt.
-              personalization)
+          kEnc, NOTEENCRYPTION_CIPHER_KEYSIZE,
+          block, 64,
+          null, 0, // No key.
+          null,    // No salt.
+          personalization)
       ) != 0) {
         throw new ZksnarkException(("hash function failure"));
       }
     }
-    
+
     /**
      * decrypt cEnc by kEnc to plain_enc generate with epk + ivk kEnc can use in encrypt also in
      * decrypt，symmetric encryption.
      */
     public static Optional<EncPlaintext> attemptEncDecryption(
-            byte[] ciphertext, byte[] ivk, byte[] epk) throws ZksnarkException {
+        byte[] ciphertext, byte[] ivk, byte[] epk) throws ZksnarkException {
       byte[] sharedsecret = new byte[32];
       //generate sharedsecret by epk and ivk
       if (!JLibrustzcash.librustzcashKaAgree(new KaAgreeParams(epk, ivk, sharedsecret))) {
@@ -176,23 +176,23 @@ public class NoteEncryption {
       plaintext.data = new byte[ZC_ENCPLAINTEXT_SIZE];
       //decrypt cEnc by kEnc
       if (JLibsodium.cryptoAeadChacha20poly1305IetfDecrypt(new Chacha20poly1305IetfDecryptParams(
-              plaintext.data, null,
-              null,
-              ciphertext, ZC_ENCCIPHERTEXT_SIZE,
-              null,
-              0,
-              cipher_nonce, kEnc)) != 0) {
+          plaintext.data, null,
+          null,
+          ciphertext, ZC_ENCCIPHERTEXT_SIZE,
+          null,
+          0,
+          cipher_nonce, kEnc)) != 0) {
         return Optional.empty();
       }
       return Optional.of(plaintext);
     }
-    
+
     /**
      * decrypt cEnc by kEnc to plain_enc generate with esk + pkD kEnc can use in encrypt also in
      * decrypt，symmetric encryption.
      */
     public static Optional<EncPlaintext> attemptEncDecryption(
-            EncCiphertext ciphertext, byte[] epk, byte[] esk, byte[] pkD) throws ZksnarkException {
+        EncCiphertext ciphertext, byte[] epk, byte[] esk, byte[] pkD) throws ZksnarkException {
       byte[] sharedsecret = new byte[32];
       //generate sharedsecret by esk and pkD. esk + pkD = sharedsecret = epk + ivk
       if (!JLibrustzcash.librustzcashKaAgree(new KaAgreeParams(pkD, esk, sharedsecret))) {
@@ -206,24 +206,24 @@ public class NoteEncryption {
       plaintext.data = new byte[ZC_ENCPLAINTEXT_SIZE];
       //decrypt cEnc by kEnc.
       if (JLibsodium.cryptoAeadChacha20poly1305IetfDecrypt(new Chacha20poly1305IetfDecryptParams(
-              plaintext.data, null,
-              null,
-              ciphertext.data, ZC_ENCCIPHERTEXT_SIZE,
-              null,
-              0,
-              cipherNonce, kEnc)) != 0) {
+          plaintext.data, null,
+          null,
+          ciphertext.data, ZC_ENCCIPHERTEXT_SIZE,
+          null,
+          0,
+          cipherNonce, kEnc)) != 0) {
         return Optional.empty();
       }
-      
+
       return Optional.of(plaintext);
     }
-    
+
     /**
      * decrypt c_out to plain_out with ock generate ovk
      */
     public static Optional<OutPlaintext> attemptOutDecryption(
-            OutCiphertext ciphertext, byte[] ovk, byte[] cv, byte[] cm, byte[] epk)
-            throws ZksnarkException {
+        OutCiphertext ciphertext, byte[] ovk, byte[] cv, byte[] cm, byte[] epk)
+        throws ZksnarkException {
       byte[] ock = new byte[NOTEENCRYPTION_CIPHER_KEYSIZE];
       //generate ock by ovk, cv, cm, epk
       prfOck(ock, ovk, cv, cm, epk);
@@ -232,40 +232,40 @@ public class NoteEncryption {
       plaintext.data = new byte[ZC_OUTPLAINTEXT_SIZE];
       //decrypt out by ock, get esk, pkD
       if (JLibsodium.cryptoAeadChacha20poly1305IetfDecrypt(new Chacha20poly1305IetfDecryptParams(
-              plaintext.data, null,
-              null,
-              ciphertext.data, ZC_OUTCIPHERTEXT_SIZE,
-              null,
-              0,
-              cipherNonce, ock)) != 0) {
+          plaintext.data, null,
+          null,
+          ciphertext.data, ZC_OUTCIPHERTEXT_SIZE,
+          null,
+          0,
+          cipherNonce, ock)) != 0) {
         return Optional.empty();
       }
       return Optional.of(plaintext);
     }
-    
+
     public static class EncCiphertext {
-      
+
       @Getter
       @Setter
       private byte[] data = new byte[ZC_ENCCIPHERTEXT_SIZE]; // ZC_ENCCIPHERTEXT_SIZE
     }
-    
+
     public static class EncPlaintext {
-      
+
       @Getter
       @Setter
       private byte[] data = new byte[ZC_ENCPLAINTEXT_SIZE]; // ZC_ENCPLAINTEXT_SIZE
     }
-    
+
     public static class OutCiphertext {
-      
+
       @Getter
       @Setter
       private byte[] data = new byte[ZC_OUTCIPHERTEXT_SIZE]; // ZC_OUTCIPHERTEXT_SIZE
     }
-    
+
     public static class OutPlaintext {
-      
+
       @Getter
       @Setter
       private byte[] data = new byte[ZC_OUTPLAINTEXT_SIZE]; // ZC_OUTPLAINTEXT_SIZE

--- a/framework/src/main/java/org/tron/core/zen/note/NoteEncryption.java
+++ b/framework/src/main/java/org/tron/core/zen/note/NoteEncryption.java
@@ -205,16 +205,6 @@ public class NoteEncryption {
       EncPlaintext plaintext = new EncPlaintext();
       plaintext.data = new byte[ZC_ENCPLAINTEXT_SIZE];
       //decrypt cEnc by kEnc.
-//      if (JLibsodium.cryptoAeadChacha20poly1305IetfDecrypt(
-//          plaintext.data, null,
-//          null,
-//          ciphertext.data, ZC_ENCCIPHERTEXT_SIZE,
-//          null,
-//          0,
-//          cipherNonce, kEnc) != 0) {
-//        return Optional.empty();
-//      }
-      
       if (JLibsodium.cryptoAeadChacha20poly1305IetfDecrypt(new Chacha20poly1305IetfDecryptParams(
               plaintext.data, null,
               null,


### PR DESCRIPTION
**What does this PR do?**

1. merge all parameters of all libsodium api into one param class.
2. restrict length of member in api param.
3. chang lower of libsodium constants to upper.
4. give more clear declaraction where ovk is missing in api createshieldedtransaction.

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

