### PR TITLE
fix support Single core

### DIFF
--- a/framework/src/main/java/org/tron/core/config/args/Args.java
+++ b/framework/src/main/java/org/tron/core/config/args/Args.java
@@ -432,7 +432,7 @@ public class Args extends CommonParameter {
 
     PARAMETER.rpcThreadNum =
         config.hasPath(Constant.NODE_RPC_THREAD) ? config.getInt(Constant.NODE_RPC_THREAD)
-            : Runtime.getRuntime().availableProcessors() / 2;
+            : (Runtime.getRuntime().availableProcessors() + 1) / 2;
 
     PARAMETER.solidityThreads =
         config.hasPath(Constant.NODE_SOLIDITY_THREADS)


### PR DESCRIPTION
**What does this PR do?**
The expression `Runtime.getRuntime().availableProcessors() / 2`  is unavailable for single-core machine.

**Why are these changes required?**
The single-core machine will throw an exception. So we must fix it.

**This PR has been tested by:**
- Unit Tests

**Follow up**

**Extra details**

