### PR TITLE
fix: check if token is trx when escape bytes

### DIFF
--- a/framework/src/main/java/org/tron/core/services/http/JsonFormat.java
+++ b/framework/src/main/java/org/tron/core/services/http/JsonFormat.java
@@ -760,6 +760,10 @@ public class JsonFormat {
     if (HttpSelfFormatFieldName.isNameStringFormat(fliedName)) {
       String result = new String(input.toByteArray());
       result = result.replaceAll("\"", "\\\\\"");
+      if (result.equals("_")) {
+        return result;
+      }
+
       try {
         DefaultJSONParser parser = new DefaultJSONParser(result, ParserConfig.getGlobalInstance(),
             0);


### PR DESCRIPTION
**What does this PR do?**
check if token is trx("_") when escape bytes

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

