### PR TITLE
add extra check for timeout in verifyTransferProof in order to solve sonar-check

### DIFF
--- a/actuator/src/main/java/org/tron/core/vm/PrecompiledContracts.java
+++ b/actuator/src/main/java/org/tron/core/vm/PrecompiledContracts.java
@@ -1242,6 +1242,11 @@ public class PrecompiledContracts {
 
         boolean withNoTimeout =  countDownLatch.await(getCPUTimeLeftInNanoSecond(),
             TimeUnit.NANOSECONDS);
+        if (!withNoTimeout) {
+          logger.info("VerifyTransferProof timeout");
+          throw Program.Exception.notEnoughTime("call VerifyTransferProof precompile method");
+        }
+
         boolean checkResult = true;
         for (Future<Boolean> future : futures) {
           boolean eachTaskResult = future.get();


### PR DESCRIPTION

**What does this PR do?**
add extra check for timeout in verifyTransferProof in order to solve sonar-check problems

**Why are these changes required?**
add extra check for timeout in verifyTransferProof in order to solve sonar-check problems

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

