### PR TITLE
remove duplicate code in hash.java

### DIFF
--- a/chainbase/src/main/java/org/tron/common/utils/Commons.java
+++ b/chainbase/src/main/java/org/tron/common/utils/Commons.java
@@ -22,12 +22,6 @@ public class Commons {
 
   public static final int ASSET_ISSUE_COUNT_LIMIT_MAX = 1000;
 
-  public static byte[] clone(byte[] value) {
-    byte[] clone = new byte[value.length];
-    System.arraycopy(value, 0, clone, 0, value.length);
-    return clone;
-  }
-
   private static byte[] decode58Check(String input) {
     byte[] decodeCheck = Base58.decode(input);
     if (decodeCheck.length <= 4) {

--- a/chainbase/src/main/java/org/tron/core/db/AbstractRevokingStore.java
+++ b/chainbase/src/main/java/org/tron/core/db/AbstractRevokingStore.java
@@ -28,6 +28,7 @@ import org.tron.common.storage.leveldb.LevelDbDataSourceImpl;
 import org.tron.common.utils.Commons;
 import org.tron.common.utils.FileUtil;
 import org.tron.common.utils.StorageUtils;
+import org.tron.common.utils.Utils;
 import org.tron.core.db.common.SourceInter;
 import org.tron.core.db2.ISession;
 import org.tron.core.db2.common.IRevokingDB;
@@ -138,7 +139,7 @@ public abstract class AbstractRevokingStore implements RevokingDatabase {
       return;
     }
 
-    state.oldValues.put(tuple, Commons.clone(value));
+    state.oldValues.put(tuple, Utils.clone(value));
   }
 
   public synchronized void onRemove(RevokingTuple tuple, byte[] value) {
@@ -163,7 +164,7 @@ public abstract class AbstractRevokingStore implements RevokingDatabase {
       return;
     }
 
-    state.removed.put(tuple, Commons.clone(value));
+    state.removed.put(tuple, Utils.clone(value));
   }
 
   @Override

--- a/framework/src/main/java/org/tron/core/capsule/utils/RLP.java
+++ b/framework/src/main/java/org/tron/core/capsule/utils/RLP.java
@@ -17,6 +17,7 @@ import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.spongycastle.util.encoders.Hex;
+import org.tron.common.crypto.Hash;
 import org.tron.common.utils.ByteUtil;
 import org.tron.common.utils.Value;
 import org.tron.core.db.ByteArrayWrapper;
@@ -78,7 +79,7 @@ public class RLP {
    * \xb9\x04\x00 followed by the string. The range of the first byte is thus [0xb8, 0xbf].
    */
   private static final int OFFSET_LONG_ITEM = 0xb7;
-  public static final byte[] EMPTY_ELEMENT_RLP = encodeElement(new byte[0]);
+  public static final byte[] EMPTY_ELEMENT_RLP = Hash.encodeElement(new byte[0]);
   /**
    * [0xc0] If the total payload of a list (i.e. the combined length of all its items) is 0-55 bytes
    * long, the RLP encoding consists of a single byte with value 0xc0 plus the length of the list
@@ -829,7 +830,7 @@ public class RLP {
   }
 
   public static byte[] encodeString(String srcString) {
-    return encodeElement(srcString.getBytes());
+    return Hash.encodeElement(srcString.getBytes());
   }
 
   public static byte[] encodeBigInteger(BigInteger srcBigInteger) {
@@ -840,59 +841,7 @@ public class RLP {
     if (srcBigInteger.equals(BigInteger.ZERO)) {
       return encodeByte((byte) 0);
     } else {
-      return encodeElement(asUnsignedByteArray(srcBigInteger));
-    }
-  }
-
-  public static byte[] encodeElement(byte[] srcData) {
-
-    // [0x80]
-    if (isNullOrZeroArray(srcData)) {
-      return new byte[]{(byte) OFFSET_SHORT_ITEM};
-
-      // [0x00]
-    } else if (isSingleZero(srcData)) {
-      return srcData;
-
-      // [0x01, 0x7f] - single byte, that byte is its own RLP encoding
-    } else if (srcData.length == 1 && (srcData[0] & 0xFF) < 0x80) {
-      return srcData;
-
-      // [0x80, 0xb7], 0 - 55 bytes
-    } else if (srcData.length < SIZE_THRESHOLD) {
-      // length = 8X
-      byte length = (byte) (OFFSET_SHORT_ITEM + srcData.length);
-      byte[] data = Arrays.copyOf(srcData, srcData.length + 1);
-      System.arraycopy(data, 0, data, 1, srcData.length);
-      data[0] = length;
-
-      return data;
-      // [0xb8, 0xbf], 56+ bytes
-    } else {
-      // length of length = BX
-      // prefix = [BX, [length]]
-      int tmpLength = srcData.length;
-      byte lengthOfLength = 0;
-      while (tmpLength != 0) {
-        ++lengthOfLength;
-        tmpLength = tmpLength >> 8;
-      }
-
-      // set length Of length at first byte
-      byte[] data = new byte[1 + lengthOfLength + srcData.length];
-      data[0] = (byte) (OFFSET_LONG_ITEM + lengthOfLength);
-
-      // copy length after first byte
-      tmpLength = srcData.length;
-      for (int i = lengthOfLength; i > 0; --i) {
-        data[i] = (byte) (tmpLength & 0xFF);
-        tmpLength = tmpLength >> 8;
-      }
-
-      // at last copy the number bytes after its length
-      System.arraycopy(srcData, 0, data, 1 + lengthOfLength, srcData.length);
-
-      return data;
+      return Hash.encodeElement(asUnsignedByteArray(srcBigInteger));
     }
   }
 
@@ -999,7 +948,7 @@ public class RLP {
     Set<byte[]> encodedElements = new HashSet<>();
     for (ByteArrayWrapper element : data) {
 
-      byte[] encodedElement = RLP.encodeElement(element.getData());
+      byte[] encodedElement = Hash.encodeElement(element.getData());
       dataLength += encodedElement.length;
       encodedElements.add(encodedElement);
     }
@@ -1026,7 +975,7 @@ public class RLP {
   public static byte[] wrapList(byte[]... data) {
     byte[][] elements = new byte[data.length][];
     for (int i = 0; i < data.length; i++) {
-      elements[i] = encodeElement(data[i]);
+      elements[i] = Hash.encodeElement(data[i]);
     }
     return encodeList(elements);
   }
@@ -1233,7 +1182,7 @@ public class RLP {
     public byte[] getEncoded() {
       byte[][] encoded = new byte[cnt][];
       for (int i = 0; i < cnt; i++) {
-        encoded[i] = encodeElement(getBytes(i));
+        encoded[i] = Hash.encodeElement(getBytes(i));
       }
       return encodeList(encoded);
     }

--- a/framework/src/main/java/org/tron/core/db/accountstate/callback/AccountStateCallBack.java
+++ b/framework/src/main/java/org/tron/core/db/accountstate/callback/AccountStateCallBack.java
@@ -38,7 +38,7 @@ public class AccountStateCallBack extends AccountStateCallBackUtils {
 
   public void exeTransFinish() {
     for (TrieEntry trieEntry : trieEntryList) {
-      trie.put(RLP.encodeElement(trieEntry.getKey()), trieEntry.getData());
+      trie.put(Hash.encodeElement(trieEntry.getKey()), trieEntry.getData());
     }
     trieEntryList.clear();
   }
@@ -47,7 +47,7 @@ public class AccountStateCallBack extends AccountStateCallBackUtils {
     if (!exe()) {
       return;
     }
-    trie.delete(RLP.encodeElement(key));
+    trie.delete(Hash.encodeElement(key));
   }
 
   public void preExecute(BlockCapsule blockCapsule) {

--- a/framework/src/main/java/org/tron/core/db/accountstate/storetrie/AccountStateStoreTrie.java
+++ b/framework/src/main/java/org/tron/core/db/accountstate/storetrie/AccountStateStoreTrie.java
@@ -6,6 +6,7 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import org.tron.common.crypto.Hash;
 import org.tron.core.capsule.BytesCapsule;
 import org.tron.core.capsule.utils.RLP;
 import org.tron.core.db.TronStoreWithRevoking;
@@ -38,7 +39,7 @@ public class AccountStateStoreTrie extends TronStoreWithRevoking<BytesCapsule> i
 
   public AccountStateEntity getAccount(byte[] key, byte[] rootHash) {
     TrieImpl trie = new TrieImpl(this, rootHash);
-    byte[] value = trie.get(RLP.encodeElement(key));
+    byte[] value = trie.get(Hash.encodeElement(key));
     return ArrayUtils.isEmpty(value) ? null : AccountStateEntity.parse(value);
   }
 


### PR DESCRIPTION
**What does this PR do?**
remove encodeElement which is duplicated in hash.java and RLP.java
**Why are these changes required?**
remove encodeElement which is duplicated in hash.java and RLP.java
**This PR has been tested by:**
- Unit Tests
- Manual Testing
