### PR TITLE
protocol: Fix spelling

### DIFF
--- a/protocol/src/main/protos/api/api.proto
+++ b/protocol/src/main/protos/api/api.proto
@@ -1110,7 +1110,7 @@ message AddressPrKeyPairMessage {
 message TransactionExtention {
   Transaction transaction = 1;
   bytes txid = 2; //transaction id =  sha256(transaction.rowdata)
-  repeated bytes constant_result = 3;
+  repeated bytes contract_result = 3;
   Return result = 4;
 }
 


### PR DESCRIPTION
**What does this PR do?**
- Fix spelling in protos/api

**Why are these changes required?**
- To correct meaning of return field

**This PR has been tested by:**
- Not yet