### PR TITLE
Add /wallet/getblockinfobylimitnext API

### DIFF
--- a/framework/src/main/java/org/tron/core/Wallet.java
+++ b/framework/src/main/java/org/tron/core/Wallet.java
@@ -62,6 +62,8 @@ import org.tron.api.GrpcAPI.AccountNetMessage;
 import org.tron.api.GrpcAPI.AccountResourceMessage;
 import org.tron.api.GrpcAPI.Address;
 import org.tron.api.GrpcAPI.AssetIssueList;
+import org.tron.api.GrpcAPI.BlockInfo;
+import org.tron.api.GrpcAPI.BlockInfoList;
 import org.tron.api.GrpcAPI.BlockList;
 import org.tron.api.GrpcAPI.BytesMessage;
 import org.tron.api.GrpcAPI.DecryptNotes;
@@ -889,7 +891,7 @@ public class Wallet {
         .setKey("getAllowTvmSolidity059")
         .setValue(chainBaseManager.getDynamicPropertiesStore().getAllowTvmSolidity059())
         .build());
-    
+
     // ALLOW_TVM_ISTANBUL
     builder.addChainParameter(
         Protocol.ChainParameters.ChainParameter.newBuilder().setKey("getAllowTvmIstanbul")
@@ -1246,6 +1248,32 @@ public class Wallet {
       logger.error(e.getMessage());
     }
     return block;
+  }
+
+  private BlockInfo blockCapsule2BlockInfo(BlockCapsule blockCapsule) {
+    Block block = blockCapsule.getInstance();
+    BlockInfo.Builder builder = BlockInfo.newBuilder();
+
+    builder.setBlockHeader(block.getBlockHeader());
+    builder.setBlockid(ByteString.copyFrom(blockCapsule.getBlockId().getBytes()));
+
+    TransactionInfoList transactionInfoList = getTransactionInfoByBlockNum(blockCapsule.getNum());
+    builder.setTransactionInfoList(transactionInfoList);
+
+    return builder.build();
+  }
+
+  public BlockInfoList getBlockInfoByLimitNext(long number, long limit) {
+    if (limit <= 0) {
+      return null;
+    }
+    BlockInfoList.Builder builder = BlockInfoList.newBuilder();
+    List<BlockCapsule> blockCapsuleList = chainBaseManager
+        .getBlockStore().getLimitNumber(number, limit);
+    for (BlockCapsule blockCapsule : blockCapsuleList) {
+      builder.addBlock(blockCapsule2BlockInfo(blockCapsule));
+    }
+    return builder.build();
   }
 
   public BlockList getBlocksByLimitNext(long number, long limit) {

--- a/framework/src/main/java/org/tron/core/services/http/FullNodeHttpApiService.java
+++ b/framework/src/main/java/org/tron/core/services/http/FullNodeHttpApiService.java
@@ -89,6 +89,8 @@ public class FullNodeHttpApiService implements Service {
   @Autowired
   private GetBlockByLimitNextServlet getBlockByLimitNextServlet;
   @Autowired
+  private GetBlockInfoByLimitNextServlet getBlockInfoByLimitNext;
+  @Autowired
   private GetBlockByLatestNumServlet getBlockByLatestNumServlet;
   @Autowired
   private GetTransactionByIdServlet getTransactionByIdServlet;
@@ -371,6 +373,8 @@ public class FullNodeHttpApiService implements Service {
       context.addServlet(new ServletHolder(getBlockByIdServlet), "/wallet/getblockbyid");
       context.addServlet(new ServletHolder(getBlockByLimitNextServlet),
           "/wallet/getblockbylimitnext");
+      context.addServlet(new ServletHolder(getBlockInfoByLimitNext),
+          "/wallet/getblockinfobylimitnext");
       context.addServlet(new ServletHolder(getBlockByLatestNumServlet),
           "/wallet/getblockbylatestnum");
       context.addServlet(new ServletHolder(getTransactionByIdServlet),

--- a/framework/src/main/java/org/tron/core/services/http/GetBlockInfoByLimitNextServlet.java
+++ b/framework/src/main/java/org/tron/core/services/http/GetBlockInfoByLimitNextServlet.java
@@ -1,0 +1,54 @@
+package org.tron.core.services.http;
+
+import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.tron.api.GrpcAPI.BlockInfoList;
+import org.tron.api.GrpcAPI.BlockLimit;
+import org.tron.core.Wallet;
+
+
+@Component
+@Slf4j(topic = "API")
+public class GetBlockInfoByLimitNextServlet extends RateLimiterServlet {
+
+  private static final long BLOCK_LIMIT_NUM = 1000;
+  @Autowired
+  private Wallet wallet;
+
+  protected void doGet(HttpServletRequest request, HttpServletResponse response) {
+    try {
+      fillResponse(Util.getVisible(request), Long.parseLong(request.getParameter("startNum")),
+          Long.parseLong(request.getParameter("endNum")), response);
+    } catch (Exception e) {
+      Util.processError(e, response);
+    }
+  }
+
+  protected void doPost(HttpServletRequest request, HttpServletResponse response) {
+    try {
+      PostParams params = PostParams.getPostParams(request);
+      BlockLimit.Builder build = BlockLimit.newBuilder();
+      JsonFormat.merge(params.getParams(), build, params.isVisible());
+      fillResponse(params.isVisible(), build.getStartNum(), build.getEndNum(), response);
+    } catch (Exception e) {
+      Util.processError(e, response);
+    }
+  }
+
+  private void fillResponse(boolean visible, long startNum, long endNum,
+      HttpServletResponse response)
+      throws IOException {
+    if (endNum > 0 && endNum > startNum && endNum - startNum <= BLOCK_LIMIT_NUM) {
+      BlockInfoList reply = wallet.getBlockInfoByLimitNext(startNum, endNum - startNum);
+      if (reply != null) {
+        response.getWriter().println(Util.printBlockInfoList(reply, visible));
+        return;
+      }
+    }
+    response.getWriter().println("{}");
+  }
+}

--- a/framework/src/main/java/org/tron/core/services/http/Util.java
+++ b/framework/src/main/java/org/tron/core/services/http/Util.java
@@ -25,10 +25,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jetty.util.StringUtil;
 import org.spongycastle.util.encoders.Hex;
+import org.tron.api.GrpcAPI.BlockInfo;
+import org.tron.api.GrpcAPI.BlockInfoList;
 import org.tron.api.GrpcAPI.BlockList;
 import org.tron.api.GrpcAPI.EasyTransferResponse;
 import org.tron.api.GrpcAPI.TransactionApprovedList;
 import org.tron.api.GrpcAPI.TransactionExtention;
+import org.tron.api.GrpcAPI.TransactionInfoList;
 import org.tron.api.GrpcAPI.TransactionList;
 import org.tron.api.GrpcAPI.TransactionSignWeight;
 import org.tron.common.crypto.Hash;
@@ -85,6 +88,13 @@ public class Util {
     return jsonObject.toJSONString();
   }
 
+  public static String printBlockInfoList(BlockInfoList blockInfoList, boolean selfType) {
+    JSONArray jsonArray = new JSONArray();
+    List<BlockInfo> blockInfos = blockInfoList.getBlockList();
+    blockInfos.stream().forEach(block -> jsonArray.add(printBlockInfoToJSON(block, selfType)));
+    return jsonArray.toJSONString();
+  }
+
   public static String printBlock(Block block, boolean selfType) {
     return printBlockToJSON(block, selfType).toJSONString();
   }
@@ -118,6 +128,25 @@ public class Util {
           printTransactionListToJSON(blockCapsule.getTransactions(), selfType));
     }
     return jsonObject;
+  }
+
+  public static JSONObject printBlockInfoToJSON(BlockInfo blockInfo, boolean selfType) {
+    JSONObject jsonObject = JSONObject.parseObject(JsonFormat.printToString(blockInfo, selfType));
+    jsonObject.put(
+        "transactionInfoList",
+        printTransactionInfoListToJSON(blockInfo.getTransactionInfoList(), selfType));
+    return jsonObject;
+  }
+
+  private static JSONArray printTransactionInfoListToJSON(
+      TransactionInfoList list, boolean selfType
+  ) {
+    JSONArray jsonArray = new JSONArray();
+    for (TransactionInfo transactionInfo : list.getTransactionInfoList()) {
+      jsonArray.add(
+          JSONObject.parseObject(JsonFormat.printToString(transactionInfo, selfType)));
+    }
+    return jsonArray;
   }
 
   public static String printTransactionList(TransactionList list, boolean selfType) {

--- a/protocol/src/main/protos/api/api.proto
+++ b/protocol/src/main/protos/api/api.proto
@@ -404,6 +404,15 @@ service Wallet {
   //Use this function instead of GetBlockByLimitNext.
   rpc GetBlockByLimitNext2 (BlockLimit) returns (BlockListExtention) {
   }
+  rpc GetBlockInfoByLimitNext (BlockLimit) returns (BlockInfoList) {
+    option (google.api.http) = {
+      post: "/wallet/getblockinfobylimitnext"
+      body: "*"
+      additional_bindings {
+        get: "/wallet/getblockinfobylimitnext"
+      }
+    };
+  }
   //Please use GetBlockByLatestNum2 instead of this function.
   rpc GetBlockByLatestNum (NumberMessage) returns (BlockList) {
     option (google.api.http) = {
@@ -1189,8 +1198,18 @@ message BlockExtention {
   bytes blockid = 3;
 }
 
+message BlockInfo {
+  TransactionInfoList transactionInfoList = 1;
+  BlockHeader block_header = 2;
+  bytes blockid = 3;
+}
+
 message BlockListExtention {
   repeated BlockExtention block = 1;
+}
+
+message BlockInfoList {
+  repeated BlockInfo block = 1;
 }
 
 message TransactionListExtention {


### PR DESCRIPTION
**What does this PR do?**

Add a `/wallet/getblockinfobylimitnext` API which is like
`/wallet/getblockbylimitnext` but returns transaction info list instead
of transaction list.

**Why are these changes required?**

Minimizes the number of API requests required when scanning transaction logs using the HTTP API.
