### PR TITLE
db: add a prefix query and CrossRevokingStore will use this method

### DIFF
--- a/actuator/src/main/java/org/tron/core/actuator/UnvoteCrossActuator.java
+++ b/actuator/src/main/java/org/tron/core/actuator/UnvoteCrossActuator.java
@@ -64,7 +64,6 @@ public class UnvoteCrossActuator extends AbstractActuator {
     if (chainBaseManager == null) {
       throw new ContractValidateException(ActuatorConstant.STORE_NOT_EXIST);
     }
-    AccountStore accountStore = chainBaseManager.getAccountStore();
     CrossRevokingStore crossRevokingStore = chainBaseManager.getCrossRevokingStore();
     if (!this.any.is(UnvoteCrossContract.class)) {
       throw new ContractValidateException(

--- a/chainbase/src/main/java/org/tron/common/storage/leveldb/LevelDbDataSourceImpl.java
+++ b/chainbase/src/main/java/org/tron/common/storage/leveldb/LevelDbDataSourceImpl.java
@@ -375,7 +375,6 @@ public class LevelDbDataSourceImpl implements DbSourceInter<byte[]>,
     resetDbLock.readLock().lock();
     try (DBIterator iterator = database.iterator()) {
       Map<byte[], byte[]> result = new HashMap<>();
-      long i = 0;
       for (iterator.seek(prefixKey); iterator.hasNext(); iterator.next()) {
         Entry<byte[], byte[]> entry = iterator.peekNext();
         if (!ByteUtil.equalPrefix(entry.getKey(), prefixKey)) {

--- a/chainbase/src/main/java/org/tron/core/db/CrossRevokingStore.java
+++ b/chainbase/src/main/java/org/tron/core/db/CrossRevokingStore.java
@@ -21,7 +21,7 @@ public class CrossRevokingStore extends TronStoreWithRevoking<BytesCapsule> {
   public static final String CHAIN_REGISTER_PREFIX = "register_";
 
   // todo: this param should can be customized
-  public static int MAX_PARACHAIN_NUM = 3;
+  public static final int MAX_PARACHAIN_NUM = 3;
 
 
   public CrossRevokingStore() {

--- a/chainbase/src/main/java/org/tron/core/db/TronDatabase.java
+++ b/chainbase/src/main/java/org/tron/core/db/TronDatabase.java
@@ -3,6 +3,7 @@ package org.tron.core.db;
 import com.google.protobuf.InvalidProtocolBufferException;
 import java.nio.file.Paths;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map.Entry;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -10,6 +11,7 @@ import org.iq80.leveldb.WriteOptions;
 import org.tron.common.parameter.CommonParameter;
 import org.tron.common.storage.leveldb.LevelDbDataSourceImpl;
 import org.tron.common.storage.rocksdb.RocksDbDataSourceImpl;
+import org.tron.common.utils.Pair;
 import org.tron.common.utils.StorageUtils;
 import org.tron.core.db.common.DbSourceInter;
 import org.tron.core.db2.core.ITronChainBase;
@@ -87,6 +89,11 @@ public abstract class TronDatabase<T> implements ITronChainBase<T> {
 
   @Override
   public Iterator<Entry<byte[], T>> iterator() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public List<Pair<byte[], T>> prefixQuery(byte[] prefixKey) {
     throw new UnsupportedOperationException();
   }
 }

--- a/chainbase/src/main/java/org/tron/core/db/common/DbSourceInter.java
+++ b/chainbase/src/main/java/org/tron/core/db/common/DbSourceInter.java
@@ -17,8 +17,10 @@
  */
 package org.tron.core.db.common;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.tron.common.utils.Pair;
 
 
 public interface DbSourceInter<V> extends BatchSourceInter<byte[], V>,
@@ -41,5 +43,7 @@ public interface DbSourceInter<V> extends BatchSourceInter<byte[], V>,
   Set<byte[]> allValues() throws RuntimeException;
 
   long getTotal() throws RuntimeException;
+
+  Map<byte[], byte[]> prefixQuery(byte[] prefixKey);
 
 }

--- a/chainbase/src/main/java/org/tron/core/db2/common/IRevokingDB.java
+++ b/chainbase/src/main/java/org/tron/core/db2/common/IRevokingDB.java
@@ -3,6 +3,7 @@ package org.tron.core.db2.common;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.tron.common.utils.Pair;
 import org.tron.core.db2.core.Chainbase;
 import org.tron.core.exception.ItemNotFoundException;
 
@@ -36,5 +37,7 @@ public interface IRevokingDB extends Iterable<Map.Entry<byte[], byte[]>> {
 
   // for blockstore
   Set<byte[]> getlatestValuesFromDisk(long limit);
+
+  List<Pair<byte[], byte[]>> prefixQuery(byte[] prefixKey);
 
 }

--- a/chainbase/src/main/java/org/tron/core/db2/core/ITronChainBase.java
+++ b/chainbase/src/main/java/org/tron/core/db2/core/ITronChainBase.java
@@ -1,7 +1,9 @@
 package org.tron.core.db2.core;
 
 import com.google.protobuf.InvalidProtocolBufferException;
+import java.util.List;
 import java.util.Map.Entry;
+import org.tron.common.utils.Pair;
 import org.tron.common.utils.Quitable;
 import org.tron.core.exception.BadItemException;
 import org.tron.core.exception.ItemNotFoundException;
@@ -31,5 +33,7 @@ public interface ITronChainBase<T> extends Iterable<Entry<byte[], T>>, Quitable 
   String getName();
 
   String getDbName();
+
+  List<Pair<byte[], T>> prefixQuery(byte[] prefixKey);
 
 }

--- a/chainbase/src/main/java/org/tron/core/db2/core/RevokingDBWithCachingOldValue.java
+++ b/chainbase/src/main/java/org/tron/core/db2/core/RevokingDBWithCachingOldValue.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.ArrayUtils;
@@ -12,6 +13,8 @@ import org.iq80.leveldb.Options;
 import org.iq80.leveldb.WriteOptions;
 import org.tron.common.parameter.CommonParameter;
 import org.tron.common.storage.leveldb.LevelDbDataSourceImpl;
+import org.tron.common.utils.ByteUtil;
+import org.tron.common.utils.Pair;
 import org.tron.common.utils.StorageUtils;
 import org.tron.core.db.AbstractRevokingStore;
 import org.tron.core.db.RevokingStore;
@@ -161,6 +164,15 @@ public class RevokingDBWithCachingOldValue implements IRevokingDB {
   @Override
   public List<byte[]> getKeysNext(byte[] key, long limit) {
     return dbSource.getKeysNext(key, limit);
+  }
+
+  @Override
+  public List<Pair<byte[], byte[]>> prefixQuery(byte[] prefixKey) {
+    return dbSource.prefixQuery(prefixKey).entrySet().stream()
+            .filter(e -> ByteUtil.equalPrefix(e.getKey(), prefixKey))
+            .sorted((e1, e2) -> ByteUtil.compare(e1.getKey(), e2.getKey()))
+            .map(e -> new Pair<>(e.getKey(), e.getValue()))
+            .collect(Collectors.toList());
   }
 
   @Override

--- a/chainbase/src/main/java/org/tron/core/db2/core/SnapshotImpl.java
+++ b/chainbase/src/main/java/org/tron/core/db2/core/SnapshotImpl.java
@@ -106,6 +106,7 @@ public class SnapshotImpl extends AbstractSnapshot<Key, Value> {
             e -> !keys.contains(WrappedByteArray.of(e.getKey()))));
   }
 
+  // todo: if set solidity/pbft, this method should filter the unsolidified snapshotImpl
   synchronized void collect(Map<WrappedByteArray, WrappedByteArray> all) {
     Snapshot next = getRoot().getNext();
     while (next != null) {

--- a/common/src/main/java/org/tron/common/utils/ByteUtil.java
+++ b/common/src/main/java/org/tron/common/utils/ByteUtil.java
@@ -430,4 +430,13 @@ public class ByteUtil {
     return ByteUtil.merge(zeroBytes, longBytes);
   }
 
+  public static boolean equalPrefix(byte[] origin, byte[] prefix) {
+    if (origin.length < prefix.length) {
+      return false;
+    }
+    byte[] subOrigin = new byte[prefix.length];
+    System.arraycopy(origin, 0, subOrigin, 0, prefix.length);
+    return Arrays.equals(subOrigin, prefix);
+  }
+
 }

--- a/framework/src/main/java/org/tron/core/db/Manager.java
+++ b/framework/src/main/java/org/tron/core/db/Manager.java
@@ -1438,8 +1438,8 @@ public class Manager {
     session.reset();
 
     logger.info(
-        "Generate block success, pendingCount: {}," +
-                " repushCount: {}, postponedCount: {}, crossCount: {}",
+        "Generate block success, pendingCount: {}," 
+                + " repushCount: {}, postponedCount: {}, crossCount: {}",
         pendingTransactions.size(), rePushTransactions.size(), postponedTrxCount,
         crossTxQueue.size());
 

--- a/framework/src/main/java/org/tron/core/db/Manager.java
+++ b/framework/src/main/java/org/tron/core/db/Manager.java
@@ -1438,7 +1438,7 @@ public class Manager {
     session.reset();
 
     logger.info(
-        "Generate block success, pendingCount: {}," 
+        "Generate block success, pendingCount: {},"
                 + " repushCount: {}, postponedCount: {}, crossCount: {}",
         pendingTransactions.size(), rePushTransactions.size(), postponedTrxCount,
         crossTxQueue.size());

--- a/framework/src/test/java/org/tron/common/storage/leveldb/LevelDbDataSourceImplTest.java
+++ b/framework/src/test/java/org/tron/common/storage/leveldb/LevelDbDataSourceImplTest.java
@@ -32,6 +32,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -308,6 +309,41 @@ public class LevelDbDataSourceImplTest {
     for (int i = 0; i < limit; i++) {
       Assert.assertArrayEquals(list.get(i), seekKeyLimitNext.get(i));
     }
+
+    dataSource.resetDb();
+    dataSource.closeDB();
+  }
+
+  @Test
+  public void prefixQueryTest() {
+    LevelDbDataSourceImpl dataSource = new LevelDbDataSourceImpl(
+            Args.getInstance().getOutputDirectory(), "test_prefixQuery");
+    dataSource.initDB();
+    dataSource.resetDb();
+
+    putSomeKeyValue(dataSource);
+    // put a kv that will not be queried.
+    byte[] key7 = "0000001".getBytes();
+    byte[] value7 = "0000001v".getBytes();
+    dataSource.putData(key7, value7);
+
+    byte[] prefix = "0000000".getBytes();
+
+    List<String> result = dataSource.prefixQuery(prefix)
+            .keySet()
+            .stream()
+            .map(ByteArray::toStr)
+            .collect(Collectors.toList());
+    List<String> list = Arrays.asList(
+            ByteArray.toStr(key1),
+            ByteArray.toStr(key2),
+            ByteArray.toStr(key3),
+            ByteArray.toStr(key4),
+            ByteArray.toStr(key5),
+            ByteArray.toStr(key6));
+
+    Assert.assertEquals(list.size(), result.size());
+    list.forEach(entry -> Assert.assertTrue(result.contains(entry)));
 
     dataSource.resetDb();
     dataSource.closeDB();

--- a/framework/src/test/java/org/tron/common/storage/leveldb/RocksDbDataSourceImplTest.java
+++ b/framework/src/test/java/org/tron/common/storage/leveldb/RocksDbDataSourceImplTest.java
@@ -14,6 +14,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -348,6 +349,41 @@ public class RocksDbDataSourceImplTest {
     for (int i = 0; i < limit; i++) {
       Assert.assertArrayEquals(list.get(i), seekKeyLimitNext.get(i));
     }
+
+    dataSource.resetDb();
+    dataSource.closeDB();
+  }
+
+  @Test
+  public void prefixQueryTest() {
+    RocksDbDataSourceImpl dataSource = new RocksDbDataSourceImpl(
+            Args.getInstance().getOutputDirectory(), "test_prefixQuery");
+    dataSource.initDB();
+    dataSource.resetDb();
+
+    putSomeKeyValue(dataSource);
+    // put a kv that will not be queried.
+    byte[] key7 = "0000001".getBytes();
+    byte[] value7 = "0000001v".getBytes();
+    dataSource.putData(key7, value7);
+
+    byte[] prefix = "0000000".getBytes();
+
+    List<String> result = dataSource.prefixQuery(prefix)
+            .keySet()
+            .stream()
+            .map(ByteArray::toStr)
+            .collect(Collectors.toList());
+    List<String> list = Arrays.asList(
+            ByteArray.toStr(key1),
+            ByteArray.toStr(key2),
+            ByteArray.toStr(key3),
+            ByteArray.toStr(key4),
+            ByteArray.toStr(key5),
+            ByteArray.toStr(key6));
+
+    Assert.assertEquals(list.size(), result.size());
+    list.forEach(entry -> Assert.assertTrue(result.contains(entry)));
 
     dataSource.resetDb();
     dataSource.closeDB();

--- a/framework/src/test/java/org/tron/common/utils/ByteArrayTest.java
+++ b/framework/src/test/java/org/tron/common/utils/ByteArrayTest.java
@@ -17,6 +17,8 @@ package org.tron.common.utils;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
@@ -79,5 +81,19 @@ public class ByteArrayTest {
     byte[] bss = new byte[]{8, 9, 12, 13, 14, 15, 16};
     assertEquals("ByteArray.toHexString is not equals Hex.toHexString", ByteArray.toHexString(bss),
         Hex.toHexString(bss));
+  }
+
+  @Test
+  public void testEqualPrefix() {
+    byte[] origin = "123_abc".getBytes();
+    byte[] prefix = "123".getBytes();
+    byte[] notPrefix1 = "0123".getBytes();
+    byte[] notPrefix2 = "124".getBytes();
+    byte[] lenLongerThanOrigin = "123_abcde".getBytes();
+
+    assertTrue(ByteUtil.equalPrefix(origin, prefix));
+    assertFalse(ByteUtil.equalPrefix(origin, notPrefix1));
+    assertFalse(ByteUtil.equalPrefix(origin, notPrefix2));
+    assertFalse(ByteUtil.equalPrefix(origin, lenLongerThanOrigin));
   }
 }

--- a/framework/src/test/java/org/tron/core/db/CrossRevokingStoreTest.java
+++ b/framework/src/test/java/org/tron/core/db/CrossRevokingStoreTest.java
@@ -1,0 +1,88 @@
+package org.tron.core.db;
+
+import static org.tron.core.db.CrossRevokingStore.CHAIN_VOTED_PREFIX;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.tron.common.application.TronApplicationContext;
+import org.tron.common.utils.ByteArray;
+import org.tron.common.utils.FileUtil;
+import org.tron.common.utils.Pair;
+import org.tron.core.Constant;
+import org.tron.core.capsule.BytesCapsule;
+import org.tron.core.config.DefaultConfig;
+import org.tron.core.config.args.Args;
+
+@Slf4j
+public class CrossRevokingStoreTest {
+
+  private static final String dbPath = "output-crossRevokingStore-test";
+  private static TronApplicationContext context;
+
+  static {
+    Args.setParam(new String[]{"--output-directory", dbPath},
+        Constant.TEST_CONF);
+    context = new TronApplicationContext(DefaultConfig.class);
+  }
+
+  private String chain1 = "chain1";
+  private String chain2 = "chain2";
+  private String chain3 = "chain3";
+  private String chain4 = "chain4";
+  private String chain5 = "chain5";
+  private byte[] otherKey = "parachaininfo1".getBytes();
+
+  private long value1 = 5;
+  private long value2 = 2;
+  private long value3 = 3;
+  private long value4 = 4;
+  private long value5 = 1;
+  private byte[] otherValue = "v".getBytes();
+
+  CrossRevokingStore crossRevokingStore;
+
+  @Before
+  public void init() {
+    crossRevokingStore = context.getBean(CrossRevokingStore.class);
+  }
+
+  @After
+  public void destroy() {
+    Args.clearParam();
+    context.destroy();
+    FileUtil.deleteDir(new File(dbPath));
+  }
+
+  @Test
+  public void testGetChainVoteCountList() {
+    crossRevokingStore.updateTotalChainVote(chain1, value1);
+    crossRevokingStore.updateTotalChainVote(chain4, value4);
+    crossRevokingStore.updateTotalChainVote(chain2, value2);
+    crossRevokingStore.updateTotalChainVote(chain5, value5);
+    crossRevokingStore.updateTotalChainVote(chain3, value3);
+    crossRevokingStore.put(otherKey, new BytesCapsule(otherValue));
+
+    List<String> result = crossRevokingStore.getChainVoteCountList()
+            .stream()
+            .map(Pair::getKey)
+            .collect(Collectors.toList());
+    List<String> list = Arrays.asList(
+            chain1,
+            chain4,
+            chain3,
+            chain2,
+            chain5);
+
+    Assert.assertEquals(list.size(), result.size());
+    for (int i = 0; i < result.size(); i++) {
+      Assert.assertEquals(list.get(i), result.get(i));
+    }
+  }
+}

--- a/framework/src/test/java/org/tron/core/db2/ChainbaseTest.java
+++ b/framework/src/test/java/org/tron/core/db2/ChainbaseTest.java
@@ -1,0 +1,164 @@
+package org.tron.core.db2;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.rocksdb.RocksDB;
+import org.tron.common.storage.leveldb.LevelDbDataSourceImpl;
+import org.tron.common.storage.rocksdb.RocksDbDataSourceImpl;
+import org.tron.common.utils.ByteArray;
+import org.tron.common.utils.FileUtil;
+import org.tron.common.utils.Pair;
+import org.tron.core.Constant;
+import org.tron.core.config.args.Args;
+import org.tron.core.db2.common.LevelDB;
+import org.tron.core.db2.core.Chainbase;
+import org.tron.core.db2.core.Snapshot;
+import org.tron.core.db2.core.SnapshotRoot;
+
+@Slf4j
+public class ChainbaseTest {
+
+  private static final String dbPath = "output-chainbase-test";
+  private Chainbase chainbase = null;
+
+  private byte[] value1 = "10000".getBytes();
+  private byte[] value2 = "20000".getBytes();
+  private byte[] value3 = "30000".getBytes();
+  private byte[] value4 = "40000".getBytes();
+  private byte[] value5 = "50000".getBytes();
+  private byte[] value6 = "60000".getBytes();
+
+  private byte[] key1 = "00000001aa".getBytes();
+  private byte[] key2 = "00000002aa".getBytes();
+  private byte[] key3 = "00000003aa".getBytes();
+  private byte[] key4 = "00000004aa".getBytes();
+  private byte[] key5 = "00000005aa".getBytes();
+  private byte[] key6 = "00000006aa".getBytes();
+
+  /**
+   * Release resources.
+   */
+  @AfterClass
+  public static void destroy() {
+    Args.clearParam();
+    if (FileUtil.deleteDir(new File(dbPath))) {
+      logger.info("Release resources successful.");
+    } else {
+      logger.info("Release resources failure.");
+    }
+  }
+
+  @Before
+  public void initDb() {
+    RocksDB.loadLibrary();
+    Args.setParam(new String[]{"--output-directory", dbPath}, Constant.TEST_CONF);
+  }
+
+  @Test
+  public void testPrefixQueryForLeveldb() {
+    byte[] prefix = "0000000".getBytes();
+
+    LevelDbDataSourceImpl dataSource = new LevelDbDataSourceImpl(
+            Args.getInstance().getOutputDirectory(), "testPrefixQueryForLeveldb");
+    dataSource.initDB();
+    this.chainbase = new Chainbase(new SnapshotRoot(
+            new LevelDB(dataSource)));
+
+    putAndAssert(chainbase, prefix);
+
+    // test leveldb
+    List<String> resultInDb = dataSource.prefixQuery(prefix)
+            .keySet()
+            .stream()
+            .map(ByteArray::toStr)
+            .collect(Collectors.toList());
+    List<String> listforDb = Arrays.asList(
+            ByteArray.toStr(key2),
+            ByteArray.toStr(key3),
+            ByteArray.toStr(key6));
+
+    Assert.assertEquals(listforDb.size(), resultInDb.size());
+    listforDb.forEach(entry -> Assert.assertTrue(resultInDb.contains(entry)));
+
+    chainbase.reset();
+    chainbase.close();
+  }
+
+  @Test
+  public void testPrefixQueryForRocksdb() {
+    byte[] prefix = "0000000".getBytes();
+
+    RocksDbDataSourceImpl dataSource = new RocksDbDataSourceImpl(
+            Args.getInstance().getOutputDirectory(), "testPrefixQueryForRocksdb");
+    dataSource.initDB();
+    this.chainbase = new Chainbase(new SnapshotRoot(
+            new org.tron.core.db2.common.RocksDB(dataSource)));
+
+    putAndAssert(chainbase, prefix);
+
+    // test leveldb
+    List<String> resultInDb = dataSource.prefixQuery(prefix)
+            .keySet()
+            .stream()
+            .map(ByteArray::toStr)
+            .collect(Collectors.toList());
+    List<String> listforDb = Arrays.asList(
+            ByteArray.toStr(key2),
+            ByteArray.toStr(key3),
+            ByteArray.toStr(key6));
+
+    Assert.assertEquals(listforDb.size(), resultInDb.size());
+    listforDb.forEach(entry -> Assert.assertTrue(resultInDb.contains(entry)));
+
+    chainbase.reset();
+    chainbase.close();
+  }
+
+  private void putAndAssert(Chainbase chainbase, byte[] prefix) {
+    byte[] keyNotQuery1 = "123".getBytes();
+    byte[] keyNotQuery2 = "0000001".getBytes();
+    byte[] valueNotQuery1 = "v123".getBytes();
+    byte[] valueNotQuery2 = "v0000001".getBytes();
+
+    chainbase.setHead(chainbase.getHead().advance());
+    Snapshot head = chainbase.getHead();
+    Snapshot root = head.getRoot();
+    // put some data in head
+    head.put(key1, value1);
+    // put some data in root
+    root.put(key2, value2);
+    root.put(key6, value6);
+    root.put(key3, value3);
+    root.put(keyNotQuery1, valueNotQuery1);
+    // advance head and put some data again
+    head = head.advance();
+    head.put(key4, value4);
+    head.put(key5, value5);
+    head.put(keyNotQuery2, valueNotQuery2);
+
+    // test for all, both in snapshotImpl and leveldb
+    List<String> result = chainbase.prefixQuery(prefix)
+            .stream()
+            .map(Pair::getKey)
+            .map(ByteArray::toStr)
+            .collect(Collectors.toList());
+    List<String> list = Arrays.asList(
+            ByteArray.toStr(key1),
+            ByteArray.toStr(key2),
+            ByteArray.toStr(key3),
+            ByteArray.toStr(key4),
+            ByteArray.toStr(key5),
+            ByteArray.toStr(key6));
+
+    Assert.assertEquals(list.size(), result.size());
+    list.forEach(entry -> Assert.assertTrue(result.contains(entry)));
+  }
+
+}


### PR DESCRIPTION
**What does this PR do?**

db: add a prefix query and CrossRevokingStore will use this method

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

