### PR TITLE
fix the bug that there is an except when transactionInfo does not have contract address

### DIFF
--- a/framework/src/main/java/org/tron/core/Wallet.java
+++ b/framework/src/main/java/org/tron/core/Wallet.java
@@ -2984,8 +2984,8 @@ public class Wallet {
         TransactionCapsule transactionCapsule = new TransactionCapsule(transaction);
         byte[] txId = transactionCapsule.getTransactionId().getBytes();
         TransactionInfo info = this.getTransactionInfoById(ByteString.copyFrom(txId));
-        if (info != null && ByteUtil.equals(info.getContractAddress().toByteArray(),
-            shieldedTRC20ContractAddress)) {
+        if (info != null && ByteArray.toHexString(info.getContractAddress().toByteArray()).equals(
+            ByteArray.toHexString(shieldedTRC20ContractAddress))) {
           DecryptNotesTRC20.NoteTx.Builder noteBuilder;
           List<TransactionInfo.Log> logList = info.getLogList();
           Optional<DecryptNotesTRC20.NoteTx> noteTx;
@@ -3137,8 +3137,8 @@ public class Wallet {
         TransactionCapsule transactionCapsule = new TransactionCapsule(transaction);
         byte[] txid = transactionCapsule.getTransactionId().getBytes();
         TransactionInfo info = this.getTransactionInfoById(ByteString.copyFrom(txid));
-        if (info != null && ByteUtil.equals(info.getContractAddress().toByteArray(),
-            shieldedTRC20ContractAddress)) {
+        if (info != null && ByteArray.toHexString(info.getContractAddress().toByteArray()).equals(
+            ByteArray.toHexString(shieldedTRC20ContractAddress))) {
           DecryptNotesTRC20.NoteTx.Builder noteBuilder;
           List<TransactionInfo.Log> logList = info.getLogList();
           Optional<DecryptNotesTRC20.NoteTx> noteTx;

--- a/framework/src/main/java/org/tron/core/Wallet.java
+++ b/framework/src/main/java/org/tron/core/Wallet.java
@@ -36,6 +36,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import java.math.BigInteger;
 import java.security.SignatureException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -2984,8 +2985,8 @@ public class Wallet {
         TransactionCapsule transactionCapsule = new TransactionCapsule(transaction);
         byte[] txId = transactionCapsule.getTransactionId().getBytes();
         TransactionInfo info = this.getTransactionInfoById(ByteString.copyFrom(txId));
-        if (info != null && ByteArray.toHexString(info.getContractAddress().toByteArray()).equals(
-            ByteArray.toHexString(shieldedTRC20ContractAddress))) {
+        if (info != null && Arrays.equals(info.getContractAddress().toByteArray(),
+            shieldedTRC20ContractAddress)) {
           DecryptNotesTRC20.NoteTx.Builder noteBuilder;
           List<TransactionInfo.Log> logList = info.getLogList();
           Optional<DecryptNotesTRC20.NoteTx> noteTx;
@@ -3137,8 +3138,8 @@ public class Wallet {
         TransactionCapsule transactionCapsule = new TransactionCapsule(transaction);
         byte[] txid = transactionCapsule.getTransactionId().getBytes();
         TransactionInfo info = this.getTransactionInfoById(ByteString.copyFrom(txid));
-        if (info != null && ByteArray.toHexString(info.getContractAddress().toByteArray()).equals(
-            ByteArray.toHexString(shieldedTRC20ContractAddress))) {
+        if (info != null && Arrays.equals(info.getContractAddress().toByteArray(),
+            shieldedTRC20ContractAddress)) {
           DecryptNotesTRC20.NoteTx.Builder noteBuilder;
           List<TransactionInfo.Log> logList = info.getLogList();
           Optional<DecryptNotesTRC20.NoteTx> noteTx;


### PR DESCRIPTION
**What does this PR do?**
fix the bug that there is an exception when transactionInfo does not have contract address

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

