### PR TITLE
[skip ci] fix modular-structure image url

### DIFF
--- a/docs/modular-introduction-en.md
+++ b/docs/modular-introduction-en.md
@@ -14,7 +14,7 @@ The aim of java-tron modularization is to enable developers to easily build a de
 
 ## Architecture of modularized java-tron
 
-![modular-structure](https://github.com/tronprotocol/java-tron/tree/develop/docs/images/module.png)
+![modular-structure](https://github.com/tronprotocol/java-tron/blob/develop/docs/images/module.png)
 
 A modularized java-tron consists of six modules: framework, protocol, common, chainbase, consensus and actuator. The function of each module is elaborated below.
 

--- a/docs/modular-introduction-zh.md
+++ b/docs/modular-introduction-zh.md
@@ -12,7 +12,7 @@ java-tron 模块化的目的是为了帮助开发者方便地构建出特定应�
 
 ## 模块化的 java-tron 架构介绍
 
-![modular-structure](https://github.com/tronprotocol/java-tron/tree/develop/docs/images/module.png)
+![modular-structure](https://github.com/tronprotocol/java-tron/blob/develop/docs/images/module.png)
 
 模块化后的 java-tron 目前分为6个模块：framework、protocol、common、chainbase、consensus、actuator，下面分别简单介绍一下各个模块的作用。
 


### PR DESCRIPTION
**What does this PR do?**

fix modular-structure image url

**Why are these changes required?**

image url was wrong

