### PR TITLE
Optimization: remove sortWitness() method

### DIFF
--- a/consensus/src/main/java/org/tron/consensus/dpos/MaintenanceManager.java
+++ b/consensus/src/main/java/org/tron/consensus/dpos/MaintenanceManager.java
@@ -23,6 +23,7 @@ import org.tron.core.capsule.AccountCapsule;
 import org.tron.core.capsule.BlockCapsule;
 import org.tron.core.capsule.VotesCapsule;
 import org.tron.core.capsule.WitnessCapsule;
+import org.tron.core.db.DelegationService;
 import org.tron.core.store.DelegationStore;
 import org.tron.core.store.DynamicPropertiesStore;
 import org.tron.core.store.VotesStore;
@@ -36,6 +37,9 @@ public class MaintenanceManager {
 
   @Autowired
   private IncentiveManager incentiveManager;
+
+  @Autowired
+  private DelegationService delegationService;
 
   @Setter
   private DposService dposService;
@@ -118,6 +122,8 @@ public class MaintenanceManager {
         delegationStore.setWitnessVote(nextCycle, witness.createDbKey(), witness.getVoteCount());
       });
     }
+    // update the witnessAddressList in delegationService
+    delegationService.updateWitnessAddressList();
   }
 
   private Map<ByteString, Long> countVote(VotesStore votesStore) {


### PR DESCRIPTION
**What does this PR do?**

Optimization: remove sortWitness() method

**Why are these changes required?**

sortWitness() takes about 7-8% percent CPU time of the whole thread, it is invoked by payReward() when processing the block, but the result of sortWitness() only changed when the maintenance is executed which interval is 6 hour, so store the result of sortWitness() in a list and update the list when maintenance happened.

**This PR has been tested by:**
- Unit Tests
- Manual Testing