### PR TITLE
[Nile testnet]fix(actuator): wrong fork version for proposal 27

### DIFF
--- a/actuator/src/main/java/org/tron/core/utils/ProposalUtil.java
+++ b/actuator/src/main/java/org/tron/core/utils/ProposalUtil.java
@@ -251,7 +251,7 @@ public class ProposalUtil {
         break;
       }
       case ALLOW_SHIELDED_TRANSACTION: {
-        if (!forkUtils.pass(ForkBlockVersionEnum.VERSION_4_0)) {
+        if (!forkUtils.pass(ForkBlockVersionEnum.VERSION_3_6_6)) {
           throw new ContractValidateException(
               "Bad chain parameter id [ALLOW_SHIELDED_TRANSACTION]");
         }


### PR DESCRIPTION
**What does this PR do?**

Fix syncing error on Nile testnet.
Current nile's branch can't sync from genesis block.

**Why are these changes required?**

- ALLOW_SHIELDED_TRANSACTION occurs at block 1628391
- where block.version is 15
- the code says it's VERSION_4_0, which will be an error
- actually it's a VERSION_3_7 feature (which is not defined on Nile's branch)
- to make things simple, make it a 3.6.6 fork

**This PR has been tested by:**
- Unit Tests
