### PR TITLE
Add optional "data" parameter on TriggerConstantSmartContract API

### DIFF
--- a/framework/src/main/java/org/tron/core/services/http/TriggerConstantContractServlet.java
+++ b/framework/src/main/java/org/tron/core/services/http/TriggerConstantContractServlet.java
@@ -45,9 +45,13 @@ public class TriggerConstantContractServlet extends RateLimiterServlet {
         || StringUtil.isNullOrEmpty(jsonObject.getString("contract_address"))) {
       throw new InvalidParameterException("contract_address isn't set.");
     }
-    if (!jsonObject.containsKey(functionSelector)
-        || StringUtil.isNullOrEmpty(jsonObject.getString(functionSelector))) {
-      throw new InvalidParameterException("function_selector isn't set.");
+    boolean isFunctionSelectorSet = jsonObject.containsKey(functionSelector) && !StringUtil.isNullOrEmpty(jsonObject.getString(functionSelector));
+    boolean isDataSet = jsonObject.containsKey("data") && !StringUtil.isNullOrEmpty(jsonObject.getString("data"));
+    if (isFunctionSelectorSet && isDataSet) {
+      throw new InvalidParameterException("set either function_selector or data but not both");
+    }
+    if (!isFunctionSelectorSet && !isDataSet) {
+      throw new InvalidParameterException("function_selector or data isn't set.");
     }
   }
 
@@ -65,9 +69,18 @@ public class TriggerConstantContractServlet extends RateLimiterServlet {
       validateParameter(contract);
       JsonFormat.merge(contract, build, visible);
       JSONObject jsonObject = JSONObject.parseObject(contract);
-      String selector = jsonObject.getString(functionSelector);
-      String parameter = jsonObject.getString("parameter");
-      String data = Util.parseMethod(selector, parameter);
+
+      boolean isDataSet = jsonObject.containsKey("data") && !StringUtil.isNullOrEmpty(jsonObject.getString("data"));
+      String data;
+
+      if (isDataSet) {
+        data = jsonObject.getString("data");
+      } else {
+        String selector = jsonObject.getString(functionSelector);
+        String parameter = jsonObject.getString("parameter");
+        data = Util.parseMethod(selector, parameter);
+      }
+
       build.setData(ByteString.copyFrom(ByteArray.fromHexString(data)));
       long feeLimit = Util.getJsonLongValue(jsonObject, "fee_limit");
 


### PR DESCRIPTION
**What does this PR do?**

Adds an optional "data" parameter on TriggerConstantSmartContract API
that allows calling contract methods using client-sided encoded function
selector/parameters. This will allow greater inter-operability with
tools built for EVM-style based blockchains like TheGraph.

**Why are these changes required?**

This API is required for interoperability with TheGraph
(https://github.com/graphprotocol/graph-node).

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**