### PR TITLE
Greater EVM interoperability

### DIFF
--- a/framework/src/main/java/org/tron/core/services/http/TriggerSmartContractServlet.java
+++ b/framework/src/main/java/org/tron/core/services/http/TriggerSmartContractServlet.java
@@ -45,9 +45,15 @@ public class TriggerSmartContractServlet extends RateLimiterServlet {
         || StringUtil.isNullOrEmpty(jsonObject.getString("contract_address"))) {
       throw new InvalidParameterException("contract_address isn't set.");
     }
-    if (!jsonObject.containsKey(functionSelector)
-        || StringUtil.isNullOrEmpty(jsonObject.getString(functionSelector))) {
-      throw new InvalidParameterException("function_selector isn't set.");
+    boolean isFunctionSelectorSet = jsonObject.containsKey(functionSelector)
+        && !StringUtil.isNullOrEmpty(jsonObject.getString(functionSelector));
+    boolean isDataSet = jsonObject.containsKey("data")
+        && !StringUtil.isNullOrEmpty(jsonObject.getString("data"));
+    if (isFunctionSelectorSet && isDataSet) {
+      throw new InvalidParameterException("set either function_selector or data but not both");
+    }
+    if (!isFunctionSelectorSet && !isDataSet) {
+      throw new InvalidParameterException("function_selector or data isn't set.");
     }
   }
 
@@ -57,7 +63,6 @@ public class TriggerSmartContractServlet extends RateLimiterServlet {
     TransactionExtention.Builder trxExtBuilder = TransactionExtention.newBuilder();
     Return.Builder retBuilder = Return.newBuilder();
     boolean visible = false;
-
     try {
       String contract = request.getReader().lines()
           .collect(Collectors.joining(System.lineSeparator()));
@@ -66,9 +71,20 @@ public class TriggerSmartContractServlet extends RateLimiterServlet {
       validateParameter(contract);
       JsonFormat.merge(contract, build, visible);
       JSONObject jsonObject = JSONObject.parseObject(contract);
-      String selector = jsonObject.getString(functionSelector);
-      String parameter = jsonObject.getString("parameter");
-      String data = Util.parseMethod(selector, parameter);
+
+      boolean isFunctionSelectorSet = jsonObject.containsKey(functionSelector)
+          && !StringUtil.isNullOrEmpty(jsonObject.getString(functionSelector));
+
+      String data;
+
+      if (isFunctionSelectorSet) {
+        String selector = jsonObject.getString(functionSelector);
+        String parameter = jsonObject.getString("parameter");
+        data = Util.parseMethod(selector, parameter);
+      } else {
+        data = jsonObject.getString("data");
+      }
+
       build.setData(ByteString.copyFrom(ByteArray.fromHexString(data)));
       build.setCallTokenValue(Util.getJsonLongValue(jsonObject, "call_token_value"));
       build.setTokenId(Util.getJsonLongValue(jsonObject, "token_id"));


### PR DESCRIPTION
Adds an optional "data" parameter on Trigger(Constant)SmartContract API
that allows calling contract methods using client-sided encoded function
selector/parameters. This will allow greater interoperability with
tools built for EVM-style based blockchains like TheGraph.

**Why are these changes required?**

This API is required for interoperability with TheGraph
(https://github.com/graphprotocol/graph-node).

**This PR has been tested by:**
- Unit Tests
- Manual Testing