### PR TITLE
remove the shutdown and shutdownService function

### DIFF
--- a/framework/src/test/java/org/tron/common/overlay/discover/node/NodeHandlerTest.java
+++ b/framework/src/test/java/org/tron/common/overlay/discover/node/NodeHandlerTest.java
@@ -56,8 +56,6 @@ public class NodeHandlerTest {
   @After
   public void destroy() {
     Args.clearParam();
-    appTest.shutdownServices();
-    appTest.shutdown();
     context.destroy();
     if (FileUtil.deleteDir(new File("output-directory"))) {
       logger.info("Release resources successful.");

--- a/framework/src/test/java/org/tron/common/overlay/discover/node/NodeManagerTest.java
+++ b/framework/src/test/java/org/tron/common/overlay/discover/node/NodeManagerTest.java
@@ -55,8 +55,6 @@ public class NodeManagerTest {
   @After
   public void destroy() {
     Args.clearParam();
-    appTest.shutdownServices();
-    appTest.shutdown();
     context.destroy();
     if (FileUtil.deleteDir(new File("output-directory"))) {
       logger.info("Release resources successful.");

--- a/framework/src/test/java/org/tron/common/runtime/InheritanceTest.java
+++ b/framework/src/test/java/org/tron/common/runtime/InheritanceTest.java
@@ -58,8 +58,6 @@ public class InheritanceTest {
   @AfterClass
   public static void destroy() {
     Args.clearParam();
-    appT.shutdownServices();
-    appT.shutdown();
     context.destroy();
     if (FileUtil.deleteDir(new File(dbPath))) {
       logger.info("Release resources successful.");

--- a/framework/src/test/java/org/tron/common/runtime/InternalTransactionComplexTest.java
+++ b/framework/src/test/java/org/tron/common/runtime/InternalTransactionComplexTest.java
@@ -60,8 +60,6 @@ public class InternalTransactionComplexTest {
   @AfterClass
   public static void destroy() {
     Args.clearParam();
-    appT.shutdownServices();
-    appT.shutdown();
     context.destroy();
     if (FileUtil.deleteDir(new File(dbPath))) {
       logger.info("Release resources successful.");

--- a/framework/src/test/java/org/tron/common/runtime/ProgramResultTest.java
+++ b/framework/src/test/java/org/tron/common/runtime/ProgramResultTest.java
@@ -78,8 +78,6 @@ public class ProgramResultTest {
   @AfterClass
   public static void destroy() {
     Args.clearParam();
-    appT.shutdownServices();
-    appT.shutdown();
     context.destroy();
     if (FileUtil.deleteDir(new File(dbPath))) {
       logger.info("Release resources successful.");

--- a/framework/src/test/java/org/tron/common/runtime/RuntimeImplTest.java
+++ b/framework/src/test/java/org/tron/common/runtime/RuntimeImplTest.java
@@ -454,8 +454,6 @@ public class RuntimeImplTest {
   @After
   public void destroy() {
     Args.clearParam();
-    AppT.shutdownServices();
-    AppT.shutdown();
     context.destroy();
     if (FileUtil.deleteDir(new File(dbPath))) {
       logger.info("Release resources successful.");

--- a/framework/src/test/java/org/tron/common/runtime/RuntimeTransferComplexTest.java
+++ b/framework/src/test/java/org/tron/common/runtime/RuntimeTransferComplexTest.java
@@ -68,8 +68,6 @@ public class RuntimeTransferComplexTest {
   @AfterClass
   public static void destroy() {
     Args.clearParam();
-    appT.shutdownServices();
-    appT.shutdown();
     context.destroy();
     if (FileUtil.deleteDir(new File(dbPath))) {
       logger.info("Release resources successful.");

--- a/framework/src/test/java/org/tron/common/runtime/vm/BandWidthRuntimeOutOfTimeTest.java
+++ b/framework/src/test/java/org/tron/common/runtime/vm/BandWidthRuntimeOutOfTimeTest.java
@@ -133,7 +133,6 @@ public class BandWidthRuntimeOutOfTimeTest {
   @AfterClass
   public static void destroy() {
     Args.clearParam();
-    ApplicationFactory.create(context).shutdown();
     context.destroy();
     FileUtil.deleteDir(new File(dbPath));
   }

--- a/framework/src/test/java/org/tron/common/runtime/vm/BandWidthRuntimeOutOfTimeWithCheckTest.java
+++ b/framework/src/test/java/org/tron/common/runtime/vm/BandWidthRuntimeOutOfTimeWithCheckTest.java
@@ -134,7 +134,6 @@ public class BandWidthRuntimeOutOfTimeWithCheckTest {
   @AfterClass
   public static void destroy() {
     Args.clearParam();
-    ApplicationFactory.create(context).shutdown();
     context.destroy();
     FileUtil.deleteDir(new File(dbPath));
   }

--- a/framework/src/test/java/org/tron/common/runtime/vm/BandWidthRuntimeTest.java
+++ b/framework/src/test/java/org/tron/common/runtime/vm/BandWidthRuntimeTest.java
@@ -132,7 +132,6 @@ public class BandWidthRuntimeTest {
   @AfterClass
   public static void destroy() {
     Args.clearParam();
-    ApplicationFactory.create(context).shutdown();
     context.destroy();
     FileUtil.deleteDir(new File(dbPath));
   }

--- a/framework/src/test/java/org/tron/common/runtime/vm/BandWidthRuntimeWithCheckTest.java
+++ b/framework/src/test/java/org/tron/common/runtime/vm/BandWidthRuntimeWithCheckTest.java
@@ -145,7 +145,6 @@ public class BandWidthRuntimeWithCheckTest {
   @AfterClass
   public static void destroy() {
     Args.clearParam();
-    ApplicationFactory.create(context).shutdown();
     context.destroy();
     FileUtil.deleteDir(new File(dbPath));
   }

--- a/framework/src/test/java/org/tron/common/runtime/vm/BatchSendTest.java
+++ b/framework/src/test/java/org/tron/common/runtime/vm/BatchSendTest.java
@@ -87,8 +87,6 @@ public class BatchSendTest {
   @AfterClass
   public static void destroy() {
     Args.clearParam();
-    appT.shutdownServices();
-    appT.shutdown();
     context.destroy();
     if (FileUtil.deleteDir(new File(dbPath))) {
       logger.info("Release resources successful.");

--- a/framework/src/test/java/org/tron/common/runtime/vm/ChargeTest.java
+++ b/framework/src/test/java/org/tron/common/runtime/vm/ChargeTest.java
@@ -462,8 +462,6 @@ public class ChargeTest {
   @After
   public void destroy() {
     Args.clearParam();
-    AppT.shutdownServices();
-    AppT.shutdown();
     context.destroy();
     if (FileUtil.deleteDir(new File(dbPath))) {
       logger.info("Release resources successful.");

--- a/framework/src/test/java/org/tron/common/runtime/vm/DepositTest.java
+++ b/framework/src/test/java/org/tron/common/runtime/vm/DepositTest.java
@@ -415,8 +415,6 @@ public class DepositTest {
   @After
   public void destroy() {
     Args.clearParam();
-    ApplicationFactory.create(context).shutdown();
-    ApplicationFactory.create(context).shutdownServices();
     context.destroy();
     if (FileUtil.deleteDir(new File(dbPath))) {
       logger.info("Release resources successful.");

--- a/framework/src/test/java/org/tron/common/runtime/vm/EnergyWhenAssertStyleTest.java
+++ b/framework/src/test/java/org/tron/common/runtime/vm/EnergyWhenAssertStyleTest.java
@@ -595,8 +595,6 @@ public class EnergyWhenAssertStyleTest {
   @After
   public void destroy() {
     Args.clearParam();
-    AppT.shutdownServices();
-    AppT.shutdown();
     context.destroy();
     if (FileUtil.deleteDir(new File(dbPath))) {
       logger.info("Release resources successful.");

--- a/framework/src/test/java/org/tron/common/runtime/vm/EnergyWhenRequireStyleTest.java
+++ b/framework/src/test/java/org/tron/common/runtime/vm/EnergyWhenRequireStyleTest.java
@@ -549,8 +549,6 @@ public class EnergyWhenRequireStyleTest {
   @After
   public void destroy() {
     Args.clearParam();
-    AppT.shutdownServices();
-    AppT.shutdown();
     context.destroy();
     if (FileUtil.deleteDir(new File(dbPath))) {
       logger.info("Release resources successful.");

--- a/framework/src/test/java/org/tron/common/runtime/vm/EnergyWhenSendAndTransferTest.java
+++ b/framework/src/test/java/org/tron/common/runtime/vm/EnergyWhenSendAndTransferTest.java
@@ -305,8 +305,6 @@ public class EnergyWhenSendAndTransferTest {
    */
   @After
   public void destroy() {
-    AppT.shutdownServices();
-    AppT.shutdown();
     context.destroy();
     Args.clearParam();
     if (FileUtil.deleteDir(new File(dbPath))) {

--- a/framework/src/test/java/org/tron/common/runtime/vm/EnergyWhenTimeoutStyleTest.java
+++ b/framework/src/test/java/org/tron/common/runtime/vm/EnergyWhenTimeoutStyleTest.java
@@ -158,8 +158,6 @@ public class EnergyWhenTimeoutStyleTest {
   @After
   public void destroy() {
     Args.clearParam();
-    AppT.shutdownServices();
-    AppT.shutdown();
     context.destroy();
     if (FileUtil.deleteDir(new File(dbPath))) {
       logger.info("Release resources successful.");

--- a/framework/src/test/java/org/tron/common/runtime/vm/InternalTransactionCallTest.java
+++ b/framework/src/test/java/org/tron/common/runtime/vm/InternalTransactionCallTest.java
@@ -354,7 +354,6 @@ public class InternalTransactionCallTest {
   @After
   public void destroy() {
     context.destroy();
-    AppT.shutdown();
     Args.clearParam();
     if (FileUtil.deleteDir(new File(dbPath))) {
       logger.info("Release resources successful.");

--- a/framework/src/test/java/org/tron/common/runtime/vm/PrecompiledContractsTest.java
+++ b/framework/src/test/java/org/tron/common/runtime/vm/PrecompiledContractsTest.java
@@ -101,8 +101,6 @@ public class PrecompiledContractsTest {
   @AfterClass
   public static void destroy() {
     Args.clearParam();
-    appT.shutdownServices();
-    appT.shutdown();
     context.destroy();
     if (FileUtil.deleteDir(new File(dbPath))) {
       logger.info("Release resources successful.");

--- a/framework/src/test/java/org/tron/common/runtime/vm/TimeBenchmarkTest.java
+++ b/framework/src/test/java/org/tron/common/runtime/vm/TimeBenchmarkTest.java
@@ -148,8 +148,6 @@ public class TimeBenchmarkTest {
   @After
   public void destroy() {
     Args.clearParam();
-    AppT.shutdownServices();
-    AppT.shutdown();
     context.destroy();
     if (FileUtil.deleteDir(new File(dbPath))) {
       logger.info("Release resources successful.");

--- a/framework/src/test/java/org/tron/common/runtime/vm/TransferToAccountTest.java
+++ b/framework/src/test/java/org/tron/common/runtime/vm/TransferToAccountTest.java
@@ -90,8 +90,6 @@ public class TransferToAccountTest {
   @AfterClass
   public static void destroy() {
     Args.clearParam();
-    appT.shutdownServices();
-    appT.shutdown();
     context.destroy();
     if (FileUtil.deleteDir(new File(dbPath))) {
       logger.info("Release resources successful.");

--- a/framework/src/test/java/org/tron/common/runtime/vm/TransferTokenTest.java
+++ b/framework/src/test/java/org/tron/common/runtime/vm/TransferTokenTest.java
@@ -77,8 +77,6 @@ public class TransferTokenTest {
   @AfterClass
   public static void destroy() {
     Args.clearParam();
-    appT.shutdownServices();
-    appT.shutdown();
     context.destroy();
     if (FileUtil.deleteDir(new File(dbPath))) {
       logger.info("Release resources successful.");

--- a/framework/src/test/java/org/tron/common/runtime/vm/VMTestBase.java
+++ b/framework/src/test/java/org/tron/common/runtime/vm/VMTestBase.java
@@ -45,8 +45,6 @@ public class VMTestBase {
   @After
   public void destroy() {
     Args.clearParam();
-    ApplicationFactory.create(context).shutdown();
-    ApplicationFactory.create(context).shutdownServices();
     context.destroy();
     if (FileUtil.deleteDir(new File(dbPath))) {
       logger.info("Release resources successful.");

--- a/framework/src/test/java/org/tron/core/actuator/AccountPermissionUpdateActuatorTest.java
+++ b/framework/src/test/java/org/tron/core/actuator/AccountPermissionUpdateActuatorTest.java
@@ -116,8 +116,6 @@ public class AccountPermissionUpdateActuatorTest {
   @AfterClass
   public static void destroy() {
     Args.clearParam();
-    AppT.shutdownServices();
-    AppT.shutdown();
     context.destroy();
     if (FileUtil.deleteDir(new File(dbPath))) {
       logger.info("Release resources successful.");

--- a/framework/src/test/java/org/tron/core/actuator/ActuatorConstantTest.java
+++ b/framework/src/test/java/org/tron/core/actuator/ActuatorConstantTest.java
@@ -39,9 +39,6 @@ public class ActuatorConstantTest {
   @AfterClass
   public static void destroy() {
     Args.clearParam();
-    AppT.shutdownServices();
-    AppT.shutdown();
-
     context.destroy();
     if (FileUtil.deleteDir(new File(dbPath))) {
       logger.info("Release resources successful.");

--- a/framework/src/test/java/org/tron/core/actuator/UpdateAssetActuatorTest.java
+++ b/framework/src/test/java/org/tron/core/actuator/UpdateAssetActuatorTest.java
@@ -75,8 +75,6 @@ public class UpdateAssetActuatorTest {
   @AfterClass
   public static void destroy() {
     Args.clearParam();
-    AppT.shutdownServices();
-    AppT.shutdown();
     context.destroy();
     if (FileUtil.deleteDir(new File(dbPath))) {
       logger.info("Release resources successful.");

--- a/framework/src/test/java/org/tron/core/actuator/utils/ProposalUtilTest.java
+++ b/framework/src/test/java/org/tron/core/actuator/utils/ProposalUtilTest.java
@@ -48,9 +48,6 @@ public class ProposalUtilTest {
   @AfterClass
   public static void destroy() {
     Args.clearParam();
-    AppT.shutdownServices();
-    AppT.shutdown();
-
     context.destroy();
     if (FileUtil.deleteDir(new File(dbPath))) {
       logger.info("Release resources successful.");

--- a/framework/src/test/java/org/tron/core/actuator/utils/TransactionUtilTest.java
+++ b/framework/src/test/java/org/tron/core/actuator/utils/TransactionUtilTest.java
@@ -40,9 +40,6 @@ public class TransactionUtilTest {
   @AfterClass
   public static void destroy() {
     Args.clearParam();
-    AppT.shutdownServices();
-    AppT.shutdown();
-
     context.destroy();
     if (FileUtil.deleteDir(new File(dbPath))) {
       logger.info("Release resources successful.");

--- a/framework/src/test/java/org/tron/core/actuator/utils/ZenChainParamsTest.java
+++ b/framework/src/test/java/org/tron/core/actuator/utils/ZenChainParamsTest.java
@@ -39,9 +39,6 @@ public class ZenChainParamsTest {
   @AfterClass
   public static void destroy() {
     Args.clearParam();
-    AppT.shutdownServices();
-    AppT.shutdown();
-
     context.destroy();
     if (FileUtil.deleteDir(new File(dbPath))) {
       logger.info("Release resources successful.");

--- a/framework/src/test/java/org/tron/core/db/NullifierStoreTest.java
+++ b/framework/src/test/java/org/tron/core/db/NullifierStoreTest.java
@@ -42,8 +42,6 @@ public class NullifierStoreTest {
   public static void destroy() {
     Args.clearParam();
     context.destroy();
-    AppT.shutdownServices();
-    AppT.shutdown();
     FileUtil.deleteDir(new File(dbPath));
   }
 

--- a/framework/src/test/java/org/tron/core/db/TransactionStoreTest.java
+++ b/framework/src/test/java/org/tron/core/db/TransactionStoreTest.java
@@ -72,8 +72,6 @@ public class TransactionStoreTest {
   @AfterClass
   public static void destroy() {
     Args.clearParam();
-    AppT.shutdownServices();
-    AppT.shutdown();
     context.destroy();
     FileUtil.deleteDir(new File(dbPath));
   }

--- a/framework/src/test/java/org/tron/core/db/api/AssetUpdateHelperTest.java
+++ b/framework/src/test/java/org/tron/core/db/api/AssetUpdateHelperTest.java
@@ -86,8 +86,6 @@ public class AssetUpdateHelperTest {
   @AfterClass
   public static void removeDb() {
     Args.clearParam();
-    AppT.shutdownServices();
-    AppT.shutdown();
     context.destroy();
     FileUtil.deleteDir(new File(dbPath));
   }

--- a/framework/src/test/java/org/tron/core/db/backup/BackupDbUtilTest.java
+++ b/framework/src/test/java/org/tron/core/db/backup/BackupDbUtilTest.java
@@ -77,8 +77,6 @@ public class BackupDbUtilTest {
 
   @After
   public void after() {
-    AppT.shutdownServices();
-    AppT.shutdown();
     context.destroy();
     if (FileUtil.deleteDir(new File(dbPath))) {
       logger.info("Release resources successful.");

--- a/framework/src/test/java/org/tron/core/db2/RevokingDbWithCacheNewValueTest.java
+++ b/framework/src/test/java/org/tron/core/db2/RevokingDbWithCacheNewValueTest.java
@@ -41,8 +41,6 @@ public class RevokingDbWithCacheNewValueTest {
   @After
   public void removeDb() {
     Args.clearParam();
-    appT.shutdownServices();
-    appT.shutdown();
     context.destroy();
     tronDatabase.close();
     FileUtil.deleteDir(new File("output_revokingStore_test"));

--- a/framework/src/test/java/org/tron/core/db2/RevokingDbWithCacheOldValueTest.java
+++ b/framework/src/test/java/org/tron/core/db2/RevokingDbWithCacheOldValueTest.java
@@ -43,8 +43,6 @@ public class RevokingDbWithCacheOldValueTest {
   @After
   public void removeDb() {
     Args.clearParam();
-    appT.shutdownServices();
-    appT.shutdown();
     context.destroy();
     FileUtil.deleteDir(new File("output_revokingStore_test"));
   }

--- a/framework/src/test/java/org/tron/core/db2/SnapshotManagerTest.java
+++ b/framework/src/test/java/org/tron/core/db2/SnapshotManagerTest.java
@@ -42,8 +42,6 @@ public class SnapshotManagerTest {
   @After
   public void removeDb() {
     Args.clearParam();
-    appT.shutdownServices();
-    appT.shutdown();
     context.destroy();
     tronDatabase.close();
     FileUtil.deleteDir(new File("output_SnapshotManager_test"));

--- a/framework/src/test/java/org/tron/core/db2/SnapshotRootTest.java
+++ b/framework/src/test/java/org/tron/core/db2/SnapshotRootTest.java
@@ -42,8 +42,6 @@ public class SnapshotRootTest {
   @After
   public void removeDb() {
     Args.clearParam();
-    appT.shutdownServices();
-    appT.shutdown();
     context.destroy();
     FileUtil.deleteDir(new File("output_revokingStore_test"));
   }


### PR DESCRIPTION
**What does this PR do?**
remove the shutdown and shutdownService function invoked in the unit test. 

**Why are these changes required?**
context.destroy() contains the shutdown() and shutdownService() 
**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

