### PR TITLE
Bugfix: Optimize sortwitness

### DIFF
--- a/chainbase/src/main/java/org/tron/core/db/DelegationService.java
+++ b/chainbase/src/main/java/org/tron/core/db/DelegationService.java
@@ -223,6 +223,7 @@ public class DelegationService {
    * As pushBlock a sync method, so no sync action to be considered on witnessAddressList.
    */
   public void updateWitnessAddressList() {
+    witnessAddressList.clear();
     for (WitnessCapsule witnessCapsule : witnessStore.getAllWitnesses()) {
       witnessAddressList.add(witnessCapsule.getAddress());
     }


### PR DESCRIPTION
**What does this PR do?**

bugfix [#3145](https://github.com/tronprotocol/java-tron/pull/3145): clear witnessAddressList when update the witnessList. 
witnessList should be cleared and read/sort again.

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing


