### PR TITLE
Feature/account asset optimization

### DIFF
--- a/actuator/src/main/java/org/tron/core/vm/program/Program.java
+++ b/actuator/src/main/java/org/tron/core/vm/program/Program.java
@@ -1701,6 +1701,10 @@ public class Program {
       if (sender == null) {
         deposit.createNormalAccount(contextAddress);
       }
+      AccountAssetIssueCapsule accountAssetIssue = deposit.getAccountAssetIssue(contextAddress);
+      if (accountAssetIssue == null) {
+        deposit.createAccountAssetIssue(contextAddress);
+      }
     }
   }
 

--- a/actuator/src/main/java/org/tron/core/vm/program/invoke/ProgramInvokeMockImpl.java
+++ b/actuator/src/main/java/org/tron/core/vm/program/invoke/ProgramInvokeMockImpl.java
@@ -60,6 +60,7 @@ public class ProgramInvokeMockImpl implements ProgramInvoke {
     this.deposit.createAccountAssetIssue(ownerAddress);
 
     this.deposit.createAccount(contractAddress, Protocol.AccountType.Contract);
+    this.deposit.createAccountAssetIssue(contractAddress);
     this.deposit.createContract(contractAddress,
         new ContractCapsule(SmartContract.newBuilder().setContractAddress(
             ByteString.copyFrom(contractAddress)).build()));

--- a/chainbase/src/main/java/org/tron/common/utils/Commons.java
+++ b/chainbase/src/main/java/org/tron/common/utils/Commons.java
@@ -115,6 +115,25 @@ public class Commons {
     }
   }
 
+
+  public static void adjustAssetBalanceV2(AccountCapsule account, String AssetID, long amount,
+                                          AccountStore accountStore, AssetIssueStore assetIssueStore,
+                                          DynamicPropertiesStore dynamicPropertiesStore)
+          throws BalanceInsufficientException {
+    if (amount < 0) {
+      if (!account.reduceAssetAmountV2(AssetID.getBytes(), -amount, dynamicPropertiesStore,
+              assetIssueStore)) {
+        throw new BalanceInsufficientException("reduceAssetAmount failed !");
+      }
+    } else if (amount > 0 &&
+            !account.addAssetAmountV2(AssetID.getBytes(), amount, dynamicPropertiesStore,
+                    assetIssueStore)) {
+      throw new BalanceInsufficientException("addAssetAmount failed !");
+    }
+    accountStore.put(account.getAddress().toByteArray(), account);
+  }
+
+
   public static void adjustAssetBalanceV2(AccountAssetIssueCapsule accountAssetIssueCapsule, String AssetID, long amount,
                                           AccountAssetIssueStore accountAssetIssueStore, AssetIssueStore assetIssueStore,
                                           DynamicPropertiesStore dynamicPropertiesStore)throws BalanceInsufficientException {
@@ -148,6 +167,15 @@ public class Commons {
           throws BalanceInsufficientException {
     AccountAssetIssueCapsule accountAssetIssueCapsule = accountAssetIssueStore.getUnchecked(accountAddress);
     adjustAssetBalanceV2(accountAssetIssueCapsule, AssetID, amount, accountAssetIssueStore, assetIssueStore,
+            dynamicPropertiesStore);
+  }
+
+  public static void adjustAssetBalanceV2(byte[] accountAddress, String AssetID, long amount
+          , AccountStore accountStore, AssetIssueStore assetIssueStore,
+                                          DynamicPropertiesStore dynamicPropertiesStore)
+          throws BalanceInsufficientException {
+    AccountCapsule account = accountStore.getUnchecked(accountAddress);
+    adjustAssetBalanceV2(account, AssetID, amount, accountStore, assetIssueStore,
             dynamicPropertiesStore);
   }
 

--- a/chainbase/src/main/java/org/tron/core/capsule/AccountAssetIssueCapsule.java
+++ b/chainbase/src/main/java/org/tron/core/capsule/AccountAssetIssueCapsule.java
@@ -42,9 +42,9 @@ public class AccountAssetIssueCapsule implements ProtoCapsule<AccountAssetIssue>
         this.accountAssetIssue = accountAssetIssue;
     }
 
-    public AccountAssetIssueCapsule(ByteString accountName, ByteString address) {
+    public AccountAssetIssueCapsule(ByteString assetIssueName, ByteString address) {
         this.accountAssetIssue = AccountAssetIssue.newBuilder()
-                .setAssetIssuedName(accountName)
+                .setAssetIssuedName(assetIssueName)
                 .setAddress(address)
                 .build();
     }
@@ -232,6 +232,21 @@ public class AccountAssetIssueCapsule implements ProtoCapsule<AccountAssetIssue>
         return assetMap;
     }
 
+    /**
+     * reduce asset amount.
+     */
+    public boolean reduceAssetAmount(byte[] key, long amount) {
+        Map<String, Long> assetMap = this.accountAssetIssue.getAssetMap();
+        String nameKey = ByteArray.toStr(key);
+        Long currentAmount = assetMap.get(nameKey);
+        if (amount > 0 && null != currentAmount && amount <= currentAmount) {
+            this.accountAssetIssue = this.accountAssetIssue.toBuilder()
+                    .putAsset(nameKey, Math.subtractExact(currentAmount, amount)).build();
+            return true;
+        }
+
+        return false;
+    }
 
     /**
      * reduce asset amount.
@@ -337,6 +352,11 @@ public class AccountAssetIssueCapsule implements ProtoCapsule<AccountAssetIssue>
         }
     return amount > 0 && null != currentAmount && amount <= currentAmount;
   }
+
+    @Override
+    public String toString() {
+        return this.accountAssetIssue.toString();
+    }
 
     @Override
     public int compareTo(AccountAssetIssue o) {

--- a/chainbase/src/main/java/org/tron/core/capsule/AccountAssetIssueCapsule.java
+++ b/chainbase/src/main/java/org/tron/core/capsule/AccountAssetIssueCapsule.java
@@ -7,7 +7,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.tron.common.utils.ByteArray;
 import org.tron.core.store.AssetIssueStore;
 import org.tron.core.store.DynamicPropertiesStore;
-import org.tron.protos.Protocol;
 import org.tron.protos.Protocol.AccountAssetIssue;
 
 import java.util.Map;
@@ -41,6 +40,13 @@ public class AccountAssetIssueCapsule implements ProtoCapsule<AccountAssetIssue>
 
     public AccountAssetIssueCapsule(AccountAssetIssue accountAssetIssue) {
         this.accountAssetIssue = accountAssetIssue;
+    }
+
+    public AccountAssetIssueCapsule(ByteString accountName, ByteString address) {
+        this.accountAssetIssue = AccountAssetIssue.newBuilder()
+                .setAssetIssuedName(accountName)
+                .setAddress(address)
+                .build();
     }
 
 

--- a/chainbase/src/main/java/org/tron/core/db/TransactionTrace.java
+++ b/chainbase/src/main/java/org/tron/core/db/TransactionTrace.java
@@ -52,6 +52,8 @@ public class TransactionTrace {
 
   private AccountStore accountStore;
 
+  private AccountAssetIssueStore accountAssetIssueStore;
+
   private CodeStore codeStore;
 
   private EnergyProcessor energyProcessor;
@@ -97,6 +99,7 @@ public class TransactionTrace {
     this.contractStore = storeFactory.getChainBaseManager().getContractStore();
     this.codeStore = storeFactory.getChainBaseManager().getCodeStore();
     this.accountStore = storeFactory.getChainBaseManager().getAccountStore();
+    this.accountAssetIssueStore = storeFactory.getChainBaseManager().getAccountAssetIssueStore();
 
     this.receipt = new ReceiptCapsule(Sha256Hash.ZERO_HASH);
     this.energyProcessor = new EnergyProcessor(dynamicPropertiesStore, accountStore);
@@ -305,6 +308,7 @@ public class TransactionTrace {
     codeStore.delete(address);
     accountStore.delete(address);
     contractStore.delete(address);
+    accountAssetIssueStore.delete(address);
   }
 
   public static byte[] convertToTronAddress(byte[] address) {

--- a/chainbase/src/main/java/org/tron/core/store/AccountAssetIssueStore.java
+++ b/chainbase/src/main/java/org/tron/core/store/AccountAssetIssueStore.java
@@ -195,7 +195,7 @@ public class AccountAssetIssueStore extends TronStoreWithRevoking<AccountAssetIs
                     MAX_POOL_SIZE,
                     KEEP_ALIVE_SECONDES,
                     TimeUnit.SECONDS,
-                    new LinkedBlockingQueue<>(20000)
+                    new LinkedBlockingQueue<>(40000)
             );
         }
 
@@ -213,7 +213,7 @@ public class AccountAssetIssueStore extends TronStoreWithRevoking<AccountAssetIs
             if (null == queue) {
                 synchronized (BlockQueueFactory.class) {
                     if (null == queue) {
-                        queue = new LinkedBlockingDeque(10000);
+                        queue = new LinkedBlockingDeque(20000);
                     }
                 }
             }

--- a/chainbase/src/main/java/org/tron/core/store/AccountAssetIssueStore.java
+++ b/chainbase/src/main/java/org/tron/core/store/AccountAssetIssueStore.java
@@ -72,45 +72,6 @@ public class AccountAssetIssueStore extends TronStoreWithRevoking<AccountAssetIs
         return getUnchecked(assertsAddress.get("Blackhole"));
     }
 
-//    public void convertAccountAssert() {
-//        if (dynamicPropertiesStore.getAllowAssetImport() == 0L) {
-//            int count = 0;
-//            for (Map.Entry<byte[], byte[]> entry : accountStore.getRevokingDB()) {
-//                AccountCapsule accountCapsule = new AccountCapsule(entry.getValue());
-////                accountCapsule.getAddress();
-////                accountCapsule.getAssetIssuedID();
-////                accountCapsule.getAssetIssuedName();
-////                accountCapsule.getAssetMap();
-////                accountCapsule.getAssetMapV2();
-////
-////                accountCapsule.getAllFreeAssetNetUsage();
-////                accountCapsule.getAllFreeAssetNetUsageV2();
-////
-////                accountCapsule.getLatestAssetOperationTimeMap();
-////                accountCapsule.getLatestAssetOperationTimeMapV2();
-//
-//                AccountAssetIssueCapsule accountAssetIssueCapsule = new AccountAssetIssueCapsule();
-//                AccountAssetIssue instance = AccountAssetIssue.newBuilder()
-//                        .setAddress(accountCapsule.getAddress())
-//                        .setAssetIssuedID(accountCapsule.getAssetIssuedID())
-//                        .setAssetIssuedName(accountCapsule.getAssetIssuedName())
-//                        .putAllAsset(accountCapsule.getAssetMap())
-//                        .putAllAssetV2(accountCapsule.getAssetMapV2())
-//
-//                        .putAllFreeAssetNetUsage(accountCapsule.getAllFreeAssetNetUsage())
-//                        .putAllFreeAssetNetUsageV2(accountCapsule.getAllFreeAssetNetUsageV2())
-//                        .putAllLatestAssetOperationTime(accountCapsule.getLatestAssetOperationTimeMap())
-//                        .putAllLatestAssetOperationTimeV2(accountCapsule.getLatestAssetOperationTimeMapV2())
-//                        .build();
-//                accountAssetIssueCapsule.setInstance(instance);
-//                this.put(entry.getKey(), accountAssetIssueCapsule);
-//                count++;
-//            }
-//            logger.info("convert count: {}", count);
-//            dynamicPropertiesStore.setAllowAssetImport(1L);
-//        }
-//    }
-
     public void convertAccountAssert() {
         long start = System.currentTimeMillis();
         logger.info("import asset of account store to account asset store ");

--- a/framework/src/main/java/org/tron/common/storage/DepositImpl.java
+++ b/framework/src/main/java/org/tron/common/storage/DepositImpl.java
@@ -505,10 +505,10 @@ public class DepositImpl implements Deposit {
       accountCapsule = createAccount(address, Protocol.AccountType.Normal);
     }
 
-    AccountAssetIssueCapsule accountAssetIssue = getAccountAssetIssue(address);
-    if (accountAssetIssue == null) {
-      accountAssetIssue = createAccountAssetIssue(address);
-    }
+//    AccountAssetIssueCapsule accountAssetIssue = getAccountAssetIssue(address);
+//    if (accountAssetIssue == null) {
+//      accountAssetIssue = createAccountAssetIssue(address);
+//    }
 
     long balance = accountCapsule.getBalance();
     if (value == 0) {
@@ -526,9 +526,9 @@ public class DepositImpl implements Deposit {
         Type.VALUE_TYPE_DIRTY | accountCache.get(key).getType().getType());
     accountCache.put(key, val);
 
-    Value V2 = Value.create(accountAssetIssue.getData(),
-            Type.VALUE_TYPE_DIRTY | accountAssetIssueCache.get(key).getType().getType());
-    accountAssetIssueCache.put(key, V2);
+//    Value V2 = Value.create(accountAssetIssue.getData(),
+//            Type.VALUE_TYPE_DIRTY | accountAssetIssueCache.get(key).getType().getType());
+//    accountAssetIssueCache.put(key, V2);
 
     return accountCapsule.getBalance();
   }

--- a/framework/src/main/java/org/tron/core/Wallet.java
+++ b/framework/src/main/java/org/tron/core/Wallet.java
@@ -171,15 +171,7 @@ import org.tron.core.exception.ZksnarkException;
 import org.tron.core.net.TronNetDelegate;
 import org.tron.core.net.TronNetService;
 import org.tron.core.net.message.TransactionMessage;
-import org.tron.core.store.AccountIdIndexStore;
-import org.tron.core.store.AccountStore;
-import org.tron.core.store.AccountTraceStore;
-import org.tron.core.store.BalanceTraceStore;
-import org.tron.core.store.ContractStore;
-import org.tron.core.store.MarketOrderStore;
-import org.tron.core.store.MarketPairPriceToOrderStore;
-import org.tron.core.store.MarketPairToPriceStore;
-import org.tron.core.store.StoreFactory;
+import org.tron.core.store.*;
 import org.tron.core.utils.TransactionUtil;
 import org.tron.core.zen.ShieldedTRC20ParametersBuilder;
 import org.tron.core.zen.ShieldedTRC20ParametersBuilder.ShieldedTRC20ParametersType;
@@ -196,6 +188,7 @@ import org.tron.core.zen.note.NoteEncryption.Encryption;
 import org.tron.core.zen.note.OutgoingPlaintext;
 import org.tron.protos.Protocol;
 import org.tron.protos.Protocol.Account;
+import org.tron.protos.Protocol.AccountAssetIssue;
 import org.tron.protos.Protocol.Block;
 import org.tron.protos.Protocol.DelegatedResourceAccountIndex;
 import org.tron.protos.Protocol.Exchange;
@@ -375,6 +368,15 @@ public class Wallet {
         + BLOCK_PRODUCED_INTERVAL * accountCapsule.getLatestConsumeTimeForEnergy());
 
     return accountCapsule.getInstance();
+  }
+
+  public AccountAssetIssue getAccountAssetIssueById(Account account) {
+    AccountAssetIssueStore accountAssetIssueStore = chainBaseManager.getAccountAssetIssueStore();
+    AccountAssetIssueCapsule accountAssetIssueCapsule = accountAssetIssueStore.get(account.getAddress().toByteArray());
+    if (accountAssetIssueCapsule == null) {
+      return null;
+    }
+    return accountAssetIssueCapsule.getInstance();
   }
 
   /**
@@ -1075,7 +1077,8 @@ public class Wallet {
     byte[] address = accountAddress.toByteArray();
     AccountCapsule accountCapsule =
         chainBaseManager.getAccountStore().get(accountAddress.toByteArray());
-    AccountAssetIssueCapsule accountAssetIssueCapsule = chainBaseManager.getAccountAssetIssueStore().get(address);
+    AccountAssetIssueCapsule accountAssetIssueCapsule =
+            chainBaseManager.getAccountAssetIssueStore().get(address);
     if (accountCapsule == null) {
       return null;
     }
@@ -1111,7 +1114,8 @@ public class Wallet {
     byte[] address = accountAddress.toByteArray();
     AccountCapsule accountCapsule =
         chainBaseManager.getAccountStore().get(address);
-    AccountAssetIssueCapsule accountAssetIssueCapsule = chainBaseManager.getAccountAssetIssueStore().get(address);
+    AccountAssetIssueCapsule accountAssetIssueCapsule =
+            chainBaseManager.getAccountAssetIssueStore().get(address);
     if (accountCapsule == null) {
       return null;
     }

--- a/framework/src/main/java/org/tron/core/db/Manager.java
+++ b/framework/src/main/java/org/tron/core/db/Manager.java
@@ -71,6 +71,7 @@ import org.tron.core.ChainBaseManager;
 import org.tron.core.Constant;
 import org.tron.core.actuator.ActuatorCreator;
 import org.tron.core.capsule.AccountCapsule;
+import org.tron.core.capsule.AccountAssetIssueCapsule;
 import org.tron.core.capsule.BlockBalanceTraceCapsule;
 import org.tron.core.capsule.BlockCapsule;
 import org.tron.core.capsule.BlockCapsule.BlockId;
@@ -467,9 +468,13 @@ public class Manager {
                       ByteString.copyFrom(account.getAddress()),
                       account.getAccountType(),
                       account.getBalance());
+
+              final AccountAssetIssueCapsule accountAssetIssueCapsule =
+                      new AccountAssetIssueCapsule(ByteString.copyFrom(account.getAddress()));
               chainBaseManager.getAccountStore().put(account.getAddress(), accountCapsule);
               chainBaseManager.getAccountIdIndexStore().put(accountCapsule);
               chainBaseManager.getAccountIndexStore().put(accountCapsule);
+              chainBaseManager.getAccountAssetIssueStore().put(account.getAddress(), accountAssetIssueCapsule);
             });
   }
 

--- a/framework/src/main/java/org/tron/core/services/http/GetAccountByIdServlet.java
+++ b/framework/src/main/java/org/tron/core/services/http/GetAccountByIdServlet.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.tron.core.Wallet;
 import org.tron.protos.Protocol.Account;
+import org.tron.protos.Protocol.AccountAssetIssue;
 
 
 @Component
@@ -46,6 +47,8 @@ public class GetAccountByIdServlet extends RateLimiterServlet {
   private void fillResponse(Account account, boolean visible, HttpServletResponse response)
       throws IOException {
     Account reply = wallet.getAccountById(account);
-    Util.printAccount(reply, response, visible);
+    AccountAssetIssue accountAssetIssue = wallet.getAccountAssetIssueById(account);
+//    Util.printAccount(reply, response, visible);
+    Util.printAccount(reply, accountAssetIssue, response, visible);
   }
 }

--- a/framework/src/main/java/org/tron/core/services/http/GetAccountServlet.java
+++ b/framework/src/main/java/org/tron/core/services/http/GetAccountServlet.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.tron.core.Wallet;
 import org.tron.protos.Protocol.Account;
+import org.tron.protos.Protocol.AccountAssetIssue;
 
 
 @Component
@@ -45,6 +46,11 @@ public class GetAccountServlet extends RateLimiterServlet {
   private void fillResponse(boolean visible, Account account, HttpServletResponse response)
       throws Exception {
     Account reply = wallet.getAccount(account);
-    Util.printAccount(reply, response, visible);
+    AccountAssetIssue accountAssetIssue = wallet.getAccountAssetIssueById(account);
+    if (null != accountAssetIssue) {
+      Util.printAccount(reply, accountAssetIssue, response, visible);
+    } else {
+      Util.printAccount(reply, response, visible);
+    }
   }
 }

--- a/framework/src/main/java/org/tron/core/services/http/Util.java
+++ b/framework/src/main/java/org/tron/core/services/http/Util.java
@@ -443,12 +443,29 @@ public class Util {
     if (accountAssetIssue.getAssetIssuedID().isEmpty()) {
       return JsonFormat.printToString(account, false);
     } else {
+      account = convertAccount(account, accountAssetIssue);
       JSONObject accountJson = JSONObject.parseObject(JsonFormat.printToString(account, false));
       String assetId = accountJson.get("asset_issued_ID").toString();
       accountJson.put("asset_issued_ID",
           ByteString.copyFrom(ByteArray.fromHexString(assetId)).toStringUtf8());
       return accountJson.toJSONString();
     }
+  }
+
+  public static Account convertAccount(Account account, AccountAssetIssue accountAssetIssue) {
+    account = account.toBuilder()
+            .setAddress(accountAssetIssue.getAddress())
+            .setAssetIssuedID(accountAssetIssue.getAssetIssuedID())
+            .setAssetIssuedName(accountAssetIssue.getAssetIssuedName())
+            .putAllAsset(accountAssetIssue.getAssetMap())
+            .putAllAssetV2(accountAssetIssue.getAssetV2Map())
+
+            .putAllFreeAssetNetUsage(accountAssetIssue.getFreeAssetNetUsageMap())
+            .putAllFreeAssetNetUsageV2(accountAssetIssue.getFreeAssetNetUsageMap())
+            .putAllLatestAssetOperationTime(accountAssetIssue.getLatestAssetOperationTimeMap())
+            .putAllLatestAssetOperationTimeV2(accountAssetIssue.getLatestAssetOperationTimeV2Map())
+            .build();
+    return account;
   }
 
   public static void printAccount(Account reply, HttpServletResponse response, Boolean visible)
@@ -468,7 +485,7 @@ public class Util {
           throws java.io.IOException {
     if (reply != null) {
       if (visible) {
-        response.getWriter().println(JsonFormat.printToString(reply, true));
+        response.getWriter().println(JsonFormat.printToString(convertAccount(reply, accountAssetIssue), true));
       } else {
         response.getWriter().println(convertOutput(reply, accountAssetIssue));
       }

--- a/framework/src/test/java/org/tron/common/runtime/vm/TransferTokenTest.java
+++ b/framework/src/test/java/org/tron/common/runtime/vm/TransferTokenTest.java
@@ -17,6 +17,7 @@ import org.tron.common.utils.ByteArray;
 import org.tron.common.utils.FileUtil;
 import org.tron.core.Constant;
 import org.tron.core.Wallet;
+import org.tron.core.capsule.AccountAssetIssueCapsule;
 import org.tron.core.capsule.AccountCapsule;
 import org.tron.core.capsule.AssetIssueCapsule;
 import org.tron.core.config.DefaultConfig;
@@ -50,6 +51,7 @@ public class TransferTokenTest {
   private static Application appT;
   private static DepositImpl deposit;
   private static AccountCapsule ownerCapsule;
+  private static AccountAssetIssueCapsule ownerAccountAssetIssueCapsule;
 
   static {
     Args.setParam(new String[]{"--output-directory", dbPath, "--debug"}, Constant.TEST_CONF);
@@ -67,8 +69,12 @@ public class TransferTokenTest {
             ByteString.copyFrom(ByteArray.fromHexString(OWNER_ADDRESS)),
             ByteString.copyFromUtf8("owner"),
             AccountType.AssetIssue);
-
     ownerCapsule.setBalance(1000_1000_1000L);
+
+    ownerAccountAssetIssueCapsule =
+            new AccountAssetIssueCapsule(
+               ByteString.copyFrom(ByteArray.fromHexString(OWNER_ADDRESS))
+            );
   }
 
   /**
@@ -107,8 +113,12 @@ public class TransferTokenTest {
     AssetIssueCapsule assetIssueCapsule = new AssetIssueCapsule(assetIssueContract);
     dbManager.getAssetIssueV2Store().put(assetIssueCapsule.createDbV2Key(), assetIssueCapsule);
 
-    ownerCapsule.addAssetV2(ByteArray.fromString(String.valueOf(id)), 100_000_000);
+//    ownerCapsule.addAssetV2(ByteArray.fromString(String.valueOf(id)), 100_000_000);
     dbManager.getAccountStore().put(ownerCapsule.getAddress().toByteArray(), ownerCapsule);
+
+    ownerAccountAssetIssueCapsule.addAssetV2(ByteArray.fromString(String.valueOf(id)), 100_000_000);
+    dbManager.getAccountAssetIssueStore()
+            .put(ownerAccountAssetIssueCapsule.getAddress().toByteArray(), ownerAccountAssetIssueCapsule);
     return id;
   }
 
@@ -132,7 +142,7 @@ public class TransferTokenTest {
     byte[] contractAddress = deployTransferTokenContract(id);
     deposit.commit();
     Assert.assertEquals(100,
-        dbManager.getAccountStore().get(contractAddress).getAssetMapV2().get(String.valueOf(id))
+        dbManager.getAccountAssetIssueStore().get(contractAddress).getAssetMapV2().get(String.valueOf(id))
             .longValue());
     Assert.assertEquals(1000, dbManager.getAccountStore().get(contractAddress).getBalance());
 
@@ -156,19 +166,22 @@ public class TransferTokenTest {
 
     org.testng.Assert.assertNull(runtime.getRuntimeError());
     Assert.assertEquals(100 + tokenValue - 9,
-        dbManager.getAccountStore().get(contractAddress).getAssetMapV2().get(String.valueOf(id))
+        dbManager.getAccountAssetIssueStore().get(contractAddress).getAssetMapV2().get(String.valueOf(id))
             .longValue());
-    Assert.assertEquals(9, dbManager.getAccountStore().get(Hex.decode(TRANSFER_TO)).getAssetMapV2()
+    Assert.assertEquals(9, dbManager.getAccountAssetIssueStore().get(Hex.decode(TRANSFER_TO)).getAssetMapV2()
         .get(String.valueOf(id)).longValue());
 
     /*   suicide test  */
     // create new token: testToken2
     long id2 = createAsset("testToken2");
     // add token balance for last created contract
-    AccountCapsule changeAccountCapsule = dbManager.getAccountStore().get(contractAddress);
-    changeAccountCapsule.addAssetAmountV2(String.valueOf(id2).getBytes(), 99,
-        dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
-    dbManager.getAccountStore().put(contractAddress, changeAccountCapsule);
+    AccountAssetIssueCapsule changeAssetIssue = dbManager.getAccountAssetIssueStore()
+            .get(contractAddress);
+    changeAssetIssue.addAssetAmountV2(String.valueOf(id2).getBytes(), 99,
+            dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
+    dbManager.getAccountAssetIssueStore().put(contractAddress, changeAssetIssue);
+
+
     String selectorStr2 = "suicide(address)";
     //TRANSFER_TO
     String params2 = "000000000000000000000000548794500882809695a8a687866e76d4271a1abc";
@@ -180,9 +193,9 @@ public class TransferTokenTest {
     runtime = TvmTestUtils.processTransactionAndReturnRuntime(transaction2, dbManager, null);
     org.testng.Assert.assertNull(runtime.getRuntimeError());
     Assert.assertEquals(100 + tokenValue - 9 + 9,
-        dbManager.getAccountStore().get(Hex.decode(TRANSFER_TO)).getAssetMapV2()
+        dbManager.getAccountAssetIssueStore().get(Hex.decode(TRANSFER_TO)).getAssetMapV2()
             .get(String.valueOf(id)).longValue());
-    Assert.assertEquals(99, dbManager.getAccountStore().get(Hex.decode(TRANSFER_TO)).getAssetMapV2()
+    Assert.assertEquals(99, dbManager.getAccountAssetIssueStore().get(Hex.decode(TRANSFER_TO)).getAssetMapV2()
         .get(String.valueOf(id2)).longValue());
   }
 

--- a/framework/src/test/java/org/tron/common/runtime/vm/TransferTokenTest.java
+++ b/framework/src/test/java/org/tron/common/runtime/vm/TransferTokenTest.java
@@ -62,6 +62,7 @@ public class TransferTokenTest {
     dbManager = context.getBean(Manager.class);
     deposit = DepositImpl.createRoot(dbManager);
     deposit.createAccount(Hex.decode(TRANSFER_TO), AccountType.Normal);
+    deposit.createAccountAssetIssue(Hex.decode(TRANSFER_TO));
     deposit.addBalance(Hex.decode(TRANSFER_TO), 10);
     deposit.commit();
     ownerCapsule =

--- a/framework/src/test/java/org/tron/common/runtime/vm/Trc10InsTest.java
+++ b/framework/src/test/java/org/tron/common/runtime/vm/Trc10InsTest.java
@@ -17,6 +17,7 @@ import org.tron.common.runtime.InternalTransaction;
 import org.tron.common.runtime.TvmTestUtils;
 import org.tron.common.utils.ByteArray;
 import org.tron.common.utils.FileUtil;
+import org.tron.core.capsule.AccountAssetIssueCapsule;
 import org.tron.core.capsule.AccountCapsule;
 import org.tron.core.capsule.AssetIssueCapsule;
 import org.tron.core.capsule.BlockCapsule;
@@ -75,11 +76,13 @@ public class Trc10InsTest {
 
     // add contract account
     deposit.createAccount(contractAddr, Protocol.AccountType.Contract);
+    deposit.createAccountAssetIssue(contractAddr);
     deposit.commit();
 
     // 1. test token issue
     // confirm contract exist and give it 1024 TRXs to issue asset
     Assert.assertNotNull(deposit.getAccount(contractAddr));
+    Assert.assertNotNull(deposit.getAccountAssetIssue(contractAddr));
     Assert.assertEquals(deposit.getBalance(contractAddr), 0);
 
     long balanceToAdd = deposit.getDynamicPropertiesStore().getAssetIssueFee();
@@ -115,11 +118,13 @@ public class Trc10InsTest {
 
     // check contract account updated
     AccountCapsule ownerAccountCap = deposit.getAccount(contractAddr);
+    AccountAssetIssueCapsule ownerAccountAssetIssueCap = deposit.getAccountAssetIssue(contractAddr);
+
     Assert.assertEquals(ByteString.copyFrom(
         Objects.requireNonNull(ByteArray.fromString(assetIssueCap.getId()))),
-        ownerAccountCap.getAssetIssuedID());
-    Assert.assertEquals(assetIssueCap.getName(), ownerAccountCap.getAssetIssuedName());
-    Assert.assertTrue(ownerAccountCap.getAssetMapV2().entrySet().stream().anyMatch(
+            ownerAccountAssetIssueCap.getAssetIssuedID());
+    Assert.assertEquals(assetIssueCap.getName(), ownerAccountAssetIssueCap.getAssetIssuedName());
+    Assert.assertTrue(ownerAccountAssetIssueCap.getAssetMapV2().entrySet().stream().anyMatch(
         e -> e.getKey().equals(createdAssetId)));
 
     // check balance of contract account and black hole account

--- a/framework/src/test/java/org/tron/core/BandwidthProcessorTest.java
+++ b/framework/src/test/java/org/tron/core/BandwidthProcessorTest.java
@@ -14,10 +14,7 @@ import org.tron.common.application.TronApplicationContext;
 import org.tron.common.runtime.RuntimeImpl;
 import org.tron.common.utils.ByteArray;
 import org.tron.common.utils.FileUtil;
-import org.tron.core.capsule.AccountCapsule;
-import org.tron.core.capsule.AssetIssueCapsule;
-import org.tron.core.capsule.TransactionCapsule;
-import org.tron.core.capsule.TransactionResultCapsule;
+import org.tron.core.capsule.*;
 import org.tron.core.config.DefaultConfig;
 import org.tron.core.config.args.Args;
 import org.tron.core.db.BandwidthProcessor;
@@ -123,8 +120,16 @@ public class BandwidthProcessorTest {
             ByteString.copyFrom(ByteArray.fromHexString(OWNER_ADDRESS)),
             AccountType.Normal,
             0L);
-    ownerCapsule.addAsset(ASSET_NAME.getBytes(), 100L);
-    ownerCapsule.addAsset(ASSET_NAME_V2.getBytes(), 100L);
+//    ownerCapsule.addAsset(ASSET_NAME.getBytes(), 100L);
+//    ownerCapsule.addAsset(ASSET_NAME_V2.getBytes(), 100L);
+
+    AccountAssetIssueCapsule ownerAssetIssueCapsule =
+            new AccountAssetIssueCapsule(
+                    ByteString.copyFromUtf8("owner"),
+                    ByteString.copyFrom(ByteArray.fromHexString(OWNER_ADDRESS)));
+    ownerAssetIssueCapsule.addAsset(ASSET_NAME.getBytes(), 100L);
+    ownerAssetIssueCapsule.addAsset(ASSET_NAME_V2.getBytes(), 100L);
+
 
     AccountCapsule toAccountCapsule =
         new AccountCapsule(
@@ -133,12 +138,22 @@ public class BandwidthProcessorTest {
             AccountType.Normal,
             0L);
 
+    AccountAssetIssueCapsule toAccountAssetIssueCapsule =
+            new AccountAssetIssueCapsule(
+                    ByteString.copyFromUtf8("toAccount"),
+                    ByteString.copyFrom(ByteArray.fromHexString(TO_ADDRESS)));
+
     AccountCapsule assetCapsule =
         new AccountCapsule(
             ByteString.copyFromUtf8("asset"),
             ByteString.copyFrom(ByteArray.fromHexString(ASSET_ADDRESS)),
             AccountType.AssetIssue,
             chainBaseManager.getDynamicPropertiesStore().getAssetIssueFee());
+
+    AccountAssetIssueCapsule accountAssetIssueCapsule =
+            new AccountAssetIssueCapsule(
+                    ByteString.copyFromUtf8("asset"),
+                    ByteString.copyFrom(ByteArray.fromHexString(ASSET_ADDRESS)));
 
     AccountCapsule assetCapsule2 =
         new AccountCapsule(
@@ -147,13 +162,28 @@ public class BandwidthProcessorTest {
             AccountType.AssetIssue,
             chainBaseManager.getDynamicPropertiesStore().getAssetIssueFee());
 
+    AccountAssetIssueCapsule accountAssetIssueCapsule2 =
+            new AccountAssetIssueCapsule(
+                    ByteString.copyFromUtf8("asset2"),
+                    ByteString.copyFrom(ByteArray.fromHexString(ASSET_ADDRESS_V2)));
+
     chainBaseManager.getAccountStore().reset();
     chainBaseManager.getAccountStore().put(ownerCapsule.getAddress().toByteArray(), ownerCapsule);
+    chainBaseManager.getAccountAssetIssueStore().put(ownerAssetIssueCapsule.getAddress().toByteArray(),
+            ownerAssetIssueCapsule);
+
+    chainBaseManager.getAccountAssetIssueStore().put(toAccountAssetIssueCapsule.getAddress().toByteArray(),
+            toAccountAssetIssueCapsule);
+    chainBaseManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.getAddress().toByteArray(),
+            accountAssetIssueCapsule);
+    chainBaseManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule2.getAddress().toByteArray(),
+            accountAssetIssueCapsule2);
+
     chainBaseManager.getAccountStore()
         .put(toAccountCapsule.getAddress().toByteArray(), toAccountCapsule);
+
     chainBaseManager.getAccountStore().put(assetCapsule.getAddress().toByteArray(), assetCapsule);
     chainBaseManager.getAccountStore().put(assetCapsule2.getAddress().toByteArray(), assetCapsule2);
-
   }
 
   private TransferAssetContract getTransferAssetContract() {
@@ -213,14 +243,16 @@ public class BandwidthProcessorTest {
     AssetIssueCapsule assetIssueCapsule = new AssetIssueCapsule(assetIssueContract);
     AccountCapsule toAccountCapsule = chainBaseManager.getAccountStore()
         .get(ByteArray.fromHexString(TO_ADDRESS));
+    AccountAssetIssueCapsule toAccountAssetIssueCapsule = chainBaseManager.getAccountAssetIssueStore()
+            .get(ByteArray.fromHexString(TO_ADDRESS));
     if (chainBaseManager.getDynamicPropertiesStore().getAllowSameTokenName() == 1) {
       chainBaseManager.getAssetIssueV2Store()
           .put(assetIssueCapsule.createDbV2Key(), assetIssueCapsule);
-      toAccountCapsule.addAssetV2(ByteArray.fromString(String.valueOf(id)), TOTAL_SUPPLY);
+      toAccountAssetIssueCapsule.addAssetV2(ByteArray.fromString(String.valueOf(id)), TOTAL_SUPPLY);
     } else {
       chainBaseManager.getAssetIssueStore()
           .put(assetIssueCapsule.createDbKey(), assetIssueCapsule);
-      toAccountCapsule.addAsset(assetName.getBytes(), TOTAL_SUPPLY);
+      toAccountAssetIssueCapsule.addAsset(assetName.getBytes(), TOTAL_SUPPLY);
     }
     chainBaseManager.getAccountStore()
         .put(toAccountCapsule.getAddress().toByteArray(), toAccountCapsule);
@@ -344,18 +376,21 @@ public class BandwidthProcessorTest {
     AccountCapsule assetCapsuleNew = chainBaseManager.getAccountStore()
         .get(ByteArray.fromHexString(ASSET_ADDRESS));
 
+    AccountAssetIssueCapsule ownerAssetIssueCapsuleNew =
+            chainBaseManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
+
     Assert.assertEquals(508882612L, assetCapsuleNew.getLatestConsumeTime());
     Assert.assertEquals(1526647838000L, ownerCapsuleNew.getLatestOperationTime());
     Assert.assertEquals(508882612L,
-        ownerCapsuleNew.getLatestAssetOperationTime(ASSET_NAME));
+            ownerAssetIssueCapsuleNew.getLatestAssetOperationTime(ASSET_NAME));
     Assert.assertEquals(
         122L + (chainBaseManager.getDynamicPropertiesStore().supportVM()
             ? Constant.MAX_RESULT_SIZE_IN_TX : 0),
-        ownerCapsuleNew.getFreeAssetNetUsage(ASSET_NAME));
+            ownerAssetIssueCapsuleNew.getFreeAssetNetUsage(ASSET_NAME));
     Assert.assertEquals(
         122L + (chainBaseManager.getDynamicPropertiesStore().supportVM()
             ? Constant.MAX_RESULT_SIZE_IN_TX : 0),
-        ownerCapsuleNew.getFreeAssetNetUsageV2("1"));
+            ownerAssetIssueCapsuleNew.getFreeAssetNetUsageV2("1"));
     Assert.assertEquals(
         122L + (chainBaseManager.getDynamicPropertiesStore().supportVM()
             ? Constant.MAX_RESULT_SIZE_IN_TX : 0),
@@ -373,18 +408,21 @@ public class BandwidthProcessorTest {
     assetCapsuleNew = chainBaseManager.getAccountStore()
         .get(ByteArray.fromHexString(ASSET_ADDRESS));
 
+    ownerAssetIssueCapsuleNew = chainBaseManager.getAccountAssetIssueStore()
+            .get(ByteArray.fromHexString(OWNER_ADDRESS));
+
     Assert.assertEquals(508897012L, assetCapsuleNew.getLatestConsumeTime());
     Assert.assertEquals(1526691038000L, ownerCapsuleNew.getLatestOperationTime());
     Assert.assertEquals(508897012L,
-        ownerCapsuleNew.getLatestAssetOperationTime(ASSET_NAME));
+            ownerAssetIssueCapsuleNew.getLatestAssetOperationTime(ASSET_NAME));
     Assert.assertEquals(61L + 122L
             + (chainBaseManager.getDynamicPropertiesStore().supportVM()
             ? Constant.MAX_RESULT_SIZE_IN_TX / 2 * 3 : 0),
-        ownerCapsuleNew.getFreeAssetNetUsage(ASSET_NAME));
+            ownerAssetIssueCapsuleNew.getFreeAssetNetUsage(ASSET_NAME));
     Assert.assertEquals(61L + 122L
             + (chainBaseManager.getDynamicPropertiesStore().supportVM()
             ? Constant.MAX_RESULT_SIZE_IN_TX / 2 * 3 : 0),
-        ownerCapsuleNew.getFreeAssetNetUsageV2("1"));
+            ownerAssetIssueCapsuleNew.getFreeAssetNetUsageV2("1"));
     Assert.assertEquals(61L + 122L
             + (chainBaseManager.getDynamicPropertiesStore().supportVM()
             ? Constant.MAX_RESULT_SIZE_IN_TX / 2 * 3 : 0),
@@ -410,6 +448,12 @@ public class BandwidthProcessorTest {
     chainBaseManager.getAccountStore().put(issuerCapsuleV2.getAddress().toByteArray(),
         issuerCapsuleV2);
 
+    AccountAssetIssueCapsule issuerAccountAsstCapsuleV2 = chainBaseManager.getAccountAssetIssueStore()
+            .get(ByteArray.fromHexString(ASSET_ADDRESS_V2));
+
+    chainBaseManager.getAccountAssetIssueStore().put(issuerAccountAsstCapsuleV2.getAddress().toByteArray(),
+            issuerAccountAsstCapsuleV2);
+
     TransactionResultCapsule ret = new TransactionResultCapsule();
     TransactionTrace trace = new TransactionTrace(trx, StoreFactory
         .getInstance(), new RuntimeImpl());
@@ -420,10 +464,16 @@ public class BandwidthProcessorTest {
     AccountCapsule issuerCapsuleNew = chainBaseManager.getAccountStore()
         .get(ByteArray.fromHexString(ASSET_ADDRESS_V2));
 
+    AccountAssetIssueCapsule ownerAssetIssueCapsule = chainBaseManager.getAccountAssetIssueStore()
+            .get(ByteArray.fromHexString(OWNER_ADDRESS));
+    AccountAssetIssueCapsule issueAssetIssueCapsule = chainBaseManager.getAccountAssetIssueStore()
+            .get(ByteArray.fromHexString(ASSET_ADDRESS_V2));
+
     Assert.assertEquals(508882612L, issuerCapsuleNew.getLatestConsumeTime());
     Assert.assertEquals(1526647838000L, ownerCapsuleNew.getLatestOperationTime());
+
     Assert.assertEquals(508882612L,
-        ownerCapsuleNew.getLatestAssetOperationTimeV2(ASSET_NAME_V2));
+            ownerAssetIssueCapsule.getLatestAssetOperationTimeV2(ASSET_NAME_V2));
     Assert.assertEquals(
         113L + (chainBaseManager.getDynamicPropertiesStore().supportVM()
             ? Constant.MAX_RESULT_SIZE_IN_TX : 0),
@@ -431,10 +481,10 @@ public class BandwidthProcessorTest {
     Assert.assertEquals(
         113L + (chainBaseManager.getDynamicPropertiesStore().supportVM()
             ? Constant.MAX_RESULT_SIZE_IN_TX : 0),
-        ownerCapsuleNew.getFreeAssetNetUsageV2(ASSET_NAME_V2));
+            ownerAssetIssueCapsule.getFreeAssetNetUsageV2(ASSET_NAME_V2));
 
     Assert.assertEquals(508882612L,
-        ownerCapsuleNew.getLatestAssetOperationTimeV2(ASSET_NAME_V2));
+            ownerAssetIssueCapsule.getLatestAssetOperationTimeV2(ASSET_NAME_V2));
     Assert.assertEquals(0L, ret.getFee());
 
     chainBaseManager.getDynamicPropertiesStore()
@@ -447,14 +497,19 @@ public class BandwidthProcessorTest {
     issuerCapsuleNew = chainBaseManager.getAccountStore()
         .get(ByteArray.fromHexString(ASSET_ADDRESS_V2));
 
+    ownerAssetIssueCapsule = chainBaseManager.getAccountAssetIssueStore()
+            .get(ByteArray.fromHexString(OWNER_ADDRESS));
+    issueAssetIssueCapsule = chainBaseManager.getAccountAssetIssueStore()
+            .get(ByteArray.fromHexString(ASSET_ADDRESS_V2));
+
     Assert.assertEquals(508897012L, issuerCapsuleNew.getLatestConsumeTime());
     Assert.assertEquals(1526691038000L, ownerCapsuleNew.getLatestOperationTime());
     Assert.assertEquals(508897012L,
-        ownerCapsuleNew.getLatestAssetOperationTimeV2(ASSET_NAME_V2));
+            ownerAssetIssueCapsule.getLatestAssetOperationTimeV2(ASSET_NAME_V2));
     Assert.assertEquals(56L + 113L
             + (chainBaseManager.getDynamicPropertiesStore().supportVM()
             ? Constant.MAX_RESULT_SIZE_IN_TX / 2 * 3 : 0),
-        ownerCapsuleNew.getFreeAssetNetUsageV2(ASSET_NAME_V2));
+            ownerAssetIssueCapsule.getFreeAssetNetUsageV2(ASSET_NAME_V2));
     Assert.assertEquals(56L + 113L
             + (chainBaseManager.getDynamicPropertiesStore().supportVM()
             ? Constant.MAX_RESULT_SIZE_IN_TX / 2 * 3 : 0),
@@ -610,6 +665,12 @@ public class BandwidthProcessorTest {
     ownerCapsule.setFrozenForBandwidth(2_000_000L, expireTime);
     chainBaseManager.getAccountStore().put(ownerCapsule.getAddress().toByteArray(), ownerCapsule);
 
+    AccountAssetIssueCapsule ownerAccountAssetIssueCapsule = new AccountAssetIssueCapsule(
+            ByteString.copyFromUtf8("owner"),
+            ByteString.copyFrom(ByteArray.fromHexString(OWNER_ADDRESS)));
+    chainBaseManager.getAccountAssetIssueStore()
+            .put(ownerAccountAssetIssueCapsule.getAddress().toByteArray(), ownerAccountAssetIssueCapsule);
+
     AccountCapsule toAddressCapsule =
         new AccountCapsule(
             ByteString.copyFromUtf8("owner"),
@@ -621,6 +682,13 @@ public class BandwidthProcessorTest {
     toAddressCapsule.setFrozenForBandwidth(2_000_000L, expireTime2);
     chainBaseManager.getAccountStore().put(toAddressCapsule.getAddress().toByteArray(),
         toAddressCapsule);
+
+    AccountAssetIssueCapsule toAccountAssetIssueCapsule = new AccountAssetIssueCapsule(
+            ByteString.copyFromUtf8("owner"),
+            ByteString.copyFrom(ByteArray.fromHexString(TO_ADDRESS)));
+    chainBaseManager.getAccountAssetIssueStore()
+            .put(toAccountAssetIssueCapsule.getAddress().toByteArray(), toAccountAssetIssueCapsule);
+
 
     TransferAssetContract contract = TransferAssetContract.newBuilder()
         .setAssetName(ByteString.copyFrom(ByteArray.fromString(ASSET_NAME)))
@@ -650,9 +718,13 @@ public class BandwidthProcessorTest {
 
       AccountCapsule fromAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
+
+      AccountAssetIssueCapsule fromAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(OWNER_ADDRESS));
+
       Assert.assertNotNull(fromAccount);
-      Assert.assertEquals(fromAccount.getFreeAssetNetUsage(ASSET_NAME), byteSize);
-      Assert.assertEquals(fromAccount.getFreeAssetNetUsageV2(String.valueOf(id)), byteSize);
+      Assert.assertEquals(fromAssetIssue.getFreeAssetNetUsage(ASSET_NAME), byteSize);
+      Assert.assertEquals(fromAssetIssue.getFreeAssetNetUsageV2(String.valueOf(id)), byteSize);
 
       AccountCapsule ownerAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
@@ -664,8 +736,8 @@ public class BandwidthProcessorTest {
           chainBaseManager.getAssetIssueV2Store().get(assetIssueCapsule.createDbV2Key());
       Assert.assertNotNull(assetIssueCapsuleV2);
       Assert.assertEquals(assetIssueCapsuleV2.getPublicFreeAssetNetUsage(), byteSize);
-      Assert.assertEquals(fromAccount.getFreeAssetNetUsage(ASSET_NAME), byteSize);
-      Assert.assertEquals(fromAccount.getFreeAssetNetUsageV2(String.valueOf(id)), byteSize);
+      Assert.assertEquals(fromAssetIssue.getFreeAssetNetUsage(ASSET_NAME), byteSize);
+      Assert.assertEquals(fromAssetIssue.getFreeAssetNetUsageV2(String.valueOf(id)), byteSize);
     } catch (ContractValidateException e) {
       Assert.assertFalse(e instanceof ContractValidateException);
     } catch (TooBigTransactionResultException e) {
@@ -723,6 +795,13 @@ public class BandwidthProcessorTest {
     ownerCapsule.setFrozenForBandwidth(2_000_000L, expireTime);
     chainBaseManager.getAccountStore().put(ownerCapsule.getAddress().toByteArray(), ownerCapsule);
 
+    AccountAssetIssueCapsule ownerAccountAssetCapsule =
+            new AccountAssetIssueCapsule(
+            ByteString.copyFromUtf8("owner"),
+            ByteString.copyFrom(ByteArray.fromHexString(OWNER_ADDRESS)));
+    chainBaseManager.getAccountAssetIssueStore()
+            .put(ownerAccountAssetCapsule.getAddress().toByteArray(), ownerAccountAssetCapsule);
+
     AccountCapsule toAddressCapsule =
         new AccountCapsule(
             ByteString.copyFromUtf8("owner"),
@@ -734,6 +813,13 @@ public class BandwidthProcessorTest {
     toAddressCapsule.setFrozenForBandwidth(2_000_000L, expireTime2);
     chainBaseManager.getAccountStore().put(toAddressCapsule.getAddress().toByteArray(),
         toAddressCapsule);
+
+    AccountAssetIssueCapsule toAccountAssetCapsule = new AccountAssetIssueCapsule(
+            ByteString.copyFromUtf8("owner"),
+            ByteString.copyFrom(ByteArray.fromHexString(TO_ADDRESS))
+    );
+    chainBaseManager.getAccountAssetIssueStore()
+            .put(toAccountAssetCapsule.getAddress().toByteArray(), toAccountAssetCapsule);
 
     TransferAssetContract contract = TransferAssetContract.newBuilder()
         .setAssetName(ByteString.copyFrom(ByteArray.fromString(String.valueOf(id))))
@@ -757,6 +843,7 @@ public class BandwidthProcessorTest {
       Assert.assertEquals(trace.getReceipt().getNetUsage(), byteSize);
       AccountCapsule ownerAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
+
       Assert.assertNotNull(ownerAccount);
       Assert.assertEquals(ownerAccount.getNetUsage(), byteSize);
 
@@ -769,8 +856,12 @@ public class BandwidthProcessorTest {
       AccountCapsule fromAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
       Assert.assertNotNull(fromAccount);
-      Assert.assertEquals(fromAccount.getFreeAssetNetUsageV2(String.valueOf(id)), byteSize);
-      Assert.assertEquals(fromAccount.getFreeAssetNetUsageV2(String.valueOf(id)), byteSize);
+
+      AccountAssetIssueCapsule fromAccountAssetIssue =
+              chainBaseManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
+
+      Assert.assertEquals(fromAccountAssetIssue.getFreeAssetNetUsageV2(String.valueOf(id)), byteSize);
+      Assert.assertEquals(fromAccountAssetIssue.getFreeAssetNetUsageV2(String.valueOf(id)), byteSize);
 
     } catch (ContractValidateException e) {
       Assert.assertFalse(e instanceof ContractValidateException);

--- a/framework/src/test/java/org/tron/core/actuator/AssetIssueActuatorTest.java
+++ b/framework/src/test/java/org/tron/core/actuator/AssetIssueActuatorTest.java
@@ -22,6 +22,7 @@ import org.tron.common.utils.FileUtil;
 import org.tron.core.ChainBaseManager;
 import org.tron.core.Constant;
 import org.tron.core.Wallet;
+import org.tron.core.capsule.AccountAssetIssueCapsule;
 import org.tron.core.capsule.AccountCapsule;
 import org.tron.core.capsule.AssetIssueCapsule;
 import org.tron.core.capsule.TransactionResultCapsule;
@@ -100,8 +101,17 @@ public class AssetIssueActuatorTest {
         ByteString.copyFrom(ByteArray.fromHexString(OWNER_ADDRESS_SECOND)), AccountType.Normal,
         dbManager.getDynamicPropertiesStore().getAssetIssueFee());
     dbManager.getAccountStore().put(ownerCapsule.getAddress().toByteArray(), ownerCapsule);
-    dbManager.getAccountStore()
-        .put(ownerSecondCapsule.getAddress().toByteArray(), ownerSecondCapsule);
+    dbManager.getAccountStore().put(ownerSecondCapsule.getAddress().toByteArray(), ownerSecondCapsule);
+
+    AccountAssetIssueCapsule ownerAssetIssueCapsule = new AccountAssetIssueCapsule(
+            ByteString.copyFrom(ByteArray.fromHexString(OWNER_ADDRESS)));
+    AccountAssetIssueCapsule ownerAssetIssueSecondCapsule = new AccountAssetIssueCapsule(
+            ByteString.copyFrom(ByteArray.fromHexString(OWNER_ADDRESS_SECOND))
+    );
+    dbManager.getAccountAssetIssueStore()
+            .put(ownerAssetIssueCapsule.getAddress().toByteArray(), ownerAssetIssueCapsule);
+    dbManager.getAccountAssetIssueStore()
+            .put(ownerAssetIssueSecondCapsule.getAddress().toByteArray(), ownerAssetIssueSecondCapsule);
 
     dbManager.getDynamicPropertiesStore().saveLatestBlockHeaderTimestamp(24 * 3600 * 1000);
     dbManager.getDynamicPropertiesStore().saveAllowSameTokenName(0);
@@ -147,6 +157,10 @@ public class AssetIssueActuatorTest {
       Assert.assertEquals(ret.getInstance().getRet(), code.SUCESS);
       AccountCapsule owner = dbManager.getAccountStore()
           .get(ByteArray.fromHexString(OWNER_ADDRESS));
+
+      AccountAssetIssueCapsule ownerAccountAssetIssue = dbManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(OWNER_ADDRESS));
+
       Assert.assertEquals(owner.getBalance(), 0L);
       Assert.assertEquals(dbManager.getAccountStore().getBlackhole().getBalance(),
           blackholeBalance + dbManager.getDynamicPropertiesStore().getAssetIssueFee());
@@ -157,7 +171,7 @@ public class AssetIssueActuatorTest {
       Assert.assertEquals(6, assetIssueCapsule.getPrecision());
       Assert.assertEquals(NUM, assetIssueCapsule.getNum());
       Assert.assertEquals(TRX_NUM, assetIssueCapsule.getTrxNum());
-      Assert.assertEquals(owner.getAssetMap().get(NAME).longValue(), TOTAL_SUPPLY);
+      Assert.assertEquals(ownerAccountAssetIssue.getAssetMap().get(NAME).longValue(), TOTAL_SUPPLY);
       // check V2
       long tokenIdNum = dbManager.getDynamicPropertiesStore().getTokenIdNum();
       AssetIssueCapsule assetIssueCapsuleV2 = dbManager.getAssetIssueV2Store()
@@ -166,7 +180,7 @@ public class AssetIssueActuatorTest {
       Assert.assertEquals(0, assetIssueCapsuleV2.getPrecision());
       Assert.assertEquals(NUM, assetIssueCapsuleV2.getNum());
       Assert.assertEquals(TRX_NUM, assetIssueCapsuleV2.getTrxNum());
-      Assert.assertEquals(owner.getAssetMapV2().get(String.valueOf(tokenIdNum)).longValue(),
+      Assert.assertEquals(ownerAccountAssetIssue.getAssetMapV2().get(String.valueOf(tokenIdNum)).longValue(),
           TOTAL_SUPPLY);
 
     } catch (ContractValidateException e) {
@@ -196,6 +210,9 @@ public class AssetIssueActuatorTest {
       Assert.assertEquals(ret.getInstance().getRet(), code.SUCESS);
       AccountCapsule owner = dbManager.getAccountStore()
           .get(ByteArray.fromHexString(OWNER_ADDRESS));
+      AccountAssetIssueCapsule ownerAccountAssetIssue = dbManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(OWNER_ADDRESS));
+
       Assert.assertEquals(owner.getBalance(), 0L);
       Assert.assertEquals(dbManager.getAccountStore().getBlackhole().getBalance(),
           blackholeBalance + dbManager.getDynamicPropertiesStore().getAssetIssueFee());
@@ -210,7 +227,7 @@ public class AssetIssueActuatorTest {
       Assert.assertEquals(6, assetIssueCapsuleV2.getPrecision());
       Assert.assertEquals(NUM, assetIssueCapsuleV2.getNum());
       Assert.assertEquals(TRX_NUM, assetIssueCapsuleV2.getTrxNum());
-      Assert.assertEquals(owner.getAssetMapV2().get(String.valueOf(tokenIdNum)).longValue(),
+      Assert.assertEquals(ownerAccountAssetIssue.getAssetMapV2().get(String.valueOf(tokenIdNum)).longValue(),
           TOTAL_SUPPLY);
 
     } catch (ContractValidateException e) {
@@ -239,6 +256,9 @@ public class AssetIssueActuatorTest {
       Assert.assertEquals(ret.getInstance().getRet(), code.SUCESS);
       AccountCapsule owner = dbManager.getAccountStore()
           .get(ByteArray.fromHexString(OWNER_ADDRESS));
+      AccountAssetIssueCapsule ownerAccountAssetIssue = dbManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(OWNER_ADDRESS));
+
       Assert.assertEquals(owner.getBalance(), 0L);
       Assert.assertEquals(dbManager.getAccountStore().getBlackhole().getBalance(),
           blackholeBalance + dbManager.getDynamicPropertiesStore().getAssetIssueFee());
@@ -253,7 +273,7 @@ public class AssetIssueActuatorTest {
       Assert.assertEquals(6, assetIssueCapsuleV2.getPrecision());
       Assert.assertEquals(NUM, assetIssueCapsuleV2.getNum());
       Assert.assertEquals(TRX_NUM, assetIssueCapsuleV2.getTrxNum());
-      Assert.assertEquals(owner.getAssetMapV2().get(String.valueOf(tokenIdNum)).longValue(),
+      Assert.assertEquals(ownerAccountAssetIssue.getAssetMapV2().get(String.valueOf(tokenIdNum)).longValue(),
           TOTAL_SUPPLY);
 
     } catch (ContractValidateException e) {
@@ -603,6 +623,8 @@ public class AssetIssueActuatorTest {
       Assert.assertEquals("Invalid assetName", e.getMessage());
       AccountCapsule owner = dbManager.getAccountStore()
           .get(ByteArray.fromHexString(OWNER_ADDRESS));
+      AccountAssetIssueCapsule ownerAccountAssetIssue = dbManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(OWNER_ADDRESS));
       AssetIssueCapsule assetIssueCapsule = dbManager.getAssetIssueStore()
           .get(ByteArray.fromString(NAME));
       Assert.assertEquals(owner.getBalance(),
@@ -713,6 +735,9 @@ public class AssetIssueActuatorTest {
       Assert.assertEquals(ret.getInstance().getRet(), code.SUCESS);
       AccountCapsule owner = dbManager.getAccountStore()
           .get(ByteArray.fromHexString(OWNER_ADDRESS));
+      AccountAssetIssueCapsule ownerAccountAssetIssue = dbManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(OWNER_ADDRESS));
+
       AssetIssueCapsule assetIssueCapsule = dbManager.getAssetIssueStore()
           .get("testname0123456789abcdefghijgklm".getBytes());
       Assert.assertNotNull(assetIssueCapsule);
@@ -720,7 +745,7 @@ public class AssetIssueActuatorTest {
       Assert.assertEquals(owner.getBalance(), 0L);
       Assert.assertEquals(dbManager.getAccountStore().getBlackhole().getBalance(),
           blackholeBalance + dbManager.getDynamicPropertiesStore().getAssetIssueFee());
-      Assert.assertEquals(owner.getAssetMap().get("testname0123456789abcdefghijgklm").longValue(),
+      Assert.assertEquals(ownerAccountAssetIssue.getAssetMap().get("testname0123456789abcdefghijgklm").longValue(),
           TOTAL_SUPPLY);
     } catch (ContractValidateException e) {
       Assert.assertFalse(e instanceof ContractValidateException);
@@ -751,13 +776,17 @@ public class AssetIssueActuatorTest {
       Assert.assertEquals(ret.getInstance().getRet(), code.SUCESS);
       AccountCapsule owner = dbManager.getAccountStore()
           .get(ByteArray.fromHexString(OWNER_ADDRESS));
+
+      AccountAssetIssueCapsule ownerAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(OWNER_ADDRESS));
+
       AssetIssueCapsule assetIssueCapsule = dbManager.getAssetIssueStore().get("0".getBytes());
       Assert.assertNotNull(assetIssueCapsule);
 
       Assert.assertEquals(owner.getBalance(), 0L);
       Assert.assertEquals(dbManager.getAccountStore().getBlackhole().getBalance(),
           blackholeBalance + dbManager.getDynamicPropertiesStore().getAssetIssueFee());
-      Assert.assertEquals(owner.getAssetMap().get("0").longValue(), TOTAL_SUPPLY);
+      Assert.assertEquals(ownerAccountAssetIssue.getAssetMap().get("0").longValue(), TOTAL_SUPPLY);
     } catch (ContractValidateException e) {
       Assert.assertFalse(e instanceof ContractValidateException);
     } catch (ContractExeException e) {
@@ -874,12 +903,16 @@ public class AssetIssueActuatorTest {
       Assert.assertEquals(ret.getInstance().getRet(), code.SUCESS);
       AccountCapsule owner = dbManager.getAccountStore()
           .get(ByteArray.fromHexString(OWNER_ADDRESS));
+
+      AccountAssetIssueCapsule ownerAccountAssetIssue = dbManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(OWNER_ADDRESS));
+
       AssetIssueCapsule assetIssueCapsule = dbManager.getAssetIssueStore().get(NAME.getBytes());
       Assert.assertNotNull(assetIssueCapsule);
       Assert.assertEquals(owner.getBalance(), 0L);
       Assert.assertEquals(dbManager.getAccountStore().getBlackhole().getBalance(),
           blackholeBalance + dbManager.getDynamicPropertiesStore().getAssetIssueFee());
-      Assert.assertEquals(owner.getAssetMap().get(NAME).longValue(), TOTAL_SUPPLY);
+      Assert.assertEquals(ownerAccountAssetIssue.getAssetMap().get(NAME).longValue(), TOTAL_SUPPLY);
     } catch (ContractValidateException e) {
       Assert.assertFalse(e instanceof ContractValidateException);
     } catch (ContractExeException e) {
@@ -909,13 +942,17 @@ public class AssetIssueActuatorTest {
       Assert.assertEquals(ret.getInstance().getRet(), code.SUCESS);
       AccountCapsule owner = dbManager.getAccountStore()
           .get(ByteArray.fromHexString(OWNER_ADDRESS));
+
+      AccountAssetIssueCapsule ownerAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(OWNER_ADDRESS));
+
       AssetIssueCapsule assetIssueCapsule = dbManager.getAssetIssueStore().get(NAME.getBytes());
       Assert.assertNotNull(assetIssueCapsule);
 
       Assert.assertEquals(owner.getBalance(), 0L);
       Assert.assertEquals(dbManager.getAccountStore().getBlackhole().getBalance(),
           blackholeBalance + dbManager.getDynamicPropertiesStore().getAssetIssueFee());
-      Assert.assertEquals(owner.getAssetMap().get(NAME).longValue(), TOTAL_SUPPLY);
+      Assert.assertEquals(ownerAccountAssetIssue.getAssetMap().get(NAME).longValue(), TOTAL_SUPPLY);
     } catch (ContractValidateException e) {
       Assert.assertFalse(e instanceof ContractValidateException);
     } catch (ContractExeException e) {
@@ -945,13 +982,17 @@ public class AssetIssueActuatorTest {
       Assert.assertEquals(ret.getInstance().getRet(), code.SUCESS);
       AccountCapsule owner = dbManager.getAccountStore()
           .get(ByteArray.fromHexString(OWNER_ADDRESS));
+
+      AccountAssetIssueCapsule ownerAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(OWNER_ADDRESS));
+
       AssetIssueCapsule assetIssueCapsule = dbManager.getAssetIssueStore().get(NAME.getBytes());
       Assert.assertNotNull(assetIssueCapsule);
 
       Assert.assertEquals(owner.getBalance(), 0L);
       Assert.assertEquals(dbManager.getAccountStore().getBlackhole().getBalance(),
           blackholeBalance + dbManager.getDynamicPropertiesStore().getAssetIssueFee());
-      Assert.assertEquals(owner.getAssetMap().get(NAME).longValue(), TOTAL_SUPPLY);
+      Assert.assertEquals(ownerAccountAssetIssue.getAssetMap().get(NAME).longValue(), TOTAL_SUPPLY);
     } catch (ContractValidateException e) {
       Assert.assertFalse(e instanceof ContractValidateException);
     } catch (ContractExeException e) {
@@ -996,6 +1037,10 @@ public class AssetIssueActuatorTest {
       Assert.assertEquals("Invalid description", e.getMessage());
       AccountCapsule owner = dbManager.getAccountStore()
           .get(ByteArray.fromHexString(OWNER_ADDRESS));
+
+      AccountAssetIssueCapsule ownerAccountAssetIssue = dbManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(OWNER_ADDRESS));
+
       AssetIssueCapsule assetIssueCapsule = dbManager.getAssetIssueStore()
           .get(ByteArray.fromString(NAME));
       Assert.assertEquals(owner.getBalance(),
@@ -1003,7 +1048,7 @@ public class AssetIssueActuatorTest {
       Assert
           .assertEquals(dbManager.getAccountStore().getBlackhole().getBalance(), blackholeBalance);
       Assert.assertNull(assetIssueCapsule);
-      Assert.assertNull(owner.getInstance().getAssetMap().get(NAME));
+      Assert.assertNull(ownerAccountAssetIssue.getInstance().getAssetMap().get(NAME));
     } catch (ContractExeException e) {
       Assert.assertFalse(e instanceof ContractExeException);
     } finally {
@@ -1030,13 +1075,16 @@ public class AssetIssueActuatorTest {
       Assert.assertEquals(ret.getInstance().getRet(), code.SUCESS);
       AccountCapsule owner = dbManager.getAccountStore()
           .get(ByteArray.fromHexString(OWNER_ADDRESS));
+      AccountAssetIssueCapsule ownerAccountAssetIssue = dbManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(OWNER_ADDRESS));
+
       AssetIssueCapsule assetIssueCapsule = dbManager.getAssetIssueStore().get(NAME.getBytes());
       Assert.assertNotNull(assetIssueCapsule);
 
       Assert.assertEquals(owner.getBalance(), 0L);
       Assert.assertEquals(dbManager.getAccountStore().getBlackhole().getBalance(),
           blackholeBalance + dbManager.getDynamicPropertiesStore().getAssetIssueFee());
-      Assert.assertEquals(owner.getAssetMap().get(NAME).longValue(), TOTAL_SUPPLY);
+      Assert.assertEquals(ownerAccountAssetIssue.getAssetMap().get(NAME).longValue(), TOTAL_SUPPLY);
     } catch (ContractValidateException e) {
       Assert.assertFalse(e instanceof ContractValidateException);
     } catch (ContractExeException e) {
@@ -1066,13 +1114,15 @@ public class AssetIssueActuatorTest {
       Assert.assertEquals(ret.getInstance().getRet(), code.SUCESS);
       AccountCapsule owner = dbManager.getAccountStore()
           .get(ByteArray.fromHexString(OWNER_ADDRESS));
+      AccountAssetIssueCapsule ownerAccountAssetIssue = dbManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(OWNER_ADDRESS));
       AssetIssueCapsule assetIssueCapsule = dbManager.getAssetIssueStore().get(NAME.getBytes());
       Assert.assertNotNull(assetIssueCapsule);
 
       Assert.assertEquals(owner.getBalance(), 0L);
       Assert.assertEquals(dbManager.getAccountStore().getBlackhole().getBalance(),
           blackholeBalance + dbManager.getDynamicPropertiesStore().getAssetIssueFee());
-      Assert.assertEquals(owner.getAssetMap().get(NAME).longValue(), TOTAL_SUPPLY);
+      Assert.assertEquals(ownerAccountAssetIssue.getAssetMap().get(NAME).longValue(), TOTAL_SUPPLY);
     } catch (ContractValidateException e) {
       Assert.assertFalse(e instanceof ContractValidateException);
     } catch (ContractExeException e) {
@@ -1102,13 +1152,17 @@ public class AssetIssueActuatorTest {
       Assert.assertEquals(ret.getInstance().getRet(), code.SUCESS);
       AccountCapsule owner = dbManager.getAccountStore()
           .get(ByteArray.fromHexString(OWNER_ADDRESS));
+
+      AccountAssetIssueCapsule ownerAccountAssetIssue = dbManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(OWNER_ADDRESS));
+
       AssetIssueCapsule assetIssueCapsule = dbManager.getAssetIssueStore().get(NAME.getBytes());
       Assert.assertNotNull(assetIssueCapsule);
 
       Assert.assertEquals(owner.getBalance(), 0L);
       Assert.assertEquals(dbManager.getAccountStore().getBlackhole().getBalance(),
           blackholeBalance + dbManager.getDynamicPropertiesStore().getAssetIssueFee());
-      Assert.assertEquals(owner.getAssetMap().get(NAME).longValue(), TOTAL_SUPPLY);
+      Assert.assertEquals(ownerAccountAssetIssue.getAssetMap().get(NAME).longValue(), TOTAL_SUPPLY);
     } catch (ContractValidateException e) {
       Assert.assertFalse(e instanceof ContractValidateException);
     } catch (ContractExeException e) {
@@ -1489,11 +1543,11 @@ public class AssetIssueActuatorTest {
     try {
       actuator.validate();
       actuator.execute(ret);
-      AccountCapsule account = dbManager.getAccountStore()
-          .get(ByteArray.fromHexString(OWNER_ADDRESS));
+      AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(OWNER_ADDRESS));
       Assert.assertEquals(ret.getInstance().getRet(), code.SUCESS);
-      Assert.assertEquals(account.getAssetIssuedName().toStringUtf8(), NAME);
-      Assert.assertEquals(account.getAssetMap().size(), 1);
+      Assert.assertEquals(accountAssetIssueCapsule.getAssetIssuedName().toStringUtf8(), NAME);
+      Assert.assertEquals(accountAssetIssueCapsule.getAssetMap().size(), 1);
     } catch (ContractValidateException e) {
       Assert.assertFalse(e instanceof ContractValidateException);
     } catch (ContractExeException e) {
@@ -1752,8 +1806,16 @@ public class AssetIssueActuatorTest {
     ownerCapsule.addAsset(NAME.getBytes(), 1000L);
     dbManager.getAccountStore().put(ownerCapsule.getAddress().toByteArray(), ownerCapsule);
 
+    AccountAssetIssueCapsule ownerAccountAssetIssue = new AccountAssetIssueCapsule(
+            ByteString.copyFromUtf8("owner11"),
+            ByteString.copyFrom(ByteArray.fromHexString(ownerAddress)));
+    ownerAccountAssetIssue.addAsset(NAME.getBytes(), 1000L);
+    dbManager.getAccountAssetIssueStore().put(ownerAccountAssetIssue.getAddress().toByteArray(), ownerAccountAssetIssue);
+
     AssetIssueActuator actuator = new AssetIssueActuator();
     actuator.setChainBaseManager(dbManager.getChainBaseManager()).setAny(getContract());
+//    ownerAccountAssetIssue.getAssetIssuedName().toStringUtf8();
+//    ownerCapsule.getAssetIssuedName().toStringUtf8();
 
     TransactionResultCapsule ret = new TransactionResultCapsule();
     Long blackholeBalance = dbManager.getAccountStore().getBlackhole().getBalance();
@@ -1769,6 +1831,9 @@ public class AssetIssueActuatorTest {
       Assert.assertEquals(ret.getInstance().getRet(), code.SUCESS);
       AccountCapsule owner = dbManager.getAccountStore()
           .get(ByteArray.fromHexString(OWNER_ADDRESS));
+      AccountAssetIssueCapsule ownerAssetIssue = dbManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(OWNER_ADDRESS));
+
       long tokenIdNum = dbManager.getDynamicPropertiesStore().getTokenIdNum();
       AssetIssueCapsule assetIssueCapsuleV2 = dbManager.getAssetIssueV2Store()
           .get(ByteArray.fromString(String.valueOf(tokenIdNum)));
@@ -1777,7 +1842,7 @@ public class AssetIssueActuatorTest {
       Assert.assertEquals(owner.getBalance(), 0L);
       Assert.assertEquals(dbManager.getAccountStore().getBlackhole().getBalance(),
           blackholeBalance + dbManager.getDynamicPropertiesStore().getAssetIssueFee());
-      Assert.assertEquals(owner.getAssetMapV2().get(String.valueOf(tokenIdNum)).longValue(),
+      Assert.assertEquals(ownerAssetIssue.getAssetMapV2().get(String.valueOf(tokenIdNum)).longValue(),
           TOTAL_SUPPLY);
     } catch (ContractValidateException e) {
       Assert.assertFalse(e instanceof ContractValidateException);

--- a/framework/src/test/java/org/tron/core/actuator/ExchangeInjectActuatorTest.java
+++ b/framework/src/test/java/org/tron/core/actuator/ExchangeInjectActuatorTest.java
@@ -19,10 +19,7 @@ import org.tron.common.utils.ByteArray;
 import org.tron.common.utils.FileUtil;
 import org.tron.core.Constant;
 import org.tron.core.Wallet;
-import org.tron.core.capsule.AccountCapsule;
-import org.tron.core.capsule.AssetIssueCapsule;
-import org.tron.core.capsule.ExchangeCapsule;
-import org.tron.core.capsule.TransactionResultCapsule;
+import org.tron.core.capsule.*;
 import org.tron.core.config.DefaultConfig;
 import org.tron.core.config.args.Args;
 import org.tron.core.db.Manager;
@@ -104,10 +101,25 @@ public class ExchangeInjectActuatorTest {
             AccountType.Normal,
             200_000_000_000L);
 
+    AccountAssetIssueCapsule ownerAccountAssetIssueFirst = new AccountAssetIssueCapsule(
+            ByteString.copyFromUtf8(ACCOUNT_NAME_FIRST),
+            ByteString.copyFrom(ByteArray.fromHexString(OWNER_ADDRESS_FIRST))
+    );
+
+    AccountAssetIssueCapsule ownerAccountAssetIssueSecond = new AccountAssetIssueCapsule(
+            ByteString.copyFromUtf8(ACCOUNT_NAME_SECOND),
+            ByteString.copyFrom(ByteArray.fromHexString(OWNER_ADDRESS_SECOND))
+    );
+
     dbManager.getAccountStore()
         .put(ownerAccountFirstCapsule.getAddress().toByteArray(), ownerAccountFirstCapsule);
     dbManager.getAccountStore()
         .put(ownerAccountSecondCapsule.getAddress().toByteArray(), ownerAccountSecondCapsule);
+
+    dbManager.getAccountAssetIssueStore()
+            .put(ownerAccountAssetIssueFirst.getAddress().toByteArray(), ownerAccountAssetIssueFirst);
+    dbManager.getAccountAssetIssueStore()
+            .put(ownerAccountSecondCapsule.getAddress().toByteArray(), ownerAccountAssetIssueSecond);
 
     dbManager.getDynamicPropertiesStore().saveLatestBlockHeaderTimestamp(1000000);
     dbManager.getDynamicPropertiesStore().saveLatestBlockHeaderNumber(10);
@@ -226,10 +238,13 @@ public class ExchangeInjectActuatorTest {
 
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_FIRST);
     AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    accountCapsule.addAssetAmount(firstTokenId.getBytes(), firstTokenQuant);
-    accountCapsule.addAssetAmount(secondTokenId.getBytes(), secondTokenQuant);
     accountCapsule.setBalance(10000_000000L);
     dbManager.getAccountStore().put(ownerAddress, accountCapsule);
+
+    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    accountAssetIssueCapsule.addAssetAmount(firstTokenId.getBytes(), firstTokenQuant);
+    accountAssetIssueCapsule.addAssetAmount(secondTokenId.getBytes(), secondTokenQuant);
+    dbManager.getAccountAssetIssueStore().put(ownerAddress, accountAssetIssueCapsule);
 
     ExchangeInjectActuator actuator = new ExchangeInjectActuator();
     actuator.setChainBaseManager(dbManager.getChainBaseManager()).setAny(getContract(
@@ -264,7 +279,9 @@ public class ExchangeInjectActuatorTest {
       Assert.assertEquals(600000000L, exchangeCapsuleV2.getSecondTokenBalance());
 
       accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-      Map<String, Long> assetMap = accountCapsule.getAssetMap();
+      accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+
+      Map<String, Long> assetMap = accountAssetIssueCapsule.getAssetMap();
       Assert.assertEquals(10000_000000L, accountCapsule.getBalance());
       Assert.assertEquals(0L, assetMap.get(firstTokenId).longValue());
       Assert.assertEquals(0L, assetMap.get(secondTokenId).longValue());
@@ -315,12 +332,15 @@ public class ExchangeInjectActuatorTest {
 
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_FIRST);
     AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    accountCapsule.addAsset(firstTokenId.getBytes(), firstTokenQuant);
-    accountCapsule.addAsset(secondTokenId.getBytes(), secondTokenQuant);
-    accountCapsule.addAssetV2(String.valueOf(1L).getBytes(), firstTokenQuant);
-    accountCapsule.addAssetV2(String.valueOf(2L).getBytes(), secondTokenQuant);
     accountCapsule.setBalance(10000_000000L);
     dbManager.getAccountStore().put(ownerAddress, accountCapsule);
+
+    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    accountAssetIssueCapsule.addAsset(firstTokenId.getBytes(), firstTokenQuant);
+    accountAssetIssueCapsule.addAsset(secondTokenId.getBytes(), secondTokenQuant);
+    accountAssetIssueCapsule.addAssetV2(String.valueOf(1L).getBytes(), firstTokenQuant);
+    accountAssetIssueCapsule.addAssetV2(String.valueOf(2L).getBytes(), secondTokenQuant);
+    dbManager.getAccountAssetIssueStore().put(ownerAddress, accountAssetIssueCapsule);
 
     ExchangeInjectActuator actuator = new ExchangeInjectActuator();
     actuator.setChainBaseManager(dbManager.getChainBaseManager()).setAny(getContract(
@@ -358,7 +378,8 @@ public class ExchangeInjectActuatorTest {
       Assert.assertEquals(600000000L, exchangeCapsuleV2.getSecondTokenBalance());
 
       accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-      Map<String, Long> assetMap = accountCapsule.getAssetMapV2();
+      accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+      Map<String, Long> assetMap = accountAssetIssueCapsule.getAssetMapV2();
       Assert.assertEquals(10000_000000L, accountCapsule.getBalance());
       Assert.assertEquals(0L, assetMap.get(String.valueOf(1)).longValue());
       Assert.assertEquals(0L, assetMap.get(String.valueOf(2)).longValue());
@@ -410,12 +431,15 @@ public class ExchangeInjectActuatorTest {
 
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_FIRST);
     AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    accountCapsule.addAssetAmountV2(firstTokenId.getBytes(), firstTokenQuant,
-        dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
-    accountCapsule.addAssetAmountV2(secondTokenId.getBytes(), secondTokenQuant,
-        dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
     accountCapsule.setBalance(10000_000000L);
     dbManager.getAccountStore().put(ownerAddress, accountCapsule);
+
+    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    accountAssetIssueCapsule.addAssetAmountV2(firstTokenId.getBytes(), firstTokenQuant,
+        dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
+    accountAssetIssueCapsule.addAssetAmountV2(secondTokenId.getBytes(), secondTokenQuant,
+        dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
+    dbManager.getAccountAssetIssueStore().put(ownerAddress, accountAssetIssueCapsule);
 
     ExchangeInjectActuator actuator = new ExchangeInjectActuator();
     actuator.setChainBaseManager(dbManager.getChainBaseManager()).setAny(getContract(
@@ -446,7 +470,8 @@ public class ExchangeInjectActuatorTest {
       Assert.assertEquals(600000000L, exchangeCapsuleV2.getSecondTokenBalance());
 
       accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-      Map<String, Long> assetV2Map = accountCapsule.getAssetMapV2();
+      accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+      Map<String, Long> assetV2Map = accountAssetIssueCapsule.getAssetMapV2();
       Assert.assertEquals(10000_000000L, accountCapsule.getBalance());
       Assert.assertEquals(0L, assetV2Map.get(firstTokenId).longValue());
       Assert.assertEquals(0L, assetV2Map.get(secondTokenId).longValue());
@@ -487,9 +512,12 @@ public class ExchangeInjectActuatorTest {
 
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_FIRST);
     AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    accountCapsule.addAssetAmount(secondTokenId.getBytes(), secondTokenQuant);
     accountCapsule.setBalance(firstTokenQuant);
     dbManager.getAccountStore().put(ownerAddress, accountCapsule);
+
+    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    accountAssetIssueCapsule.addAssetAmount(secondTokenId.getBytes(), secondTokenQuant);
+    dbManager.getAccountAssetIssueStore().put(ownerAddress, accountAssetIssueCapsule);
 
     ExchangeInjectActuator actuator = new ExchangeInjectActuator();
     actuator.setChainBaseManager(dbManager.getChainBaseManager()).setAny(getContract(
@@ -524,7 +552,9 @@ public class ExchangeInjectActuatorTest {
       Assert.assertEquals(11_000_000L, exchangeCapsule2.getSecondTokenBalance());
 
       accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-      Map<String, Long> assetMap = accountCapsule.getAssetMap();
+      accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+
+      Map<String, Long> assetMap = accountAssetIssueCapsule.getAssetMap();
       Assert.assertEquals(0L, accountCapsule.getBalance());
       Assert.assertEquals(3_000_000L, assetMap.get(secondTokenId).longValue());
 
@@ -566,11 +596,14 @@ public class ExchangeInjectActuatorTest {
 
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_FIRST);
     AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    accountCapsule.addAssetAmountV2(secondTokenId.getBytes(), secondTokenQuant,
+    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+
+    accountAssetIssueCapsule.addAssetAmountV2(secondTokenId.getBytes(), secondTokenQuant,
         dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
 
     accountCapsule.setBalance(firstTokenQuant);
     dbManager.getAccountStore().put(ownerAddress, accountCapsule);
+    dbManager.getAccountAssetIssueStore().put(ownerAddress, accountAssetIssueCapsule);
 
     ExchangeInjectActuator actuator = new ExchangeInjectActuator();
     actuator.setChainBaseManager(dbManager.getChainBaseManager()).setAny(getContract(
@@ -598,9 +631,9 @@ public class ExchangeInjectActuatorTest {
       Assert.assertEquals(1_100_000_000000L, exchangeV2Capsule.getFirstTokenBalance());
       Assert.assertEquals(secondTokenId, ByteArray.toStr(exchangeV2Capsule.getSecondTokenId()));
       Assert.assertEquals(11_000_000L, exchangeV2Capsule.getSecondTokenBalance());
-
       accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-      Map<String, Long> assetV2Map = accountCapsule.getAssetMapV2();
+      accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+      Map<String, Long> assetV2Map = accountAssetIssueCapsule.getAssetMapV2();
       Assert.assertEquals(0L, accountCapsule.getBalance());
       Assert.assertEquals(3_000_000L, assetV2Map.get(secondTokenId).longValue());
 
@@ -1481,10 +1514,13 @@ public class ExchangeInjectActuatorTest {
 
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_FIRST);
     AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    accountCapsule.addAssetAmount(firstTokenId.getBytes(), firstTokenQuant - 1);
-    accountCapsule.addAssetAmount(secondTokenId.getBytes(), secondTokenQuant);
+    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
     accountCapsule.setBalance(10000_000000L);
     dbManager.getAccountStore().put(ownerAddress, accountCapsule);
+
+    accountAssetIssueCapsule.addAssetAmount(firstTokenId.getBytes(), firstTokenQuant - 1);
+    accountAssetIssueCapsule.addAssetAmount(secondTokenId.getBytes(), secondTokenQuant);
+    dbManager.getAccountAssetIssueStore().put(ownerAddress, accountAssetIssueCapsule);
 
     ExchangeInjectActuator actuator = new ExchangeInjectActuator();
     actuator.setChainBaseManager(dbManager.getChainBaseManager()).setAny(getContract(
@@ -1525,12 +1561,15 @@ public class ExchangeInjectActuatorTest {
 
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_FIRST);
     AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    accountCapsule.addAssetAmountV2(firstTokenId.getBytes(), firstTokenQuant - 1,
-        dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
-    accountCapsule.addAssetAmountV2(secondTokenId.getBytes(), secondTokenQuant,
-        dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
     accountCapsule.setBalance(10000_000000L);
     dbManager.getAccountStore().put(ownerAddress, accountCapsule);
+
+    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    accountAssetIssueCapsule.addAssetAmountV2(firstTokenId.getBytes(), firstTokenQuant - 1,
+        dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
+    accountAssetIssueCapsule.addAssetAmountV2(secondTokenId.getBytes(), secondTokenQuant,
+        dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
+    dbManager.getAccountAssetIssueStore().put(ownerAddress, accountAssetIssueCapsule);
 
     ExchangeInjectActuator actuator = new ExchangeInjectActuator();
     actuator.setChainBaseManager(dbManager.getChainBaseManager()).setAny(getContract(
@@ -1569,9 +1608,12 @@ public class ExchangeInjectActuatorTest {
 
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_FIRST);
     AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    accountCapsule.addAssetAmount(secondTokenId.getBytes(), secondTokenQuant);
     accountCapsule.setBalance(399_000000L);
     dbManager.getAccountStore().put(ownerAddress, accountCapsule);
+
+    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    accountAssetIssueCapsule.addAssetAmount(secondTokenId.getBytes(), secondTokenQuant);
+    dbManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.createDbKey(), accountAssetIssueCapsule);
 
     ExchangeInjectActuator actuator = new ExchangeInjectActuator();
     actuator.setChainBaseManager(dbManager.getChainBaseManager()).setAny(getContract(
@@ -1610,10 +1652,13 @@ public class ExchangeInjectActuatorTest {
 
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_FIRST);
     AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    accountCapsule.addAssetAmountV2(secondTokenId.getBytes(), secondTokenQuant,
-        dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
     accountCapsule.setBalance(399_000000L);
     dbManager.getAccountStore().put(ownerAddress, accountCapsule);
+
+    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    accountAssetIssueCapsule.addAssetAmountV2(secondTokenId.getBytes(), secondTokenQuant,
+            dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
+    dbManager.getAccountAssetIssueStore().put(ownerAddress, accountAssetIssueCapsule);
 
     ExchangeInjectActuator actuator = new ExchangeInjectActuator();
     actuator.setChainBaseManager(dbManager.getChainBaseManager()).setAny(getContract(
@@ -1654,10 +1699,13 @@ public class ExchangeInjectActuatorTest {
 
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_FIRST);
     AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    accountCapsule.addAssetAmount(firstTokenId.getBytes(), firstTokenQuant - 1);
-    accountCapsule.addAssetAmount(secondTokenId.getBytes(), secondTokenQuant);
     accountCapsule.setBalance(10000_000000L);
     dbManager.getAccountStore().put(ownerAddress, accountCapsule);
+
+    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    accountAssetIssueCapsule.addAssetAmount(firstTokenId.getBytes(), firstTokenQuant - 1);
+    accountAssetIssueCapsule.addAssetAmount(secondTokenId.getBytes(), secondTokenQuant);
+    dbManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.createDbKey(), accountAssetIssueCapsule);
 
     ExchangeInjectActuator actuator = new ExchangeInjectActuator();
     actuator.setChainBaseManager(dbManager.getChainBaseManager()).setAny(getContract(
@@ -1698,12 +1746,15 @@ public class ExchangeInjectActuatorTest {
 
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_FIRST);
     AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    accountCapsule.addAssetAmountV2(firstTokenId.getBytes(), firstTokenQuant - 1,
-        dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
-    accountCapsule.addAssetAmountV2(secondTokenId.getBytes(), secondTokenQuant,
-        dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
     accountCapsule.setBalance(10000_000000L);
     dbManager.getAccountStore().put(ownerAddress, accountCapsule);
+
+    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    accountAssetIssueCapsule.addAssetAmountV2(firstTokenId.getBytes(), firstTokenQuant - 1,
+        dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
+    accountAssetIssueCapsule.addAssetAmountV2(secondTokenId.getBytes(), secondTokenQuant,
+        dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
+    dbManager.getAccountAssetIssueStore().put(ownerAddress, accountAssetIssueCapsule);
 
     ExchangeInjectActuator actuator = new ExchangeInjectActuator();
     actuator.setChainBaseManager(dbManager.getChainBaseManager()).setAny(getContract(
@@ -1821,10 +1872,13 @@ public class ExchangeInjectActuatorTest {
     TransactionResultCapsule ret = null;
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_FIRST);
     AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    accountCapsule.addAssetAmount(firstTokenId.getBytes(), firstTokenQuant);
-    accountCapsule.addAssetAmount(secondTokenId.getBytes(), secondTokenQuant);
     accountCapsule.setBalance(10000_000000L);
     dbManager.getAccountStore().put(ownerAddress, accountCapsule);
+
+    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    accountAssetIssueCapsule.addAssetAmount(firstTokenId.getBytes(), firstTokenQuant);
+    accountAssetIssueCapsule.addAssetAmount(secondTokenId.getBytes(), secondTokenQuant);
+    dbManager.getAccountAssetIssueStore().put(ownerAddress, accountAssetIssueCapsule);
 
     processAndCheckInvalid(actuator, ret, "TransactionResultCapsule is null",
         "TransactionResultCapsule is null");

--- a/framework/src/test/java/org/tron/core/actuator/ExchangeWithdrawActuatorTest.java
+++ b/framework/src/test/java/org/tron/core/actuator/ExchangeWithdrawActuatorTest.java
@@ -20,10 +20,7 @@ import org.tron.common.utils.ByteArray;
 import org.tron.common.utils.FileUtil;
 import org.tron.core.Constant;
 import org.tron.core.Wallet;
-import org.tron.core.capsule.AccountCapsule;
-import org.tron.core.capsule.AssetIssueCapsule;
-import org.tron.core.capsule.ExchangeCapsule;
-import org.tron.core.capsule.TransactionResultCapsule;
+import org.tron.core.capsule.*;
 import org.tron.core.config.DefaultConfig;
 import org.tron.core.config.args.Args;
 import org.tron.core.db.Manager;
@@ -98,17 +95,32 @@ public class ExchangeWithdrawActuatorTest {
             ByteString.copyFrom(ByteArray.fromHexString(OWNER_ADDRESS_FIRST)),
             AccountType.Normal,
             10000_000_000L);
+    AccountAssetIssueCapsule ownerAccountAssetIssueFirst =
+            new AccountAssetIssueCapsule(
+                    ByteString.copyFromUtf8(ACCOUNT_NAME_FIRST),
+                    ByteString.copyFrom(ByteArray.fromHexString(OWNER_ADDRESS_FIRST))
+            );
+
     AccountCapsule ownerAccountSecondCapsule =
         new AccountCapsule(
             ByteString.copyFromUtf8(ACCOUNT_NAME_SECOND),
             ByteString.copyFrom(ByteArray.fromHexString(OWNER_ADDRESS_SECOND)),
             AccountType.Normal,
             20000_000_000L);
+    AccountAssetIssueCapsule ownerAccountAssetIssueSecond =
+            new AccountAssetIssueCapsule(
+                    ByteString.copyFromUtf8(ACCOUNT_NAME_SECOND),
+                    ByteString.copyFrom(ByteArray.fromHexString(OWNER_ADDRESS_SECOND))
+            );
+
 
     dbManager.getAccountStore()
         .put(ownerAccountFirstCapsule.getAddress().toByteArray(), ownerAccountFirstCapsule);
     dbManager.getAccountStore()
         .put(ownerAccountSecondCapsule.getAddress().toByteArray(), ownerAccountSecondCapsule);
+
+    dbManager.getAccountAssetIssueStore().put(ownerAccountAssetIssueFirst.getAddress().toByteArray(), ownerAccountAssetIssueFirst);
+    dbManager.getAccountAssetIssueStore().put(ownerAccountAssetIssueSecond.getAddress().toByteArray(), ownerAccountAssetIssueSecond);
 
     dbManager.getDynamicPropertiesStore().saveLatestBlockHeaderTimestamp(1000000);
     dbManager.getDynamicPropertiesStore().saveLatestBlockHeaderNumber(10);
@@ -272,7 +284,9 @@ public class ExchangeWithdrawActuatorTest {
 
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_FIRST);
     AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    Map<String, Long> assetMap = accountCapsule.getAssetMap();
+    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+
+    Map<String, Long> assetMap = accountAssetIssueCapsule.getAssetMap();
     Assert.assertEquals(10000_000000L, accountCapsule.getBalance());
     Assert.assertEquals(null, assetMap.get(firstTokenId));
     Assert.assertEquals(null, assetMap.get(secondTokenId));
@@ -308,7 +322,8 @@ public class ExchangeWithdrawActuatorTest {
       Assert.assertEquals(0L, exchangeCapsule2.getSecondTokenBalance());
 
       accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-      assetMap = accountCapsule.getAssetMap();
+      accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+      assetMap = accountAssetIssueCapsule.getAssetMap();
       Assert.assertEquals(10000_000000L, accountCapsule.getBalance());
       Assert.assertEquals(firstTokenQuant, assetMap.get(firstTokenId).longValue());
       Assert.assertEquals(secondTokenQuant, assetMap.get(secondTokenId).longValue());
@@ -346,7 +361,8 @@ public class ExchangeWithdrawActuatorTest {
 
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_FIRST);
     AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    Map<String, Long> assetMap = accountCapsule.getAssetMap();
+    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    Map<String, Long> assetMap = accountAssetIssueCapsule.getAssetMap();
     Assert.assertEquals(10000_000000L, accountCapsule.getBalance());
     Assert.assertEquals(null, assetMap.get(firstTokenId));
     Assert.assertEquals(null, assetMap.get(secondTokenId));
@@ -383,7 +399,8 @@ public class ExchangeWithdrawActuatorTest {
       Assert.assertEquals(0L, exchangeCapsule2.getSecondTokenBalance());
 
       accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-      assetMap = accountCapsule.getAssetMapV2();
+      accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+      assetMap = accountAssetIssueCapsule.getAssetMapV2();
       Assert.assertEquals(10000_000000L, accountCapsule.getBalance());
       Assert.assertEquals(firstTokenQuant, assetMap.get(String.valueOf(1)).longValue());
       Assert.assertEquals(secondTokenQuant, assetMap.get(String.valueOf(2)).longValue());
@@ -420,7 +437,9 @@ public class ExchangeWithdrawActuatorTest {
 
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_FIRST);
     AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    Map<String, Long> assetV2Map = accountCapsule.getAssetMapV2();
+    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+
+    Map<String, Long> assetV2Map = accountAssetIssueCapsule.getAssetMapV2();
     Assert.assertEquals(10000_000000L, accountCapsule.getBalance());
     Assert.assertEquals(null, assetV2Map.get(firstTokenId));
     Assert.assertEquals(null, assetV2Map.get(secondTokenId));
@@ -451,8 +470,8 @@ public class ExchangeWithdrawActuatorTest {
       Assert.assertEquals(secondTokenId, ByteArray.toStr(exchangeCapsuleV2.getSecondTokenId()));
       Assert.assertEquals(0L, exchangeCapsuleV2.getSecondTokenBalance());
 
-      accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-      assetV2Map = accountCapsule.getAssetMapV2();
+      accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+      assetV2Map = accountAssetIssueCapsule.getAssetMapV2();
       Assert.assertEquals(10000_000000L, accountCapsule.getBalance());
       Assert.assertEquals(firstTokenQuant, assetV2Map.get(firstTokenId).longValue());
       Assert.assertEquals(secondTokenQuant, assetV2Map.get(secondTokenId).longValue());
@@ -487,7 +506,9 @@ public class ExchangeWithdrawActuatorTest {
 
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_FIRST);
     AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    Map<String, Long> assetMap = accountCapsule.getAssetMap();
+    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+
+    Map<String, Long> assetMap = accountAssetIssueCapsule.getAssetMap();
     Assert.assertEquals(10000_000000L, accountCapsule.getBalance());
     Assert.assertEquals(null, assetMap.get(secondTokenId));
 
@@ -524,7 +545,8 @@ public class ExchangeWithdrawActuatorTest {
       Assert.assertEquals(0L, exchangeCapsule2.getSecondTokenBalance());
 
       accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-      assetMap = accountCapsule.getAssetMap();
+      accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+      assetMap = accountAssetIssueCapsule.getAssetMap();
       Assert.assertEquals(firstTokenQuant + 10000_000000L, accountCapsule.getBalance());
       Assert.assertEquals(10_000_000L, assetMap.get(secondTokenId).longValue());
 
@@ -558,7 +580,9 @@ public class ExchangeWithdrawActuatorTest {
 
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_FIRST);
     AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    Map<String, Long> assetV2Map = accountCapsule.getAssetMapV2();
+    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+
+    Map<String, Long> assetV2Map = accountAssetIssueCapsule.getAssetMapV2();
     Assert.assertEquals(10000_000000L, accountCapsule.getBalance());
     Assert.assertEquals(null, assetV2Map.get(secondTokenId));
 
@@ -589,7 +613,8 @@ public class ExchangeWithdrawActuatorTest {
       Assert.assertEquals(0L, exchangeCapsuleV2.getSecondTokenBalance());
 
       accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-      assetV2Map = accountCapsule.getAssetMapV2();
+      accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+      assetV2Map = accountAssetIssueCapsule.getAssetMapV2();
       Assert.assertEquals(firstTokenQuant + 10000_000000L, accountCapsule.getBalance());
       Assert.assertEquals(10_000_000L, assetV2Map.get(secondTokenId).longValue());
 

--- a/framework/src/test/java/org/tron/core/actuator/MarketSellAssetActuatorTest.java
+++ b/framework/src/test/java/org/tron/core/actuator/MarketSellAssetActuatorTest.java
@@ -19,12 +19,7 @@ import org.tron.common.utils.FileUtil;
 import org.tron.core.ChainBaseManager;
 import org.tron.core.Constant;
 import org.tron.core.Wallet;
-import org.tron.core.capsule.AccountCapsule;
-import org.tron.core.capsule.AssetIssueCapsule;
-import org.tron.core.capsule.MarketAccountOrderCapsule;
-import org.tron.core.capsule.MarketOrderCapsule;
-import org.tron.core.capsule.MarketOrderIdListCapsule;
-import org.tron.core.capsule.TransactionResultCapsule;
+import org.tron.core.capsule.*;
 import org.tron.core.capsule.utils.MarketUtils;
 import org.tron.core.config.DefaultConfig;
 import org.tron.core.config.args.Args;
@@ -125,6 +120,21 @@ public class MarketSellAssetActuatorTest {
         .put(ownerAccountFirstCapsule.getAddress().toByteArray(), ownerAccountFirstCapsule);
     dbManager.getAccountStore()
         .put(ownerAccountSecondCapsule.getAddress().toByteArray(), ownerAccountSecondCapsule);
+
+    AccountAssetIssueCapsule ownerAccountAssetIssueFirstCapsule =
+            new AccountAssetIssueCapsule(
+                    ByteString.copyFromUtf8(ACCOUNT_NAME_FIRST),
+                    ByteString.copyFrom(ownerAddressFirstBytes));
+    AccountAssetIssueCapsule ownerAccountAssetIssueSecondCapsule =
+            new AccountAssetIssueCapsule(
+                    ByteString.copyFromUtf8(ACCOUNT_NAME_SECOND),
+                    ByteString.copyFrom(ownerAddressSecondBytes));
+    dbManager.getAccountAssetIssueStore()
+            .put(ownerAccountAssetIssueFirstCapsule.getAddress().toByteArray(),
+                    ownerAccountAssetIssueFirstCapsule);
+    dbManager.getAccountAssetIssueStore()
+            .put(ownerAccountAssetIssueSecondCapsule.getAddress().toByteArray(),
+                    ownerAccountAssetIssueSecondCapsule);
   }
 
   private void InitAsset() {
@@ -503,10 +513,11 @@ public class MarketSellAssetActuatorTest {
     long buyTokenQuant = 200_000000L;
 
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_FIRST);
-    AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    accountCapsule.addAssetAmountV2(sellTokenId.getBytes(), sellTokenQuant,
-        dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
-    dbManager.getAccountStore().put(ownerAddress, accountCapsule);
+    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore()
+            .get(ownerAddress);
+    accountAssetIssueCapsule.addAssetAmountV2(sellTokenId.getBytes(), sellTokenQuant,
+            dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
+    dbManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.getAddress().toByteArray(), accountAssetIssueCapsule);
 
     MarketSellAssetActuator actuator = new MarketSellAssetActuator();
     actuator.setChainBaseManager(dbManager.getChainBaseManager()).setAny(getContract(
@@ -535,12 +546,12 @@ public class MarketSellAssetActuatorTest {
     long orderNum = 100L;
 
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_FIRST);
-    AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    accountCapsule.addAssetAmountV2(sellTokenId.getBytes(), sellTokenQuant * orderNum,
-        dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
-    dbManager.getAccountStore().put(ownerAddress, accountCapsule);
-    Assert.assertEquals(sellTokenQuant * orderNum,
-        (long) accountCapsule.getAssetMapV2().get(sellTokenId));
+    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore()
+            .get(ownerAddress);
+    accountAssetIssueCapsule.addAssetAmountV2(sellTokenId.getBytes(), sellTokenQuant,
+            dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
+    dbManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.getAddress().toByteArray(), accountAssetIssueCapsule);
+    Assert.assertEquals(sellTokenQuant, (long) accountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
 
     // Initialize the order book
 
@@ -584,10 +595,11 @@ public class MarketSellAssetActuatorTest {
     }
 
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_FIRST);
-    AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    accountCapsule.addAssetAmountV2(sellTokenId.getBytes(), sellTokenQuant,
-        dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
-    dbManager.getAccountStore().put(ownerAddress, accountCapsule);
+    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore()
+            .get(ownerAddress);
+    accountAssetIssueCapsule.addAssetAmountV2(sellTokenId.getBytes(), sellTokenQuant,
+            dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
+    dbManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.getAddress().toByteArray(), accountAssetIssueCapsule);
 
     MarketSellAssetActuator actuator = new MarketSellAssetActuator();
     actuator.setChainBaseManager(dbManager.getChainBaseManager()).setAny(getContract(
@@ -615,10 +627,12 @@ public class MarketSellAssetActuatorTest {
 
     byte[] ownerAddress = ByteArray.fromHexString(ownAddress);
     AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    accountCapsule.addAssetAmountV2(sellTokenId.getBytes(), sellTokenQuant,
+    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore()
+            .get(ownerAddress);
+    accountAssetIssueCapsule.addAssetAmountV2(sellTokenId.getBytes(), sellTokenQuant,
         dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
     dbManager.getAccountStore().put(ownerAddress, accountCapsule);
-
+    dbManager.getAccountAssetIssueStore().put(ownerAddress, accountAssetIssueCapsule);
     // do process
     MarketSellAssetActuator actuator = new MarketSellAssetActuator();
     actuator.setChainBaseManager(dbManager.getChainBaseManager()).setAny(getContract(
@@ -744,11 +758,16 @@ public class MarketSellAssetActuatorTest {
 
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_FIRST);
     AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    accountCapsule.addAssetAmountV2(sellTokenId.getBytes(), sellTokenQuant,
-        dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
     dbManager.getAccountStore().put(ownerAddress, accountCapsule);
+
+    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore()
+            .get(ownerAddress);
+    accountAssetIssueCapsule.addAssetAmountV2(sellTokenId.getBytes(), sellTokenQuant,
+            dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
+    dbManager.getAccountAssetIssueStore()
+            .put(accountAssetIssueCapsule.getAddress().toByteArray(), accountAssetIssueCapsule);
     long balanceBefore = accountCapsule.getBalance();
-    Assert.assertEquals(sellTokenQuant, (long) accountCapsule.getAssetMapV2().get(sellTokenId));
+    Assert.assertEquals(sellTokenQuant, (long) accountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
 
     MarketSellAssetActuator actuator = new MarketSellAssetActuator();
     actuator.setChainBaseManager(dbManager.getChainBaseManager()).setAny(getContract(
@@ -768,9 +787,10 @@ public class MarketSellAssetActuatorTest {
 
     //check balance and token
     accountCapsule = dbManager.getAccountStore().get(ownerAddress);
+    accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
     Assert.assertEquals(balanceBefore,
         dbManager.getDynamicPropertiesStore().getMarketSellFee() + accountCapsule.getBalance());
-    Assert.assertEquals(0L, (long) accountCapsule.getAssetMapV2().get(sellTokenId));
+    Assert.assertEquals(0L, (long) accountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
 
     //check accountOrder
     MarketAccountOrderCapsule accountOrderCapsule = marketAccountStore.get(ownerAddress);
@@ -824,11 +844,15 @@ public class MarketSellAssetActuatorTest {
 
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_FIRST);
     AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    accountCapsule.addAssetAmountV2(sellTokenId.getBytes(), sellTokenQuant,
-        dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
-    dbManager.getAccountStore().put(ownerAddress, accountCapsule);
+
+    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore()
+            .get(ownerAddress);
+    accountAssetIssueCapsule.addAssetAmountV2(sellTokenId.getBytes(), sellTokenQuant,
+            dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
+    dbManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.getAddress().toByteArray(), accountAssetIssueCapsule);
+
     long balanceBefore = accountCapsule.getBalance();
-    Assert.assertEquals(sellTokenQuant, (long) accountCapsule.getAssetMapV2().get(sellTokenId));
+    Assert.assertEquals(sellTokenQuant, (long) accountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
 
     MarketSellAssetActuator actuator = new MarketSellAssetActuator();
     actuator.setChainBaseManager(dbManager.getChainBaseManager()).setAny(getContract(
@@ -848,9 +872,10 @@ public class MarketSellAssetActuatorTest {
 
     //check balance and token
     accountCapsule = dbManager.getAccountStore().get(ownerAddress);
+    accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
     Assert.assertEquals(balanceBefore,
         dbManager.getDynamicPropertiesStore().getMarketSellFee() + accountCapsule.getBalance());
-    Assert.assertEquals(0L, (long) accountCapsule.getAssetMapV2().get(sellTokenId));
+    Assert.assertEquals(0L, (long) accountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
 
     //check accountOrder
     MarketAccountOrderCapsule accountOrderCapsule = marketAccountStore.get(ownerAddress);
@@ -905,11 +930,13 @@ public class MarketSellAssetActuatorTest {
     long buyTokenQuant = 300L;
 
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_FIRST);
-    AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    accountCapsule.addAssetAmountV2(sellTokenId.getBytes(), sellTokenQuant,
-        dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
-    dbManager.getAccountStore().put(ownerAddress, accountCapsule);
-    Assert.assertEquals(sellTokenQuant, (long) accountCapsule.getAssetMapV2().get(sellTokenId));
+
+    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore()
+            .get(ownerAddress);
+    accountAssetIssueCapsule.addAssetAmountV2(sellTokenId.getBytes(), sellTokenQuant,
+            dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
+    dbManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.getAddress().toByteArray(), accountAssetIssueCapsule);
+    Assert.assertEquals(sellTokenQuant, (long) accountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
 
     // Initialize the order book
 
@@ -990,11 +1017,13 @@ public class MarketSellAssetActuatorTest {
     long buyTokenQuant = 300L;
 
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_FIRST);
-    AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    accountCapsule.addAssetAmountV2(sellTokenId.getBytes(), sellTokenQuant,
-        dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
-    dbManager.getAccountStore().put(ownerAddress, accountCapsule);
-    Assert.assertEquals(sellTokenQuant, (long) accountCapsule.getAssetMapV2().get(sellTokenId));
+    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore()
+            .get(ownerAddress);
+    accountAssetIssueCapsule.addAssetAmountV2(sellTokenId.getBytes(), sellTokenQuant,
+            dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
+    dbManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.getAddress().toByteArray(), accountAssetIssueCapsule);
+
+    Assert.assertEquals(sellTokenQuant, (long) accountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
 
     // Initialize the order book
 
@@ -1076,11 +1105,14 @@ public class MarketSellAssetActuatorTest {
     long buyTokenQuant = 100L;
 
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_FIRST);
-    AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    accountCapsule.addAssetAmountV2(sellTokenId.getBytes(), sellTokenQuant,
-        dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
-    dbManager.getAccountStore().put(ownerAddress, accountCapsule);
-    Assert.assertEquals(sellTokenQuant, (long) accountCapsule.getAssetMapV2().get(sellTokenId));
+    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore()
+            .get(ownerAddress);
+    accountAssetIssueCapsule.addAssetAmountV2(sellTokenId.getBytes(), sellTokenQuant,
+            dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
+    dbManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.getAddress().toByteArray(), accountAssetIssueCapsule);
+    Assert.assertEquals(sellTokenQuant, (long) accountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
+
+
 
     // Initialize the order book
     //add three order with different price by the same account
@@ -1111,8 +1143,9 @@ public class MarketSellAssetActuatorTest {
         .getMarketPairPriceToOrderStore();
 
     //check balance and token
-    accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    Assert.assertEquals(0L, (long) accountCapsule.getAssetMapV2().get(sellTokenId));
+    accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+
+    Assert.assertEquals(0L, (long) accountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
 
     //check accountOrder
     MarketAccountOrderCapsule accountOrderCapsule = marketAccountStore.get(ownerAddress);
@@ -1170,10 +1203,14 @@ public class MarketSellAssetActuatorTest {
 
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_FIRST);
     AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    accountCapsule.addAssetAmountV2(sellTokenId.getBytes(), sellTokenQuant,
-        dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
     dbManager.getAccountStore().put(ownerAddress, accountCapsule);
-    Assert.assertEquals(sellTokenQuant, (long) accountCapsule.getAssetMapV2().get(sellTokenId));
+
+    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore()
+            .get(ownerAddress);
+    accountAssetIssueCapsule.addAssetAmountV2(sellTokenId.getBytes(), sellTokenQuant,
+        dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
+    dbManager.getAccountAssetIssueStore().put(ownerAddress, accountAssetIssueCapsule);
+    Assert.assertEquals(sellTokenQuant, (long) accountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
 
     // Initialize the order book
 
@@ -1214,8 +1251,9 @@ public class MarketSellAssetActuatorTest {
 
     //check balance and token
     accountCapsule = dbManager.getAccountStore().get(ownerAddress);
+    accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
     // Assert.assertTrue(accountCapsule.getAssetMapV2().get(sellTokenId) == 0L);
-    Assert.assertEquals(0L, accountCapsule.getAssetMapV2().get(sellTokenId).longValue());
+    Assert.assertEquals(0L, accountAssetIssueCapsule.getAssetMapV2().get(sellTokenId).longValue());
 
     //check accountOrder
     MarketAccountOrderCapsule accountOrderCapsule = marketAccountStore.get(ownerAddress);
@@ -1280,11 +1318,18 @@ public class MarketSellAssetActuatorTest {
     long buyTokenQuant = 1000L * num;
 
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_FIRST);
-    AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    accountCapsule.addAssetAmountV2(sellTokenId.getBytes(), sellTokenQuant,
-        dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
-    dbManager.getAccountStore().put(ownerAddress, accountCapsule);
-    Assert.assertEquals(sellTokenQuant, (long) accountCapsule.getAssetMapV2().get(sellTokenId));
+//    AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
+//    accountCapsule.addAssetAmountV2(sellTokenId.getBytes(), sellTokenQuant,
+//        dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
+//    dbManager.getAccountStore().put(ownerAddress, accountCapsule);
+//    Assert.assertEquals(sellTokenQuant, (long) accountCapsule.getAssetMapV2().get(sellTokenId));
+
+    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore()
+            .get(ownerAddress);
+    accountAssetIssueCapsule.addAssetAmountV2(sellTokenId.getBytes(), sellTokenQuant,
+            dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
+    dbManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.getAddress().toByteArray(), accountAssetIssueCapsule);
+    Assert.assertEquals(sellTokenQuant, (long) accountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
 
     // Initialize the order book
 
@@ -1324,11 +1369,12 @@ public class MarketSellAssetActuatorTest {
     long buyTokenQuant = 200L;
 
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_FIRST);
-    AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    accountCapsule.addAssetAmountV2(sellTokenId.getBytes(), sellTokenQuant,
-        dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
-    dbManager.getAccountStore().put(ownerAddress, accountCapsule);
-    Assert.assertEquals(sellTokenQuant, (long) accountCapsule.getAssetMapV2().get(sellTokenId));
+    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore()
+            .get(ownerAddress);
+    accountAssetIssueCapsule.addAssetAmountV2(sellTokenId.getBytes(), sellTokenQuant,
+            dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
+    dbManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.getAddress().toByteArray(), accountAssetIssueCapsule);
+    Assert.assertEquals(sellTokenQuant, (long) accountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
 
     // Initialize the order book
 
@@ -1368,13 +1414,13 @@ public class MarketSellAssetActuatorTest {
         .getMarketPairPriceToOrderStore();
 
     //check balance and token
-    accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    Assert.assertEquals(0L, (long) accountCapsule.getAssetMapV2().get(sellTokenId));
-    Assert.assertEquals(200L, (long) accountCapsule.getAssetMapV2().get(buyTokenId));
+    accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    Assert.assertEquals(0L, (long) accountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
+    Assert.assertEquals(200L, (long) accountAssetIssueCapsule.getAssetMapV2().get(buyTokenId));
 
     byte[] makerAddress = ByteArray.fromHexString(OWNER_ADDRESS_SECOND);
-    AccountCapsule makerAccountCapsule = dbManager.getAccountStore().get(makerAddress);
-    Assert.assertEquals(400L, (long) makerAccountCapsule.getAssetMapV2().get(sellTokenId));
+    AccountAssetIssueCapsule makerAccountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(makerAddress);
+    Assert.assertEquals(400L, (long) makerAccountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
 
     //check accountOrder
     MarketAccountOrderCapsule accountOrderCapsule = marketAccountStore.get(ownerAddress);
@@ -1472,11 +1518,12 @@ public class MarketSellAssetActuatorTest {
     long buyTokenQuant = 200L;
 
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_FIRST);
-    AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    accountCapsule.addAssetAmountV2(sellTokenId.getBytes(), sellTokenQuant,
-        dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
-    dbManager.getAccountStore().put(ownerAddress, accountCapsule);
-    Assert.assertEquals(sellTokenQuant, (long) accountCapsule.getAssetMapV2().get(sellTokenId));
+    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore()
+            .get(ownerAddress);
+    accountAssetIssueCapsule.addAssetAmountV2(sellTokenId.getBytes(), sellTokenQuant,
+            dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
+    dbManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.getAddress().toByteArray(), accountAssetIssueCapsule);
+    Assert.assertEquals(sellTokenQuant, (long) accountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
 
     //get storeDB instance
     ChainBaseManager chainBaseManager = dbManager.getChainBaseManager();
@@ -1510,13 +1557,13 @@ public class MarketSellAssetActuatorTest {
     actuator.execute(ret);
 
     //check balance and token
-    accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    Assert.assertEquals(0L, (long) accountCapsule.getAssetMapV2().get(sellTokenId));
-    Assert.assertEquals(200L, (long) accountCapsule.getAssetMapV2().get(buyTokenId));
+    accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    Assert.assertEquals(0L, (long) accountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
+    Assert.assertEquals(200L, (long) accountAssetIssueCapsule.getAssetMapV2().get(buyTokenId));
 
     byte[] makerAddress = ByteArray.fromHexString(OWNER_ADDRESS_SECOND);
-    AccountCapsule makerAccountCapsule = dbManager.getAccountStore().get(makerAddress);
-    Assert.assertEquals(500L, (long) makerAccountCapsule.getAssetMapV2().get(sellTokenId));
+    AccountAssetIssueCapsule makerAccountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(makerAddress);
+    Assert.assertEquals(500L, (long) makerAccountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
 
     //check accountOrder
     MarketAccountOrderCapsule accountOrderCapsule = marketAccountStore.get(ownerAddress);
@@ -1617,10 +1664,15 @@ public class MarketSellAssetActuatorTest {
 
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_FIRST);
     AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    accountCapsule.addAssetAmountV2(sellTokenId.getBytes(), sellTokenQuant,
-        dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
     dbManager.getAccountStore().put(ownerAddress, accountCapsule);
-    Assert.assertEquals(sellTokenQuant, (long) accountCapsule.getAssetMapV2().get(sellTokenId));
+
+    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore()
+            .get(ownerAddress);
+    accountAssetIssueCapsule.addAssetAmountV2(sellTokenId.getBytes(), sellTokenQuant,
+        dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
+    dbManager.getAccountAssetIssueStore().put(ownerAddress, accountAssetIssueCapsule);
+
+    Assert.assertEquals(sellTokenQuant, (long) accountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
 
     // Initialize the order book
 
@@ -1655,12 +1707,14 @@ public class MarketSellAssetActuatorTest {
 
     //check balance and token
     accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    Assert.assertEquals(0L, (long) accountCapsule.getAssetMapV2().get(sellTokenId));
-    Assert.assertEquals(250L, (long) accountCapsule.getAssetMapV2().get(buyTokenId));
+    accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    Assert.assertEquals(0L, (long) accountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
+    Assert.assertEquals(250L, (long) accountAssetIssueCapsule.getAssetMapV2().get(buyTokenId));
 
     byte[] makerAddress = ByteArray.fromHexString(OWNER_ADDRESS_SECOND);
-    AccountCapsule makerAccountCapsule = dbManager.getAccountStore().get(makerAddress);
-    Assert.assertEquals(800L, (long) makerAccountCapsule.getAssetMapV2().get(sellTokenId));
+    AccountAssetIssueCapsule makerAccountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(makerAddress);
+
+    Assert.assertEquals(800L, (long) makerAccountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
 
     //check accountOrder
     MarketAccountOrderCapsule accountOrderCapsule = marketAccountStore.get(ownerAddress);
@@ -1735,10 +1789,13 @@ public class MarketSellAssetActuatorTest {
 
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_FIRST);
     AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    accountCapsule.addAssetAmountV2(sellTokenId.getBytes(), sellTokenQuant,
-        dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
-    dbManager.getAccountStore().put(ownerAddress, accountCapsule);
-    Assert.assertEquals(sellTokenQuant, (long) accountCapsule.getAssetMapV2().get(sellTokenId));
+
+    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore()
+            .get(ownerAddress);
+    accountAssetIssueCapsule.addAssetAmountV2(sellTokenId.getBytes(), sellTokenQuant,
+            dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
+    dbManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.getAddress().toByteArray(), accountAssetIssueCapsule);
+    Assert.assertEquals(sellTokenQuant, (long) accountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
 
     // Initialize the order book
 
@@ -1769,13 +1826,14 @@ public class MarketSellAssetActuatorTest {
         .getMarketPairPriceToOrderStore();
 
     //check balance and token
-    accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    Assert.assertEquals(1L, (long) accountCapsule.getAssetMapV2().get(sellTokenId));
-    Assert.assertEquals(100L, (long) accountCapsule.getAssetMapV2().get(buyTokenId));
+//    accountCapsule = dbManager.getAccountStore().get(ownerAddress);
+    accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    Assert.assertEquals(1L, (long) accountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
+    Assert.assertEquals(100L, (long) accountAssetIssueCapsule.getAssetMapV2().get(buyTokenId));
 
     byte[] makerAddress = ByteArray.fromHexString(OWNER_ADDRESS_SECOND);
-    AccountCapsule makerAccountCapsule = dbManager.getAccountStore().get(makerAddress);
-    Assert.assertEquals(200L, (long) makerAccountCapsule.getAssetMapV2().get(sellTokenId));
+    AccountAssetIssueCapsule makerAccountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(makerAddress);
+    Assert.assertEquals(200L, (long) makerAccountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
 
     //check accountOrder
     MarketAccountOrderCapsule accountOrderCapsule = marketAccountStore.get(ownerAddress);
@@ -1842,11 +1900,12 @@ public class MarketSellAssetActuatorTest {
     long sellTokenQuant = buyTokenQuant * (end / start + 1);
 
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_FIRST);
-    AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    accountCapsule.addAssetAmountV2(sellTokenId.getBytes(), sellTokenQuant,
-        dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
-    dbManager.getAccountStore().put(ownerAddress, accountCapsule);
-    Assert.assertEquals(sellTokenQuant, (long) accountCapsule.getAssetMapV2().get(sellTokenId));
+    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore()
+            .get(ownerAddress);
+    accountAssetIssueCapsule.addAssetAmountV2(sellTokenId.getBytes(), sellTokenQuant,
+            dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
+    dbManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.getAddress().toByteArray(), accountAssetIssueCapsule);
+    Assert.assertEquals(sellTokenQuant, (long) accountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
 
     // Initialize the order book
 

--- a/framework/src/test/java/org/tron/core/actuator/ParticipateAssetIssueActuatorTest.java
+++ b/framework/src/test/java/org/tron/core/actuator/ParticipateAssetIssueActuatorTest.java
@@ -17,6 +17,7 @@ import org.tron.common.utils.FileUtil;
 import org.tron.core.ChainBaseManager;
 import org.tron.core.Constant;
 import org.tron.core.Wallet;
+import org.tron.core.capsule.AccountAssetIssueCapsule;
 import org.tron.core.capsule.AccountCapsule;
 import org.tron.core.capsule.AssetIssueCapsule;
 import org.tron.core.capsule.TransactionResultCapsule;
@@ -118,6 +119,26 @@ public class ParticipateAssetIssueActuatorTest {
     chainBaseManager.getAccountStore()
         .put(toAccountCapsule2.getAddress().toByteArray(), toAccountCapsule2);
     chainBaseManager.getDynamicPropertiesStore().saveAllowSameTokenName(0);
+
+    AccountAssetIssueCapsule ownerAssetIssueCapsule =
+            new AccountAssetIssueCapsule(
+                    ByteString.copyFromUtf8("owner"),
+                    ByteString.copyFrom(ByteArray.fromHexString(OWNER_ADDRESS)));
+    AccountAssetIssueCapsule toAccountAssetIssueCapsule =
+            new AccountAssetIssueCapsule(
+                    ByteString.copyFromUtf8("toAccount"),
+                    ByteString.copyFrom(ByteArray.fromHexString(TO_ADDRESS)));
+    AccountAssetIssueCapsule toAccountAssetIssueCapsule2 =
+            new AccountAssetIssueCapsule(
+                    ByteString.copyFromUtf8("toAccount2"),
+                    ByteString.copyFrom(ByteArray.fromHexString(TO_ADDRESS_2))
+            );
+    chainBaseManager.getAccountAssetIssueStore()
+            .put(ownerAssetIssueCapsule.getAddress().toByteArray(), ownerAssetIssueCapsule);
+    chainBaseManager.getAccountAssetIssueStore()
+            .put(toAccountAssetIssueCapsule.getAddress().toByteArray(), toAccountAssetIssueCapsule);
+    chainBaseManager.getAccountAssetIssueStore()
+            .put(toAccountAssetIssueCapsule2.getAddress().toByteArray(), toAccountAssetIssueCapsule2);
   }
 
   private boolean isNullOrZero(Long value) {
@@ -216,22 +237,26 @@ public class ParticipateAssetIssueActuatorTest {
     AssetIssueCapsule assetIssueCapsule = new AssetIssueCapsule(assetIssueContract);
     AccountCapsule toAccountCapsule = chainBaseManager.getAccountStore()
         .get(ByteArray.fromHexString(TO_ADDRESS));
+    AccountAssetIssueCapsule toAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+            .get(ByteArray.fromHexString(TO_ADDRESS));
+
     if (chainBaseManager.getDynamicPropertiesStore().getAllowSameTokenName() == 0) {
       chainBaseManager.getAssetIssueStore().put(assetIssueCapsule.createDbKey(),
           assetIssueCapsule);
       assetIssueCapsule.setPrecision(0);
       chainBaseManager.getAssetIssueV2Store().put(assetIssueCapsule.createDbV2Key(),
           assetIssueCapsule);
-      toAccountCapsule.addAsset(ASSET_NAME.getBytes(), TOTAL_SUPPLY);
-      toAccountCapsule.addAssetV2(ByteArray.fromString(String.valueOf(id)), TOTAL_SUPPLY);
+      toAccountAssetIssue.addAsset(ASSET_NAME.getBytes(), TOTAL_SUPPLY);
+      toAccountAssetIssue.addAssetV2(ByteArray.fromString(String.valueOf(id)), TOTAL_SUPPLY);
     } else {
       chainBaseManager.getAssetIssueV2Store().put(assetIssueCapsule.createDbV2Key(),
           assetIssueCapsule);
-      toAccountCapsule.addAssetV2(ByteArray.fromString(String.valueOf(id)), TOTAL_SUPPLY);
+      toAccountAssetIssue.addAssetV2(ByteArray.fromString(String.valueOf(id)), TOTAL_SUPPLY);
     }
 
     chainBaseManager.getAccountStore().put(toAccountCapsule.getAddress().toByteArray(),
         toAccountCapsule);
+    chainBaseManager.getAccountAssetIssueStore().put(toAccountAssetIssue.getAddress().toByteArray(), toAccountAssetIssue);
   }
 
   private void initAssetIssue(long startTimestmp, long endTimestmp, String assetName) {
@@ -255,22 +280,27 @@ public class ParticipateAssetIssueActuatorTest {
     AssetIssueCapsule assetIssueCapsule = new AssetIssueCapsule(assetIssueContract);
     AccountCapsule toAccountCapsule = chainBaseManager.getAccountStore()
         .get(ByteArray.fromHexString(TO_ADDRESS));
+    AccountAssetIssueCapsule toAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+            .get(ByteArray.fromHexString(TO_ADDRESS));
+
     if (chainBaseManager.getDynamicPropertiesStore().getAllowSameTokenName() == 0) {
       chainBaseManager.getAssetIssueStore().put(assetIssueCapsule.createDbKey(), assetIssueCapsule);
       assetIssueCapsule.setPrecision(0);
       chainBaseManager.getAssetIssueV2Store().put(assetIssueCapsule.createDbV2Key(),
           assetIssueCapsule);
 
-      toAccountCapsule.addAsset(assetName.getBytes(), TOTAL_SUPPLY);
-      toAccountCapsule.addAssetV2(ByteArray.fromString(String.valueOf(id)), TOTAL_SUPPLY);
+      toAccountAssetIssue.addAsset(assetName.getBytes(), TOTAL_SUPPLY);
+      toAccountAssetIssue.addAssetV2(ByteArray.fromString(String.valueOf(id)), TOTAL_SUPPLY);
     } else {
       chainBaseManager.getAssetIssueV2Store().put(assetIssueCapsule.createDbV2Key(),
           assetIssueCapsule);
-      toAccountCapsule.addAssetV2(ByteArray.fromString(String.valueOf(id)), TOTAL_SUPPLY);
+      toAccountAssetIssue.addAssetV2(ByteArray.fromString(String.valueOf(id)), TOTAL_SUPPLY);
     }
 
     chainBaseManager.getAccountStore().put(toAccountCapsule.getAddress().toByteArray(),
         toAccountCapsule);
+    chainBaseManager.getAccountAssetIssueStore().put(toAccountCapsule.getAddress().toByteArray(),
+            toAccountAssetIssue);
   }
 
   private void initAssetIssueWithOwner(long startTimestmp, long endTimestmp, String owner) {
@@ -294,22 +324,27 @@ public class ParticipateAssetIssueActuatorTest {
     AssetIssueCapsule assetIssueCapsule = new AssetIssueCapsule(assetIssueContract);
     AccountCapsule toAccountCapsule = chainBaseManager.getAccountStore()
         .get(ByteArray.fromHexString(TO_ADDRESS));
+
+    AccountAssetIssueCapsule toAccountAssetIssueCapsule = chainBaseManager.getAccountAssetIssueStore()
+            .get(ByteArray.fromHexString(TO_ADDRESS));
     if (chainBaseManager.getDynamicPropertiesStore().getAllowSameTokenName() == 0) {
       chainBaseManager.getAssetIssueStore().put(assetIssueCapsule.createDbKey(),
           assetIssueCapsule);
       assetIssueCapsule.setPrecision(0);
       chainBaseManager.getAssetIssueV2Store().put(assetIssueCapsule.createDbV2Key(),
           assetIssueCapsule);
-      toAccountCapsule.addAsset(ASSET_NAME.getBytes(), TOTAL_SUPPLY);
-      toAccountCapsule.addAssetV2(ByteArray.fromString(String.valueOf(id)), TOTAL_SUPPLY);
+      toAccountAssetIssueCapsule.addAsset(ASSET_NAME.getBytes(), TOTAL_SUPPLY);
+      toAccountAssetIssueCapsule.addAssetV2(ByteArray.fromString(String.valueOf(id)), TOTAL_SUPPLY);
     } else {
       chainBaseManager.getAssetIssueV2Store().put(assetIssueCapsule.createDbV2Key(),
           assetIssueCapsule);
-      toAccountCapsule.addAssetV2(ByteArray.fromString(String.valueOf(id)), TOTAL_SUPPLY);
+      toAccountAssetIssueCapsule.addAssetV2(ByteArray.fromString(String.valueOf(id)), TOTAL_SUPPLY);
     }
 
     chainBaseManager.getAccountStore().put(toAccountCapsule.getAddress().toByteArray(),
         toAccountCapsule);
+    chainBaseManager.getAccountAssetIssueStore().put(toAccountAssetIssueCapsule.getAddress().toByteArray(),
+            toAccountAssetIssueCapsule);
   }
 
   /**
@@ -334,16 +369,21 @@ public class ParticipateAssetIssueActuatorTest {
           .get(ByteArray.fromHexString(TO_ADDRESS));
       Assert.assertEquals(owner.getBalance(), OWNER_BALANCE - 1000);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE + 1000);
+
+      AccountAssetIssueCapsule ownerAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(OWNER_ADDRESS));
+      AccountAssetIssueCapsule toAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(TO_ADDRESS));
       //V1
-      Assert.assertEquals(owner.getAssetMap().get(ASSET_NAME).longValue(),
+      Assert.assertEquals(ownerAccountAssetIssue.getAssetMap().get(ASSET_NAME).longValue(),
           (1000L) / TRX_NUM * NUM);
-      Assert.assertEquals(toAccount.getAssetMap().get(ASSET_NAME).longValue(),
+      Assert.assertEquals(toAccountAssetIssue.getAssetMap().get(ASSET_NAME).longValue(),
           TOTAL_SUPPLY - (1000L) / TRX_NUM * NUM);
       //V2
       long tokenId = chainBaseManager.getDynamicPropertiesStore().getTokenIdNum();
-      Assert.assertEquals(owner.getAssetMapV2().get(String.valueOf(tokenId)).longValue(),
+      Assert.assertEquals(ownerAccountAssetIssue.getAssetMapV2().get(String.valueOf(tokenId)).longValue(),
           (1000L) / TRX_NUM * NUM);
-      Assert.assertEquals(toAccount.getAssetMapV2().get(String.valueOf(tokenId)).longValue(),
+      Assert.assertEquals(toAccountAssetIssue.getAssetMapV2().get(String.valueOf(tokenId)).longValue(),
           TOTAL_SUPPLY - (1000L) / TRX_NUM * NUM);
 
     } catch (ContractValidateException e) {
@@ -376,16 +416,22 @@ public class ParticipateAssetIssueActuatorTest {
           .get(ByteArray.fromHexString(OWNER_ADDRESS));
       AccountCapsule toAccount = chainBaseManager.getAccountStore()
           .get(ByteArray.fromHexString(TO_ADDRESS));
+
+      AccountAssetIssueCapsule ownerAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(OWNER_ADDRESS));
+      AccountAssetIssueCapsule toAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(TO_ADDRESS));
+
       Assert.assertEquals(owner.getBalance(), OWNER_BALANCE - 1000);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE + 1000);
       //V1 data not update
-      Assert.assertNull(owner.getAssetMap().get(ASSET_NAME));
-      Assert.assertEquals(toAccount.getAssetMap().get(ASSET_NAME).longValue(), TOTAL_SUPPLY);
+      Assert.assertNull(ownerAccountAssetIssue.getAssetMap().get(ASSET_NAME));
+      Assert.assertEquals(toAccountAssetIssue.getAssetMap().get(ASSET_NAME).longValue(), TOTAL_SUPPLY);
       //V2
       long tokenId = chainBaseManager.getDynamicPropertiesStore().getTokenIdNum();
-      Assert.assertEquals(owner.getAssetMapV2().get(String.valueOf(tokenId)).longValue(),
+      Assert.assertEquals(ownerAccountAssetIssue.getAssetMapV2().get(String.valueOf(tokenId)).longValue(),
           (1000L) / TRX_NUM * NUM);
-      Assert.assertEquals(toAccount.getAssetMapV2().get(String.valueOf(tokenId)).longValue(),
+      Assert.assertEquals(toAccountAssetIssue.getAssetMapV2().get(String.valueOf(tokenId)).longValue(),
           TOTAL_SUPPLY - (1000L) / TRX_NUM * NUM);
 
     } catch (ContractValidateException e) {
@@ -416,17 +462,21 @@ public class ParticipateAssetIssueActuatorTest {
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
       AccountCapsule toAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
+      AccountAssetIssueCapsule ownerAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(OWNER_ADDRESS));
+      AccountAssetIssueCapsule toAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(TO_ADDRESS));
       Assert.assertEquals(owner.getBalance(), OWNER_BALANCE - 1000);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE + 1000);
       // V1, data is not exist
-      Assert.assertNull(owner.getAssetMap().get(ASSET_NAME));
-      Assert.assertNull(toAccount.getAssetMap().get(ASSET_NAME));
+      Assert.assertNull(ownerAccountAssetIssue.getAssetMap().get(ASSET_NAME));
+      Assert.assertNull(toAccountAssetIssue.getAssetMap().get(ASSET_NAME));
       //V2
       long id = chainBaseManager.getDynamicPropertiesStore().getTokenIdNum();
-      Assert.assertEquals(owner.getAssetMapV2().get(String.valueOf(id)).longValue(),
+      Assert.assertEquals(ownerAccountAssetIssue.getAssetMapV2().get(String.valueOf(id)).longValue(),
           (1000L) / TRX_NUM * NUM);
       Assert.assertEquals(
-          toAccount.getAssetMapV2().get(String.valueOf(id)).longValue(),
+              toAccountAssetIssue.getAssetMapV2().get(String.valueOf(id)).longValue(),
           TOTAL_SUPPLY - (1000L) / TRX_NUM * NUM);
     } catch (ContractValidateException e) {
       Assert.assertFalse(e instanceof ContractValidateException);
@@ -457,11 +507,15 @@ public class ParticipateAssetIssueActuatorTest {
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
       AccountCapsule toAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
+      AccountAssetIssueCapsule ownerAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(OWNER_ADDRESS));
+      AccountAssetIssueCapsule toAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(TO_ADDRESS));
 
       Assert.assertEquals(owner.getBalance(), OWNER_BALANCE);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE);
-      Assert.assertTrue(isNullOrZero(owner.getAssetMap().get(ASSET_NAME)));
-      Assert.assertEquals(toAccount.getAssetMap().get(ASSET_NAME).longValue(), TOTAL_SUPPLY);
+      Assert.assertTrue(isNullOrZero(ownerAccountAssetIssue.getAssetMap().get(ASSET_NAME)));
+      Assert.assertEquals(toAccountAssetIssue.getAssetMap().get(ASSET_NAME).longValue(), TOTAL_SUPPLY);
     } catch (ContractExeException e) {
       Assert.assertFalse(e instanceof ContractExeException);
     }
@@ -491,11 +545,16 @@ public class ParticipateAssetIssueActuatorTest {
       AccountCapsule toAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
 
+      AccountAssetIssueCapsule ownerAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(OWNER_ADDRESS));
+      AccountAssetIssueCapsule toAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(TO_ADDRESS));
+
       Assert.assertEquals(owner.getBalance(), OWNER_BALANCE);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE);
       long id = chainBaseManager.getDynamicPropertiesStore().getTokenIdNum();
-      Assert.assertTrue(isNullOrZero(owner.getAssetMapV2().get(String.valueOf(id))));
-      Assert.assertEquals(toAccount.getAssetMapV2().get(String.valueOf(id)).longValue(),
+      Assert.assertTrue(isNullOrZero(ownerAccountAssetIssue.getAssetMapV2().get(String.valueOf(id))));
+      Assert.assertEquals(toAccountAssetIssue.getAssetMapV2().get(String.valueOf(id)).longValue(),
           TOTAL_SUPPLY);
     } catch (ContractExeException e) {
       Assert.assertFalse(e instanceof ContractExeException);
@@ -525,10 +584,15 @@ public class ParticipateAssetIssueActuatorTest {
       AccountCapsule toAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
 
+      AccountAssetIssueCapsule ownerAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(OWNER_ADDRESS));
+      AccountAssetIssueCapsule toAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(TO_ADDRESS));
+
       Assert.assertEquals(owner.getBalance(), OWNER_BALANCE);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE);
-      Assert.assertTrue(isNullOrZero(owner.getAssetMap().get(ASSET_NAME)));
-      Assert.assertEquals(toAccount.getAssetMap().get(ASSET_NAME).longValue(), TOTAL_SUPPLY);
+      Assert.assertTrue(isNullOrZero(ownerAccountAssetIssue.getAssetMap().get(ASSET_NAME)));
+      Assert.assertEquals(toAccountAssetIssue.getAssetMap().get(ASSET_NAME).longValue(), TOTAL_SUPPLY);
     } catch (ContractExeException e) {
       Assert.assertFalse(e instanceof ContractExeException);
     }
@@ -557,12 +621,15 @@ public class ParticipateAssetIssueActuatorTest {
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
       AccountCapsule toAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
-
+      AccountAssetIssueCapsule ownerAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(OWNER_ADDRESS));
+      AccountAssetIssueCapsule toAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(TO_ADDRESS));
       Assert.assertEquals(owner.getBalance(), OWNER_BALANCE);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE);
       long id = chainBaseManager.getDynamicPropertiesStore().getTokenIdNum();
-      Assert.assertTrue(isNullOrZero(owner.getAssetMapV2().get(String.valueOf(id))));
-      Assert.assertEquals(toAccount.getAssetMapV2().get(String.valueOf(id)).longValue(),
+      Assert.assertTrue(isNullOrZero(ownerAccountAssetIssue.getAssetMapV2().get(String.valueOf(id))));
+      Assert.assertEquals(toAccountAssetIssue.getAssetMapV2().get(String.valueOf(id)).longValue(),
           TOTAL_SUPPLY);
     } catch (ContractExeException e) {
       Assert.assertFalse(e instanceof ContractExeException);
@@ -585,15 +652,15 @@ public class ParticipateAssetIssueActuatorTest {
       actuator.validate();
       actuator.execute(ret);
 
-      AccountCapsule owner =
-          chainBaseManager.getAccountStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
-      AccountCapsule toAccount =
-          chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
+      AccountAssetIssueCapsule ownerAccountAssetIssue = dbManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(OWNER_ADDRESS));
+      AccountAssetIssueCapsule toAccountAssetIssue = dbManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(TO_ADDRESS));
 
-      Assert.assertEquals(owner.getAssetMap().get(ASSET_NAME).longValue(),
+      Assert.assertEquals(ownerAccountAssetIssue.getAssetMap().get(ASSET_NAME).longValue(),
           (999L * NUM) / TRX_NUM);
       Assert.assertEquals(
-          toAccount.getAssetMap().get(ASSET_NAME).longValue(),
+              toAccountAssetIssue.getAssetMap().get(ASSET_NAME).longValue(),
           TOTAL_SUPPLY - (999L * NUM) / TRX_NUM);
     } catch (ContractValidateException e) {
       Assert.assertFalse(e instanceof ContractValidateException);
@@ -619,15 +686,16 @@ public class ParticipateAssetIssueActuatorTest {
       actuator.validate();
       actuator.execute(ret);
 
-      AccountCapsule owner =
-          chainBaseManager.getAccountStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
-      AccountCapsule toAccount =
-          chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
+      AccountAssetIssueCapsule ownerAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(OWNER_ADDRESS));
+      AccountAssetIssueCapsule toAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(TO_ADDRESS));
+
       long id = chainBaseManager.getDynamicPropertiesStore().getTokenIdNum();
-      Assert.assertEquals(owner.getAssetMapV2().get(String.valueOf(id)).longValue(),
+      Assert.assertEquals(ownerAccountAssetIssue.getAssetMapV2().get(String.valueOf(id)).longValue(),
           (999L * NUM) / TRX_NUM);
       Assert.assertEquals(
-          toAccount.getAssetMapV2().get(String.valueOf(id)).longValue(),
+              toAccountAssetIssue.getAssetMapV2().get(String.valueOf(id)).longValue(),
           TOTAL_SUPPLY - (999L * NUM) / TRX_NUM);
     } catch (ContractValidateException e) {
       Assert.assertFalse(e instanceof ContractValidateException);
@@ -659,11 +727,14 @@ public class ParticipateAssetIssueActuatorTest {
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
       AccountCapsule toAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
-
+      AccountAssetIssueCapsule ownerAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(OWNER_ADDRESS));
+      AccountAssetIssueCapsule toAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(TO_ADDRESS));
       Assert.assertEquals(owner.getBalance(), OWNER_BALANCE);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE);
-      Assert.assertTrue(isNullOrZero(owner.getAssetMap().get(ASSET_NAME)));
-      Assert.assertEquals(toAccount.getAssetMap().get(ASSET_NAME).longValue(), TOTAL_SUPPLY);
+      Assert.assertTrue(isNullOrZero(ownerAccountAssetIssue.getAssetMap().get(ASSET_NAME)));
+      Assert.assertEquals(toAccountAssetIssue.getAssetMap().get(ASSET_NAME).longValue(), TOTAL_SUPPLY);
     } catch (ContractExeException e) {
       Assert.assertFalse(e instanceof ContractExeException);
     }
@@ -693,13 +764,16 @@ public class ParticipateAssetIssueActuatorTest {
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
       AccountCapsule toAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
-
+      AccountAssetIssueCapsule ownerAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(OWNER_ADDRESS));
+      AccountAssetIssueCapsule toAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(TO_ADDRESS));
       Assert.assertEquals(owner.getBalance(), OWNER_BALANCE);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE);
       long id = chainBaseManager.getDynamicPropertiesStore().getTokenIdNum();
 
-      Assert.assertTrue(isNullOrZero(owner.getAssetMapV2().get(String.valueOf(id))));
-      Assert.assertEquals(toAccount.getAssetMapV2().get(String.valueOf(id)).longValue(),
+      Assert.assertTrue(isNullOrZero(ownerAccountAssetIssue.getAssetMapV2().get(String.valueOf(id))));
+      Assert.assertEquals(toAccountAssetIssue.getAssetMapV2().get(String.valueOf(id)).longValue(),
           TOTAL_SUPPLY);
     } catch (ContractExeException e) {
       Assert.assertFalse(e instanceof ContractExeException);
@@ -729,11 +803,15 @@ public class ParticipateAssetIssueActuatorTest {
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
       AccountCapsule toAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
+      AccountAssetIssueCapsule ownerAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(OWNER_ADDRESS));
+      AccountAssetIssueCapsule toAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(TO_ADDRESS));
 
       Assert.assertEquals(owner.getBalance(), OWNER_BALANCE);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE);
-      Assert.assertTrue(isNullOrZero(owner.getAssetMap().get(ASSET_NAME)));
-      Assert.assertEquals(toAccount.getAssetMap().get(ASSET_NAME).longValue(), TOTAL_SUPPLY);
+      Assert.assertTrue(isNullOrZero(ownerAccountAssetIssue.getAssetMap().get(ASSET_NAME)));
+      Assert.assertEquals(toAccountAssetIssue.getAssetMap().get(ASSET_NAME).longValue(), TOTAL_SUPPLY);
     } catch (ContractExeException e) {
       Assert.assertFalse(e instanceof ContractExeException);
     }
@@ -763,13 +841,17 @@ public class ParticipateAssetIssueActuatorTest {
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
       AccountCapsule toAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
+      AccountAssetIssueCapsule ownerAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(OWNER_ADDRESS));
+      AccountAssetIssueCapsule toAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(TO_ADDRESS));
 
       Assert.assertEquals(owner.getBalance(), OWNER_BALANCE);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE);
       long id = chainBaseManager.getDynamicPropertiesStore().getTokenIdNum();
 
-      Assert.assertTrue(isNullOrZero(owner.getAssetMapV2().get(String.valueOf(id))));
-      Assert.assertEquals(toAccount.getAssetMapV2().get(String.valueOf(id)).longValue(),
+      Assert.assertTrue(isNullOrZero(ownerAccountAssetIssue.getAssetMapV2().get(String.valueOf(id))));
+      Assert.assertEquals(toAccountAssetIssue.getAssetMapV2().get(String.valueOf(id)).longValue(),
           TOTAL_SUPPLY);
     } catch (ContractExeException e) {
       Assert.assertFalse(e instanceof ContractExeException);
@@ -802,10 +884,15 @@ public class ParticipateAssetIssueActuatorTest {
       AccountCapsule toAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
 
+      AccountAssetIssueCapsule ownerAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(OWNER_ADDRESS));
+      AccountAssetIssueCapsule toAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(TO_ADDRESS));
+
       Assert.assertEquals(owner.getBalance(), OWNER_BALANCE);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE);
-      Assert.assertTrue(isNullOrZero(owner.getAssetMap().get(ASSET_NAME)));
-      Assert.assertEquals(toAccount.getAssetMap().get(ASSET_NAME).longValue(), TOTAL_SUPPLY);
+      Assert.assertTrue(isNullOrZero(ownerAccountAssetIssue.getAssetMap().get(ASSET_NAME)));
+      Assert.assertEquals(toAccountAssetIssue.getAssetMap().get(ASSET_NAME).longValue(), TOTAL_SUPPLY);
     } catch (ContractExeException e) {
       Assert.assertFalse(e instanceof ContractExeException);
     }
@@ -837,12 +924,16 @@ public class ParticipateAssetIssueActuatorTest {
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
       AccountCapsule toAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
+      AccountAssetIssueCapsule ownerAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(OWNER_ADDRESS));
 
+      AccountAssetIssueCapsule toAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(TO_ADDRESS));
       Assert.assertEquals(owner.getBalance(), OWNER_BALANCE);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE);
       long id = chainBaseManager.getDynamicPropertiesStore().getTokenIdNum();
-      Assert.assertTrue(isNullOrZero(owner.getAssetMapV2().get(String.valueOf(id))));
-      Assert.assertEquals(toAccount.getAssetMapV2().get(String.valueOf(id)).longValue(),
+      Assert.assertTrue(isNullOrZero(ownerAccountAssetIssue.getAssetMapV2().get(String.valueOf(id))));
+      Assert.assertEquals(toAccountAssetIssue.getAssetMapV2().get(String.valueOf(id)).longValue(),
           TOTAL_SUPPLY);
     } catch (ContractExeException e) {
       Assert.assertFalse(e instanceof ContractExeException);
@@ -877,11 +968,15 @@ public class ParticipateAssetIssueActuatorTest {
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
       AccountCapsule toAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
+      AccountAssetIssueCapsule ownerAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(OWNER_ADDRESS));
+      AccountAssetIssueCapsule toAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(TO_ADDRESS));
 
       Assert.assertEquals(owner.getBalance(), OWNER_BALANCE);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE);
-      Assert.assertTrue(isNullOrZero(owner.getAssetMap().get(ASSET_NAME)));
-      Assert.assertEquals(toAccount.getAssetMap().get(ASSET_NAME).longValue(), TOTAL_SUPPLY);
+      Assert.assertTrue(isNullOrZero(ownerAccountAssetIssue.getAssetMap().get(ASSET_NAME)));
+      Assert.assertEquals(toAccountAssetIssue.getAssetMap().get(ASSET_NAME).longValue(), TOTAL_SUPPLY);
     } catch (ContractExeException e) {
       Assert.assertFalse(e instanceof ContractExeException);
     }
@@ -917,12 +1012,16 @@ public class ParticipateAssetIssueActuatorTest {
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
       AccountCapsule toAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
+      AccountAssetIssueCapsule ownerAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(OWNER_ADDRESS));
+      AccountAssetIssueCapsule toAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(TO_ADDRESS));
 
       Assert.assertEquals(owner.getBalance(), OWNER_BALANCE);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE);
       long id = chainBaseManager.getDynamicPropertiesStore().getTokenIdNum();
-      Assert.assertTrue(isNullOrZero(owner.getAssetMapV2().get(String.valueOf(id))));
-      Assert.assertEquals(toAccount.getAssetMapV2().get(String.valueOf(id)).longValue(),
+      Assert.assertTrue(isNullOrZero(ownerAccountAssetIssue.getAssetMapV2().get(String.valueOf(id))));
+      Assert.assertEquals(toAccountAssetIssue.getAssetMapV2().get(String.valueOf(id)).longValue(),
           TOTAL_SUPPLY);
     } catch (ContractExeException e) {
       Assert.assertFalse(e instanceof ContractExeException);
@@ -958,10 +1057,15 @@ public class ParticipateAssetIssueActuatorTest {
       AccountCapsule toAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
 
+      AccountAssetIssueCapsule ownerAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(OWNER_ADDRESS));
+      AccountAssetIssueCapsule toAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(TO_ADDRESS));
+
       Assert.assertEquals(owner.getBalance(), OWNER_BALANCE);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE);
-      Assert.assertTrue(isNullOrZero(owner.getAssetMap().get(ASSET_NAME)));
-      Assert.assertEquals(toAccount.getAssetMap().get(ASSET_NAME).longValue(), TOTAL_SUPPLY);
+      Assert.assertTrue(isNullOrZero(ownerAccountAssetIssue.getAssetMap().get(ASSET_NAME)));
+      Assert.assertEquals(toAccountAssetIssue.getAssetMap().get(ASSET_NAME).longValue(), TOTAL_SUPPLY);
     } catch (ContractExeException e) {
       Assert.assertFalse(e instanceof ContractExeException);
     }
@@ -997,11 +1101,16 @@ public class ParticipateAssetIssueActuatorTest {
       AccountCapsule toAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
 
+      AccountAssetIssueCapsule ownerAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(OWNER_ADDRESS));
+      AccountAssetIssueCapsule toAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(TO_ADDRESS));
+
       Assert.assertEquals(owner.getBalance(), OWNER_BALANCE);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE);
       long id = chainBaseManager.getDynamicPropertiesStore().getTokenIdNum();
-      Assert.assertTrue(isNullOrZero(owner.getAssetMapV2().get(String.valueOf(id))));
-      Assert.assertEquals(toAccount.getAssetMapV2().get(String.valueOf(id)).longValue(),
+      Assert.assertTrue(isNullOrZero(ownerAccountAssetIssue.getAssetMapV2().get(String.valueOf(id))));
+      Assert.assertEquals(toAccountAssetIssue.getAssetMapV2().get(String.valueOf(id)).longValue(),
           TOTAL_SUPPLY);
     } catch (ContractExeException e) {
       Assert.assertFalse(e instanceof ContractExeException);
@@ -1034,10 +1143,15 @@ public class ParticipateAssetIssueActuatorTest {
       AccountCapsule toAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
 
+      AccountAssetIssueCapsule ownerAccountAssetIssue =
+              chainBaseManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
+      AccountAssetIssueCapsule toAccountAssetIssue =
+              chainBaseManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(TO_ADDRESS));
+
       Assert.assertEquals(owner.getBalance(), OWNER_BALANCE);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE);
-      Assert.assertTrue(isNullOrZero(owner.getAssetMap().get(ASSET_NAME)));
-      Assert.assertEquals(toAccount.getAssetMap().get(ASSET_NAME).longValue(), TOTAL_SUPPLY);
+      Assert.assertTrue(isNullOrZero(ownerAccountAssetIssue.getAssetMap().get(ASSET_NAME)));
+      Assert.assertEquals(toAccountAssetIssue.getAssetMap().get(ASSET_NAME).longValue(), TOTAL_SUPPLY);
     } catch (ContractExeException e) {
       Assert.assertFalse(e instanceof ContractExeException);
     }
@@ -1069,12 +1183,15 @@ public class ParticipateAssetIssueActuatorTest {
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
       AccountCapsule toAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
-
+      AccountAssetIssueCapsule ownerAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(OWNER_ADDRESS));
+      AccountAssetIssueCapsule toAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(TO_ADDRESS));
       Assert.assertEquals(owner.getBalance(), OWNER_BALANCE);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE);
       long id = chainBaseManager.getDynamicPropertiesStore().getTokenIdNum();
-      Assert.assertTrue(isNullOrZero(owner.getAssetMapV2().get(String.valueOf(id))));
-      Assert.assertEquals(toAccount.getAssetMapV2().get(String.valueOf(id)).longValue(),
+      Assert.assertTrue(isNullOrZero(ownerAccountAssetIssue.getAssetMapV2().get(String.valueOf(id))));
+      Assert.assertEquals(toAccountAssetIssue.getAssetMapV2().get(String.valueOf(id)).longValue(),
           TOTAL_SUPPLY);
     } catch (ContractExeException e) {
       Assert.assertFalse(e instanceof ContractExeException);
@@ -1128,11 +1245,16 @@ public class ParticipateAssetIssueActuatorTest {
       AccountCapsule toAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
 
+      AccountAssetIssueCapsule ownerAccountAssetIssue =
+              chainBaseManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
+      AccountAssetIssueCapsule toAccountAssetIssue =
+              chainBaseManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(TO_ADDRESS));
+
       Assert.assertEquals(owner.getBalance(), OWNER_BALANCE - 1000);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE + 1000);
-      Assert.assertEquals(owner.getAssetMap().get(assetName).longValue(),
+      Assert.assertEquals(ownerAccountAssetIssue.getAssetMap().get(assetName).longValue(),
           (1000L) / TRX_NUM * NUM);
-      Assert.assertEquals(toAccount.getAssetMap().get(assetName).longValue(),
+      Assert.assertEquals(toAccountAssetIssue.getAssetMap().get(assetName).longValue(),
           TOTAL_SUPPLY - (1000L) / TRX_NUM * NUM);
     } catch (ContractValidateException e) {
       Assert.assertFalse(e instanceof ContractValidateException);
@@ -1160,11 +1282,16 @@ public class ParticipateAssetIssueActuatorTest {
       AccountCapsule toAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
 
+      AccountAssetIssueCapsule ownerAccountAssetIssue =
+              chainBaseManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
+      AccountAssetIssueCapsule toAccountAssetIssue =
+              chainBaseManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(TO_ADDRESS));
+
       Assert.assertEquals(owner.getBalance(), OWNER_BALANCE - 2000);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE + 2000);
-      Assert.assertEquals(owner.getAssetMap().get(assetName).longValue(),
+      Assert.assertEquals(ownerAccountAssetIssue.getAssetMap().get(assetName).longValue(),
           (1000L) / TRX_NUM * NUM);
-      Assert.assertEquals(toAccount.getAssetMap().get(assetName).longValue(),
+      Assert.assertEquals(toAccountAssetIssue.getAssetMap().get(assetName).longValue(),
           TOTAL_SUPPLY - (1000L) / TRX_NUM * NUM);
     } catch (ContractValidateException e) {
       Assert.assertFalse(e instanceof ContractValidateException);
@@ -1203,10 +1330,15 @@ public class ParticipateAssetIssueActuatorTest {
       AccountCapsule toAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
 
+      AccountAssetIssueCapsule ownerAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(OWNER_ADDRESS));
+      AccountAssetIssueCapsule toAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(TO_ADDRESS));
+
       Assert.assertEquals(owner.getBalance(), 100);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE);
-      Assert.assertTrue(isNullOrZero(owner.getAssetMap().get(ASSET_NAME)));
-      Assert.assertEquals(toAccount.getAssetMap().get(ASSET_NAME).longValue(), TOTAL_SUPPLY);
+      Assert.assertTrue(isNullOrZero(ownerAccountAssetIssue.getAssetMap().get(ASSET_NAME)));
+      Assert.assertEquals(toAccountAssetIssue.getAssetMap().get(ASSET_NAME).longValue(), TOTAL_SUPPLY);
     } catch (ContractExeException e) {
       Assert.assertFalse(e instanceof ContractExeException);
     }
@@ -1227,6 +1359,10 @@ public class ParticipateAssetIssueActuatorTest {
         .get(ByteArray.fromHexString(OWNER_ADDRESS));
     owner.setBalance(100);
     chainBaseManager.getAccountStore().put(owner.getAddress().toByteArray(), owner);
+
+    AccountAssetIssueCapsule ownerAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+            .get(ByteArray.fromHexString(OWNER_ADDRESS));
+
     ParticipateAssetIssueActuator actuator = new ParticipateAssetIssueActuator();
     actuator.setChainBaseManager(chainBaseManager).setAny(getContract(101));
 
@@ -1240,14 +1376,17 @@ public class ParticipateAssetIssueActuatorTest {
       Assert.assertTrue("No enough balance !".equals(e.getMessage()));
 
       owner = chainBaseManager.getAccountStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
+      ownerAssetIssue = chainBaseManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
+
       AccountCapsule toAccount = chainBaseManager.getAccountStore()
           .get(ByteArray.fromHexString(TO_ADDRESS));
-
+      AccountAssetIssueCapsule toAccountAssetIssue =
+              chainBaseManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(TO_ADDRESS));
       Assert.assertEquals(owner.getBalance(), 100);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE);
       long id = chainBaseManager.getDynamicPropertiesStore().getTokenIdNum();
-      Assert.assertTrue(isNullOrZero(owner.getAssetMapV2().get(String.valueOf(id))));
-      Assert.assertEquals(toAccount.getAssetMapV2().get(String.valueOf(id)).longValue(),
+      Assert.assertTrue(isNullOrZero(ownerAssetIssue.getAssetMapV2().get(String.valueOf(id))));
+      Assert.assertEquals(toAccountAssetIssue.getAssetMapV2().get(String.valueOf(id)).longValue(),
           TOTAL_SUPPLY);
     } catch (ContractExeException e) {
       Assert.assertFalse(e instanceof ContractExeException);
@@ -1265,9 +1404,15 @@ public class ParticipateAssetIssueActuatorTest {
     // First, reduce to account asset balance. Else can't complete this test case.
     AccountCapsule toAccount =
         chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
-    toAccount.reduceAssetAmount(ByteString.copyFromUtf8(ASSET_NAME).toByteArray(),
-        TOTAL_SUPPLY - 10000);
     chainBaseManager.getAccountStore().put(toAccount.getAddress().toByteArray(), toAccount);
+
+    AccountAssetIssueCapsule toAccountAssetIssue =
+            chainBaseManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(TO_ADDRESS));
+    toAccountAssetIssue.reduceAssetAmount(ByteString.copyFromUtf8(ASSET_NAME).toByteArray(),
+            TOTAL_SUPPLY - 10000);
+    chainBaseManager.getAccountAssetIssueStore()
+            .put(toAccountAssetIssue.getAddress().toByteArray(), toAccountAssetIssue);
+
     ParticipateAssetIssueActuator actuator = new ParticipateAssetIssueActuator();
     actuator.setChainBaseManager(chainBaseManager).setAny(getContract(1));
 
@@ -1285,10 +1430,15 @@ public class ParticipateAssetIssueActuatorTest {
       toAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
 
+      AccountAssetIssueCapsule ownerAccountAssetIssue =
+              dbManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
+      toAccountAssetIssue =
+              dbManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(TO_ADDRESS));
+
       Assert.assertEquals(owner.getBalance(), OWNER_BALANCE);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE);
-      Assert.assertTrue(isNullOrZero(owner.getAssetMap().get(ASSET_NAME)));
-      Assert.assertEquals(toAccount.getAssetMap().get(ASSET_NAME).longValue(), 10000);
+      Assert.assertTrue(isNullOrZero(ownerAccountAssetIssue.getAssetMap().get(ASSET_NAME)));
+      Assert.assertEquals(toAccountAssetIssue.getAssetMap().get(ASSET_NAME).longValue(), 10000);
     } catch (ContractExeException e) {
       Assert.assertFalse(e instanceof ContractExeException);
     }
@@ -1309,10 +1459,13 @@ public class ParticipateAssetIssueActuatorTest {
         .get(ByteArray.fromHexString(TO_ADDRESS));
     long id = chainBaseManager.getDynamicPropertiesStore().getTokenIdNum();
 
-    toAccount.reduceAssetAmountV2(ByteString.copyFromUtf8(String.valueOf(id)).toByteArray(),
-        TOTAL_SUPPLY - 10000, chainBaseManager.getDynamicPropertiesStore(),
-        chainBaseManager.getAssetIssueStore());
-    chainBaseManager.getAccountStore().put(toAccount.getAddress().toByteArray(), toAccount);
+    AccountAssetIssueCapsule toAccountAssetIssue = dbManager.getAccountAssetIssueStore()
+            .get(ByteArray.fromHexString(TO_ADDRESS));
+    toAccountAssetIssue.reduceAssetAmountV2(ByteString.copyFromUtf8(String.valueOf(id)).toByteArray(),
+            TOTAL_SUPPLY - 10000, chainBaseManager.getDynamicPropertiesStore(),
+            chainBaseManager.getAssetIssueStore());
+    chainBaseManager.getAccountAssetIssueStore().put(toAccountAssetIssue.getAddress().toByteArray(), toAccountAssetIssue);
+
     ParticipateAssetIssueActuator actuator = new ParticipateAssetIssueActuator();
     actuator.setChainBaseManager(chainBaseManager).setAny(getContract(1));
 
@@ -1330,12 +1483,16 @@ public class ParticipateAssetIssueActuatorTest {
       toAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
 
+      AccountAssetIssueCapsule ownerAccountAssetIssue =
+              chainBaseManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
+      toAccountAssetIssue =
+              chainBaseManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(TO_ADDRESS));
       Assert.assertEquals(owner.getBalance(), OWNER_BALANCE);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE);
 
-      Assert.assertTrue(isNullOrZero(owner.getAssetMapV2().get(String.valueOf(id))));
+      Assert.assertTrue(isNullOrZero(ownerAccountAssetIssue.getAssetMapV2().get(String.valueOf(id))));
       Assert.assertEquals(
-          toAccount.getAssetMapV2().get(String.valueOf(id)).longValue(), 10000);
+              toAccountAssetIssue.getAssetMapV2().get(String.valueOf(id)).longValue(), 10000);
     } catch (ContractExeException e) {
       Assert.assertFalse(e instanceof ContractExeException);
     }
@@ -1366,10 +1523,16 @@ public class ParticipateAssetIssueActuatorTest {
       AccountCapsule toAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
 
+      AccountAssetIssueCapsule ownerAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(OWNER_ADDRESS));
+
+      AccountAssetIssueCapsule toAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(TO_ADDRESS));
+
       Assert.assertEquals(owner.getBalance(), OWNER_BALANCE);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE);
-      Assert.assertTrue(isNullOrZero(owner.getAssetMap().get(ASSET_NAME)));
-      Assert.assertEquals(toAccount.getAssetMap().get(ASSET_NAME).longValue(), TOTAL_SUPPLY);
+      Assert.assertTrue(isNullOrZero(ownerAccountAssetIssue.getAssetMap().get(ASSET_NAME)));
+      Assert.assertEquals(toAccountAssetIssue.getAssetMap().get(ASSET_NAME).longValue(), TOTAL_SUPPLY);
     } catch (ContractExeException e) {
       Assert.assertFalse(e instanceof ContractExeException);
     }
@@ -1402,11 +1565,16 @@ public class ParticipateAssetIssueActuatorTest {
       AccountCapsule toAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
 
+      AccountAssetIssueCapsule ownerAccountAssetIssue = dbManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(OWNER_ADDRESS));
+      AccountAssetIssueCapsule toAccountAssetIssue = dbManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(TO_ADDRESS));
+
       Assert.assertEquals(owner.getBalance(), OWNER_BALANCE);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE);
       long id = chainBaseManager.getDynamicPropertiesStore().getTokenIdNum();
-      Assert.assertTrue(isNullOrZero(owner.getAssetMapV2().get(String.valueOf(id))));
-      Assert.assertEquals(toAccount.getAssetMapV2().get(String.valueOf(id)).longValue(),
+      Assert.assertTrue(isNullOrZero(ownerAccountAssetIssue.getAssetMapV2().get(String.valueOf(id))));
+      Assert.assertEquals(toAccountAssetIssue.getAssetMapV2().get(String.valueOf(id)).longValue(),
           TOTAL_SUPPLY);
     } catch (ContractExeException e) {
       Assert.assertFalse(e instanceof ContractExeException);
@@ -1424,8 +1592,13 @@ public class ParticipateAssetIssueActuatorTest {
     // First, increase the owner asset balance. Else can't complete this test case.
     AccountCapsule owner = chainBaseManager.getAccountStore()
         .get(ByteArray.fromHexString(OWNER_ADDRESS));
-    owner.addAsset(ASSET_NAME.getBytes(), Long.MAX_VALUE);
     chainBaseManager.getAccountStore().put(owner.getAddress().toByteArray(), owner);
+
+    AccountAssetIssueCapsule ownerAccountAssetIssue = dbManager.getAccountAssetIssueStore()
+            .get(ByteArray.fromHexString(OWNER_ADDRESS));
+    ownerAccountAssetIssue.addAsset(ASSET_NAME.getBytes(), Long.MAX_VALUE);
+    chainBaseManager.getAccountAssetIssueStore().put(ownerAccountAssetIssue.getAddress().toByteArray(), ownerAccountAssetIssue);
+
     ParticipateAssetIssueActuator actuator = new ParticipateAssetIssueActuator();
     actuator.setChainBaseManager(chainBaseManager).setAny(getContract(1L));
 
@@ -1447,10 +1620,15 @@ public class ParticipateAssetIssueActuatorTest {
       AccountCapsule toAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
 
+      ownerAccountAssetIssue =
+              chainBaseManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
+      AccountAssetIssueCapsule toAccountAssetIssue =
+              chainBaseManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(TO_ADDRESS));
+
       Assert.assertEquals(owner.getBalance(), OWNER_BALANCE);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE);
-      Assert.assertEquals(owner.getAssetMap().get(ASSET_NAME).longValue(), Long.MAX_VALUE);
-      Assert.assertEquals(toAccount.getAssetMap().get(ASSET_NAME).longValue(), TOTAL_SUPPLY);
+      Assert.assertEquals(ownerAccountAssetIssue.getAssetMap().get(ASSET_NAME).longValue(), Long.MAX_VALUE);
+      Assert.assertEquals(toAccountAssetIssue.getAssetMap().get(ASSET_NAME).longValue(), TOTAL_SUPPLY);
     }
   }
 
@@ -1467,9 +1645,13 @@ public class ParticipateAssetIssueActuatorTest {
     // First, increase the owner asset balance. Else can't complete this test case.
     AccountCapsule owner = chainBaseManager.getAccountStore()
         .get(ByteArray.fromHexString(OWNER_ADDRESS));
+
+    AccountAssetIssueCapsule ownerAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+            .get(ByteArray.fromHexString(OWNER_ADDRESS));
     long id = chainBaseManager.getDynamicPropertiesStore().getTokenIdNum();
-    owner.addAssetV2(ByteString.copyFromUtf8(String.valueOf(id)).toByteArray(), Long.MAX_VALUE);
-    chainBaseManager.getAccountStore().put(owner.getAddress().toByteArray(), owner);
+    ownerAccountAssetIssue.addAssetV2(ByteString.copyFromUtf8(String.valueOf(id)).toByteArray(), Long.MAX_VALUE);
+    chainBaseManager.getAccountAssetIssueStore().put(ownerAccountAssetIssue.getAddress().toByteArray(), ownerAccountAssetIssue);
+
     ParticipateAssetIssueActuator actuator = new ParticipateAssetIssueActuator();
     actuator.setChainBaseManager(chainBaseManager).setAny(getContract(1L));
 
@@ -1486,16 +1668,18 @@ public class ParticipateAssetIssueActuatorTest {
       Assert.assertTrue(e instanceof ContractExeException);
       Assert.assertTrue(("long overflow").equals(e.getMessage()));
 
-      owner = chainBaseManager.getAccountStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
+      ownerAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
       AccountCapsule toAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
+      AccountAssetIssueCapsule toAccountAssetIssue =
+              chainBaseManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(TO_ADDRESS));
 
       Assert.assertEquals(owner.getBalance(), OWNER_BALANCE);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE);
 
-      Assert.assertEquals(owner.getAssetMapV2().get(String.valueOf(id)).longValue(),
+      Assert.assertEquals(ownerAccountAssetIssue.getAssetMapV2().get(String.valueOf(id)).longValue(),
           Long.MAX_VALUE);
-      Assert.assertEquals(toAccount.getAssetMapV2().get(String.valueOf(id)).longValue(),
+      Assert.assertEquals(toAccountAssetIssue.getAssetMapV2().get(String.valueOf(id)).longValue(),
           TOTAL_SUPPLY);
     }
   }
@@ -1513,6 +1697,10 @@ public class ParticipateAssetIssueActuatorTest {
         .get(ByteArray.fromHexString(OWNER_ADDRESS));
     owner.setBalance(100000000000000L);
     chainBaseManager.getAccountStore().put(owner.getAddress().toByteArray(), owner);
+
+    AccountAssetIssueCapsule ownerAccountAssetIssue =
+            chainBaseManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
+
     ParticipateAssetIssueActuator actuator = new ParticipateAssetIssueActuator();
     actuator.setChainBaseManager(
         chainBaseManager).setAny(getContract(8589934597L));
@@ -1535,13 +1723,16 @@ public class ParticipateAssetIssueActuatorTest {
 
       owner =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
+      ownerAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(OWNER_ADDRESS));
       AccountCapsule toAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
-
+      AccountAssetIssueCapsule toAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(TO_ADDRESS));
       Assert.assertEquals(owner.getBalance(), 100000000000000L);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE);
-      Assert.assertTrue(isNullOrZero(owner.getAssetMap().get(ASSET_NAME)));
-      Assert.assertEquals(toAccount.getAssetMap().get(ASSET_NAME).longValue(), TOTAL_SUPPLY);
+      Assert.assertTrue(isNullOrZero(ownerAccountAssetIssue.getAssetMap().get(ASSET_NAME)));
+      Assert.assertEquals(toAccountAssetIssue.getAssetMap().get(ASSET_NAME).longValue(), TOTAL_SUPPLY);
     } catch (ContractExeException e) {
       Assert.assertFalse(e instanceof ContractExeException);
     }
@@ -1562,6 +1753,10 @@ public class ParticipateAssetIssueActuatorTest {
         .get(ByteArray.fromHexString(OWNER_ADDRESS));
     owner.setBalance(100000000000000L);
     chainBaseManager.getAccountStore().put(owner.getAddress().toByteArray(), owner);
+
+    AccountAssetIssueCapsule ownerAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+            .get(ByteArray.fromHexString(OWNER_ADDRESS));
+
     ParticipateAssetIssueActuator actuator = new ParticipateAssetIssueActuator();
     actuator.setChainBaseManager(
         chainBaseManager).setAny(getContract(8589934597L));
@@ -1586,12 +1781,14 @@ public class ParticipateAssetIssueActuatorTest {
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
       AccountCapsule toAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
+      AccountAssetIssueCapsule toAccountAssetIssue =
+          chainBaseManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(TO_ADDRESS));
 
       Assert.assertEquals(owner.getBalance(), 100000000000000L);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE);
       long id = chainBaseManager.getDynamicPropertiesStore().getTokenIdNum();
       Assert.assertTrue(isNullOrZero(owner.getAssetMapV2().get(String.valueOf(id))));
-      Assert.assertEquals(toAccount.getAssetMapV2().get(String.valueOf(id)).longValue(),
+      Assert.assertEquals(toAccountAssetIssue.getAssetMapV2().get(String.valueOf(id)).longValue(),
           TOTAL_SUPPLY);
     } catch (ContractExeException e) {
       Assert.assertFalse(e instanceof ContractExeException);

--- a/framework/src/test/java/org/tron/core/actuator/UpdateAssetActuatorTest.java
+++ b/framework/src/test/java/org/tron/core/actuator/UpdateAssetActuatorTest.java
@@ -20,6 +20,7 @@ import org.tron.common.utils.FileUtil;
 import org.tron.common.utils.StringUtil;
 import org.tron.core.Constant;
 import org.tron.core.Wallet;
+import org.tron.core.capsule.AccountAssetIssueCapsule;
 import org.tron.core.capsule.AccountCapsule;
 import org.tron.core.capsule.AssetIssueCapsule;
 import org.tron.core.capsule.TransactionResultCapsule;
@@ -94,10 +95,18 @@ public class UpdateAssetActuatorTest {
             ByteString.copyFrom(ByteArray.fromHexString(SECOND_ACCOUNT_ADDRESS)),
             ByteString.copyFromUtf8(OWNER_ADDRESS_ACCOUNT_NAME),
             Protocol.AccountType.Normal);
+
+    AccountAssetIssueCapsule secondAccountAssetIssue =
+            new AccountAssetIssueCapsule(
+                    ByteString.copyFrom(ByteArray.fromHexString(SECOND_ACCOUNT_ADDRESS))
+            );
+
     dbManager.getAccountStore().put(ByteArray.fromHexString(SECOND_ACCOUNT_ADDRESS), secondAccount);
+    dbManager.getAccountAssetIssueStore().put(ByteArray.fromHexString(SECOND_ACCOUNT_ADDRESS), secondAccountAssetIssue);
 
     // address does not exist in accountStore
     dbManager.getAccountStore().delete(ByteArray.fromHexString(OWNER_ADDRESS_NOTEXIST));
+    dbManager.getAccountAssetIssueStore().delete(ByteArray.fromHexString(OWNER_ADDRESS_NOTEXIST));
   }
 
   private Any getContract(
@@ -141,19 +150,25 @@ public class UpdateAssetActuatorTest {
             ByteString.copyFrom(ByteArray.fromHexString(OWNER_ADDRESS)),
             ByteString.copyFromUtf8(OWNER_ADDRESS_ACCOUNT_NAME),
             Protocol.AccountType.Normal);
+    AccountAssetIssueCapsule accountAssetIssueCapsule =
+            new AccountAssetIssueCapsule(
+            ByteString.copyFrom(ByteArray.fromHexString(OWNER_ADDRESS))
+    );
 
     // add asset issue
     AssetIssueCapsule assetIssueCapsule = new AssetIssueCapsule(getAssetIssueContract());
     dbManager.getAssetIssueStore().put(assetIssueCapsule.createDbKey(), assetIssueCapsule);
     dbManager.getAssetIssueV2Store().put(assetIssueCapsule.createDbV2Key(), assetIssueCapsule);
 
-    accountCapsule.setAssetIssuedName(assetIssueCapsule.createDbKey());
-    accountCapsule.setAssetIssuedID(assetIssueCapsule.getId().getBytes());
+    accountAssetIssueCapsule.setAssetIssuedName(assetIssueCapsule.createDbKey());
+    accountAssetIssueCapsule.setAssetIssuedID(assetIssueCapsule.getId().getBytes());
 
-    accountCapsule.addAsset(assetIssueCapsule.createDbKey(), TOTAL_SUPPLY);
-    accountCapsule.addAssetV2(assetIssueCapsule.createDbV2Key(), TOTAL_SUPPLY);
+    accountAssetIssueCapsule.addAsset(assetIssueCapsule.createDbKey(), TOTAL_SUPPLY);
+    accountAssetIssueCapsule.addAssetV2(assetIssueCapsule.createDbV2Key(), TOTAL_SUPPLY);
 
     dbManager.getAccountStore().put(ByteArray.fromHexString(OWNER_ADDRESS), accountCapsule);
+    dbManager.getAccountAssetIssueStore()
+            .put(ByteArray.fromHexString(OWNER_ADDRESS), accountAssetIssueCapsule);
   }
 
   private void createAssertSameTokenNameActive() {
@@ -170,11 +185,16 @@ public class UpdateAssetActuatorTest {
     AssetIssueCapsule assetIssueCapsule = new AssetIssueCapsule(getAssetIssueContract());
     dbManager.getAssetIssueV2Store().put(assetIssueCapsule.createDbV2Key(), assetIssueCapsule);
 
-    accountCapsule.setAssetIssuedName(assetIssueCapsule.createDbKey());
-    accountCapsule.setAssetIssuedID(assetIssueCapsule.getId().getBytes());
-    accountCapsule.addAssetV2(assetIssueCapsule.createDbV2Key(), TOTAL_SUPPLY);
-
+    AccountAssetIssueCapsule accountAssetIssueCapsule = new
+            AccountAssetIssueCapsule(
+            ByteString.copyFromUtf8(OWNER_ADDRESS_ACCOUNT_NAME),
+            ByteString.copyFrom(ByteArray.fromHexString(OWNER_ADDRESS))
+    );
+    accountAssetIssueCapsule.setAssetIssuedName(assetIssueCapsule.createDbKey());
+    accountAssetIssueCapsule.setAssetIssuedID(assetIssueCapsule.getId().getBytes());
+    accountAssetIssueCapsule.addAssetV2(assetIssueCapsule.createDbV2Key(), TOTAL_SUPPLY);
     dbManager.getAccountStore().put(ByteArray.fromHexString(OWNER_ADDRESS), accountCapsule);
+    dbManager.getAccountAssetIssueStore().put(ByteArray.fromHexString(OWNER_ADDRESS), accountAssetIssueCapsule);
   }
 
   @Test

--- a/framework/src/test/java/org/tron/core/db/api/AssetUpdateHelperTest.java
+++ b/framework/src/test/java/org/tron/core/db/api/AssetUpdateHelperTest.java
@@ -1,161 +1,161 @@
-//package org.tron.core.db.api;
-//
-//import static org.tron.core.config.Parameter.ChainSymbol.TRX_SYMBOL_BYTES;
-//
-//import com.google.protobuf.ByteString;
-//import java.io.File;
-//import org.junit.AfterClass;
-//import org.junit.Assert;
-//import org.junit.BeforeClass;
-//import org.testng.annotations.Test;
-//import org.tron.common.application.Application;
-//import org.tron.common.application.ApplicationFactory;
-//import org.tron.common.application.TronApplicationContext;
-//import org.tron.common.utils.ByteArray;
-//import org.tron.common.utils.FileUtil;
-//import org.tron.common.utils.Sha256Hash;
-//import org.tron.core.ChainBaseManager;
-//import org.tron.core.capsule.AccountCapsule;
-//import org.tron.core.capsule.AssetIssueCapsule;
-//import org.tron.core.capsule.BlockCapsule;
-//import org.tron.core.capsule.ExchangeCapsule;
-//import org.tron.core.capsule.TransactionCapsule;
-//import org.tron.core.config.DefaultConfig;
-//import org.tron.core.config.args.Args;
-//import org.tron.protos.Protocol.Account;
-//import org.tron.protos.Protocol.Exchange;
-//import org.tron.protos.Protocol.Transaction.Contract.ContractType;
-//import org.tron.protos.contract.AssetIssueContractOuterClass.AssetIssueContract;
-//
-//public class AssetUpdateHelperTest {
-//
-//  private static ChainBaseManager chainBaseManager;
-//  private static TronApplicationContext context;
-//  private static String dbPath = "output_AssetUpdateHelperTest_test";
-//  private static Application AppT;
-//
-//  private static ByteString assetName = ByteString.copyFrom("assetIssueName".getBytes());
-//
-//  static {
-//    Args.setParam(new String[]{"-d", dbPath, "-w"}, "config-test-index.conf");
-//    Args.getInstance().setSolidityNode(true);
-//    context = new TronApplicationContext(DefaultConfig.class);
-//    AppT = ApplicationFactory.create(context);
-//  }
-//
-//  @BeforeClass
-//  public static void init() {
-//
-//    chainBaseManager = context.getBean(ChainBaseManager.class);
-//
-//    AssetIssueContract contract =
-//        AssetIssueContract.newBuilder().setName(assetName).setNum(12581).setPrecision(5).build();
-//    AssetIssueCapsule assetIssueCapsule = new AssetIssueCapsule(contract);
-//    chainBaseManager.getAssetIssueStore().put(assetIssueCapsule.createDbKey(), assetIssueCapsule);
-//
-//    BlockCapsule blockCapsule = new BlockCapsule(1,
-//        Sha256Hash.wrap(ByteString.copyFrom(
-//            ByteArray.fromHexString(
-//                "0000000000000002498b464ac0292229938a342238077182498b464ac0292222"))),
-//        1234, ByteString.copyFrom("1234567".getBytes()));
-//
-//    blockCapsule.addTransaction(new TransactionCapsule(contract, ContractType.AssetIssueContract));
-//    chainBaseManager.getDynamicPropertiesStore().saveLatestBlockHeaderNumber(1L);
-//    chainBaseManager.getBlockIndexStore().put(blockCapsule.getBlockId());
-//    chainBaseManager.getBlockStore().put(blockCapsule.getBlockId().getBytes(), blockCapsule);
-//
-//    ExchangeCapsule exchangeCapsule =
-//        new ExchangeCapsule(
-//            Exchange.newBuilder()
-//                .setExchangeId(1L)
-//                .setFirstTokenId(assetName)
-//                .setSecondTokenId(ByteString.copyFrom(TRX_SYMBOL_BYTES))
-//                .build());
-//    chainBaseManager.getExchangeStore().put(exchangeCapsule.createDbKey(), exchangeCapsule);
-//
-//    AccountCapsule accountCapsule =
-//        new AccountCapsule(
-//            Account.newBuilder()
-//                .setAssetIssuedName(assetName)
-//                .putAsset("assetIssueName", 100)
-//                .putFreeAssetNetUsage("assetIssueName", 20000)
-//                .putLatestAssetOperationTime("assetIssueName", 30000000)
-//                .setAddress(ByteString.copyFrom(ByteArray.fromHexString("121212abc")))
-//                .build());
-//    chainBaseManager.getAccountStore().put(ByteArray.fromHexString("121212abc"),
-//        accountCapsule);
-//  }
-//
-//  @AfterClass
-//  public static void removeDb() {
-//    Args.clearParam();
-//    context.destroy();
-//    FileUtil.deleteDir(new File(dbPath));
-//  }
-//
-//  @Test
-//  public void test() {
-//
-//    if (chainBaseManager == null) {
-//      init();
-//    }
-//    AssetUpdateHelper assetUpdateHelper = new AssetUpdateHelper(chainBaseManager);
-//    assetUpdateHelper.init();
-//    {
-//      assetUpdateHelper.updateAsset();
-//
-//      String idNum = "1000001";
-//
-//      AssetIssueCapsule assetIssueCapsule =
-//          chainBaseManager.getAssetIssueStore().get(assetName.toByteArray());
-//      Assert.assertEquals(idNum, assetIssueCapsule.getId());
-//      Assert.assertEquals(5L, assetIssueCapsule.getPrecision());
-//
-//      AssetIssueCapsule assetIssueCapsule2 =
-//          chainBaseManager.getAssetIssueV2Store().get(ByteArray.fromString(String.valueOf(idNum)));
-//
-//      Assert.assertEquals(idNum, assetIssueCapsule2.getId());
-//      Assert.assertEquals(assetName, assetIssueCapsule2.getName());
-//      Assert.assertEquals(0L, assetIssueCapsule2.getPrecision());
-//    }
-//
-//    {
-//      assetUpdateHelper.updateExchange();
-//
-//      try {
-//        ExchangeCapsule exchangeCapsule =
-//            chainBaseManager.getExchangeV2Store().get(ByteArray.fromLong(1L));
-//        Assert.assertEquals("1000001", ByteArray.toStr(exchangeCapsule.getFirstTokenId()));
-//        Assert.assertEquals("_", ByteArray.toStr(exchangeCapsule.getSecondTokenId()));
-//      } catch (Exception ex) {
-//        throw new RuntimeException("testUpdateExchange error");
-//      }
-//    }
-//
-//    {
-//      assetUpdateHelper.updateAccount();
-//
-//      AccountCapsule accountCapsule =
-//          chainBaseManager.getAccountStore().get(ByteArray.fromHexString("121212abc"));
-//
-//      Assert.assertEquals(
-//          ByteString.copyFrom(ByteArray.fromString("1000001")), accountCapsule.getAssetIssuedID());
-//
-//      Assert.assertEquals(1, accountCapsule.getAssetMapV2().size());
-//
-//      Assert.assertEquals(100L, accountCapsule.getAssetMapV2().get("1000001").longValue());
-//
-//      Assert.assertEquals(1, accountCapsule.getAllFreeAssetNetUsageV2().size());
-//
-//      Assert.assertEquals(
-//          20000L, accountCapsule.getAllFreeAssetNetUsageV2().get("1000001").longValue());
-//
-//      Assert.assertEquals(1, accountCapsule.getLatestAssetOperationTimeMapV2().size());
-//
-//      Assert.assertEquals(
-//          30000000L, accountCapsule.getLatestAssetOperationTimeMapV2().get("1000001").longValue());
-//    }
-//
-//    removeDb();
-//  }
-//}
+package org.tron.core.db.api;
+
+import static org.tron.core.config.Parameter.ChainSymbol.TRX_SYMBOL_BYTES;
+
+import com.google.protobuf.ByteString;
+import java.io.File;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.testng.annotations.Test;
+import org.tron.common.application.Application;
+import org.tron.common.application.ApplicationFactory;
+import org.tron.common.application.TronApplicationContext;
+import org.tron.common.utils.ByteArray;
+import org.tron.common.utils.FileUtil;
+import org.tron.common.utils.Sha256Hash;
+import org.tron.core.ChainBaseManager;
+import org.tron.core.capsule.AccountCapsule;
+import org.tron.core.capsule.AssetIssueCapsule;
+import org.tron.core.capsule.BlockCapsule;
+import org.tron.core.capsule.ExchangeCapsule;
+import org.tron.core.capsule.TransactionCapsule;
+import org.tron.core.config.DefaultConfig;
+import org.tron.core.config.args.Args;
+import org.tron.protos.Protocol.Account;
+import org.tron.protos.Protocol.Exchange;
+import org.tron.protos.Protocol.Transaction.Contract.ContractType;
+import org.tron.protos.contract.AssetIssueContractOuterClass.AssetIssueContract;
+
+public class AssetUpdateHelperTest {
+
+    private static ChainBaseManager chainBaseManager;
+    private static TronApplicationContext context;
+    private static String dbPath = "output_AssetUpdateHelperTest_test";
+    private static Application AppT;
+
+    private static ByteString assetName = ByteString.copyFrom("assetIssueName".getBytes());
+
+    static {
+        Args.setParam(new String[]{"-d", dbPath, "-w"}, "config-test-index.conf");
+        Args.getInstance().setSolidityNode(true);
+        context = new TronApplicationContext(DefaultConfig.class);
+        AppT = ApplicationFactory.create(context);
+    }
+
+    @BeforeClass
+    public static void init() {
+
+        chainBaseManager = context.getBean(ChainBaseManager.class);
+
+        AssetIssueContract contract =
+                AssetIssueContract.newBuilder().setName(assetName).setNum(12581).setPrecision(5).build();
+        AssetIssueCapsule assetIssueCapsule = new AssetIssueCapsule(contract);
+        chainBaseManager.getAssetIssueStore().put(assetIssueCapsule.createDbKey(), assetIssueCapsule);
+
+        BlockCapsule blockCapsule = new BlockCapsule(1,
+                Sha256Hash.wrap(ByteString.copyFrom(
+                        ByteArray.fromHexString(
+                                "0000000000000002498b464ac0292229938a342238077182498b464ac0292222"))),
+                1234, ByteString.copyFrom("1234567".getBytes()));
+
+        blockCapsule.addTransaction(new TransactionCapsule(contract, ContractType.AssetIssueContract));
+        chainBaseManager.getDynamicPropertiesStore().saveLatestBlockHeaderNumber(1L);
+        chainBaseManager.getBlockIndexStore().put(blockCapsule.getBlockId());
+        chainBaseManager.getBlockStore().put(blockCapsule.getBlockId().getBytes(), blockCapsule);
+
+        ExchangeCapsule exchangeCapsule =
+                new ExchangeCapsule(
+                        Exchange.newBuilder()
+                                .setExchangeId(1L)
+                                .setFirstTokenId(assetName)
+                                .setSecondTokenId(ByteString.copyFrom(TRX_SYMBOL_BYTES))
+                                .build());
+        chainBaseManager.getExchangeStore().put(exchangeCapsule.createDbKey(), exchangeCapsule);
+
+        AccountCapsule accountCapsule =
+                new AccountCapsule(
+                        Account.newBuilder()
+                                .setAssetIssuedName(assetName)
+                                .putAsset("assetIssueName", 100)
+                                .putFreeAssetNetUsage("assetIssueName", 20000)
+                                .putLatestAssetOperationTime("assetIssueName", 30000000)
+                                .setAddress(ByteString.copyFrom(ByteArray.fromHexString("121212abc")))
+                                .build());
+        chainBaseManager.getAccountStore().put(ByteArray.fromHexString("121212abc"),
+                accountCapsule);
+    }
+
+    @AfterClass
+    public static void removeDb() {
+        Args.clearParam();
+        context.destroy();
+        FileUtil.deleteDir(new File(dbPath));
+    }
+
+    @Test
+    public void test() {
+
+        if (chainBaseManager == null) {
+            init();
+        }
+        AssetUpdateHelper assetUpdateHelper = new AssetUpdateHelper(chainBaseManager);
+        assetUpdateHelper.init();
+        {
+            assetUpdateHelper.updateAsset();
+
+            String idNum = "1000001";
+
+            AssetIssueCapsule assetIssueCapsule =
+                    chainBaseManager.getAssetIssueStore().get(assetName.toByteArray());
+            Assert.assertEquals(idNum, assetIssueCapsule.getId());
+            Assert.assertEquals(5L, assetIssueCapsule.getPrecision());
+
+            AssetIssueCapsule assetIssueCapsule2 =
+                    chainBaseManager.getAssetIssueV2Store().get(ByteArray.fromString(String.valueOf(idNum)));
+
+            Assert.assertEquals(idNum, assetIssueCapsule2.getId());
+            Assert.assertEquals(assetName, assetIssueCapsule2.getName());
+            Assert.assertEquals(0L, assetIssueCapsule2.getPrecision());
+        }
+
+        {
+            assetUpdateHelper.updateExchange();
+
+            try {
+                ExchangeCapsule exchangeCapsule =
+                        chainBaseManager.getExchangeV2Store().get(ByteArray.fromLong(1L));
+                Assert.assertEquals("1000001", ByteArray.toStr(exchangeCapsule.getFirstTokenId()));
+                Assert.assertEquals("_", ByteArray.toStr(exchangeCapsule.getSecondTokenId()));
+            } catch (Exception ex) {
+                throw new RuntimeException("testUpdateExchange error");
+            }
+        }
+
+        {
+            assetUpdateHelper.updateAccountAssetIssue();
+
+            AccountCapsule accountCapsule =
+                    chainBaseManager.getAccountStore().get(ByteArray.fromHexString("121212abc"));
+
+            Assert.assertEquals(
+                    ByteString.copyFrom(ByteArray.fromString("1000001")), accountCapsule.getAssetIssuedID());
+
+            Assert.assertEquals(1, accountCapsule.getAssetMapV2().size());
+
+            Assert.assertEquals(100L, accountCapsule.getAssetMapV2().get("1000001").longValue());
+
+            Assert.assertEquals(1, accountCapsule.getAllFreeAssetNetUsageV2().size());
+
+            Assert.assertEquals(
+                    20000L, accountCapsule.getAllFreeAssetNetUsageV2().get("1000001").longValue());
+
+            Assert.assertEquals(1, accountCapsule.getLatestAssetOperationTimeMapV2().size());
+
+            Assert.assertEquals(
+                    30000000L, accountCapsule.getLatestAssetOperationTimeMapV2().get("1000001").longValue());
+        }
+
+        removeDb();
+    }
+}

--- a/framework/src/test/java/org/tron/core/zksnark/SendCoinShieldTest.java
+++ b/framework/src/test/java/org/tron/core/zksnark/SendCoinShieldTest.java
@@ -50,6 +50,7 @@ import org.tron.core.capsule.ReceiveDescriptionCapsule;
 import org.tron.core.capsule.SpendDescriptionCapsule;
 import org.tron.core.capsule.TransactionCapsule;
 import org.tron.core.capsule.TransactionResultCapsule;
+import org.tron.core.capsule.AccountAssetIssueCapsule;
 import org.tron.core.config.DefaultConfig;
 import org.tron.core.config.args.Args;
 import org.tron.core.db.Manager;
@@ -116,9 +117,9 @@ public class SendCoinShieldTest {
     Args.setParam(new String[]{"--output-directory", dbPath}, "config-test-mainnet.conf");
     context = new TronApplicationContext(DefaultConfig.class);
     PUBLIC_ADDRESS_ONE =
-        Wallet.getAddressPreFixString() + "a7d8a35b260395c14aa456297662092ba3b76fc0";
+            Wallet.getAddressPreFixString() + "a7d8a35b260395c14aa456297662092ba3b76fc0";
     DEFAULT_OVK = ByteArray
-        .fromHexString("030c8c2bc59fb3eb8afb047a8ea4b028743d23e7d38c6fa30908358431e2314d");
+            .fromHexString("030c8c2bc59fb3eb8afb047a8ea4b028743d23e7d38c6fa30908358431e2314d");
   }
 
   /**
@@ -151,14 +152,23 @@ public class SendCoinShieldTest {
     dbManager.getDynamicPropertiesStore().saveTokenIdNum(tokenId);
 
     AssetIssueContract assetIssueContract = AssetIssueContract.newBuilder()
-        .setOwnerAddress(ByteString.copyFrom(ByteArray.fromHexString(PUBLIC_ADDRESS_ONE)))
-        .setName(ByteString.copyFrom(ByteArray.fromString(ASSET_NAME)))
-        .setId(Long.toString(tokenId)).setTotalSupply(OWNER_BALANCE).setTrxNum(TRX_NUM).setNum(NUM)
-        .setStartTime(START_TIME).setEndTime(END_TIME).setVoteScore(VOTE_SCORE)
-        .setDescription(ByteString.copyFrom(ByteArray.fromString(DESCRIPTION)))
-        .setUrl(ByteString.copyFrom(ByteArray.fromString(URL))).build();
+            .setOwnerAddress(ByteString.copyFrom(ByteArray.fromHexString(PUBLIC_ADDRESS_ONE)))
+            .setName(ByteString.copyFrom(ByteArray.fromString(ASSET_NAME)))
+            .setId(Long.toString(tokenId)).setTotalSupply(OWNER_BALANCE).setTrxNum(TRX_NUM).setNum(NUM)
+            .setStartTime(START_TIME).setEndTime(END_TIME).setVoteScore(VOTE_SCORE)
+            .setDescription(ByteString.copyFrom(ByteArray.fromString(DESCRIPTION)))
+            .setUrl(ByteString.copyFrom(ByteArray.fromString(URL))).build();
     AssetIssueCapsule assetIssueCapsule = new AssetIssueCapsule(assetIssueContract);
     dbManager.getAssetIssueV2Store().put(assetIssueCapsule.createDbV2Key(), assetIssueCapsule);
+  }
+
+  private void createAccountAssetIssueCapsule() {
+    AccountAssetIssueCapsule ownerCapsule =
+            new AccountAssetIssueCapsule(
+                    ByteString.copyFromUtf8("owner"),
+                    ByteString.copyFrom(ByteArray.fromHexString(PUBLIC_ADDRESS_ONE))
+            );
+    dbManager.getAccountAssetIssueStore().put(ownerCapsule.createDbKey(), ownerCapsule);
   }
 
   private void addZeroValueOutputNote(ZenTransactionBuilder builder) throws ZksnarkException {
@@ -198,9 +208,9 @@ public class SendCoinShieldTest {
   }
 
   private IncrementalMerkleVoucherContainer createComplexMerkleVoucherContainer(byte[] cm)
-      throws ZksnarkException {
+          throws ZksnarkException {
     IncrementalMerkleTreeContainer tree = new IncrementalMerkleTreeContainer(
-        new IncrementalMerkleTreeCapsule());
+            new IncrementalMerkleTreeCapsule());
     String s1 = "556f3af94225d46b1ef652abc9005dee873b2e245eef07fd5be587e0f21023b0";
     PedersenHash a = String2PedersenHash(s1);
     String s2 = "5814b127a6c6b8f07ed03f0f6e2843ff04c9851ff824a4e5b4dad5b5f3475722";
@@ -217,9 +227,9 @@ public class SendCoinShieldTest {
   }
 
   private IncrementalMerkleVoucherContainer createSimpleMerkleVoucherContainer(byte[] cm)
-      throws ZksnarkException {
+          throws ZksnarkException {
     IncrementalMerkleTreeContainer tree = new IncrementalMerkleTreeContainer(
-        new IncrementalMerkleTreeCapsule());
+            new IncrementalMerkleTreeCapsule());
     PedersenHashCapsule compressCapsule1 = new PedersenHashCapsule();
     compressCapsule1.setContent(ByteString.copyFrom(cm));
     PedersenHash a = compressCapsule1.getInstance();
@@ -235,7 +245,7 @@ public class SendCoinShieldTest {
   @Test
   public void testStringRevert() throws Exception {
     byte[] bytes = ByteArray
-        .fromHexString("6c030e6d7460f91668cc842ceb78cdb54470469e78cd59cf903d3a6e1aa03e7c");
+            .fromHexString("6c030e6d7460f91668cc842ceb78cdb54470469e78cd59cf903d3a6e1aa03e7c");
     ByteUtil.reverse(bytes);
     System.out.println("testStringRevert------" + ByteArray.toHexString(bytes));
   }
@@ -245,7 +255,7 @@ public class SendCoinShieldTest {
     librustzcashInitZksnarkParams();
     ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
     SpendingKey sk = SpendingKey
-        .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
+            .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
     ExpandedSpendingKey expsk = sk.expandedSpendingKey();
 
     DiversifierT diversifierT = new DiversifierT();
@@ -266,7 +276,7 @@ public class SendCoinShieldTest {
 
     Note note = new Note(op.get(), 100);
     note.setRcm(ByteArray
-        .fromHexString("bf4b2042e3e8c4a0b390e407a79a0b46e36eff4f7bb54b2349dbb0046ee21e02"));
+            .fromHexString("bf4b2042e3e8c4a0b390e407a79a0b46e36eff4f7bb54b2349dbb0046ee21e02"));
 
     IncrementalMerkleVoucherContainer voucher = createComplexMerkleVoucherContainer(note.cm());
 
@@ -303,15 +313,15 @@ public class SendCoinShieldTest {
     long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
     builder.addOutput(fullViewingKey.getOvk(), paymentAddress, 4000, new byte[512]);
     ReceiveDescriptionCapsule capsule = builder
-        .generateOutputProof(builder.getReceives().get(0), ctx);
+            .generateOutputProof(builder.getReceives().get(0), ctx);
     JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
     ReceiveDescription receiveDescription = capsule.getInstance();
     ctx = JLibrustzcash.librustzcashSaplingVerificationCtxInit();
     if (!JLibrustzcash.librustzcashSaplingCheckOutput(
-        new CheckOutputParams(ctx, receiveDescription.getValueCommitment().toByteArray(),
-            receiveDescription.getNoteCommitment().toByteArray(),
-            receiveDescription.getEpk().toByteArray(),
-            receiveDescription.getZkproof().toByteArray()))) {
+            new CheckOutputParams(ctx, receiveDescription.getValueCommitment().toByteArray(),
+                    receiveDescription.getNoteCommitment().toByteArray(),
+                    receiveDescription.getEpk().toByteArray(),
+                    receiveDescription.getZkproof().toByteArray()))) {
       JLibrustzcash.librustzcashSaplingVerificationCtxFree(ctx);
       throw new RuntimeException("librustzcashSaplingCheckOutput error");
     }
@@ -340,8 +350,8 @@ public class SendCoinShieldTest {
     ReceiveDescription receiveDescription = receiveDescriptionCapsule.getInstance();
 
     Optional<Note> ret1 = Note.decrypt(receiveDescription.getCEnc().toByteArray(),//ciphertext
-        fullViewingKey.inViewingKey().getValue(), receiveDescription.getEpk().toByteArray(),//epk
-        receiveDescription.getNoteCommitment().toByteArray() //cm
+            fullViewingKey.inViewingKey().getValue(), receiveDescription.getEpk().toByteArray(),//epk
+            receiveDescription.getNoteCommitment().toByteArray() //cm
     );
 
     Assert.assertTrue(ret1.isPresent());
@@ -349,7 +359,7 @@ public class SendCoinShieldTest {
     Note noteText = ret1.get();
     byte[] pkD = new byte[32];
     if (!JLibrustzcash.librustzcashIvkToPkd(
-        new IvkToPkdParams(incomingViewingKey.getValue(), noteText.getD().getData(), pkD))) {
+            new IvkToPkdParams(incomingViewingKey.getValue(), noteText.getD().getData(), pkD))) {
       JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
       return;
     }
@@ -361,8 +371,8 @@ public class SendCoinShieldTest {
     String paymentAddressStr = KeyIo.encodePaymentAddress(new PaymentAddress(noteText.getD(), pkD));
 
     GrpcAPI.Note grpcAPINote = GrpcAPI.Note.newBuilder().setPaymentAddress(paymentAddressStr)
-        .setValue(noteText.getValue()).setRcm(ByteString.copyFrom(noteText.getRcm()))
-        .setMemo(ByteString.copyFrom(noteText.getMemo())).build();
+            .setValue(noteText.getValue()).setRcm(ByteString.copyFrom(noteText.getRcm()))
+            .setMemo(ByteString.copyFrom(noteText.getMemo())).build();
 
     JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
   }
@@ -386,7 +396,7 @@ public class SendCoinShieldTest {
 
     // construct payment address
     SpendingKey spendingKey2 = SpendingKey
-        .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
+            .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
     PaymentAddress paymentAddress2 = spendingKey2.defaultAddress();
     FullViewingKey fullViewingKey = spendingKey2.fullViewingKey();
 
@@ -401,7 +411,7 @@ public class SendCoinShieldTest {
     byte[] pkd = paymentAddress2.getPkD();
     Note note = new Note(paymentAddress2, 4000);//construct function:this.pkD = address.getPkD();
     note.setRcm(ByteArray
-        .fromHexString("83d36fd4c8eebec516c3a8ce2fe4832e01eb57bd7f9f9c9e0bd68cc69a5b0f06"));
+            .fromHexString("83d36fd4c8eebec516c3a8ce2fe4832e01eb57bd7f9f9c9e0bd68cc69a5b0f06"));
     byte[] memo = org.tron.keystore.Wallet.generateRandomBytes(512);
     note.setMemo(memo);
 
@@ -414,14 +424,14 @@ public class SendCoinShieldTest {
 
     // encrypt with ovk
     Encryption.OutCiphertext outCiphertext = outgoingPlaintext
-        .encrypt(fullViewingKey.getOvk(), receiveDescription.getValueCommitment().toByteArray(),
-            receiveDescription.getNoteCommitment().toByteArray(), encryptor);
+            .encrypt(fullViewingKey.getOvk(), receiveDescription.getValueCommitment().toByteArray(),
+                    receiveDescription.getNoteCommitment().toByteArray(), encryptor);
 
     // get pkD, esk from decryption of c_out with ovk
     Optional<OutgoingPlaintext> ret2 = OutgoingPlaintext
-        .decrypt(outCiphertext, fullViewingKey.getOvk(),
-            receiveDescription.getValueCommitment().toByteArray(),
-            receiveDescription.getNoteCommitment().toByteArray(), encryptor.getEpk());
+            .decrypt(outCiphertext, fullViewingKey.getOvk(),
+                    receiveDescription.getValueCommitment().toByteArray(),
+                    receiveDescription.getNoteCommitment().toByteArray(), encryptor.getEpk());
 
     if (ret2.isPresent()) {
       OutgoingPlaintext decryptedOutgoingPlaintext = ret2.get();
@@ -432,8 +442,8 @@ public class SendCoinShieldTest {
       Encryption.EncCiphertext ciphertext = new Encryption.EncCiphertext();
       ciphertext.setData(enc.getEncCiphertext());
       Optional<Note> foo = Note
-          .decrypt(ciphertext, encryptor.getEpk(), decryptedOutgoingPlaintext.getEsk(),
-              decryptedOutgoingPlaintext.getPkD(), cmuOpt);
+              .decrypt(ciphertext, encryptor.getEpk(), decryptedOutgoingPlaintext.getEsk(),
+                      decryptedOutgoingPlaintext.getPkD(), cmuOpt);
 
       if (foo.isPresent()) {
         Note bar = foo.get();
@@ -454,21 +464,20 @@ public class SendCoinShieldTest {
 
   @Test
   public void pushShieldedTransactionAndDecryptWithIvk()
-      throws ContractValidateException, TooBigTransactionException,
-      TooBigTransactionResultException, TaposException, TransactionExpirationException,
-      ReceiptCheckErrException, DupTransactionException, VMIllegalException,
-      ValidateSignatureException, BadItemException, ContractExeException,
-      AccountResourceInsufficientException, InvalidProtocolBufferException, ZksnarkException {
+          throws ContractValidateException, TooBigTransactionException,
+          TooBigTransactionResultException, TaposException, TransactionExpirationException,
+          ReceiptCheckErrException, DupTransactionException, VMIllegalException,
+          ValidateSignatureException, BadItemException, ContractExeException,
+          AccountResourceInsufficientException, InvalidProtocolBufferException, ZksnarkException {
     long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
 
     librustzcashInitZksnarkParams();
     dbManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
     dbManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(1000 * 1000000L);
     ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-
     // generate spend proof
     SpendingKey sk = SpendingKey
-        .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
+            .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
     ExpandedSpendingKey expsk = sk.expandedSpendingKey();
     byte[] senderOvk = expsk.getOvk();
     PaymentAddress address = sk.defaultAddress();
@@ -476,9 +485,10 @@ public class SendCoinShieldTest {
     IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
     byte[] anchor = voucher.root().getContent().toByteArray();
     dbManager.getMerkleContainer()
-        .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
+            .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
     builder.addSpend(expsk, note, anchor, voucher);
 
+    createAccountAssetIssueCapsule();
     // generate output proof
     SpendingKey spendingKey = SpendingKey.random();
     FullViewingKey fullViewingKey = spendingKey.fullViewingKey();
@@ -486,8 +496,8 @@ public class SendCoinShieldTest {
     PaymentAddress paymentAddress = incomingViewingKey.address(new DiversifierT()).get();
     byte[] memo = org.tron.keystore.Wallet.generateRandomBytes(512);
     builder
-        .addOutput(senderOvk, paymentAddress, 1000 * 1000000L - wallet.getShieldedTransactionFee(),
-            memo);
+            .addOutput(senderOvk, paymentAddress, 1000 * 1000000L - wallet.getShieldedTransactionFee(),
+                    memo);
 
     TransactionCapsule transactionCap = builder.build();
 
@@ -503,25 +513,25 @@ public class SendCoinShieldTest {
         continue;
       }
       ShieldedTransferContract stContract = c.getParameter()
-          .unpack(ShieldedTransferContract.class);
+              .unpack(ShieldedTransferContract.class);
       ReceiveDescription receiveDescription = stContract.getReceiveDescription(0);
 
       Optional<Note> ret1 = Note.decrypt(receiveDescription.getCEnc().toByteArray(),//ciphertext
-          ivk, receiveDescription.getEpk().toByteArray(),//epk
-          receiveDescription.getNoteCommitment().toByteArray() //cm
+              ivk, receiveDescription.getEpk().toByteArray(),//epk
+              receiveDescription.getNoteCommitment().toByteArray() //cm
       );
 
       if (ret1.isPresent()) {
         Note noteText = ret1.get();
         byte[] pkD = new byte[32];
         if (!JLibrustzcash.librustzcashIvkToPkd(
-            new IvkToPkdParams(incomingViewingKey.getValue(), noteText.getD().getData(), pkD))) {
+                new IvkToPkdParams(incomingViewingKey.getValue(), noteText.getD().getData(), pkD))) {
           JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
           return;
         }
         Assert.assertArrayEquals(paymentAddress.getPkD(), pkD);
         Assert.assertEquals(1000 * 1000000L - wallet.getShieldedTransactionFee(),
-            noteText.getValue());
+                noteText.getValue());
         Assert.assertArrayEquals(memo, noteText.getMemo());
       } else {
         Assert.assertFalse(true);
@@ -536,16 +546,16 @@ public class SendCoinShieldTest {
   public void testDefaultAddress() throws ZksnarkException, BadItemException {
     PaymentAddress paymentAddress = SpendingKey.random().defaultAddress();
     Assert.assertNotEquals("0000000000000000000000000000000000000000000000000000000000000000",
-        ByteArray.toHexString(paymentAddress.getPkD()));
+            ByteArray.toHexString(paymentAddress.getPkD()));
   }
 
   @Test
   public void pushShieldedTransactionAndDecryptWithOvk()
-      throws ContractValidateException, TooBigTransactionException,
-      TooBigTransactionResultException, TaposException, TransactionExpirationException,
-      ReceiptCheckErrException, DupTransactionException, VMIllegalException,
-      ValidateSignatureException, BadItemException, ContractExeException,
-      AccountResourceInsufficientException, InvalidProtocolBufferException, ZksnarkException {
+          throws ContractValidateException, TooBigTransactionException,
+          TooBigTransactionResultException, TaposException, TransactionExpirationException,
+          ReceiptCheckErrException, DupTransactionException, VMIllegalException,
+          ValidateSignatureException, BadItemException, ContractExeException,
+          AccountResourceInsufficientException, InvalidProtocolBufferException, ZksnarkException {
     long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
 
     librustzcashInitZksnarkParams();
@@ -555,7 +565,7 @@ public class SendCoinShieldTest {
 
     // generate spend proof
     SpendingKey sk = SpendingKey
-        .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
+            .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
     ExpandedSpendingKey expsk = sk.expandedSpendingKey();
     byte[] senderOvk = expsk.getOvk();
     PaymentAddress address = sk.defaultAddress();
@@ -563,7 +573,7 @@ public class SendCoinShieldTest {
     IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
     byte[] anchor = voucher.root().getContent().toByteArray();
     dbManager.getMerkleContainer()
-        .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
+            .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
     builder.addSpend(expsk, note, anchor, voucher);
 
     // generate output proof
@@ -573,8 +583,8 @@ public class SendCoinShieldTest {
     PaymentAddress paymentAddress = incomingViewingKey.address(new DiversifierT()).get();
     byte[] memo = org.tron.keystore.Wallet.generateRandomBytes(512);
     builder
-        .addOutput(senderOvk, paymentAddress, 1000 * 1000000L - wallet.getShieldedTransactionFee(),
-            memo);
+            .addOutput(senderOvk, paymentAddress, 1000 * 1000000L - wallet.getShieldedTransactionFee(),
+                    memo);
 
     TransactionCapsule transactionCap = builder.build();
     boolean ok = dbManager.pushTransaction(transactionCap);
@@ -587,16 +597,16 @@ public class SendCoinShieldTest {
         continue;
       }
       ShieldedTransferContract stContract = c.getParameter()
-          .unpack(ShieldedTransferContract.class);
+              .unpack(ShieldedTransferContract.class);
       ReceiveDescription receiveDescription = stContract.getReceiveDescription(0);
 
       //first try to decrypt cOut with ovk, get pkd、esk
       Encryption.OutCiphertext cOut = new Encryption.OutCiphertext();
       cOut.setData(receiveDescription.getCOut().toByteArray());
       Optional<OutgoingPlaintext> notePlaintext = OutgoingPlaintext.decrypt(cOut,//ciphertext
-          senderOvk, receiveDescription.getValueCommitment().toByteArray(), //cv
-          receiveDescription.getNoteCommitment().toByteArray(), //cmu
-          receiveDescription.getEpk().toByteArray() //epk
+              senderOvk, receiveDescription.getValueCommitment().toByteArray(), //cv
+              receiveDescription.getNoteCommitment().toByteArray(), //cmu
+              receiveDescription.getEpk().toByteArray() //epk
       );
 
       //then decrypt c_enc with pkd、esk, get decoded note == ciphertext
@@ -606,8 +616,8 @@ public class SendCoinShieldTest {
         Encryption.EncCiphertext ciphertext = new Encryption.EncCiphertext();
         ciphertext.setData(receiveDescription.getCEnc().toByteArray());
         Optional<Note> foo = Note.decrypt(ciphertext, receiveDescription.getEpk().toByteArray(),
-            decryptedOutgoingPlaintext.getEsk(), decryptedOutgoingPlaintext.getPkD(),
-            receiveDescription.getNoteCommitment().toByteArray());
+                decryptedOutgoingPlaintext.getEsk(), decryptedOutgoingPlaintext.getPkD(),
+                receiveDescription.getNoteCommitment().toByteArray());
 
         if (foo.isPresent()) {
           Note bar = foo.get();
@@ -627,7 +637,7 @@ public class SendCoinShieldTest {
 
   private byte[] getHash() {
     return Sha256Hash.of(CommonParameter
-        .getInstance().isECKeyCryptoEngine(), "this is a test".getBytes()).getBytes();
+            .getInstance().isECKeyCryptoEngine(), "this is a test".getBytes()).getBytes();
   }
 
   public void checkZksnark() throws BadItemException, ZksnarkException {
@@ -639,14 +649,14 @@ public class SendCoinShieldTest {
     dbManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(4010 * 1000000L);
     ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
     SpendingKey sk = SpendingKey
-        .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
+            .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
     ExpandedSpendingKey expsk = sk.expandedSpendingKey();
     PaymentAddress address = sk.defaultAddress();
     Note note = new Note(address, 4010 * 1000000L);
     IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
     byte[] anchor = voucher.root().getContent().toByteArray();
     dbManager.getMerkleContainer()
-        .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
+            .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
     builder.addSpend(expsk, note, anchor, voucher);
     // generate output proof
     SpendingKey spendingKey = SpendingKey.random();
@@ -657,8 +667,8 @@ public class SendCoinShieldTest {
     TransactionCapsule transactionCap = builder.build();
     JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
     boolean ret = ZksnarkClient.getInstance().checkZksnarkProof(transactionCap.getInstance(),
-        getShieldTransactionHashIgnoreTypeException(transactionCap.getInstance()),
-        10 * 1000000);
+            getShieldTransactionHashIgnoreTypeException(transactionCap.getInstance()),
+            10 * 1000000);
     Assert.assertTrue(ret);
   }
 
@@ -667,7 +677,7 @@ public class SendCoinShieldTest {
     librustzcashInitZksnarkParams();
     ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
     SpendingKey sk = SpendingKey
-        .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
+            .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
     ExpandedSpendingKey expsk = sk.expandedSpendingKey();
     PaymentAddress address = sk.defaultAddress();
     long value = 100;
@@ -680,20 +690,20 @@ public class SendCoinShieldTest {
     SpendDescriptionInfo spend = new SpendDescriptionInfo(expsk, note, anchor, voucher);
     long proofContext = JLibrustzcash.librustzcashSaplingProvingCtxInit();
     SpendDescriptionCapsule spendDescriptionCapsule = builder
-        .generateSpendProof(spend, proofContext);
+            .generateSpendProof(spend, proofContext);
     JLibrustzcash.librustzcashSaplingProvingCtxFree(proofContext);
 
     byte[] result = new byte[64];
     JLibrustzcash.librustzcashSaplingSpendSig(
-        new SpendSigParams(expsk.getAsk(), spend.getAlpha(), getHash(), result));
+            new SpendSigParams(expsk.getAsk(), spend.getAlpha(), getHash(), result));
 
     long verifyContext = JLibrustzcash.librustzcashSaplingVerificationCtxInit();
     boolean ok = JLibrustzcash.librustzcashSaplingCheckSpend(new CheckSpendParams(verifyContext,
-        spendDescriptionCapsule.getValueCommitment().toByteArray(),
-        spendDescriptionCapsule.getAnchor().toByteArray(),
-        spendDescriptionCapsule.getNullifier().toByteArray(),
-        spendDescriptionCapsule.getRk().toByteArray(),
-        spendDescriptionCapsule.getZkproof().toByteArray(), result, getHash()));
+            spendDescriptionCapsule.getValueCommitment().toByteArray(),
+            spendDescriptionCapsule.getAnchor().toByteArray(),
+            spendDescriptionCapsule.getNullifier().toByteArray(),
+            spendDescriptionCapsule.getRk().toByteArray(),
+            spendDescriptionCapsule.getZkproof().toByteArray(), result, getHash()));
     JLibrustzcash.librustzcashSaplingVerificationCtxFree(verifyContext);
     Assert.assertEquals(ok, true);
   }
@@ -705,7 +715,7 @@ public class SendCoinShieldTest {
     librustzcashInitZksnarkParams();
     ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
     SpendingKey sk = SpendingKey
-        .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
+            .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
     ExpandedSpendingKey expsk = sk.expandedSpendingKey();
     PaymentAddress address = sk.defaultAddress();
     Note note = new Note(address, 4010 * 1000000L);
@@ -724,18 +734,18 @@ public class SendCoinShieldTest {
     // test create binding sig
     byte[] bindingSig = new byte[64];
     boolean ret = JLibrustzcash.librustzcashSaplingBindingSig(
-        new BindingSigParams(ctx, builder.getValueBalance(), getHash(), bindingSig));
+            new BindingSigParams(ctx, builder.getValueBalance(), getHash(), bindingSig));
     JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
     Assert.assertTrue(ret);
   }
 
   @Test
   public void pushShieldedTransaction()
-      throws ContractValidateException, TooBigTransactionException,
-      TooBigTransactionResultException,
-      TaposException, TransactionExpirationException, ReceiptCheckErrException,
-      DupTransactionException, VMIllegalException, ValidateSignatureException, BadItemException,
-      ContractExeException, AccountResourceInsufficientException, ZksnarkException {
+          throws ContractValidateException, TooBigTransactionException,
+          TooBigTransactionResultException,
+          TaposException, TransactionExpirationException, ReceiptCheckErrException,
+          DupTransactionException, VMIllegalException, ValidateSignatureException, BadItemException,
+          ContractExeException, AccountResourceInsufficientException, ZksnarkException {
     long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
     // generate spend proof
     librustzcashInitZksnarkParams();
@@ -743,14 +753,14 @@ public class SendCoinShieldTest {
     dbManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(4010 * 1000000L);
     ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
     SpendingKey sk = SpendingKey
-        .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
+            .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
     ExpandedSpendingKey expsk = sk.expandedSpendingKey();
     PaymentAddress address = sk.defaultAddress();
     Note note = new Note(address, 4010 * 1000000L);
     IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
     byte[] anchor = voucher.root().getContent().toByteArray();
     dbManager.getMerkleContainer()
-        .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
+            .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
     builder.addSpend(expsk, note, anchor, voucher);
     // generate output proof
     SpendingKey spendingKey = SpendingKey.random();
@@ -758,7 +768,7 @@ public class SendCoinShieldTest {
     IncomingViewingKey incomingViewingKey = fullViewingKey.inViewingKey();
     PaymentAddress paymentAddress = incomingViewingKey.address(DiversifierT.random()).get();
     builder.addOutput(fullViewingKey.getOvk(), paymentAddress,
-        4010 * 1000000L - wallet.getShieldedTransactionFee(), new byte[512]);
+            4010 * 1000000L - wallet.getShieldedTransactionFee(), new byte[512]);
     TransactionCapsule transactionCap = builder.build();
     boolean ok = dbManager.pushTransaction(transactionCap);
     JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
@@ -772,7 +782,7 @@ public class SendCoinShieldTest {
     ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
     // generate spend proof
     SpendingKey sk = SpendingKey
-        .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
+            .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
     ExpandedSpendingKey expsk = sk.expandedSpendingKey();
     PaymentAddress address = sk.defaultAddress();
     Note note = new Note(address, 4010 * 1000000L);
@@ -780,7 +790,7 @@ public class SendCoinShieldTest {
     byte[] anchor = voucher.root().getContent().toByteArray();
     builder.addSpend(expsk, note, anchor, voucher);
     SpendDescriptionCapsule spendDescriptionCapsule = builder
-        .generateSpendProof(builder.getSpends().get(0), ctx);
+            .generateSpendProof(builder.getSpends().get(0), ctx);
     // generate output proof
     SpendingKey spendingKey = SpendingKey.random();
     FullViewingKey fullViewingKey = spendingKey.fullViewingKey();
@@ -788,41 +798,41 @@ public class SendCoinShieldTest {
     PaymentAddress paymentAddress = incomingViewingKey.address(new DiversifierT()).get();
     builder.addOutput(fullViewingKey.getOvk(), paymentAddress, 4000 * 1000000L, new byte[512]);
     ReceiveDescriptionCapsule receiveDescriptionCapsule = builder
-        .generateOutputProof(builder.getReceives().get(0), ctx);
+            .generateOutputProof(builder.getReceives().get(0), ctx);
 
     //create binding sig
     byte[] bindingSig = new byte[64];
     boolean ret = JLibrustzcash.librustzcashSaplingBindingSig(
-        new BindingSigParams(ctx, builder.getValueBalance(), getHash(), bindingSig));
+            new BindingSigParams(ctx, builder.getValueBalance(), getHash(), bindingSig));
     JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
     Assert.assertTrue(ret);
     // check spend
     ctx = JLibrustzcash.librustzcashSaplingVerificationCtxInit();
     byte[] result = new byte[64];
     JLibrustzcash.librustzcashSaplingSpendSig(
-        new SpendSigParams(expsk.getAsk(), builder.getSpends().get(0).getAlpha(), getHash(),
-            result));
+            new SpendSigParams(expsk.getAsk(), builder.getSpends().get(0).getAlpha(), getHash(),
+                    result));
 
     SpendDescription spendDescription = spendDescriptionCapsule.getInstance();
     boolean ok;
     ok = JLibrustzcash.librustzcashSaplingCheckSpend(
-        new CheckSpendParams(ctx, spendDescription.getValueCommitment().toByteArray(),
-            spendDescription.getAnchor().toByteArray(),
-            spendDescription.getNullifier().toByteArray(), spendDescription.getRk().toByteArray(),
-            spendDescription.getZkproof().toByteArray(), result, getHash()));
+            new CheckSpendParams(ctx, spendDescription.getValueCommitment().toByteArray(),
+                    spendDescription.getAnchor().toByteArray(),
+                    spendDescription.getNullifier().toByteArray(), spendDescription.getRk().toByteArray(),
+                    spendDescription.getZkproof().toByteArray(), result, getHash()));
     Assert.assertTrue(ok);
 
     // check output
     ReceiveDescription receiveDescription = receiveDescriptionCapsule.getInstance();
     ok = JLibrustzcash.librustzcashSaplingCheckOutput(
-        new CheckOutputParams(ctx, receiveDescription.getValueCommitment().toByteArray(),
-            receiveDescription.getNoteCommitment().toByteArray(),
-            receiveDescription.getEpk().toByteArray(),
-            receiveDescription.getZkproof().toByteArray()));
+            new CheckOutputParams(ctx, receiveDescription.getValueCommitment().toByteArray(),
+                    receiveDescription.getNoteCommitment().toByteArray(),
+                    receiveDescription.getEpk().toByteArray(),
+                    receiveDescription.getZkproof().toByteArray()));
     Assert.assertTrue(ok);
     // final check
     ok = JLibrustzcash.librustzcashSaplingFinalCheck(
-        new FinalCheckParams(ctx, builder.getValueBalance(), bindingSig, getHash()));
+            new FinalCheckParams(ctx, builder.getValueBalance(), bindingSig, getHash()));
     Assert.assertTrue(ok);
     JLibrustzcash.librustzcashSaplingVerificationCtxFree(ctx);
   }
@@ -832,7 +842,7 @@ public class SendCoinShieldTest {
     byte[] bytes = IncrementalMerkleTreeContainer.emptyRoot().getContent().toByteArray();
     ByteUtil.reverse(bytes);
     Assert.assertEquals("3e49b5f954aa9d3545bc6c37744661eea48d7c34e3000d82b7f0010c30f4c2fb",
-        ByteArray.toHexString(bytes));
+            ByteArray.toHexString(bytes));
   }
 
   @Test
@@ -848,7 +858,7 @@ public class SendCoinShieldTest {
 
   private JSONArray readFile(String fileName) throws Exception {
     String file1 = SendCoinShieldTest.class.getClassLoader()
-        .getResource("json" + File.separator + fileName).getFile();
+            .getResource("json" + File.separator + fileName).getFile();
     List<String> readLines = Files.readLines(new File(file1), Charsets.UTF_8);
     JSONArray array = JSONArray.parseArray(readLines.stream().reduce((s, s2) -> s + s2).get());
     return array;
@@ -859,11 +869,11 @@ public class SendCoinShieldTest {
   public void testComputeCm() throws Exception {
     byte[] result = new byte[32];
     if (!JLibrustzcash.librustzcashComputeCm(
-        new ComputeCmParams((ByteArray.fromHexString("fc6eb90855700861de6639")), ByteArray
-            .fromHexString("1abfbf64bc4934aaf7f29b9fea995e5a16e654e63dbe07db0ef035499d216e19"),
-            9990000000L, ByteArray
-            .fromHexString("08e3a2ff1101b628147125b786c757b483f1cf7c309f8a647055bfb1ca819c02"),
-            result))) {
+            new ComputeCmParams((ByteArray.fromHexString("fc6eb90855700861de6639")), ByteArray
+                    .fromHexString("1abfbf64bc4934aaf7f29b9fea995e5a16e654e63dbe07db0ef035499d216e19"),
+                    9990000000L, ByteArray
+                    .fromHexString("08e3a2ff1101b628147125b786c757b483f1cf7c309f8a647055bfb1ca819c02"),
+                    result))) {
       System.out.println(" error");
     } else {
       System.out.println(" ok");
@@ -873,15 +883,15 @@ public class SendCoinShieldTest {
   @Test
   public void getSpendingKey() throws Exception {
     SpendingKey sk = SpendingKey
-        .decode("0b862f0e70048551c08518ff49a19db027d62cdeeb2fa974db91c10e6ebcdc16");
+            .decode("0b862f0e70048551c08518ff49a19db027d62cdeeb2fa974db91c10e6ebcdc16");
     System.out.println(sk.encode());
     System.out.println(
-        "sk.expandedSpendingKey()" + ByteArray.toHexString(sk.expandedSpendingKey().encode()));
+            "sk.expandedSpendingKey()" + ByteArray.toHexString(sk.expandedSpendingKey().encode()));
     System.out.println("sk.fullViewKey()" + ByteArray.toHexString(sk.fullViewingKey().encode()));
     System.out
-        .println("sk.ivk()" + ByteArray.toHexString(sk.fullViewingKey().inViewingKey().getValue()));
+            .println("sk.ivk()" + ByteArray.toHexString(sk.fullViewingKey().inViewingKey().getValue()));
     System.out.println(
-        "sk.defaultDiversifier:" + ByteArray.toHexString(sk.defaultDiversifier().getData()));
+            "sk.defaultDiversifier:" + ByteArray.toHexString(sk.defaultDiversifier().getData()));
 
     System.out.println("sk.defaultAddress:" + ByteArray.toHexString(sk.defaultAddress().encode()));
 
@@ -934,9 +944,9 @@ public class SendCoinShieldTest {
       // check
       PaymentAddress paymentAddress = KeyIo.decodePaymentAddress(address);
       Assert.assertEquals(ByteArray.toHexString(paymentAddress.getD().getData()),
-          ByteArray.toHexString(d));
+              ByteArray.toHexString(d));
       Assert.assertEquals(ByteArray.toHexString(paymentAddress.getPkD()),
-          ByteArray.toHexString(op.get().getPkD()));
+              ByteArray.toHexString(op.get().getPkD()));
 
     }
   }
@@ -954,7 +964,7 @@ public class SendCoinShieldTest {
     PaymentAddress address1 = sk1.defaultAddress();
     Note note1 = new Note(address1, 1000 * 1000000L);
     IncrementalMerkleTreeContainer tree = new IncrementalMerkleTreeContainer(
-        new IncrementalMerkleTreeCapsule());
+            new IncrementalMerkleTreeCapsule());
     PedersenHashCapsule compressCapsule1 = new PedersenHashCapsule();
     compressCapsule1.setContent(ByteString.copyFrom(note1.cm()));
     PedersenHash a = compressCapsule1.getInstance();
@@ -962,7 +972,7 @@ public class SendCoinShieldTest {
     IncrementalMerkleVoucherContainer voucher = tree.toVoucher();
     byte[] anchor = voucher.root().getContent().toByteArray();
     dbManager.getMerkleContainer()
-        .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
+            .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
     builder.addSpend(expsk1, note1, anchor, voucher);
 
     /*SpendingKey sk2 = SpendingKey.random();
@@ -986,7 +996,7 @@ public class SendCoinShieldTest {
     IncomingViewingKey incomingViewingKey = fullViewingKey.inViewingKey();
     PaymentAddress paymentAddress = incomingViewingKey.address(new DiversifierT()).get();
     builder.addOutput(fullViewingKey.getOvk(), paymentAddress,
-        1000 * 1000000L - wallet.getShieldedTransactionFee(), new byte[512]);
+            1000 * 1000000L - wallet.getShieldedTransactionFee(), new byte[512]);
     TransactionCapsule transactionCap = builder.build();
     //execute
     List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
@@ -1010,14 +1020,20 @@ public class SendCoinShieldTest {
     {
       ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
       String OWNER_ADDRESS =
-          Wallet.getAddressPreFixString() + "548794500882809695a8a687866e76d4271a1abc";
+              Wallet.getAddressPreFixString() + "548794500882809695a8a687866e76d4271a1abc";
       AccountCapsule ownerCapsule = new AccountCapsule(ByteString.copyFromUtf8("owner"),
-          ByteString.copyFrom(ByteArray.fromHexString(OWNER_ADDRESS)), AccountType.Normal,
-          110_000_000L);
-      ownerCapsule.setInstance(ownerCapsule.getInstance().toBuilder()
-          .putAssetV2(CommonParameter.getInstance().zenTokenId, 110_000_000L).build());
-
+              ByteString.copyFrom(ByteArray.fromHexString(OWNER_ADDRESS)), AccountType.Normal,
+              110_000_000L);
       dbManager.getAccountStore().put(ownerCapsule.getAddress().toByteArray(), ownerCapsule);
+
+      AccountAssetIssueCapsule ownerAccountAssetIssue = new AccountAssetIssueCapsule(
+              ByteString.copyFromUtf8("owner"),
+              ByteString.copyFrom(ByteArray.fromHexString(OWNER_ADDRESS))
+      );
+      ownerAccountAssetIssue.setInstance(ownerAccountAssetIssue.getInstance().toBuilder()
+              .putAssetV2(CommonParameter.getInstance().zenTokenId, 110_000_000L).build());
+      dbManager.getAccountAssetIssueStore().put(ownerAccountAssetIssue.getAddress().toByteArray(), ownerAccountAssetIssue);
+
       builder.setTransparentInput(ByteArray.fromHexString(OWNER_ADDRESS), 100_000_000L);
 
       // generate output proof
@@ -1045,14 +1061,21 @@ public class SendCoinShieldTest {
       ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
 
       String OWNER_ADDRESS =
-          Wallet.getAddressPreFixString() + "548794500882809695a8a687866e76d4271a1abc";
+              Wallet.getAddressPreFixString() + "548794500882809695a8a687866e76d4271a1abc";
       AccountCapsule ownerCapsule = new AccountCapsule(ByteString.copyFromUtf8("owner"),
-          ByteString.copyFrom(ByteArray.fromHexString(OWNER_ADDRESS)), AccountType.Normal,
-          110_000_000L);
-
-      ownerCapsule.setInstance(ownerCapsule.getInstance().toBuilder()
-          .putAssetV2(CommonParameter.getInstance().zenTokenId, 110_000_000L).build());
+              ByteString.copyFrom(ByteArray.fromHexString(OWNER_ADDRESS)), AccountType.Normal,
+              110_000_000L);
       dbManager.getAccountStore().put(ownerCapsule.getAddress().toByteArray(), ownerCapsule);
+
+      AccountAssetIssueCapsule ownerAccountAssetIssue = new AccountAssetIssueCapsule(
+              ByteString.copyFromUtf8("owner"),
+              ByteString.copyFrom(ByteArray.fromHexString(OWNER_ADDRESS))
+      );
+      ownerAccountAssetIssue.setInstance(ownerAccountAssetIssue.getInstance().toBuilder()
+              .putAssetV2(CommonParameter.getInstance().zenTokenId, 110_000_000L).build());
+      dbManager.getAccountAssetIssueStore().put(ownerAccountAssetIssue.getAddress().toByteArray(),
+              ownerAccountAssetIssue);
+
       builder.setTransparentInput(ByteArray.fromHexString(OWNER_ADDRESS), 100_000_000L);
 
       // generate output proof
@@ -1063,10 +1086,15 @@ public class SendCoinShieldTest {
       builder.addOutput(fullViewingKey.getOvk(), paymentAddress, 200 * 1000000L, new byte[512]);
 
       String TO_ADDRESS =
-          Wallet.getAddressPreFixString() + "b48794500882809695a8a687866e76d4271a1abc";
+              Wallet.getAddressPreFixString() + "b48794500882809695a8a687866e76d4271a1abc";
       AccountCapsule toCapsule = new AccountCapsule(ByteString.copyFromUtf8("to"),
-          ByteString.copyFrom(ByteArray.fromHexString(TO_ADDRESS)), AccountType.Normal, 0L);
+              ByteString.copyFrom(ByteArray.fromHexString(TO_ADDRESS)), AccountType.Normal, 0L);
       dbManager.getAccountStore().put(toCapsule.getAddress().toByteArray(), toCapsule);
+      AccountAssetIssueCapsule toAccountAssetIssue = new AccountAssetIssueCapsule(
+              ByteString.copyFromUtf8("to"),
+              ByteString.copyFrom(ByteArray.fromHexString(TO_ADDRESS))
+      );
+      dbManager.getAccountAssetIssueStore().put(toAccountAssetIssue.getAddress().toByteArray(), toAccountAssetIssue);
       builder.setTransparentOutput(ByteArray.fromHexString(TO_ADDRESS), 10_000_000L);
 
       TransactionCapsule transactionCap = builder.build();
@@ -1093,7 +1121,7 @@ public class SendCoinShieldTest {
       Note note1 = new Note(address1, 110 * 1000000L);
 
       IncrementalMerkleTreeContainer tree = new IncrementalMerkleTreeContainer(
-          new IncrementalMerkleTreeCapsule());
+              new IncrementalMerkleTreeCapsule());
       PedersenHashCapsule compressCapsule1 = new PedersenHashCapsule();
       compressCapsule1.setContent(ByteString.copyFrom(note1.cm()));
       PedersenHash a = compressCapsule1.getInstance();
@@ -1101,22 +1129,29 @@ public class SendCoinShieldTest {
       IncrementalMerkleVoucherContainer voucher = tree.toVoucher();
       byte[] anchor = voucher.root().getContent().toByteArray();
       dbManager.getMerkleContainer()
-          .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
+              .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
 
       //add spendDesc into builder
       builder.addSpend(expsk1, note1, anchor, voucher);
 
       String TO_ADDRESS =
-          Wallet.getAddressPreFixString() + "b48794500882809695a8a687866e76d4271a1abc";
+              Wallet.getAddressPreFixString() + "b48794500882809695a8a687866e76d4271a1abc";
       AccountCapsule toCapsule = new AccountCapsule(ByteString.copyFromUtf8("to"),
-          ByteString.copyFrom(ByteArray.fromHexString(TO_ADDRESS)), AccountType.Normal, 0L);
+              ByteString.copyFrom(ByteArray.fromHexString(TO_ADDRESS)), AccountType.Normal, 0L);
       dbManager.getAccountStore().put(toCapsule.getAddress().toByteArray(), toCapsule);
+
+      AccountAssetIssueCapsule toAccountAssetIssue = new AccountAssetIssueCapsule(
+              ByteString.copyFromUtf8("to"),
+              ByteString.copyFrom(ByteArray.fromHexString(TO_ADDRESS))
+      );
+      dbManager.getAccountAssetIssueStore().put(toAccountAssetIssue.getAddress().toByteArray(), toAccountAssetIssue);
+
       addZeroValueOutputNote(builder);
       builder.setTransparentOutput(ByteArray.fromHexString(TO_ADDRESS), 10_000_000L);
 
       TransactionCapsule transactionCap = builder.build();
 
-      //   0L + 110_000_000L  !=  200_000_000L + 0L + 10_000_000L
+      //  0L + 110_000_000L  !=  200_000_000L + 0L + 10_000_000L
       try {
         executeTx(transactionCap);
         Assert.fail();
@@ -1138,7 +1173,7 @@ public class SendCoinShieldTest {
       Note note1 = new Note(address1, 110 * 1000000L);
 
       IncrementalMerkleTreeContainer tree = new IncrementalMerkleTreeContainer(
-          new IncrementalMerkleTreeCapsule());
+              new IncrementalMerkleTreeCapsule());
       PedersenHashCapsule compressCapsule1 = new PedersenHashCapsule();
       compressCapsule1.setContent(ByteString.copyFrom(note1.cm()));
       PedersenHash a = compressCapsule1.getInstance();
@@ -1146,7 +1181,7 @@ public class SendCoinShieldTest {
       IncrementalMerkleVoucherContainer voucher = tree.toVoucher();
       byte[] anchor = voucher.root().getContent().toByteArray();
       dbManager.getMerkleContainer()
-          .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
+              .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
 
       //add spendDesc into builder
       builder.addSpend(expsk1, note1, anchor, voucher);
@@ -1160,7 +1195,7 @@ public class SendCoinShieldTest {
 
       TransactionCapsule transactionCap = builder.build();
 
-      //   110_000_000L + 0L!=  200_000_000L + 0L + 10_000_000L
+      //  110_000_000L + 0L!=  200_000_000L + 0L + 10_000_000L
       try {
         executeTx(transactionCap);
         Assert.fail();
@@ -1182,7 +1217,7 @@ public class SendCoinShieldTest {
       Note note1 = new Note(address1, 110 * 1000000L);
 
       IncrementalMerkleTreeContainer tree = new IncrementalMerkleTreeContainer(
-          new IncrementalMerkleTreeCapsule());
+              new IncrementalMerkleTreeCapsule());
       PedersenHashCapsule compressCapsule1 = new PedersenHashCapsule();
       compressCapsule1.setContent(ByteString.copyFrom(note1.cm()));
       PedersenHash a = compressCapsule1.getInstance();
@@ -1190,7 +1225,7 @@ public class SendCoinShieldTest {
       IncrementalMerkleVoucherContainer voucher = tree.toVoucher();
       byte[] anchor = voucher.root().getContent().toByteArray();
       dbManager.getMerkleContainer()
-          .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
+              .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
 
       //add spendDesc into builder
       builder.addSpend(expsk1, note1, anchor, voucher);
@@ -1203,15 +1238,15 @@ public class SendCoinShieldTest {
       builder.addOutput(fullViewingKey.getOvk(), paymentAddress, 200 * 1000000L, new byte[512]);
 
       String TO_ADDRESS =
-          Wallet.getAddressPreFixString() + "b48794500882809695a8a687866e76d4271a1abc";
+              Wallet.getAddressPreFixString() + "b48794500882809695a8a687866e76d4271a1abc";
       AccountCapsule toCapsule = new AccountCapsule(ByteString.copyFromUtf8("to"),
-          ByteString.copyFrom(ByteArray.fromHexString(TO_ADDRESS)), AccountType.Normal, 0L);
+              ByteString.copyFrom(ByteArray.fromHexString(TO_ADDRESS)), AccountType.Normal, 0L);
       dbManager.getAccountStore().put(toCapsule.getAddress().toByteArray(), toCapsule);
       builder.setTransparentOutput(ByteArray.fromHexString(TO_ADDRESS), 10_000_000L);
 
       TransactionCapsule transactionCap = builder.build();
 
-      //     0L + 110_000_000L !=  200_000_000L + 10_000_000L + 10_000_000L
+      //    0L + 110_000_000L !=  200_000_000L + 10_000_000L + 10_000_000L
       try {
         executeTx(transactionCap);
         Assert.fail();
@@ -1232,13 +1267,13 @@ public class SendCoinShieldTest {
     {
       ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
       String OWNER_ADDRESS =
-          Wallet.getAddressPreFixString() + "548794500882809695a8a687866e76d4271a1abc";
+              Wallet.getAddressPreFixString() + "548794500882809695a8a687866e76d4271a1abc";
       AccountCapsule ownerCapsule = new AccountCapsule(ByteString.copyFromUtf8("owner"),
-          ByteString.copyFrom(ByteArray.fromHexString(OWNER_ADDRESS)), AccountType.Normal,
-          220_000_000L);
+              ByteString.copyFrom(ByteArray.fromHexString(OWNER_ADDRESS)), AccountType.Normal,
+              220_000_000L);
 
       ownerCapsule.setInstance(ownerCapsule.getInstance().toBuilder()
-          .putAssetV2(CommonParameter.getInstance().zenTokenId, 220_000_000L).build());
+              .putAssetV2(CommonParameter.getInstance().zenTokenId, 220_000_000L).build());
       dbManager.getAccountStore().put(ownerCapsule.getAddress().toByteArray(), ownerCapsule);
       builder.setTransparentInput(ByteArray.fromHexString(OWNER_ADDRESS), 210_000_000L);
 
@@ -1261,12 +1296,12 @@ public class SendCoinShieldTest {
       ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
 
       String OWNER_ADDRESS =
-          Wallet.getAddressPreFixString() + "548794500882809695a8a687866e76d4271a1abc";
+              Wallet.getAddressPreFixString() + "548794500882809695a8a687866e76d4271a1abc";
       AccountCapsule ownerCapsule = new AccountCapsule(ByteString.copyFromUtf8("owner"),
-          ByteString.copyFrom(ByteArray.fromHexString(OWNER_ADDRESS)), AccountType.Normal,
-          230_000_000L);
+              ByteString.copyFrom(ByteArray.fromHexString(OWNER_ADDRESS)), AccountType.Normal,
+              230_000_000L);
       ownerCapsule.setInstance(ownerCapsule.getInstance().toBuilder()
-          .putAssetV2(CommonParameter.getInstance().zenTokenId, 230_000_000L).build());
+              .putAssetV2(CommonParameter.getInstance().zenTokenId, 230_000_000L).build());
       dbManager.getAccountStore().put(ownerCapsule.getAddress().toByteArray(), ownerCapsule);
       builder.setTransparentInput(ByteArray.fromHexString(OWNER_ADDRESS), 220_000_000L);
 
@@ -1278,9 +1313,9 @@ public class SendCoinShieldTest {
       builder.addOutput(fullViewingKey.getOvk(), paymentAddress, 200 * 1000000L, new byte[512]);
 
       String TO_ADDRESS =
-          Wallet.getAddressPreFixString() + "b48794500882809695a8a687866e76d4271a1abc";
+              Wallet.getAddressPreFixString() + "b48794500882809695a8a687866e76d4271a1abc";
       AccountCapsule toCapsule = new AccountCapsule(ByteString.copyFromUtf8("to"),
-          ByteString.copyFrom(ByteArray.fromHexString(TO_ADDRESS)), AccountType.Normal, 0L);
+              ByteString.copyFrom(ByteArray.fromHexString(TO_ADDRESS)), AccountType.Normal, 0L);
       dbManager.getAccountStore().put(toCapsule.getAddress().toByteArray(), toCapsule);
       builder.setTransparentOutput(ByteArray.fromHexString(TO_ADDRESS), 10_000_000L);
 
@@ -1303,7 +1338,7 @@ public class SendCoinShieldTest {
       Note note1 = new Note(address1, 20 * 1000000L);
 
       IncrementalMerkleTreeContainer tree = new IncrementalMerkleTreeContainer(
-          new IncrementalMerkleTreeCapsule());
+              new IncrementalMerkleTreeCapsule());
       PedersenHashCapsule compressCapsule1 = new PedersenHashCapsule();
       compressCapsule1.setContent(ByteString.copyFrom(note1.cm()));
       PedersenHash a = compressCapsule1.getInstance();
@@ -1311,15 +1346,15 @@ public class SendCoinShieldTest {
       IncrementalMerkleVoucherContainer voucher = tree.toVoucher();
       byte[] anchor = voucher.root().getContent().toByteArray();
       dbManager.getMerkleContainer()
-          .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
+              .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
 
       //add spendDesc into builder
       builder.addSpend(expsk1, note1, anchor, voucher);
 
       String TO_ADDRESS =
-          Wallet.getAddressPreFixString() + "b48794500882809695a8a687866e76d4271a1abc";
+              Wallet.getAddressPreFixString() + "b48794500882809695a8a687866e76d4271a1abc";
       AccountCapsule toCapsule = new AccountCapsule(ByteString.copyFromUtf8("to"),
-          ByteString.copyFrom(ByteArray.fromHexString(TO_ADDRESS)), AccountType.Normal, 0L);
+              ByteString.copyFrom(ByteArray.fromHexString(TO_ADDRESS)), AccountType.Normal, 0L);
       dbManager.getAccountStore().put(toCapsule.getAddress().toByteArray(), toCapsule);
       builder.setTransparentOutput(ByteArray.fromHexString(TO_ADDRESS), 10_000_000L);
 
@@ -1359,7 +1394,7 @@ public class SendCoinShieldTest {
       Note note2 = new Note(address2, 20 * 1000000L);
 
       IncrementalMerkleTreeContainer tree = new IncrementalMerkleTreeContainer(
-          new IncrementalMerkleTreeCapsule());
+              new IncrementalMerkleTreeCapsule());
       PedersenHashCapsule compressCapsule1 = new PedersenHashCapsule();
       compressCapsule1.setContent(ByteString.copyFrom(note1.cm()));
       PedersenHash a = compressCapsule1.getInstance();
@@ -1367,7 +1402,7 @@ public class SendCoinShieldTest {
       IncrementalMerkleVoucherContainer voucher1 = tree.toVoucher();
       byte[] anchor1 = voucher1.root().getContent().toByteArray();
       dbManager.getMerkleContainer()
-          .putMerkleTreeIntoStore(anchor1, voucher1.getVoucherCapsule().getTree());
+              .putMerkleTreeIntoStore(anchor1, voucher1.getVoucherCapsule().getTree());
 
       PedersenHashCapsule compressCapsule2 = new PedersenHashCapsule();
       compressCapsule2.setContent(ByteString.copyFrom(note2.cm()));
@@ -1376,15 +1411,15 @@ public class SendCoinShieldTest {
       IncrementalMerkleVoucherContainer voucher2 = tree.toVoucher();
       byte[] anchor2 = voucher2.root().getContent().toByteArray();
       dbManager.getMerkleContainer()
-          .putMerkleTreeIntoStore(anchor2, voucher2.getVoucherCapsule().getTree());
+              .putMerkleTreeIntoStore(anchor2, voucher2.getVoucherCapsule().getTree());
 
       ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet) {
         @Override
         public SpendDescriptionCapsule generateSpendProof(SpendDescriptionInfo spend, long ctx)
-            throws ZksnarkException {
+                throws ZksnarkException {
 
           SpendDescriptionInfo fakeSpend = new SpendDescriptionInfo(expsk1, note1, anchor1,
-              voucher1);
+                  voucher1);
           super.generateSpendProof(fakeSpend, ctx);
           return super.generateSpendProof(spend, ctx);
         }
@@ -1394,9 +1429,9 @@ public class SendCoinShieldTest {
       builder.addSpend(expsk2, note2, anchor2, voucher2);
 
       String TO_ADDRESS =
-          Wallet.getAddressPreFixString() + "b48794500882809695a8a687866e76d4271a1abc";
+              Wallet.getAddressPreFixString() + "b48794500882809695a8a687866e76d4271a1abc";
       AccountCapsule toCapsule = new AccountCapsule(ByteString.copyFromUtf8("to"),
-          ByteString.copyFrom(ByteArray.fromHexString(TO_ADDRESS)), AccountType.Normal, 0L);
+              ByteString.copyFrom(ByteArray.fromHexString(TO_ADDRESS)), AccountType.Normal, 0L);
       dbManager.getAccountStore().put(toCapsule.getAddress().toByteArray(), toCapsule);
       addZeroValueOutputNote(builder);
       builder.setTransparentOutput(ByteArray.fromHexString(TO_ADDRESS), 10_000_000L);
@@ -1430,7 +1465,7 @@ public class SendCoinShieldTest {
       Note note2 = new Note(address2, 20 * 1000000L);
 
       IncrementalMerkleTreeContainer tree = new IncrementalMerkleTreeContainer(
-          new IncrementalMerkleTreeCapsule());
+              new IncrementalMerkleTreeCapsule());
 
       PedersenHashCapsule compressCapsule2 = new PedersenHashCapsule();
       compressCapsule2.setContent(ByteString.copyFrom(note2.cm()));
@@ -1439,12 +1474,12 @@ public class SendCoinShieldTest {
       IncrementalMerkleVoucherContainer voucher2 = tree.toVoucher();
       byte[] anchor2 = voucher2.root().getContent().toByteArray();
       dbManager.getMerkleContainer()
-          .putMerkleTreeIntoStore(anchor2, voucher2.getVoucherCapsule().getTree());
+              .putMerkleTreeIntoStore(anchor2, voucher2.getVoucherCapsule().getTree());
 
       ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet) {
         @Override
         public SpendDescriptionCapsule generateSpendProof(SpendDescriptionInfo spend, long ctx)
-            throws ZksnarkException {
+                throws ZksnarkException {
           long fakeCtx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
           return super.generateSpendProof(spend, fakeCtx);
         }
@@ -1454,9 +1489,9 @@ public class SendCoinShieldTest {
       builder.addSpend(expsk2, note2, anchor2, voucher2);
 
       String TO_ADDRESS =
-          Wallet.getAddressPreFixString() + "b48794500882809695a8a687866e76d4271a1abc";
+              Wallet.getAddressPreFixString() + "b48794500882809695a8a687866e76d4271a1abc";
       AccountCapsule toCapsule = new AccountCapsule(ByteString.copyFromUtf8("to"),
-          ByteString.copyFrom(ByteArray.fromHexString(TO_ADDRESS)), AccountType.Normal, 0L);
+              ByteString.copyFrom(ByteArray.fromHexString(TO_ADDRESS)), AccountType.Normal, 0L);
       dbManager.getAccountStore().put(toCapsule.getAddress().toByteArray(), toCapsule);
       addZeroValueOutputNote(builder);
       builder.setTransparentOutput(ByteArray.fromHexString(TO_ADDRESS), 10_000_000L);
@@ -1487,7 +1522,7 @@ public class SendCoinShieldTest {
       Note note2 = new Note(address2, 20 * 1000000L);
 
       IncrementalMerkleTreeContainer tree = new IncrementalMerkleTreeContainer(
-          new IncrementalMerkleTreeCapsule());
+              new IncrementalMerkleTreeCapsule());
 
       PedersenHashCapsule compressCapsule2 = new PedersenHashCapsule();
       compressCapsule2.setContent(ByteString.copyFrom(note2.cm()));
@@ -1497,17 +1532,17 @@ public class SendCoinShieldTest {
       byte[] anchor2 = voucher2.root().getContent().toByteArray();
 
       SpendDescriptionInfo spendDescriptionInfo = new SpendDescriptionInfo(expsk2, note2, anchor2,
-          voucher2);
+              voucher2);
       byte[] bytes = ByteArray
-          .fromHexString("0eadb4ea6533afa906673b0101343b00a6682093ccc81082d0970e5ed6f72cbd");
+              .fromHexString("0eadb4ea6533afa906673b0101343b00a6682093ccc81082d0970e5ed6f72cbd");
       spendDescriptionInfo.setAlpha(bytes);
 
       byte[] dataToBeSigned = ByteArray
-          .fromHexString("0eadb4ea6533afa906673b0101343b00a6682093ccc81082d0970e5ed6f72cbd");
+              .fromHexString("0eadb4ea6533afa906673b0101343b00a6682093ccc81082d0970e5ed6f72cbd");
       byte[] result = new byte[64];
       JLibrustzcash.librustzcashSaplingSpendSig(
-          new SpendSigParams(spendDescriptionInfo.getExpsk().getAsk(),
-              spendDescriptionInfo.getAlpha(), dataToBeSigned, result));
+              new SpendSigParams(spendDescriptionInfo.getExpsk().getAsk(),
+                      spendDescriptionInfo.getAlpha(), dataToBeSigned, result));
     }
   }
 
@@ -1530,7 +1565,7 @@ public class SendCoinShieldTest {
     byte[] anchor = voucher.root().getContent().toByteArray();
     builder.addSpend(expsk, note, anchor, voucher);
     SpendDescriptionCapsule spendDescriptionCapsule = builder
-        .generateSpendProof(builder.getSpends().get(0), ctx);
+            .generateSpendProof(builder.getSpends().get(0), ctx);
 
   }
 
@@ -1547,7 +1582,7 @@ public class SendCoinShieldTest {
       Note note2 = new Note(address2, 20 * 1000000L);
 
       IncrementalMerkleTreeContainer tree = new IncrementalMerkleTreeContainer(
-          new IncrementalMerkleTreeCapsule());
+              new IncrementalMerkleTreeCapsule());
 
       PedersenHashCapsule compressCapsule2 = new PedersenHashCapsule();
       compressCapsule2.setContent(ByteString.copyFrom(note2.cm()));
@@ -1556,10 +1591,10 @@ public class SendCoinShieldTest {
       IncrementalMerkleVoucherContainer voucher2 = tree.toVoucher();
       byte[] anchor2 = voucher2.root().getContent().toByteArray();
       dbManager.getMerkleContainer()
-          .putMerkleTreeIntoStore(anchor2, voucher2.getVoucherCapsule().getTree());
+              .putMerkleTreeIntoStore(anchor2, voucher2.getVoucherCapsule().getTree());
 
       byte[] fakeAsk = ByteArray
-          .fromHexString("0xe7db4ea6533afa906673b0101343b00a6682093ccc81082d0970e5ed6f72cb6");
+              .fromHexString("0xe7db4ea6533afa906673b0101343b00a6682093ccc81082d0970e5ed6f72cb6");
 
       ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet) {
         @Override
@@ -1567,10 +1602,10 @@ public class SendCoinShieldTest {
           for (int i = 0; i < this.getSpends().size(); i++) {
             byte[] result = new byte[64];
             JLibrustzcash.librustzcashSaplingSpendSig(
-                new SpendSigParams(fakeAsk, this.getSpends().get(i).getAlpha(), dataToBeSigned,
-                    result));
+                    new SpendSigParams(fakeAsk, this.getSpends().get(i).getAlpha(), dataToBeSigned,
+                            result));
             this.getContractBuilder().getSpendDescriptionBuilder(i)
-                .setSpendAuthoritySignature(ByteString.copyFrom(result));
+                    .setSpendAuthoritySignature(ByteString.copyFrom(result));
           }
         }
       };
@@ -1579,9 +1614,9 @@ public class SendCoinShieldTest {
       builder.addSpend(expsk2, note2, anchor2, voucher2);
 
       String TO_ADDRESS =
-          Wallet.getAddressPreFixString() + "b48794500882809695a8a687866e76d4271a1abc";
+              Wallet.getAddressPreFixString() + "b48794500882809695a8a687866e76d4271a1abc";
       AccountCapsule toCapsule = new AccountCapsule(ByteString.copyFromUtf8("to"),
-          ByteString.copyFrom(ByteArray.fromHexString(TO_ADDRESS)), AccountType.Normal, 0L);
+              ByteString.copyFrom(ByteArray.fromHexString(TO_ADDRESS)), AccountType.Normal, 0L);
       dbManager.getAccountStore().put(toCapsule.getAddress().toByteArray(), toCapsule);
 
       addZeroValueOutputNote(builder);
@@ -1607,7 +1642,7 @@ public class SendCoinShieldTest {
     Note note = new Note(address, 1000 * 1000000L);
 
     IncrementalMerkleTreeContainer tree = new IncrementalMerkleTreeContainer(
-        new IncrementalMerkleTreeCapsule());
+            new IncrementalMerkleTreeCapsule());
 
     PedersenHashCapsule compressCapsule = new PedersenHashCapsule();
     compressCapsule.setContent(ByteString.copyFrom(note.cm()));
@@ -1616,22 +1651,33 @@ public class SendCoinShieldTest {
     IncrementalMerkleVoucherContainer voucher = tree.toVoucher();
     byte[] anchor = voucher.root().getContent().toByteArray();
     dbManager.getMerkleContainer()
-        .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
+            .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
 
     return new SpendDescriptionInfo(expsk, note, anchor, voucher);
   }
 
   private String generateDefaultToAccount() {
     String TO_ADDRESS =
-        Wallet.getAddressPreFixString() + "b48794500882809695a8a687866e76d4271a1abc";
+            Wallet.getAddressPreFixString() + "b48794500882809695a8a687866e76d4271a1abc";
     AccountCapsule toCapsule = new AccountCapsule(ByteString.copyFromUtf8("to"),
-        ByteString.copyFrom(ByteArray.fromHexString(TO_ADDRESS)), AccountType.Normal, 0L);
+            ByteString.copyFrom(ByteArray.fromHexString(TO_ADDRESS)), AccountType.Normal, 0L);
     dbManager.getAccountStore().put(toCapsule.getAddress().toByteArray(), toCapsule);
+    generateDefaultToAccountAssetIssue();
+    return TO_ADDRESS;
+  }
+
+  private String generateDefaultToAccountAssetIssue() {
+    String TO_ADDRESS =
+            Wallet.getAddressPreFixString() + "b48794500882809695a8a687866e76d4271a1abc";
+    AccountAssetIssueCapsule toCapsule = new AccountAssetIssueCapsule(
+            ByteString.copyFromUtf8("to"),
+            ByteString.copyFrom(ByteArray.fromHexString(TO_ADDRESS)));
+    dbManager.getAccountAssetIssueStore().put(toCapsule.getAddress().toByteArray(), toCapsule);
     return TO_ADDRESS;
   }
 
   private TransactionCapsule generateDefaultBuilder(ZenTransactionBuilder builder)
-      throws BadItemException, ZksnarkException {
+          throws BadItemException, ZksnarkException {
     //add spendDesc into builder
     SpendDescriptionInfo spendDescriptionInfo = generateDefaultSpend();
     builder.addSpend(spendDescriptionInfo);
@@ -1640,7 +1686,7 @@ public class SendCoinShieldTest {
     addZeroValueOutputNote(builder);
     String TO_ADDRESS = generateDefaultToAccount();
     builder.setTransparentOutput(ByteArray.fromHexString(TO_ADDRESS),
-        1000 * 1000000L - wallet.getShieldedTransactionFee());
+            1000 * 1000000L - wallet.getShieldedTransactionFee());
 
     TransactionCapsule transactionCap = builder.build();
     return transactionCap;
@@ -1667,14 +1713,14 @@ public class SendCoinShieldTest {
         //set wrong rk
         @Override
         public SpendDescriptionCapsule generateSpendProof(SpendDescriptionInfo spend, long ctx)
-            throws ZksnarkException {
+                throws ZksnarkException {
           SpendDescriptionCapsule spendDescriptionCapsule = super.generateSpendProof(spend, ctx);
           //The format is correct, but it does not belong to this
           // note value ,fake : 200_000_000,real:20_000_000
           byte[] fakeRk = ByteArray
-              .fromHexString("a167824f65f874075cf81968f9f41096c28a2d9c6396601291f76782e6bdc0a4");
+                  .fromHexString("a167824f65f874075cf81968f9f41096c28a2d9c6396601291f76782e6bdc0a4");
           System.out.println(
-              "rk:" + ByteArray.toHexString(spendDescriptionCapsule.getRk().toByteArray()));
+                  "rk:" + ByteArray.toHexString(spendDescriptionCapsule.getRk().toByteArray()));
           spendDescriptionCapsule.setRk(fakeRk);
           return spendDescriptionCapsule;
         }
@@ -1704,18 +1750,18 @@ public class SendCoinShieldTest {
         //set wrong proof
         @Override
         public SpendDescriptionCapsule generateSpendProof(SpendDescriptionInfo spend, long ctx)
-            throws ZksnarkException {
+                throws ZksnarkException {
           SpendDescriptionCapsule spendDescriptionCapsule = super.generateSpendProof(spend, ctx);
           //The format is correct, but it does not belong to this
           // note value ,fake : 200_000_000,real:20_000_000
           byte[] fakeProof = ByteArray.fromHexString(
-              "0ac001af7f0059cdfec9eed3900b3a4b25ace3cdeb7e962929be9432e51b222be6d7b885d5393"
-                  + "c0d373c5b3dbc19210f94e7de831750c5d3a545bbe3732b4d87e4b4350c29519cbebdabd599db"
-                  + "9e685f37af2440abc29b3c11cc1dc6712582f74fe06506182e9202b20467017c53fb6d744cd6e"
-                  + "08b6428d0e0607688b67876036d2e30617fe020b1fd33ce96cda898e679f44f9715d5681ee0e4"
-                  + "2f419d7af4d438240fee7b6519e525f452d2ac56b1fb7cd12e9fb0b39caf6f84918b76fa5d46");
+                  "0ac001af7f0059cdfec9eed3900b3a4b25ace3cdeb7e962929be9432e51b222be6d7b885d5393"
+                          + "c0d373c5b3dbc19210f94e7de831750c5d3a545bbe3732b4d87e4b4350c29519cbebdabd599db"
+                          + "9e685f37af2440abc29b3c11cc1dc6712582f74fe06506182e9202b20467017c53fb6d744cd6e"
+                          + "08b6428d0e0607688b67876036d2e30617fe020b1fd33ce96cda898e679f44f9715d5681ee0e4"
+                          + "2f419d7af4d438240fee7b6519e525f452d2ac56b1fb7cd12e9fb0b39caf6f84918b76fa5d46");
           System.out.println("zkproof:" + ByteArray
-              .toHexString(spendDescriptionCapsule.getZkproof().toByteArray()));
+                  .toHexString(spendDescriptionCapsule.getZkproof().toByteArray()));
 
           spendDescriptionCapsule.setZkproof(fakeProof);
           return spendDescriptionCapsule;
@@ -1746,15 +1792,15 @@ public class SendCoinShieldTest {
         //set wrong nf
         @Override
         public SpendDescriptionCapsule generateSpendProof(SpendDescriptionInfo spend, long ctx)
-            throws ZksnarkException {
+                throws ZksnarkException {
           SpendDescriptionCapsule spendDescriptionCapsule = super.generateSpendProof(spend, ctx);
 
           //The format is correct, but it does not belong to this
           // note value ,fake : 200_000_000,real:20_000_000
           byte[] bytes = ByteArray.fromHexString(
-              "7b21b1bc8aba1bb8d5a3638ef8e3c741b84ca7c122053a1072a932c043a0a95");//256
+                  "7b21b1bc8aba1bb8d5a3638ef8e3c741b84ca7c122053a1072a932c043a0a95");//256
           System.out.println(
-              "nf:" + ByteArray.toHexString(spendDescriptionCapsule.getNullifier().toByteArray()));
+                  "nf:" + ByteArray.toHexString(spendDescriptionCapsule.getNullifier().toByteArray()));
           spendDescriptionCapsule.setNullifier(bytes);
           return spendDescriptionCapsule;
         }
@@ -1784,14 +1830,14 @@ public class SendCoinShieldTest {
         //set wrong anchor
         @Override
         public SpendDescriptionCapsule generateSpendProof(SpendDescriptionInfo spend, long ctx)
-            throws ZksnarkException {
+                throws ZksnarkException {
           SpendDescriptionCapsule spendDescriptionCapsule = super.generateSpendProof(spend, ctx);
           //The format is correct, but it does not belong to this
           // note value ,fake : 200_000_000,real:20_000_000
           byte[] bytes = ByteArray.fromHexString(
-              "bd7e296f492ffc23248b1815277b29af3a8970fff70f8256492bbea79b9a5e3e");//256
+                  "bd7e296f492ffc23248b1815277b29af3a8970fff70f8256492bbea79b9a5e3e");//256
           System.out.println(
-              "bytes:" + ByteArray.toHexString(spendDescriptionCapsule.getAnchor().toByteArray()));
+                  "bytes:" + ByteArray.toHexString(spendDescriptionCapsule.getAnchor().toByteArray()));
           spendDescriptionCapsule.setAnchor(bytes);
           return spendDescriptionCapsule;
         }

--- a/framework/src/test/java/org/tron/core/zksnark/ShieldedReceiveTest.java
+++ b/framework/src/test/java/org/tron/core/zksnark/ShieldedReceiveTest.java
@@ -51,6 +51,7 @@ import org.tron.core.capsule.ReceiveDescriptionCapsule;
 import org.tron.core.capsule.SpendDescriptionCapsule;
 import org.tron.core.capsule.TransactionCapsule;
 import org.tron.core.capsule.TransactionResultCapsule;
+import org.tron.core.capsule.AccountAssetIssueCapsule;
 import org.tron.core.capsule.WitnessCapsule;
 import org.tron.core.config.DefaultConfig;
 import org.tron.core.config.args.Args;
@@ -73,6 +74,7 @@ import org.tron.core.exception.VMIllegalException;
 import org.tron.core.exception.ValidateSignatureException;
 import org.tron.core.exception.ZksnarkException;
 import org.tron.core.services.http.FullNodeHttpApiService;
+import org.tron.core.store.AccountAssetIssueStore;
 import org.tron.core.utils.TransactionUtil;
 import org.tron.core.zen.ZenTransactionBuilder;
 import org.tron.core.zen.ZenTransactionBuilder.ReceiveDescriptionInfo;
@@ -106,2473 +108,2489 @@ import org.tron.protos.contract.ShieldContract.SpendDescription;
 @Slf4j
 public class ShieldedReceiveTest extends BlockGenerate {
 
-  private static final String dbPath = "receive_description_test";
-  private static final String FROM_ADDRESS;
-  private static final String ADDRESS_ONE_PRIVATE_KEY;
-  private static final long OWNER_BALANCE = 100_000_000;
-  private static final long FROM_AMOUNT = 110_000_000;
-  private static final long tokenId = 1;
-  private static final String ASSET_NAME = "trx";
-  private static final int TRX_NUM = 10;
-  private static final int NUM = 1;
-  private static final long START_TIME = 1;
-  private static final long END_TIME = 2;
-  private static final int VOTE_SCORE = 2;
-  private static final String DESCRIPTION = "TRX";
-  private static final String URL = "https://tron.network";
-  private static Manager dbManager;
-  private static ChainBaseManager chainBaseManager;
-  private static ConsensusService consensusService;
-  private static TronApplicationContext context;
-  private static Wallet wallet;
-  private static TransactionUtil transactionUtil;
+    private static final String dbPath = "receive_description_test";
+    private static final String FROM_ADDRESS;
+    private static final String ADDRESS_ONE_PRIVATE_KEY;
+    private static final long OWNER_BALANCE = 100_000_000;
+    private static final long FROM_AMOUNT = 110_000_000;
+    private static final long tokenId = 1;
+    private static final String ASSET_NAME = "trx";
+    private static final int TRX_NUM = 10;
+    private static final int NUM = 1;
+    private static final long START_TIME = 1;
+    private static final long END_TIME = 2;
+    private static final int VOTE_SCORE = 2;
+    private static final String DESCRIPTION = "TRX";
+    private static final String URL = "https://tron.network";
+    private static Manager dbManager;
+    private static ChainBaseManager chainBaseManager;
+    private static ConsensusService consensusService;
+    private static TronApplicationContext context;
+    private static Wallet wallet;
+    private static TransactionUtil transactionUtil;
 
-  static {
-    Args.setParam(new String[]{"--output-directory", dbPath}, "config-localtest.conf");
-    context = new TronApplicationContext(DefaultConfig.class);
-    FROM_ADDRESS = Wallet.getAddressPreFixString() + "a7d8a35b260395c14aa456297662092ba3b76fc0";
-    ADDRESS_ONE_PRIVATE_KEY = "7f7f701e94d4f1dd60ee5205e7ea8ee31121427210417b608a6b2e96433549a7";
-  }
-
-  /**
-   * Init data.
-   */
-  @BeforeClass
-  public static void init() {
-    FileUtil.deleteDir(new File(dbPath));
-
-    wallet = context.getBean(Wallet.class);
-    transactionUtil = context.getBean(TransactionUtil.class);
-    dbManager = context.getBean(Manager.class);
-    chainBaseManager = context.getBean(ChainBaseManager.class);
-    setManager(dbManager);
-    consensusService = context.getBean(ConsensusService.class);
-    consensusService.start();
-    //give a big value for pool, avoid for
-    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(10_000_000_000L);
-    // Args.getInstance().setAllowShieldedTransaction(1);
-  }
-
-  /**
-   * Release resources.
-   */
-  @AfterClass
-  public static void destroy() {
-    Args.clearParam();
-    context.destroy();
-
-    if (FileUtil.deleteDir(new File(dbPath))) {
-      logger.info("Release resources successful.");
-    } else {
-      logger.info("Release resources failure.");
-    }
-  }
-
-  private static void librustzcashInitZksnarkParams() {
-    FullNodeHttpApiService.librustzcashInitZksnarkParams();
-  }
-
-  private static byte[] randomUint256() {
-    return org.tron.keystore.Wallet.generateRandomBytes(32);
-  }
-
-  private static byte[] randomUint640() {
-    return org.tron.keystore.Wallet.generateRandomBytes(80);
-  }
-
-  private static byte[] randomUint1536() {
-    return org.tron.keystore.Wallet.generateRandomBytes(192);
-  }
-
-  private static byte[] randomUint4640() {
-    return org.tron.keystore.Wallet.generateRandomBytes(580);
-  }
-
-  /**
-   * create temp Capsule test need.
-   */
-  @Before
-  public void createToken() {
-    Args.getInstance().setZenTokenId(String.valueOf(tokenId));
-    chainBaseManager.getDynamicPropertiesStore().saveAllowSameTokenName(1);
-    chainBaseManager.getDynamicPropertiesStore().saveTokenIdNum(tokenId);
-
-    AssetIssueContract assetIssueContract =
-        AssetIssueContract.newBuilder()
-            .setOwnerAddress(ByteString.copyFrom(ByteArray.fromHexString(FROM_ADDRESS)))
-            .setName(ByteString.copyFrom(ByteArray.fromString(ASSET_NAME)))
-            .setId(Long.toString(tokenId))
-            .setTotalSupply(OWNER_BALANCE)
-            .setTrxNum(TRX_NUM)
-            .setNum(NUM)
-            .setStartTime(START_TIME)
-            .setEndTime(END_TIME)
-            .setVoteScore(VOTE_SCORE)
-            .setDescription(ByteString.copyFrom(ByteArray.fromString(DESCRIPTION)))
-            .setUrl(ByteString.copyFrom(ByteArray.fromString(URL)))
-            .build();
-    AssetIssueCapsule assetIssueCapsule = new AssetIssueCapsule(assetIssueContract);
-    chainBaseManager
-        .getAssetIssueV2Store().put(assetIssueCapsule.createDbV2Key(), assetIssueCapsule);
-  }
-
-  /**
-   * create temp transparent address for  test need.
-   */
-  private void createCapsule() {
-    AccountCapsule ownerCapsule =
-        new AccountCapsule(
-            ByteString.copyFromUtf8("owner"),
-            ByteString.copyFrom(ByteArray.fromHexString(FROM_ADDRESS)),
-            AccountType.Normal,
-            OWNER_BALANCE);
-    ownerCapsule.addAssetV2(ByteArray.fromString(String.valueOf(tokenId)), OWNER_BALANCE);
-    chainBaseManager.getAccountStore().put(ownerCapsule.getAddress().toByteArray(), ownerCapsule);
-  }
-
-  public IncrementalMerkleVoucherContainer createSimpleMerkleVoucherContainer(byte[] cm)
-      throws ZksnarkException {
-    IncrementalMerkleTreeContainer tree =
-        new IncrementalMerkleTreeContainer(new IncrementalMerkleTreeCapsule());
-    PedersenHashCapsule compressCapsule1 = new PedersenHashCapsule();
-    compressCapsule1.setContent(ByteString.copyFrom(cm));
-    PedersenHash a = compressCapsule1.getInstance();
-    tree.append(a);
-    IncrementalMerkleVoucherContainer voucher = tree.toVoucher();
-    return voucher;
-  }
-
-  private void updateTotalShieldedPoolValue(long valueBalance) {
-    long totalShieldedPoolValue =
-        chainBaseManager.getDynamicPropertiesStore().getTotalShieldedPoolValue();
-    totalShieldedPoolValue -= valueBalance;
-    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(totalShieldedPoolValue);
-  }
-
-  /*
-   * test of change ShieldedTransactionFee proposal
-   */
-  @Test
-  public void testSetShieldedTransactionFee() {
-    long fee = wallet.getShieldedTransactionFee();
-
-    chainBaseManager.getDynamicPropertiesStore().saveShieldedTransactionFee(2_000_000);
-    Assert.assertEquals(2_000_000, wallet.getShieldedTransactionFee());
-
-    chainBaseManager.getDynamicPropertiesStore().saveShieldedTransactionFee(fee);
-  }
-
-  /*
-   * test of creating shielded transaction before turn on the switch
-   */
-  @Test
-  public void testCreateBeforeAllowZksnark() throws ZksnarkException {
-    librustzcashInitZksnarkParams();
-    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(0);
-    createCapsule();
-    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-
-    //generate input
-    builder.setTransparentInput(ByteArray.fromHexString(FROM_ADDRESS), OWNER_BALANCE); //success
-    byte[] senderOvk = randomUint256();
-
-    //generate output
-    SpendingKey sk = SpendingKey.random();
-    FullViewingKey fullViewingKey12 = sk.fullViewingKey();
-    IncomingViewingKey ivk = fullViewingKey12.inViewingKey();
-    PaymentAddress paymentAddress = ivk.address(new DiversifierT()).get();
-    builder.addOutput(senderOvk, paymentAddress,
-        OWNER_BALANCE - wallet.getShieldedTransactionFee(), new byte[512]); //success
-
-    updateTotalShieldedPoolValue(builder.getValueBalance());
-    TransactionCapsule transactionCap = builder.build();
-
-    //online
-    try {
-      //validate
-      List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
-      actuator.get(0).validate();
-      Assert.assertFalse(true);
-    } catch (Exception e) {
-      Assert.assertTrue(e instanceof ContractValidateException);
-      Assert.assertEquals(
-          "Not support Shielded Transaction, need to be opened by the committee",
-          e.getMessage());
-    }
-  }
-
-  /*
-   * test of broadcasting shielded transaction before allow shielded transaction
-   */
-  @Test
-  public void testBroadcastBeforeAllowZksnark()
-      throws ZksnarkException, SignatureFormatException, SignatureException, PermissionException {
-    librustzcashInitZksnarkParams();
-    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(0);// or 1
-    createCapsule();
-    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-
-    //generate input
-    builder.setTransparentInput(ByteArray.fromHexString(FROM_ADDRESS), OWNER_BALANCE); //success
-    byte[] senderOvk = randomUint256();
-
-    //generate output
-    SpendingKey sk = SpendingKey.random();
-    FullViewingKey fullViewingKey12 = sk.fullViewingKey();
-    IncomingViewingKey ivk = fullViewingKey12.inViewingKey();
-    PaymentAddress paymentAddress = ivk.address(new DiversifierT()).get();
-    long fee = chainBaseManager.getDynamicPropertiesStore().getShieldedTransactionFee();
-    builder.addOutput(senderOvk, paymentAddress,
-        OWNER_BALANCE - fee, new byte[512]); //success
-
-    updateTotalShieldedPoolValue(builder.getValueBalance());
-    TransactionCapsule transactionCap = builder.build();
-
-    //Add public address sign
-    TransactionSign.Builder transactionSignBuild = TransactionSign.newBuilder();
-    transactionSignBuild.setTransaction(transactionCap.getInstance());
-    transactionSignBuild.setPrivateKey(ByteString.copyFrom(
-        ByteArray.fromHexString(ADDRESS_ONE_PRIVATE_KEY)));
-
-    transactionCap = transactionUtil.addSign(transactionSignBuild.build());
-
-    try {
-      dbManager.pushTransaction(transactionCap);
-      Assert.assertFalse(true);
-    } catch (Exception e) {
-      Assert.assertTrue(e instanceof ContractValidateException);
-      Assert.assertEquals(
-          "Not support Shielded Transaction, need to be opened by the committee",
-          e.getMessage());
-    }
-  }
-
-  /*
-   * generate spendproof, dataToBeSigned, outputproof example dynamicly according to the params file
-   */
-  public String[] generateSpendAndOutputParams() throws ZksnarkException, BadItemException {
-    librustzcashInitZksnarkParams();
-    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-    long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
-
-    //generate input
-    SpendingKey sk = SpendingKey.random();
-    ExpandedSpendingKey expsk = sk.expandedSpendingKey();
-    PaymentAddress address = sk.defaultAddress();
-
-    Note note = new Note(address, 100 * 1000000L);
-    IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
-    byte[] anchor = voucher.root().getContent().toByteArray();
-    chainBaseManager.getMerkleContainer()
-        .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
-    builder.addSpend(expsk, note, anchor, voucher);
-
-    // generate output
-    SpendingKey sk1 = SpendingKey.random();
-    FullViewingKey fullViewingKey1 = sk1.fullViewingKey();
-    IncomingViewingKey ivk1 = fullViewingKey1.inViewingKey();
-    PaymentAddress paymentAddress1 = ivk1.address(new DiversifierT()).get();
-    builder.addOutput(expsk.getOvk(), paymentAddress1,
-        100 * 1000000 - wallet.getShieldedTransactionFee(), new byte[512]);
-
-    // Create Sapling SpendDescriptions
-    for (SpendDescriptionInfo spend2 : builder.getSpends()) {
-      SpendDescriptionCapsule spendDescriptionCapsule = builder.generateSpendProof(spend2, ctx);
-      builder.getContractBuilder().addSpendDescription(spendDescriptionCapsule.getInstance());
+    static {
+        Args.setParam(new String[]{"--output-directory", dbPath}, "config-localtest.conf");
+        context = new TronApplicationContext(DefaultConfig.class);
+        FROM_ADDRESS = Wallet.getAddressPreFixString() + "a7d8a35b260395c14aa456297662092ba3b76fc0";
+        ADDRESS_ONE_PRIVATE_KEY = "7f7f701e94d4f1dd60ee5205e7ea8ee31121427210417b608a6b2e96433549a7";
     }
 
-    // Create Sapling OutputDescriptions
-    for (ReceiveDescriptionInfo receive : builder.getReceives()) {
-      ReceiveDescriptionCapsule receiveDescriptionCapsule = builder
-          .generateOutputProof(receive, ctx);
-      builder.getContractBuilder().addReceiveDescription(receiveDescriptionCapsule.getInstance());
+    /**
+     * Init data.
+     */
+    @BeforeClass
+    public static void init() {
+        FileUtil.deleteDir(new File(dbPath));
+
+        wallet = context.getBean(Wallet.class);
+        transactionUtil = context.getBean(TransactionUtil.class);
+        dbManager = context.getBean(Manager.class);
+        chainBaseManager = context.getBean(ChainBaseManager.class);
+        setManager(dbManager);
+        consensusService = context.getBean(ConsensusService.class);
+        consensusService.start();
+        //give a big value for pool, avoid for
+        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(10_000_000_000L);
+        // Args.getInstance().setAllowShieldedTransaction(1);
     }
 
-    // begin to generate dataToBeSigned
-    TransactionCapsule transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
-        builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
-    byte[] dataToBeSigned = TransactionCapsule
-        .getShieldTransactionHashIgnoreTypeException(transactionCapsule.getInstance());
-    TransactionCapsule transactionCap = generateTransactionCapsule(builder, ctx, dataToBeSigned,
-        transactionCapsule);
-
-    // generate checkSpendParams
-    SpendDescription spendDescription = builder.getContractBuilder().getSpendDescription(0);
-    CheckSpendParams checkSpendParams = new CheckSpendParams(ctx,
-        spendDescription.getValueCommitment().toByteArray(),
-        spendDescription.getAnchor().toByteArray(),
-        spendDescription.getNullifier().toByteArray(),
-        spendDescription.getRk().toByteArray(),
-        spendDescription.getZkproof().toByteArray(),
-        spendDescription.getSpendAuthoritySignature().toByteArray(),
-        dataToBeSigned);
-
-    boolean ok1 = JLibrustzcash.librustzcashSaplingCheckSpend(checkSpendParams);
-    Assert.assertTrue(ok1);
-
-    byte[] checkSpendParamsData = new byte[385];
-    System.arraycopy(
-        checkSpendParams.getCv(), 0, checkSpendParamsData, 0, 32);
-    System.arraycopy(
-        checkSpendParams.getAnchor(), 0, checkSpendParamsData, 32, 32);
-    System.arraycopy(
-        checkSpendParams.getNullifier(), 0, checkSpendParamsData, 64, 32);
-    System.arraycopy(
-        checkSpendParams.getRk(), 0, checkSpendParamsData, 96, 32);
-    System.arraycopy(
-        checkSpendParams.getZkproof(), 0, checkSpendParamsData, 128, 192);
-    System.arraycopy(
-        checkSpendParams.getSpendAuthSig(), 0, checkSpendParamsData, 320, 64);
-
-    // generate CheckOutputParams
-    ReceiveDescription receiveDescription =
-        builder.getContractBuilder().getReceiveDescription(0);
-    CheckOutputParams checkOutputParams = new CheckOutputParams(ctx,
-        receiveDescription.getValueCommitment().toByteArray(),
-        receiveDescription.getNoteCommitment().toByteArray(),
-        receiveDescription.getEpk().toByteArray(),
-        receiveDescription.getZkproof().toByteArray()
-    );
-
-    boolean ok2 = JLibrustzcash.librustzcashSaplingCheckOutput(checkOutputParams);
-    Assert.assertTrue(ok2);
-
-    return new String[]{ByteArray.toHexString(checkSpendParamsData),
-        ByteArray.toHexString(dataToBeSigned),
-        ByteArray.toHexString(checkOutputParams.encode())};
-  }
-
-  private long benchmarkVerifySpend(String spend, String dataToBeSigned) throws ZksnarkException {
-    long startTime = System.currentTimeMillis();
-    long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
-
-    CheckSpendParams checkSpendParams = CheckSpendParams.decode(ctx,
-        ByteArray.fromHexString(spend),
-        ByteArray.fromHexString(dataToBeSigned));
-
-    boolean ok = JLibrustzcash.librustzcashSaplingCheckSpend(checkSpendParams);
-
-    JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
-    Assert.assertTrue(ok);
-
-    long endTime = System.currentTimeMillis();
-    long time = endTime - startTime;
-
-    System.out.println("--- time is: " + time + ", result is " + ok);
-    return time;
-  }
-
-  private long benchmarkVerifyOutput(String outputParams) throws ZksnarkException {
-    // expect true
-    long startTime = System.currentTimeMillis();
-    long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
-
-    CheckOutputParams checkOutputParams = CheckOutputParams.decode(ctx,
-        ByteArray.fromHexString(outputParams));
-
-    boolean ok = JLibrustzcash.librustzcashSaplingCheckOutput(checkOutputParams);
-
-    JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
-    Assert.assertTrue(ok);
-
-    long endTime = System.currentTimeMillis();
-    long time = endTime - startTime;
-
-    System.out.println("--- time is: " + time + ", result is " + ok);
-    return time;
-  }
-
-  @Test
-  public void calBenchmarkVerifySpend() throws ZksnarkException, BadItemException {
-    librustzcashInitZksnarkParams();
-    System.out.println("--- load ok ---");
-
-    int count = 10;
-    long minTime = 500;
-    long maxTime = 0;
-    double totalTime = 0.0;
-
-    String[] result = generateSpendAndOutputParams();
-    String spend = result[0];
-    String dataToBeSigned = result[1];
-
-    for (int i = 0; i < count; i++) {
-      long time = benchmarkVerifySpend(spend, dataToBeSigned);
-      if (time < minTime) {
-        minTime = time;
-      }
-      if (time > maxTime) {
-        maxTime = time;
-      }
-      totalTime += time;
-    }
-
-    System.out.println("---- result ----");
-    System.out.println("---- maxTime is: " + maxTime);
-    System.out.println("---- minTime is: " + minTime);
-    System.out.println("---- avgTime is: " + totalTime / count);
-
-  }
-
-  @Test
-  public void calBenchmarkVerifyOutput() throws ZksnarkException, BadItemException {
-    librustzcashInitZksnarkParams();
-    System.out.println("--- load ok ---");
-
-    int count = 2;
-    long minTime = 500;
-    long maxTime = 0;
-    double totalTime = 0.0;
-
-    String[] result = generateSpendAndOutputParams();
-    String outputParams = result[2];
-
-    for (int i = 0; i < count; i++) {
-      long time = benchmarkVerifyOutput(outputParams);
-      if (time < minTime) {
-        minTime = time;
-      }
-      if (time > maxTime) {
-        maxTime = time;
-      }
-      totalTime += time;
-    }
-
-    System.out.println("---- result ----");
-    System.out.println("---- maxTime is: " + maxTime);
-    System.out.println("---- minTime is: " + minTime);
-    System.out.println("---- avgTime is: " + totalTime / count);
-
-  }
-
-  private ZenTransactionBuilder generateBuilderWithoutColumnInDescription(
-      ZenTransactionBuilder builder, long ctx, TestReceiveMissingColumn column)
-      throws ZksnarkException, BadItemException {
-    //generate input
-    SpendingKey sk = SpendingKey.random();
-    ExpandedSpendingKey expsk = sk.expandedSpendingKey();
-    PaymentAddress address = sk.defaultAddress();
-
-    Note note = new Note(address, 100 * 1000000L);
-    IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
-    byte[] anchor = voucher.root().getContent().toByteArray();
-    chainBaseManager.getMerkleContainer()
-        .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
-    builder.addSpend(expsk, note, anchor, voucher);
-
-    // generate output
-    SpendingKey sk1 = SpendingKey.random();
-    FullViewingKey fullViewingKey1 = sk1.fullViewingKey();
-    IncomingViewingKey ivk1 = fullViewingKey1.inViewingKey();
-    PaymentAddress paymentAddress1 = ivk1.address(new DiversifierT()).get();
-    builder.addOutput(expsk.getOvk(), paymentAddress1,
-        100 * 1000000 - wallet.getShieldedTransactionFee(), new byte[512]);
-
-    // Create Sapling SpendDescriptions
-    for (SpendDescriptionInfo spend : builder.getSpends()) {
-      SpendDescriptionCapsule spendDescriptionCapsule = builder.generateSpendProof(spend, ctx);
-      builder.getContractBuilder().addSpendDescription(spendDescriptionCapsule.getInstance());
-    }
-
-    // Create Sapling OutputDescriptions
-    for (ReceiveDescriptionInfo receive : builder.getReceives()) {
-      ReceiveDescriptionCapsule receiveDescriptionCapsule = builder
-          .generateOutputProof(receive, ctx);
-      switch (column) {
-        case CV:
-          receiveDescriptionCapsule.setValueCommitment(ByteString.EMPTY);
-          break;
-        case CM:
-          receiveDescriptionCapsule.setNoteCommitment(ByteString.EMPTY);
-          break;
-        case EPK:
-          receiveDescriptionCapsule.setEpk(ByteString.EMPTY);
-          break;
-        case ZKPROOF:
-          receiveDescriptionCapsule.setZkproof(ByteString.EMPTY);
-          break;
-        case C_ENC:
-          receiveDescriptionCapsule.setCEnc(ByteString.EMPTY);
-          break;
-        case C_OUT:
-          receiveDescriptionCapsule.setCOut(ByteString.EMPTY);
-          break;
-        default:
-          break;
-      }
-      builder.getContractBuilder().addReceiveDescription(receiveDescriptionCapsule.getInstance());
-    }
-
-    return builder;
-  }
-
-  /*
-   * test of empty CV in receive description
-   */
-  @Test
-  public void testReceiveDescriptionWithEmptyCv()
-      throws BadItemException, RuntimeException, ZksnarkException {
-    librustzcashInitZksnarkParams();
-    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-    long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
-
-    builder = generateBuilderWithoutColumnInDescription(builder, ctx, TestReceiveMissingColumn.CV);
-
-    // Empty output script.
-    byte[] dataToBeSigned;//256
-    TransactionCapsule transactionCapsule;
-    try {
-      transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
-          builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
-      TransactionExtention transactionExtention = TransactionExtention.newBuilder()
-          .setTransaction(transactionCapsule.getInstance()).build();
-
-      dataToBeSigned = TransactionCapsule.hashShieldTransaction(transactionCapsule.getInstance(),
-          CommonParameter.getInstance().getZenTokenId());
-    } catch (Exception ex) {
-      JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
-      throw new RuntimeException("Could not construct signature hash: " + ex.getMessage());
-    }
-
-    TransactionCapsule transactionCap = generateTransactionCapsule(builder, ctx, dataToBeSigned,
-        transactionCapsule);
-
-    try {
-      //validate
-      List<Actuator> actuator = ActuatorCreator
-          .getINSTANCE().createActuator(transactionCap);
-      actuator.get(0).validate();
-      Assert.assertTrue(false);
-    } catch (Exception e) {
-      Assert.assertTrue(e instanceof ContractValidateException);
-      Assert.assertEquals("param is null", e.getMessage());
-    }
-    JLibrustzcash.librustzcashSaplingVerificationCtxFree(ctx);
-  }
-
-  /*
-   * test of empty cm in receive description
-   */
-  @Test
-  public void testReceiveDescriptionWithEmptyCm()
-      throws BadItemException, RuntimeException, ZksnarkException {
-    librustzcashInitZksnarkParams();
-    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-    long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
-
-    builder = generateBuilderWithoutColumnInDescription(builder, ctx, TestReceiveMissingColumn.CM);
-
-    // Empty output script.
-    byte[] dataToBeSigned;//256
-    TransactionCapsule transactionCapsule;
-    try {
-      transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
-          builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
-      dataToBeSigned = TransactionCapsule.hashShieldTransaction(transactionCapsule.getInstance(),
-          CommonParameter.getInstance().getZenTokenId());
-    } catch (Exception ex) {
-      JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
-      throw new RuntimeException("Could not construct signature hash: " + ex.getMessage());
-    }
-
-    TransactionCapsule transactionCap = generateTransactionCapsule(builder, ctx, dataToBeSigned,
-        transactionCapsule);
-
-    try {
-      //validate
-      List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
-      actuator.get(0).validate();
-
-      Assert.assertTrue(false);
-    } catch (Exception e) {
-      Assert.assertTrue(e instanceof ContractValidateException);
-      Assert.assertEquals("param is null", e.getMessage());
-    }
-    JLibrustzcash.librustzcashSaplingVerificationCtxFree(ctx);
-  }
-
-  /*
-   * test of empty epk in receive description
-   */
-  @Test
-  public void testReceiveDescriptionWithEmptyEpk()
-      throws BadItemException, RuntimeException, ZksnarkException {
-    librustzcashInitZksnarkParams();
-    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-    long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
-
-    builder = generateBuilderWithoutColumnInDescription(builder, ctx, TestReceiveMissingColumn.EPK);
-
-    // Empty output script.
-    byte[] dataToBeSigned;//256
-    TransactionCapsule transactionCapsule;
-    try {
-      transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
-          builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
-      dataToBeSigned = TransactionCapsule.hashShieldTransaction(transactionCapsule.getInstance(),
-          CommonParameter.getInstance().getZenTokenId());
-    } catch (Exception ex) {
-      JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
-      throw new RuntimeException("Could not construct signature hash: " + ex.getMessage());
-    }
-
-    TransactionCapsule transactionCap = generateTransactionCapsule(builder, ctx, dataToBeSigned,
-        transactionCapsule);
-
-    try {
-      //validate
-      List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
-      actuator.get(0).validate();
-      Assert.assertTrue(false);
-    } catch (Exception e) {
-      Assert.assertTrue(e instanceof ContractValidateException);
-      Assert.assertEquals("param is null", e.getMessage());
-    }
-    JLibrustzcash.librustzcashSaplingVerificationCtxFree(ctx);
-  }
-
-  /*
-   * test of empty zkproof in receive description
-   */
-  @Test
-  public void testReceiveDescriptionWithEmptyZkproof()
-      throws BadItemException, RuntimeException, ZksnarkException {
-    librustzcashInitZksnarkParams();
-    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-    long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
-
-    builder = generateBuilderWithoutColumnInDescription(builder, ctx,
-        TestReceiveMissingColumn.ZKPROOF);
-
-    // Empty output script.
-    byte[] dataToBeSigned;//256
-    TransactionCapsule transactionCapsule;
-    try {
-      transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
-          builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
-      dataToBeSigned = TransactionCapsule.hashShieldTransaction(transactionCapsule.getInstance(),
-          CommonParameter.getInstance().getZenTokenId());
-    } catch (Exception ex) {
-      JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
-      throw new RuntimeException("Could not construct signature hash: " + ex.getMessage());
-    }
-
-    TransactionCapsule transactionCap = generateTransactionCapsule(builder, ctx, dataToBeSigned,
-        transactionCapsule);
-
-    try {
-      //validate
-      List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
-      actuator.get(0).validate();
-      Assert.assertTrue(false);
-    } catch (Exception e) {
-      Assert.assertTrue(e instanceof ContractValidateException);
-      Assert.assertEquals("param is null", e.getMessage());
-    }
-    JLibrustzcash.librustzcashSaplingVerificationCtxFree(ctx);
-  }
-
-  /*
-   * test of empty c_enc in receive description
-   */
-  @Test
-  public void testReceiveDescriptionWithEmptyCenc()
-      throws BadItemException, RuntimeException, ZksnarkException {
-    librustzcashInitZksnarkParams();
-    dbManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-    dbManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-    long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
-
-    builder = generateBuilderWithoutColumnInDescription(builder, ctx,
-        TestReceiveMissingColumn.C_ENC);
-
-    // Empty output script.
-    byte[] dataToBeSigned;//256
-    TransactionCapsule transactionCapsule;
-    try {
-      transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
-          builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
-      dataToBeSigned = TransactionCapsule.hashShieldTransaction(transactionCapsule.getInstance(),
-          CommonParameter.getInstance().getZenTokenId());
-    } catch (Exception ex) {
-      JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
-      throw new RuntimeException("Could not construct signature hash: " + ex.getMessage());
-    }
-
-    TransactionCapsule transactionCap = generateTransactionCapsule(builder, ctx, dataToBeSigned,
-        transactionCapsule);
-
-    try {
-      //validate
-      List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
-      actuator.get(0).validate();
-      Assert.assertTrue(false);
-    } catch (Exception e) {
-      Assert.assertTrue(e instanceof ContractValidateException);
-      Assert.assertEquals("Cout or CEnc size error", e.getMessage());
-    }
-    JLibrustzcash.librustzcashSaplingVerificationCtxFree(ctx);
-  }
-
-  /*
-   * test of empty c_out in receive description
-   */
-  @Test
-  public void testReceiveDescriptionWithEmptyCout()
-      throws BadItemException, RuntimeException, ZksnarkException {
-    librustzcashInitZksnarkParams();
-    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-    long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
-
-    builder = generateBuilderWithoutColumnInDescription(builder, ctx,
-        TestReceiveMissingColumn.C_OUT);
-
-    // Empty output script.
-    byte[] dataToBeSigned;//256
-    TransactionCapsule transactionCapsule;
-    try {
-      transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
-          builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
-      dataToBeSigned = TransactionCapsule.hashShieldTransaction(transactionCapsule.getInstance(),
-          CommonParameter.getInstance().getZenTokenId());
-    } catch (Exception ex) {
-      JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
-      throw new RuntimeException("Could not construct signature hash: " + ex.getMessage());
-    }
-
-    TransactionCapsule transactionCap = generateTransactionCapsule(builder, ctx, dataToBeSigned,
-        transactionCapsule);
-
-    try {
-      //validate
-      List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
-      actuator.get(0).validate();
-      Assert.assertTrue(false);
-    } catch (Exception e) {
-      Assert.assertTrue(e instanceof ContractValidateException);
-      Assert.assertEquals("Cout or CEnc size error", e.getMessage());
-    }
-    JLibrustzcash.librustzcashSaplingVerificationCtxFree(ctx);
-  }
-
-  /*
-   * test some column in ReceiveDescription is wrong
-   */
-  private ReceiveDescriptionCapsule changeGenerateOutputProof(ReceiveDescriptionInfo output,
-      long ctx, TestColumn testColumn)
-      throws ZksnarkException {
-    byte[] cm = output.getNote().cm();
-    if (ByteArray.isEmpty(cm)) {
-      JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
-      throw new ZksnarkException("Output is invalid");
-    }
-
-    Optional<NotePlaintextEncryptionResult> res = output.getNote()
-        .encrypt(output.getNote().getPkD());
-    if (!res.isPresent()) {
-      JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
-      throw new ZksnarkException("Failed to encrypt note");
-    }
-
-    NotePlaintextEncryptionResult enc = res.get();
-    NoteEncryption encryptor = enc.getNoteEncryption();
-
-    byte[] cv = new byte[32];
-    byte[] zkProof = new byte[192];
-    if (!JLibrustzcash.librustzcashSaplingOutputProof(
-        new OutputProofParams(ctx,
-            encryptor.getEsk(),
-            output.getNote().getD().getData(),
-            output.getNote().getPkD(),
-            output.getNote().getRcm(),
-            output.getNote().getValue(),
-            cv,
-            zkProof))) {
-      JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
-      throw new ZksnarkException("Output proof failed");
-    }
-
-    ReceiveDescriptionCapsule receiveDescriptionCapsule = new ReceiveDescriptionCapsule();
-    receiveDescriptionCapsule.setValueCommitment(cv);
-    receiveDescriptionCapsule.setNoteCommitment(cm);
-    receiveDescriptionCapsule.setEpk(encryptor.getEpk());
-    receiveDescriptionCapsule.setCEnc(enc.getEncCiphertext());
-    receiveDescriptionCapsule.setZkproof(zkProof);
-
-    OutgoingPlaintext outPlaintext =
-        new OutgoingPlaintext(output.getNote().getPkD(), encryptor.getEsk());
-    receiveDescriptionCapsule.setCOut(outPlaintext
-        .encrypt(output.getOvk(), receiveDescriptionCapsule.getValueCommitment().toByteArray(),
-            receiveDescriptionCapsule.getCm().toByteArray(),
-            encryptor).getData());
-
-    Note newNote = output.getNote();
-    byte[] newCm;
-    switch (testColumn) {
-      case CV:
-        receiveDescriptionCapsule.setValueCommitment(randomUint256());
-        break;
-      case ZKPOOF:
-        receiveDescriptionCapsule.setZkproof(randomUint1536());
-        break;
-      case D_CM:
-        newNote.setD(DiversifierT.random());
-        newCm = newNote.cm();
-        if (newCm == null) {
-          receiveDescriptionCapsule.setNoteCommitment(ByteString.EMPTY);
+    /**
+     * Release resources.
+     */
+    @AfterClass
+    public static void destroy() {
+        Args.clearParam();
+        context.destroy();
+
+        if (FileUtil.deleteDir(new File(dbPath))) {
+            logger.info("Release resources successful.");
         } else {
-          receiveDescriptionCapsule.setNoteCommitment(newCm);
+            logger.info("Release resources failure.");
         }
-        break;
-      case PKD_CM:
-        newNote.setPkD(randomUint256());
-        newCm = newNote.cm();
-        if (newCm == null) {
-          receiveDescriptionCapsule.setNoteCommitment(ByteString.EMPTY);
-        } else {
-          receiveDescriptionCapsule.setNoteCommitment(newCm);
+    }
+
+    private static void librustzcashInitZksnarkParams() {
+        FullNodeHttpApiService.librustzcashInitZksnarkParams();
+    }
+
+    private static byte[] randomUint256() {
+        return org.tron.keystore.Wallet.generateRandomBytes(32);
+    }
+
+    private static byte[] randomUint640() {
+        return org.tron.keystore.Wallet.generateRandomBytes(80);
+    }
+
+    private static byte[] randomUint1536() {
+        return org.tron.keystore.Wallet.generateRandomBytes(192);
+    }
+
+    private static byte[] randomUint4640() {
+        return org.tron.keystore.Wallet.generateRandomBytes(580);
+    }
+
+    /**
+     * create temp Capsule test need.
+     */
+    @Before
+    public void createToken() {
+        Args.getInstance().setZenTokenId(String.valueOf(tokenId));
+        chainBaseManager.getDynamicPropertiesStore().saveAllowSameTokenName(1);
+        chainBaseManager.getDynamicPropertiesStore().saveTokenIdNum(tokenId);
+
+        AssetIssueContract assetIssueContract =
+                AssetIssueContract.newBuilder()
+                        .setOwnerAddress(ByteString.copyFrom(ByteArray.fromHexString(FROM_ADDRESS)))
+                        .setName(ByteString.copyFrom(ByteArray.fromString(ASSET_NAME)))
+                        .setId(Long.toString(tokenId))
+                        .setTotalSupply(OWNER_BALANCE)
+                        .setTrxNum(TRX_NUM)
+                        .setNum(NUM)
+                        .setStartTime(START_TIME)
+                        .setEndTime(END_TIME)
+                        .setVoteScore(VOTE_SCORE)
+                        .setDescription(ByteString.copyFrom(ByteArray.fromString(DESCRIPTION)))
+                        .setUrl(ByteString.copyFrom(ByteArray.fromString(URL)))
+                        .build();
+        AssetIssueCapsule assetIssueCapsule = new AssetIssueCapsule(assetIssueContract);
+        chainBaseManager
+                .getAssetIssueV2Store().put(assetIssueCapsule.createDbV2Key(), assetIssueCapsule);
+    }
+
+    /**
+     * create temp transparent address for  test need.
+     */
+    private void createCapsule() {
+        AccountCapsule ownerCapsule =
+                new AccountCapsule(
+                        ByteString.copyFromUtf8("owner"),
+                        ByteString.copyFrom(ByteArray.fromHexString(FROM_ADDRESS)),
+                        AccountType.Normal,
+                        OWNER_BALANCE);
+        ownerCapsule.addAssetV2(ByteArray.fromString(String.valueOf(tokenId)), OWNER_BALANCE);
+        chainBaseManager.getAccountStore().put(ownerCapsule.getAddress().toByteArray(), ownerCapsule);
+    }
+
+    private void createAccountAssetIssue() {
+        AccountAssetIssueCapsule ownerAssetIssueCapsule =
+                new AccountAssetIssueCapsule(
+                        ByteString.copyFromUtf8("owner"),
+                        ByteString.copyFrom(ByteArray.fromHexString(FROM_ADDRESS))
+                );
+        ownerAssetIssueCapsule.addAssetV2(ByteArray.fromString(String.valueOf(tokenId)), OWNER_BALANCE);
+        chainBaseManager.getAccountAssetIssueStore().put(ownerAssetIssueCapsule.getAddress().toByteArray(), ownerAssetIssueCapsule);
+        AccountAssetIssueCapsule blackhole = chainBaseManager.getAccountAssetIssueStore().getBlackhole();
+        AccountCapsule blackhole1 = chainBaseManager.getAccountStore().getBlackhole();
+        blackhole.getAssetIssuedName();
+        blackhole1.getBalance();
+    }
+
+    public IncrementalMerkleVoucherContainer createSimpleMerkleVoucherContainer(byte[] cm)
+            throws ZksnarkException {
+        IncrementalMerkleTreeContainer tree =
+                new IncrementalMerkleTreeContainer(new IncrementalMerkleTreeCapsule());
+        PedersenHashCapsule compressCapsule1 = new PedersenHashCapsule();
+        compressCapsule1.setContent(ByteString.copyFrom(cm));
+        PedersenHash a = compressCapsule1.getInstance();
+        tree.append(a);
+        IncrementalMerkleVoucherContainer voucher = tree.toVoucher();
+        return voucher;
+    }
+
+    private void updateTotalShieldedPoolValue(long valueBalance) {
+        long totalShieldedPoolValue =
+                chainBaseManager.getDynamicPropertiesStore().getTotalShieldedPoolValue();
+        totalShieldedPoolValue -= valueBalance;
+        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(totalShieldedPoolValue);
+    }
+
+    /*
+     * test of change ShieldedTransactionFee proposal
+     */
+    @Test
+    public void testSetShieldedTransactionFee() {
+        long fee = wallet.getShieldedTransactionFee();
+
+        chainBaseManager.getDynamicPropertiesStore().saveShieldedTransactionFee(2_000_000);
+        Assert.assertEquals(2_000_000, wallet.getShieldedTransactionFee());
+
+        chainBaseManager.getDynamicPropertiesStore().saveShieldedTransactionFee(fee);
+    }
+
+    /*
+     * test of creating shielded transaction before turn on the switch
+     */
+    @Test
+    public void testCreateBeforeAllowZksnark() throws ZksnarkException {
+        librustzcashInitZksnarkParams();
+        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(0);
+        createCapsule();
+        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+
+        //generate input
+        builder.setTransparentInput(ByteArray.fromHexString(FROM_ADDRESS), OWNER_BALANCE); //success
+        byte[] senderOvk = randomUint256();
+
+        //generate output
+        SpendingKey sk = SpendingKey.random();
+        FullViewingKey fullViewingKey12 = sk.fullViewingKey();
+        IncomingViewingKey ivk = fullViewingKey12.inViewingKey();
+        PaymentAddress paymentAddress = ivk.address(new DiversifierT()).get();
+        builder.addOutput(senderOvk, paymentAddress,
+                OWNER_BALANCE - wallet.getShieldedTransactionFee(), new byte[512]); //success
+
+        updateTotalShieldedPoolValue(builder.getValueBalance());
+        TransactionCapsule transactionCap = builder.build();
+
+        //online
+        try {
+            //validate
+            List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
+            actuator.get(0).validate();
+            Assert.assertFalse(true);
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof ContractValidateException);
+            Assert.assertEquals(
+                    "Not support Shielded Transaction, need to be opened by the committee",
+                    e.getMessage());
         }
-        break;
-      case VALUE_CM:
-        newNote.setValue(newNote.getValue() + 10000);
-        newCm = newNote.cm();
-        if (newCm == null) {
-          receiveDescriptionCapsule.setNoteCommitment(ByteString.EMPTY);
-        } else {
-          receiveDescriptionCapsule.setNoteCommitment(newCm);
+    }
+
+    /*
+     * test of broadcasting shielded transaction before allow shielded transaction
+     */
+    @Test
+    public void testBroadcastBeforeAllowZksnark()
+            throws ZksnarkException, SignatureFormatException, SignatureException, PermissionException {
+        librustzcashInitZksnarkParams();
+        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(0);// or 1
+        createCapsule();
+        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+
+        //generate input
+        builder.setTransparentInput(ByteArray.fromHexString(FROM_ADDRESS), OWNER_BALANCE); //success
+        byte[] senderOvk = randomUint256();
+
+        //generate output
+        SpendingKey sk = SpendingKey.random();
+        FullViewingKey fullViewingKey12 = sk.fullViewingKey();
+        IncomingViewingKey ivk = fullViewingKey12.inViewingKey();
+        PaymentAddress paymentAddress = ivk.address(new DiversifierT()).get();
+        long fee = chainBaseManager.getDynamicPropertiesStore().getShieldedTransactionFee();
+        builder.addOutput(senderOvk, paymentAddress,
+                OWNER_BALANCE - fee, new byte[512]); //success
+
+        updateTotalShieldedPoolValue(builder.getValueBalance());
+        TransactionCapsule transactionCap = builder.build();
+
+        //Add public address sign
+        TransactionSign.Builder transactionSignBuild = TransactionSign.newBuilder();
+        transactionSignBuild.setTransaction(transactionCap.getInstance());
+        transactionSignBuild.setPrivateKey(ByteString.copyFrom(
+                ByteArray.fromHexString(ADDRESS_ONE_PRIVATE_KEY)));
+
+        transactionCap = transactionUtil.addSign(transactionSignBuild.build());
+
+        try {
+            dbManager.pushTransaction(transactionCap);
+            Assert.assertFalse(true);
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof ContractValidateException);
+            Assert.assertEquals(
+                    "Not support Shielded Transaction, need to be opened by the committee",
+                    e.getMessage());
         }
-        break;
-      case R_CM:
-        newNote.setRcm(Note.generateR());
-        newCm = newNote.cm();
-        if (newCm == null) {
-          receiveDescriptionCapsule.setNoteCommitment(ByteString.EMPTY);
-        } else {
-          receiveDescriptionCapsule.setNoteCommitment(newCm);
+    }
+
+    /*
+     * generate spendproof, dataToBeSigned, outputproof example dynamicly according to the params file
+     */
+    public String[] generateSpendAndOutputParams() throws ZksnarkException, BadItemException {
+        librustzcashInitZksnarkParams();
+        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+        long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
+
+        //generate input
+        SpendingKey sk = SpendingKey.random();
+        ExpandedSpendingKey expsk = sk.expandedSpendingKey();
+        PaymentAddress address = sk.defaultAddress();
+
+        Note note = new Note(address, 100 * 1000000L);
+        IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
+        byte[] anchor = voucher.root().getContent().toByteArray();
+        chainBaseManager.getMerkleContainer()
+                .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
+        builder.addSpend(expsk, note, anchor, voucher);
+
+        // generate output
+        SpendingKey sk1 = SpendingKey.random();
+        FullViewingKey fullViewingKey1 = sk1.fullViewingKey();
+        IncomingViewingKey ivk1 = fullViewingKey1.inViewingKey();
+        PaymentAddress paymentAddress1 = ivk1.address(new DiversifierT()).get();
+        builder.addOutput(expsk.getOvk(), paymentAddress1,
+                100 * 1000000 - wallet.getShieldedTransactionFee(), new byte[512]);
+
+        // Create Sapling SpendDescriptions
+        for (SpendDescriptionInfo spend2 : builder.getSpends()) {
+            SpendDescriptionCapsule spendDescriptionCapsule = builder.generateSpendProof(spend2, ctx);
+            builder.getContractBuilder().addSpendDescription(spendDescriptionCapsule.getInstance());
         }
-        break;
 
-      default:
-        break;
-    }
-
-    return receiveDescriptionCapsule;
-  }
-
-  private TransactionCapsule changeBuildOutputProof(ZenTransactionBuilder builder, long ctx,
-      TestColumn testColumn)
-      throws ZksnarkException {
-    ShieldedTransferContract.Builder contractBuilder = builder.getContractBuilder();
-
-    // Create Sapling SpendDescriptions
-    for (SpendDescriptionInfo spend : builder.getSpends()) {
-      SpendDescriptionCapsule spendDescriptionCapsule = builder.generateSpendProof(spend, ctx);
-      contractBuilder.addSpendDescription(spendDescriptionCapsule.getInstance());
-    }
-
-    // Create Sapling OutputDescriptions
-    for (ReceiveDescriptionInfo receive : builder.getReceives()) {
-      //test case
-      ReceiveDescriptionCapsule receiveDescriptionCapsule = changeGenerateOutputProof(receive, ctx,
-          testColumn);
-      //end of test case
-      contractBuilder.addReceiveDescription(receiveDescriptionCapsule.getInstance());
-    }
-
-    // Empty output script.
-    byte[] dataToBeSigned;//256
-    TransactionCapsule transactionCapsule;
-    try {
-      transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
-          contractBuilder.build(), ContractType.ShieldedTransferContract);
-
-      dataToBeSigned = TransactionCapsule.hashShieldTransaction(transactionCapsule.getInstance(),
-          CommonParameter.getInstance().getZenTokenId());
-    } catch (Exception ex) {
-      JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
-      throw new ZksnarkException("Could not construct signature hash: " + ex.getMessage());
-    }
-
-    // Create Sapling spendAuth and binding signatures
-    builder.createSpendAuth(dataToBeSigned);
-    byte[] bindingSig = new byte[64];
-    JLibrustzcash.librustzcashSaplingBindingSig(
-        new BindingSigParams(ctx,
-            builder.getValueBalance(),
-            dataToBeSigned,
-            bindingSig)
-    );
-    contractBuilder.setBindingSignature(ByteString.copyFrom(bindingSig));
-    JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
-
-    Transaction.raw.Builder rawBuilder = transactionCapsule.getInstance().toBuilder()
-        .getRawDataBuilder()
-        .clearContract()
-        .addContract(
-            Transaction.Contract.newBuilder().setType(ContractType.ShieldedTransferContract)
-                .setParameter(
-                    Any.pack(contractBuilder.build())).build());
-
-    Transaction transaction = transactionCapsule.getInstance().toBuilder().clearRawData()
-        .setRawData(rawBuilder).build();
-    return new TransactionCapsule(transaction);
-  }
-
-  private ZenTransactionBuilder generateBuilder(ZenTransactionBuilder builder, long ctx)
-      throws ZksnarkException, BadItemException {
-    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-
-    // generate input
-    SpendingKey sk = SpendingKey.random();
-    ExpandedSpendingKey expsk = sk.expandedSpendingKey();
-    PaymentAddress address = sk.defaultAddress();
-    Note note = new Note(address, 100 * 1000000L);
-    IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
-    byte[] anchor = voucher.root().getContent().toByteArray();
-    //put the voucher and anchor into db
-    chainBaseManager.getMerkleContainer()
-        .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
-    builder.addSpend(expsk, note, anchor, voucher);
-
-    // generate output
-    SpendingKey sk1 = SpendingKey.random();
-    FullViewingKey fullViewingKey1 = sk1.fullViewingKey();
-    IncomingViewingKey ivk1 = fullViewingKey1.inViewingKey();
-    PaymentAddress paymentAddress1 = ivk1.address(new DiversifierT()).get();
-    Note note2 = new Note(paymentAddress1, 100 * 1000000L - wallet.getShieldedTransactionFee());
-    builder
-        .addOutput(expsk.getOvk(), note2.getD(), note2.getPkD(), note2.getValue(), note2.getRcm(),
-            new byte[512]);
-
-    return builder;
-  }
-
-  /*
-   * test wrong value_commitment in ReceiveDescription
-   */
-  @Test
-  public void testReceiveDescriptionWithWrongCv()
-      throws BadItemException, RuntimeException, ZksnarkException {
-    librustzcashInitZksnarkParams();
-    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-    long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
-
-    builder = generateBuilder(builder, ctx);
-
-    TestColumn testColumn = TestColumn.CV;
-    TransactionCapsule transactionCap = changeBuildOutputProof(builder, ctx, testColumn);
-
-    updateTotalShieldedPoolValue(builder.getValueBalance());
-
-    try {
-      List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
-      actuator.get(0).validate();
-      Assert.assertFalse(true);
-    } catch (Exception e) {
-      Assert.assertTrue(e instanceof ContractValidateException);
-      Assert.assertEquals("librustzcashSaplingCheckOutput error", e.getMessage());
-    }
-  }
-
-  /*
-   * test wrong zkproof in ReceiveDescription
-   */
-  @Test
-  public void testReceiveDescriptionWithWrongZkproof()
-      throws BadItemException, RuntimeException, ZksnarkException {
-    librustzcashInitZksnarkParams();
-    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-    long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
-
-    builder = generateBuilder(builder, ctx);
-
-    TestColumn testColumn = TestColumn.ZKPOOF;
-    TransactionCapsule transactionCap = changeBuildOutputProof(builder, ctx, testColumn);
-
-    updateTotalShieldedPoolValue(builder.getValueBalance());
-
-    try {
-      List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
-      actuator.get(0).validate();
-      Assert.assertFalse(true);
-    } catch (Exception e) {
-      Assert.assertTrue(e instanceof ContractValidateException);
-      Assert.assertEquals("librustzcashSaplingCheckOutput error", e.getMessage());
-    }
-  }
-
-  /*
-   * test note_commitment in ReceiveDescription generated by wrong d
-   */
-  @Test
-  public void testReceiveDescriptionWithWrongD()
-      throws BadItemException, RuntimeException, ZksnarkException {
-    librustzcashInitZksnarkParams();
-    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-    long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
-
-    builder = generateBuilder(builder, ctx);
-
-    TestColumn testColumn = TestColumn.D_CM;
-    TransactionCapsule transactionCap = changeBuildOutputProof(builder, ctx, testColumn);
-
-    updateTotalShieldedPoolValue(builder.getValueBalance());
-
-    try {
-      List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
-      actuator.get(0).validate();
-      Assert.assertFalse(true);
-    } catch (Exception e) {
-      Assert.assertTrue(e instanceof ContractValidateException);
-      //if generate cm successful, checkout error; else param is null because of cm is null
-      Assert.assertTrue("librustzcashSaplingCheckOutput error".equalsIgnoreCase(e.getMessage())
-          || "param is null".equalsIgnoreCase(e.getMessage()));
-    }
-  }
-
-  /*
-   * test note_commitment in ReceiveDescription generated by wrong pkd
-   */
-  @Test
-  public void testReceiveDescriptionWithWrongPkd()
-      throws BadItemException, RuntimeException, ZksnarkException {
-    librustzcashInitZksnarkParams();
-    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-    long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
-
-    builder = generateBuilder(builder, ctx);
-
-    TestColumn testColumn = TestColumn.PKD_CM;
-    TransactionCapsule transactionCap = changeBuildOutputProof(builder, ctx, testColumn);
-
-    updateTotalShieldedPoolValue(builder.getValueBalance());
-
-    try {
-      List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
-      actuator.get(0).validate();
-      Assert.assertFalse(true);
-    } catch (Exception e) {
-      Assert.assertTrue(e instanceof ContractValidateException);
-      //if generate cm successful, checkout error; else param is null because of cm is null
-      Assert.assertTrue("librustzcashSaplingCheckOutput error".equalsIgnoreCase(e.getMessage())
-          || "param is null".equalsIgnoreCase(e.getMessage()));
-    }
-  }
-
-  /*
-   * test note_commitment in ReceiveDescription generated by wrong value
-   */
-  @Test
-  public void testReceiveDescriptionWithWrongValue()
-      throws BadItemException, RuntimeException, ZksnarkException {
-    librustzcashInitZksnarkParams();
-    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-    long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
-
-    builder = generateBuilder(builder, ctx);
-
-    TestColumn testColumn = TestColumn.VALUE_CM;
-    TransactionCapsule transactionCap = changeBuildOutputProof(builder, ctx, testColumn);
-
-    updateTotalShieldedPoolValue(builder.getValueBalance());
-
-    try {
-      List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
-      actuator.get(0).validate();
-      Assert.assertFalse(true);
-    } catch (Exception e) {
-      Assert.assertTrue(e instanceof ContractValidateException);
-      Assert.assertTrue(e.getMessage().equalsIgnoreCase("librustzcashSaplingCheckOutput error"));
-    }
-  }
-
-  /*
-   * test note_commitment in ReceiveDescription generated by wrong r
-   */
-  @Test
-  public void testReceiveDescriptionWithWrongRcm()
-      throws BadItemException, RuntimeException, ZksnarkException {
-    librustzcashInitZksnarkParams();
-    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-    long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
-
-    builder = generateBuilder(builder, ctx);
-
-    TestColumn testColumn = TestColumn.R_CM;
-    TransactionCapsule transactionCap = changeBuildOutputProof(builder, ctx, testColumn);
-
-    updateTotalShieldedPoolValue(builder.getValueBalance());
-
-    try {
-      List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
-      actuator.get(0).validate();
-      Assert.assertFalse(true);
-    } catch (Exception e) {
-      Assert.assertTrue(e instanceof ContractValidateException);
-      Assert.assertEquals("librustzcashSaplingCheckOutput error", e.getMessage());
-    }
-  }
-
-  /**
-   * use ask or nsk not belongs to sk.
-   */
-  @Test
-  public void testNotMatchAskAndNsk()
-      throws BadItemException, RuntimeException, ZksnarkException {
-    librustzcashInitZksnarkParams();
-    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-
-    // generate sk
-    SpendingKey sk = SpendingKey
-        .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
-    ExpandedSpendingKey expsk = sk.expandedSpendingKey();
-    PaymentAddress address = sk.defaultAddress();
-
-    //generate a note belongs to this sk
-    Note note = new Note(address, 100 * 1000000L);
-    IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
-    byte[] anchor = voucher.root().getContent().toByteArray();
-    //put the voucher and anchor into db
-    chainBaseManager.getMerkleContainer()
-        .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
-
-    //test case: give a random Ask or nsk
-    expsk.setAsk(randomUint256());
-    //expsk.setNsk(randomUint256());
-    //end of test case
-
-    builder.addSpend(expsk, note, anchor, voucher);
-
-    // generate output
-    SpendingKey sk1 = SpendingKey.random();
-    FullViewingKey fullViewingKey1 = sk1.fullViewingKey();
-    IncomingViewingKey ivk1 = fullViewingKey1.inViewingKey();
-    PaymentAddress paymentAddress1 = ivk1.address(new DiversifierT()).get();
-    builder.addOutput(expsk.getOvk(), paymentAddress1,
-        100 * 1000000L - wallet.getShieldedTransactionFee(), new byte[512]);
-
-    updateTotalShieldedPoolValue(builder.getValueBalance());
-    try {
-      TransactionCapsule transactionCap = builder.build();
-      Assert.assertFalse(true);
-
-    } catch (Exception e) {
-      Assert.assertTrue(e instanceof ZksnarkException);
-      Assert.assertEquals("Spend proof failed", e.getMessage());
-    }
-  }
-
-  /**
-   * use random ovk not related to sk.
-   */
-  @Test
-  public void testRandomOvk()
-      throws BadItemException, RuntimeException, ZksnarkException {
-    librustzcashInitZksnarkParams();
-    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-
-    // generate sk
-    SpendingKey sk = SpendingKey
-        .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
-    ExpandedSpendingKey expsk = sk.expandedSpendingKey();
-    PaymentAddress address = sk.defaultAddress();
-
-    //generate a note belongs to this sk
-    Note note = new Note(address, 100 * 1000000L);
-    IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
-    byte[] anchor = voucher.root().getContent().toByteArray();
-    //put the voucher and anchor into db
-    chainBaseManager.getMerkleContainer()
-        .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
-
-    //test case: give a random Ovk
-    expsk.setOvk(randomUint256());
-    //end of test case
-
-    builder.addSpend(expsk, note, anchor, voucher);
-
-    // generate output
-    SpendingKey sk1 = SpendingKey.random();
-    FullViewingKey fullViewingKey1 = sk1.fullViewingKey();
-    IncomingViewingKey ivk1 = fullViewingKey1.inViewingKey();
-    PaymentAddress paymentAddress1 = ivk1.address(new DiversifierT()).get();
-    builder.addOutput(expsk.getOvk(), paymentAddress1,
-        100 * 1000000L - wallet.getShieldedTransactionFee(), new byte[512]);
-
-    updateTotalShieldedPoolValue(builder.getValueBalance());
-    TransactionCapsule transactionCap = builder.build();
-    Assert.assertTrue(true);
-  }
-
-  /*
-   * test add two same cm into spend
-   */
-  //@Test not used
-  public void testSameInputCm()
-      throws BadItemException, RuntimeException, ZksnarkException {
-    librustzcashInitZksnarkParams();
-    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-
-    // generate input
-    SpendingKey sk = SpendingKey
-        .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
-    ExpandedSpendingKey expsk = sk.expandedSpendingKey();
-    PaymentAddress address = sk.defaultAddress();
-    Note note = new Note(address, 100 * 1000000L);
-    IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
-    byte[] anchor = voucher.root().getContent().toByteArray();
-    //put the voucher and anchor into db
-    chainBaseManager.getMerkleContainer()
-        .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
-
-    //add two same cm
-    builder.addSpend(expsk, note, anchor, voucher);
-    builder.addSpend(expsk, note, anchor, voucher);
-
-    // generate output
-    SpendingKey sk1 = SpendingKey.random();
-    FullViewingKey fullViewingKey1 = sk1.fullViewingKey();
-    IncomingViewingKey ivk1 = fullViewingKey1.inViewingKey();
-    PaymentAddress paymentAddress1 = ivk1.address(new DiversifierT()).get();
-    builder.addOutput(expsk.getOvk(), paymentAddress1,
-        200 * 1000000L - wallet.getShieldedTransactionFee(), new byte[512]);
-
-    updateTotalShieldedPoolValue(builder.getValueBalance());
-    TransactionCapsule transactionCap = builder.build();
-
-    try {
-      //validate
-      List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
-      actuator.get(0).validate();
-      Assert.assertFalse(true);
-    } catch (Exception e) {
-      Assert.assertTrue(e instanceof ContractValidateException);
-      Assert.assertEquals("duplicate sapling nullifiers in this transaction", e.getMessage());
-    }
-  }
-
-  /*
-   * test add two same cm into output
-   */
-  @Test
-  public void testSameOutputCm()
-      throws BadItemException, RuntimeException, ZksnarkException {
-    librustzcashInitZksnarkParams();
-    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-
-    // generate input
-    SpendingKey sk = SpendingKey
-        .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
-    ExpandedSpendingKey expsk = sk.expandedSpendingKey();
-    PaymentAddress address = sk.defaultAddress();
-    Note note = new Note(address, 100 * 1000000L);
-    IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
-    byte[] anchor = voucher.root().getContent().toByteArray();
-    //put the voucher and anchor into db
-    chainBaseManager.getMerkleContainer()
-        .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
-    builder.addSpend(expsk, note, anchor, voucher);
-
-    // generate output
-    SpendingKey sk1 = SpendingKey.random();
-    FullViewingKey fullViewingKey1 = sk1.fullViewingKey();
-    IncomingViewingKey ivk1 = fullViewingKey1.inViewingKey();
-    PaymentAddress paymentAddress1 = ivk1.address(new DiversifierT()).get();
-    Note note2 = new Note(address, (100 * 1000000L - wallet.getShieldedTransactionFee()) / 2);
-    //add two same output note
-    builder
-        .addOutput(expsk.getOvk(), note2.getD(), note2.getPkD(), note2.getValue(), note2.getRcm(),
-            new byte[512]);
-    builder
-        .addOutput(expsk.getOvk(), note2.getD(), note2.getPkD(), note2.getValue(), note2.getRcm(),
-            new byte[512]);//same output cm
-
-    updateTotalShieldedPoolValue(builder.getValueBalance());
-    TransactionCapsule transactionCap = builder.build();
-
-    try {
-      //validate
-      List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
-      actuator.get(0).validate();
-      Assert.assertFalse(true);
-    } catch (Exception e) {
-      Assert.assertTrue(e instanceof ContractValidateException);
-      Assert.assertEquals("duplicate cm in receive_description", e.getMessage());
-    }
-  }
-
-  /**
-   * test of transferring insufficient money from shield address to shield address.
-   */
-  @Test
-  public void testShieldInputInsufficient()
-      throws BadItemException, RuntimeException, ZksnarkException {
-    librustzcashInitZksnarkParams();
-    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-
-    // generate input
-    SpendingKey sk = SpendingKey
-        .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
-    ExpandedSpendingKey expsk = sk.expandedSpendingKey();
-    PaymentAddress address = sk.defaultAddress();
-    Note note = new Note(address, 100 * 1000000L);
-    IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
-    byte[] anchor = voucher.root().getContent().toByteArray();
-    chainBaseManager.getMerkleContainer()
-        .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
-
-    //set value that's bigger than own
-    note.setValue(note.getValue() + 10 * 1000000L); //test case of insufficient money
-
-    builder.addSpend(expsk, note, anchor, voucher);
-
-    // generate output
-    SpendingKey sk1 = SpendingKey.random();
-    FullViewingKey fullViewingKey1 = sk1.fullViewingKey();
-    IncomingViewingKey ivk1 = fullViewingKey1.inViewingKey();
-    PaymentAddress paymentAddress1 = ivk1.address(new DiversifierT()).get();
-    builder.addOutput(expsk.getOvk(), paymentAddress1,
-        100 * 1000000L - wallet.getShieldedTransactionFee(), new byte[512]);
-
-    updateTotalShieldedPoolValue(builder.getValueBalance());
-
-    try {
-      TransactionCapsule transactionCap = builder.build();
-      Assert.assertFalse(true);
-    } catch (Exception e) {
-      Assert.assertTrue(e instanceof ZksnarkException);
-      Assert.assertEquals("Spend proof failed", e.getMessage());
-    }
-  }
-
-  /**
-   * test of transferring insufficient money from transparent address to shield address.
-   */
-  @Test
-  public void testTransparentInputInsufficient() throws RuntimeException, ZksnarkException {
-    librustzcashInitZksnarkParams();
-    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-    long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
-    createCapsule();
-
-    //generate input
-    builder.setTransparentInput(ByteArray.fromHexString(FROM_ADDRESS), FROM_AMOUNT); // fail
-    //builder.setTransparentInput(ByteArray.fromHexString(FROM_ADDRESS), OWNER_BALANCE); //success
-    byte[] senderOvk = randomUint256();
-
-    //generate output
-    SpendingKey sk = SpendingKey.random();
-    FullViewingKey fullViewingKey12 = sk.fullViewingKey();
-    IncomingViewingKey ivk = fullViewingKey12.inViewingKey();
-    PaymentAddress paymentAddress = ivk.address(new DiversifierT()).get();
-    builder.addOutput(senderOvk, paymentAddress,
-        FROM_AMOUNT - wallet.getShieldedTransactionFee(), new byte[512]); // fail
-    //builder.addOutput(senderOvk, paymentAddress,
-    //        OWNER_BALANCE - wallet.getShieldedTransactionFee(), new byte[512]); //success
-
-    updateTotalShieldedPoolValue(builder.getValueBalance());
-    TransactionCapsule transactionCap = builder.build();
-
-    try {
-      //valdiate
-      List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
-      actuator.get(0).validate();
-      Assert.assertFalse(true);
-    } catch (Exception e) {
-      Assert.assertTrue(e instanceof ContractValidateException);
-      Assert.assertEquals("Validate ShieldedTransferContract error, balance is not sufficient",
-          e.getMessage());
-    }
-  }
-
-  /*
-  test if random DiversifierT is valid.
- */
-  @Test
-  public void testDiversifierT() throws ZksnarkException {
-    //byte[] data = org.tron.keystore.Wallet.generateRandomBytes(Constant.ZC_DIVERSIFIER_SIZE);
-    byte[] data1 = ByteArray.fromHexString("93c9e5679850252b37a991");
-    byte[] data2 = ByteArray.fromHexString("c50124c6a9a2e1700fc0b5");
-    Assert.assertFalse(JLibrustzcash.librustzcashCheckDiversifier(data1));
-    Assert.assertTrue(JLibrustzcash.librustzcashCheckDiversifier(data2));
-  }
-
-  private byte[] hashWithMissingColumn(TransactionCapsule tx, TestSignMissingColumn column)
-      throws InvalidProtocolBufferException {
-    Any contractParameter = tx.getInstance().getRawData().getContract(0).getParameter();
-    ShieldedTransferContract shieldedTransferContract = contractParameter
-        .unpack(ShieldedTransferContract.class);
-    ShieldedTransferContract.Builder newContract = ShieldedTransferContract.newBuilder();
-
-    if (column != null) {
-      switch (column) {
-        case FROM_ADDRESS:
-          newContract.setFromAmount(shieldedTransferContract.getFromAmount());
-          newContract
-              .addAllReceiveDescription(shieldedTransferContract.getReceiveDescriptionList());
-          newContract.setToAmount(shieldedTransferContract.getToAmount());
-          newContract.setTransparentToAddress(shieldedTransferContract.getTransparentToAddress());
-          for (SpendDescription spendDescription : shieldedTransferContract
-              .getSpendDescriptionList()) {
-            newContract
-                .addSpendDescription(
-                    spendDescription.toBuilder().clearSpendAuthoritySignature().build());
-          }
-          break;
-        case FROM_AMOUNT:
-          //newContract.setFromAmount(shieldedTransferContract.getFromAmount());
-          newContract
-              .addAllReceiveDescription(shieldedTransferContract.getReceiveDescriptionList());
-          newContract.setToAmount(shieldedTransferContract.getToAmount());
-          newContract
-              .setTransparentFromAddress(shieldedTransferContract.getTransparentFromAddress());
-          newContract.setTransparentToAddress(shieldedTransferContract.getTransparentToAddress());
-          for (SpendDescription spendDescription : shieldedTransferContract
-              .getSpendDescriptionList()) {
-            newContract
-                .addSpendDescription(
-                    spendDescription.toBuilder().clearSpendAuthoritySignature().build());
-          }
-          break;
-        case SPEND_DESCRITPION:
-          newContract.setFromAmount(shieldedTransferContract.getFromAmount());
-          newContract
-              .addAllReceiveDescription(shieldedTransferContract.getReceiveDescriptionList());
-          newContract.setToAmount(shieldedTransferContract.getToAmount());
-          newContract
-              .setTransparentFromAddress(shieldedTransferContract.getTransparentFromAddress());
-          newContract.setTransparentToAddress(shieldedTransferContract.getTransparentToAddress());
-          break;
-        case RECEIVE_DESCRIPTION:
-          newContract.setFromAmount(shieldedTransferContract.getFromAmount());
-          newContract.setToAmount(shieldedTransferContract.getToAmount());
-          newContract
-              .setTransparentFromAddress(shieldedTransferContract.getTransparentFromAddress());
-          newContract.setTransparentToAddress(shieldedTransferContract.getTransparentToAddress());
-          for (SpendDescription spendDescription : shieldedTransferContract
-              .getSpendDescriptionList()) {
-            newContract
-                .addSpendDescription(
-                    spendDescription.toBuilder().clearSpendAuthoritySignature().build());
-          }
-          break;
-        case TO_ADDRESS:
-          newContract.setFromAmount(shieldedTransferContract.getFromAmount());
-          newContract
-              .addAllReceiveDescription(shieldedTransferContract.getReceiveDescriptionList());
-          newContract.setToAmount(shieldedTransferContract.getToAmount());
-          newContract
-              .setTransparentFromAddress(shieldedTransferContract.getTransparentFromAddress());
-          //newContract.setTransparentToAddress(shieldedTransferContract.getTransparentToAddress());
-          for (SpendDescription spendDescription : shieldedTransferContract
-              .getSpendDescriptionList()) {
-            newContract
-                .addSpendDescription(
-                    spendDescription.toBuilder().clearSpendAuthoritySignature().build());
-          }
-          break;
-        case TO_AMOUNT:
-          newContract.setFromAmount(shieldedTransferContract.getFromAmount());
-          newContract
-              .addAllReceiveDescription(shieldedTransferContract.getReceiveDescriptionList());
-          //newContract.setToAmount(shieldedTransferContract.getToAmount());
-          newContract
-              .setTransparentFromAddress(shieldedTransferContract.getTransparentFromAddress());
-          newContract.setTransparentToAddress(shieldedTransferContract.getTransparentToAddress());
-          for (SpendDescription spendDescription : shieldedTransferContract
-              .getSpendDescriptionList()) {
-            newContract
-                .addSpendDescription(
-                    spendDescription.toBuilder().clearSpendAuthoritySignature().build());
-          }
-          break;
-        default:
-          break;
-      }
-    }
-    Transaction.raw.Builder rawBuilder = tx.getInstance().toBuilder()
-        .getRawDataBuilder()
-        .clearContract()
-        .addContract(
-            Transaction.Contract.newBuilder().setType(ContractType.ShieldedTransferContract)
-                .setParameter(
-                    Any.pack(newContract.build())).build());
-
-    Transaction transaction = tx.getInstance().toBuilder().clearRawData()
-        .setRawData(rawBuilder).build();
-
-    byte[] mergedByte = Bytes.concat(
-        Sha256Hash.of(
-            CommonParameter
-                .getInstance().isECKeyCryptoEngine(),
-            CommonParameter.getInstance().getZenTokenId().getBytes()).getBytes(),
-        transaction.getRawData().toByteArray());
-    return Sha256Hash.of(CommonParameter
-        .getInstance().isECKeyCryptoEngine(), mergedByte).getBytes();
-  }
-
-  private ZenTransactionBuilder generateShield2ShieldBuilder(ZenTransactionBuilder builder,
-      long ctx)
-      throws ZksnarkException, BadItemException {
-    //generate input
-    SpendingKey sk = SpendingKey.random();
-    ExpandedSpendingKey expsk = sk.expandedSpendingKey();
-    PaymentAddress address = sk.defaultAddress();
-    Note note = new Note(address, 100 * 1000000L);
-    IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
-    byte[] anchor = voucher.root().getContent().toByteArray();
-    chainBaseManager.getMerkleContainer()
-        .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
-    builder.addSpend(expsk, note, anchor, voucher);
-
-    // generate output
-    SpendingKey sk1 = SpendingKey.random();
-    FullViewingKey fullViewingKey1 = sk1.fullViewingKey();
-    IncomingViewingKey ivk1 = fullViewingKey1.inViewingKey();
-    PaymentAddress paymentAddress1 = ivk1.address(new DiversifierT()).get();
-    builder.addOutput(expsk.getOvk(), paymentAddress1,
-        100 * 1000000L - wallet.getShieldedTransactionFee(), new byte[512]);
-
-    // Create Sapling SpendDescriptions
-    for (SpendDescriptionInfo spend : builder.getSpends()) {
-      SpendDescriptionCapsule spendDescriptionCapsule = builder.generateSpendProof(spend, ctx);
-      builder.getContractBuilder().addSpendDescription(spendDescriptionCapsule.getInstance());
-    }
-
-    // Create Sapling OutputDescriptions
-    for (ReceiveDescriptionInfo receive : builder.getReceives()) {
-      ReceiveDescriptionCapsule receiveDescriptionCapsule = builder
-          .generateOutputProof(receive, ctx);
-      builder.getContractBuilder().addReceiveDescription(receiveDescriptionCapsule.getInstance());
-    }
-
-    return builder;
-  }
-
-  public TransactionCapsule generateTransactionCapsule(ZenTransactionBuilder builder,
-      long ctx, byte[] hashOfTransaction, TransactionCapsule transactionCapsule)
-      throws ZksnarkException {
-    // Create Sapling spendAuth
-    for (int i = 0; i < builder.getSpends().size(); i++) {
-      byte[] result = new byte[64];
-      JLibrustzcash.librustzcashSaplingSpendSig(
-          new SpendSigParams(builder.getSpends().get(i).getExpsk().getAsk(),
-              builder.getSpends().get(i).getAlpha(),
-              hashOfTransaction,
-              result));
-      builder.getContractBuilder().getSpendDescriptionBuilder(i)
-          .setSpendAuthoritySignature(ByteString.copyFrom(result));
-    }
-
-    //create binding signatures
-    byte[] bindingSig = new byte[64];
-    JLibrustzcash.librustzcashSaplingBindingSig(
-        new BindingSigParams(ctx,
-            builder.getValueBalance(),
-            hashOfTransaction,
-            bindingSig)
-    );
-    builder.getContractBuilder().setBindingSignature(ByteString.copyFrom(bindingSig));
-
-    Transaction.raw.Builder rawBuilder = transactionCapsule.getInstance().toBuilder()
-        .getRawDataBuilder()
-        .clearContract()
-        .addContract(Transaction.Contract.newBuilder()
-            .setType(ContractType.ShieldedTransferContract)
-            .setParameter(Any.pack(builder.getContractBuilder().build()))
-            .build());
-
-    Transaction transaction = transactionCapsule.getInstance().toBuilder().clearRawData()
-        .setRawData(rawBuilder).build();
-    TransactionCapsule transactionCap = new TransactionCapsule(transaction);
-
-    updateTotalShieldedPoolValue(builder.getValueBalance());
-
-    return transactionCap;
-  }
-
-  /*
-   * test signature for shield to shield transaction with some column missing
-   */
-  @Test
-  public void testSignWithoutFromAddress()
-      throws BadItemException, ContractValidateException, RuntimeException,
-      ZksnarkException {
-    librustzcashInitZksnarkParams();
-    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-    long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
-
-    builder = generateShield2ShieldBuilder(builder, ctx);
-
-    // Empty output script.
-    byte[] hashOfTransaction;//256
-    TransactionCapsule transactionCapsule;
-    try {
-      transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
-          builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
-
-      //test case
-      hashOfTransaction = hashWithMissingColumn(transactionCapsule,
-          TestSignMissingColumn.FROM_ADDRESS);
-      //end of test case
-
-    } catch (Exception ex) {
-      JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
-      throw new RuntimeException("Could not construct signature hash: " + ex.getMessage());
-    }
-
-    TransactionCapsule transactionCap = generateTransactionCapsule(builder, ctx, hashOfTransaction,
-        transactionCapsule);
-
-    List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
-    actuator.get(0).validate(); //there is hash(transaction) in librustzcashSaplingFinalCheck
-    Assert.assertTrue(true);
-  }
-
-  /*
-   * test signature for shield to shield transaction with some column missing
-   */
-  @Test
-  public void testSignWithoutFromAmout()
-      throws BadItemException, ContractValidateException, RuntimeException,
-      ZksnarkException {
-    librustzcashInitZksnarkParams();
-    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-    long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
-
-    builder = generateShield2ShieldBuilder(builder, ctx);
-
-    // Empty output script.
-    byte[] hashOfTransaction;//256
-    TransactionCapsule transactionCapsule;
-    try {
-      transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
-          builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
-
-      //test case
-      hashOfTransaction = hashWithMissingColumn(transactionCapsule,
-          TestSignMissingColumn.FROM_AMOUNT);
-      //end of test case
-
-    } catch (Exception ex) {
-      JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
-      throw new RuntimeException("Could not construct signature hash: " + ex.getMessage());
-    }
-
-    TransactionCapsule transactionCap = generateTransactionCapsule(builder, ctx, hashOfTransaction,
-        transactionCapsule);
-
-    List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
-    actuator.get(0).validate(); //there is hash(transaction) in librustzcashSaplingFinalCheck
-    Assert.assertTrue(true);
-  }
-
-  /*
-   * test signature for shield to shield transaction with some column missing
-   */
-  @Test
-  public void testSignWithoutSpendDescription()
-      throws BadItemException, RuntimeException, ZksnarkException {
-    librustzcashInitZksnarkParams();
-    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-    long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
-
-    builder = generateShield2ShieldBuilder(builder, ctx);
-
-    // Empty output script.
-    byte[] hashOfTransaction;//256
-    TransactionCapsule transactionCapsule;
-    try {
-      transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
-          builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
-
-      //test case
-      hashOfTransaction = hashWithMissingColumn(transactionCapsule,
-          TestSignMissingColumn.SPEND_DESCRITPION);
-      //end of test case
-
-    } catch (Exception ex) {
-      JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
-      throw new RuntimeException("Could not construct signature hash: " + ex.getMessage());
-    }
-
-    TransactionCapsule transactionCap = generateTransactionCapsule(builder, ctx, hashOfTransaction,
-        transactionCapsule);
-
-    try {
-      //validate
-      List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
-      actuator.get(0).validate(); //there is hash(transaction) in librustzcashSaplingFinalCheck
-      Assert.assertFalse(true);
-    } catch (Exception e) {
-      Assert.assertTrue(e instanceof ContractValidateException);
-      Assert.assertEquals("librustzcashSaplingCheckSpend error", e.getMessage());
-    }
-    JLibrustzcash.librustzcashSaplingVerificationCtxFree(ctx);
-  }
-
-  /*
-   * test signature for shield to shield transaction with some column missing
-   */
-  @Test
-  public void testSignWithoutReceiveDescription()
-      throws BadItemException, RuntimeException, ZksnarkException {
-    librustzcashInitZksnarkParams();
-    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-    long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
-
-    builder = generateShield2ShieldBuilder(builder, ctx);
-
-    // Empty output script.
-    byte[] hashOfTransaction;//256
-    TransactionCapsule transactionCapsule;
-    try {
-      transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
-          builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
-
-      //test case
-      hashOfTransaction = hashWithMissingColumn(transactionCapsule,
-          TestSignMissingColumn.RECEIVE_DESCRIPTION);
-      //end of test case
-
-    } catch (Exception ex) {
-      JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
-      throw new RuntimeException("Could not construct signature hash: " + ex.getMessage());
-    }
-
-    TransactionCapsule transactionCap = generateTransactionCapsule(builder, ctx, hashOfTransaction,
-        transactionCapsule);
-
-    try {
-      //validate
-      List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
-      actuator.get(0).validate(); //there is hash(transaction) in librustzcashSaplingFinalCheck
-      Assert.assertFalse(true);
-    } catch (Exception e) {
-      Assert.assertTrue(e instanceof ContractValidateException);
-      Assert.assertEquals("librustzcashSaplingCheckSpend error", e.getMessage());
-    }
-    JLibrustzcash.librustzcashSaplingVerificationCtxFree(ctx);
-  }
-
-  /*
-   * test signature for shield to shield transaction with some column missing
-   */
-  @Test
-  public void testSignWithoutToAddress()
-      throws BadItemException, ContractValidateException, RuntimeException,
-      ZksnarkException {
-    librustzcashInitZksnarkParams();
-    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-    long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
-
-    builder = generateShield2ShieldBuilder(builder, ctx);
-
-    // Empty output script.
-    byte[] hashOfTransaction;//256
-    TransactionCapsule transactionCapsule;
-    try {
-      transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
-          builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
-
-      //test case
-      hashOfTransaction = hashWithMissingColumn(transactionCapsule,
-          TestSignMissingColumn.TO_ADDRESS);
-      //end of test case
-
-    } catch (Exception ex) {
-      JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
-      throw new RuntimeException("Could not construct signature hash: " + ex.getMessage());
-    }
-
-    TransactionCapsule transactionCap = generateTransactionCapsule(builder, ctx, hashOfTransaction,
-        transactionCapsule);
-
-    List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
-    actuator.get(0).validate(); //there is hash(transaction) in librustzcashSaplingFinalCheck
-    Assert.assertTrue(true);
-  }
-
-  /*
-   * test signature for shield to shield transaction with some column missing
-   */
-  @Test
-  public void testSignWithoutToAmount()
-      throws BadItemException, ContractValidateException, RuntimeException,
-      ZksnarkException {
-    librustzcashInitZksnarkParams();
-    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-    long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
-
-    builder = generateShield2ShieldBuilder(builder, ctx);
-
-    // Empty output script.
-    byte[] hashOfTransaction;//256
-    TransactionCapsule transactionCapsule;
-    try {
-      transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
-          builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
-
-      //test case
-      hashOfTransaction = hashWithMissingColumn(transactionCapsule,
-          TestSignMissingColumn.TO_AMOUNT);
-      //end of test case
-
-    } catch (Exception ex) {
-      JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
-      throw new RuntimeException("Could not construct signature hash: " + ex.getMessage());
-    }
-
-    TransactionCapsule transactionCap = generateTransactionCapsule(builder, ctx, hashOfTransaction,
-        transactionCapsule);
-
-    List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
-    actuator.get(0).validate(); //there is hash(transaction) in librustzcashSaplingFinalCheck
-    Assert.assertTrue(true);
-  }
-
-  /*
-   * test spend authorize signature with some wrong column
-   */
-  @Test
-  public void testSpendSignatureWithWrongColumn()
-      throws BadItemException, RuntimeException, ZksnarkException {
-    librustzcashInitZksnarkParams();
-    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-    long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
-
-    // generate input
-    SpendingKey sk = SpendingKey
-        .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
-    ExpandedSpendingKey expsk = sk.expandedSpendingKey();
-    PaymentAddress address = sk.defaultAddress();
-    Note note = new Note(address, 100 * 1000000L);
-    IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
-    byte[] anchor = voucher.root().getContent().toByteArray();
-    chainBaseManager.getMerkleContainer()
-        .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
-    builder.addSpend(expsk, note, anchor, voucher);
-
-    //shield transparent input
-    //createCapsule();
-    //builder.setTransparentInput(ByteArray.fromHexString(FROM_ADDRESS), OWNER_BALANCE);
-
-    // generate output
-    SpendingKey sk1 = SpendingKey.random();
-    FullViewingKey fullViewingKey1 = sk1.fullViewingKey();
-    IncomingViewingKey ivk1 = fullViewingKey1.inViewingKey();
-    PaymentAddress paymentAddress1 = ivk1.address(new DiversifierT()).get();
-    builder.addOutput(expsk.getOvk(), paymentAddress1,
-        100 * 1000000L - wallet.getShieldedTransactionFee(), new byte[512]);
-
-    // Create Sapling SpendDescriptions
-    for (SpendDescriptionInfo spend : builder.getSpends()) {
-      SpendDescriptionCapsule spendDescriptionCapsule = builder.generateSpendProof(spend, ctx);
-      builder.getContractBuilder().addSpendDescription(spendDescriptionCapsule.getInstance());
-    }
-
-    // Create Sapling OutputDescriptions
-    for (ReceiveDescriptionInfo receive : builder.getReceives()) {
-      ReceiveDescriptionCapsule receiveDescriptionCapsule = builder
-          .generateOutputProof(receive, ctx);
-      builder.getContractBuilder().addReceiveDescription(receiveDescriptionCapsule.getInstance());
-    }
-
-    // Empty output script.
-    byte[] hashOfTransaction;//256
-    TransactionCapsule transactionCapsule;
-    try {
-      transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
-          builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
-
-      hashOfTransaction = TransactionCapsule
-          .hashShieldTransaction(transactionCapsule.getInstance(),
-              CommonParameter.getInstance().getZenTokenId());
-
-    } catch (Exception ex) {
-      JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
-      throw new RuntimeException("Could not construct signature hash: " + ex.getMessage());
-    }
-
-    // Create Sapling spendAuth
-    for (int i = 0; i < builder.getSpends().size(); i++) {
-      byte[] result = new byte[64];
-      JLibrustzcash.librustzcashSaplingSpendSig(
-          new SpendSigParams(builder.getSpends().get(i).getExpsk().getAsk(),
-              Note.generateR(),
-              //replace builder.getSpends().get(i).alpha with random alpha, should fail
-              hashOfTransaction,
-              result));
-      builder.getContractBuilder().getSpendDescriptionBuilder(i)
-          .setSpendAuthoritySignature(ByteString.copyFrom(result));
-    }
-
-    //create binding signatures
-    byte[] bindingSig = new byte[64];
-    JLibrustzcash.librustzcashSaplingBindingSig(
-        new BindingSigParams(ctx,
-            builder.getValueBalance(),
-            hashOfTransaction,
-            bindingSig)
-    );
-    builder.getContractBuilder().setBindingSignature(ByteString.copyFrom(bindingSig));
-
-    Transaction.raw.Builder rawBuilder = transactionCapsule.getInstance().toBuilder()
-        .getRawDataBuilder()
-        .clearContract()
-        .addContract(Transaction.Contract.newBuilder()
-            .setType(ContractType.ShieldedTransferContract)
-            .setParameter(Any.pack(builder.getContractBuilder().build()))
-            .build());
-
-    Transaction transaction = transactionCapsule.getInstance().toBuilder().clearRawData()
-        .setRawData(rawBuilder).build();
-    TransactionCapsule transactionCap = new TransactionCapsule(transaction);
-
-    updateTotalShieldedPoolValue(builder.getValueBalance());
-
-    try {
-      //validate
-      List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
-      actuator.get(0)
-          .validate(); //there is getSpendAuthoritySignature in librustzcashSaplingCheckSpend
-      Assert.assertFalse(true);
-    } catch (Exception e) {
-      Assert.assertTrue(e instanceof ContractValidateException);
-      //signature for spend with some wrong column
-      //if transparent to shield, ok
-      //if shield to shield or shield to transparent, librustzcashSaplingFinalCheck error
-      Assert.assertTrue(e.getMessage().equalsIgnoreCase("librustzcashSaplingCheckSpend error"));
-    }
-    JLibrustzcash.librustzcashSaplingVerificationCtxFree(ctx);
-  }
-
-  /*
-   * test use isolate method to build the signature
-   */
-  @Test
-  public void testIsolateSignature()
-      throws ZksnarkException, BadItemException, ContractValidateException, ContractExeException {
-    librustzcashInitZksnarkParams();
-    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-    long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
-
-    // generate shield spend
-    SpendingKey sk = SpendingKey
-        .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
-    ExpandedSpendingKey expsk = sk.expandedSpendingKey();
-
-    //build transaction without spend signature and get transactionHash
-    TransactionHash transactionHash = new TransactionHash(new byte[32]);
-    TransactionCapsule transactionCapsule = buildShieldedTransactionWithoutSpendAuthSig(
-        sk.defaultAddress(),
-        sk.fullViewingKey().getAk(),
-        expsk.getNsk(),
-        expsk.getOvk(),
-        transactionHash,
-        builder,
-        ctx);
-    //filled with Sapling spendAuth in builder
-    List<SpendDescriptionInfo> spends = builder.getSpends();
-    for (int i = 0; i < spends.size(); i++) {
-      //replace with interface
-      SpendAuthSigParameters spendAuthSigParameters = SpendAuthSigParameters.newBuilder()
-          .setAsk(ByteString.copyFrom(expsk.getAsk())) //ask => ak
-          .setAlpha(ByteString.copyFrom(spends.get(i).getAlpha()))
-          .setTxHash(ByteString.copyFrom(transactionHash.getHash()))
-          .build();
-      BytesMessage spendAuthSig = wallet.createSpendAuthSig(spendAuthSigParameters);
-      builder.getContractBuilder().getSpendDescriptionBuilder(i)
-          .setSpendAuthoritySignature(spendAuthSig.getValue());
-    }
-
-    Transaction.raw.Builder rawBuilder = transactionCapsule.getInstance().toBuilder()
-        .getRawDataBuilder()
-        .clearContract()
-        .addContract(Transaction.Contract.newBuilder()
-            .setType(ContractType.ShieldedTransferContract)
-            .setParameter(Any.pack(builder.getContractBuilder().build()))
-            .build());
-    Transaction transaction = transactionCapsule.getInstance().toBuilder().clearRawData()
-        .setRawData(rawBuilder).build();
-
-    TransactionCapsule transactionCap = new TransactionCapsule(transaction);
-    //validate
-    List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
-    actuator.get(0).validate();
-    //execute
-    TransactionResultCapsule resultCapsule = new TransactionResultCapsule();
-    boolean executeResult = actuator.get(0).execute(resultCapsule);
-    Assert.assertTrue(executeResult);
-  }
-
-  /*
-   * build ShieldedTransaction Without SpendAuthSig
-   */
-  public TransactionCapsule buildShieldedTransactionWithoutSpendAuthSig(PaymentAddress address,
-      byte[] ak,
-      byte[] nsk, byte[] ovk, TransactionHash dataHashToBeSigned, ZenTransactionBuilder builder,
-      long ctx)
-      throws ZksnarkException, BadItemException, ContractValidateException {
-    // generate input
-    Note note = new Note(address, 100 * 1000000L);
-    note.setRcm(ByteArray.fromHexString(
-        "eb1aa5dd257b9da4e4064a853dec94651be38078e29fe441a9a8075016cfa701"));
-    IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
-    byte[] anchor = voucher.root().getContent().toByteArray();
-    chainBaseManager.getMerkleContainer()
-        .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
-    SpendDescriptionInfo skSpend = new SpendDescriptionInfo(ak,
-        nsk,
-        ovk,
-        note,
-        Note.generateR(),
-        anchor,
-        voucher
-    );
-    builder.addSpend(skSpend);
-
-    // generate output
-    SpendingKey sk1 = SpendingKey.random();
-    FullViewingKey fullViewingKey1 = sk1.fullViewingKey();
-    IncomingViewingKey ivk1 = fullViewingKey1.inViewingKey();
-    PaymentAddress paymentAddress1 = ivk1.address(new DiversifierT()).get();
-    builder.addOutput(ovk, paymentAddress1,
-        100 * 1000000L - wallet.getShieldedTransactionFee(), new byte[512]);
-
-    // Create Sapling SpendDescriptions
-    for (SpendDescriptionInfo spend : builder.getSpends()) {
-      SpendDescriptionCapsule spendDescriptionCapsule = builder.generateSpendProof(spend, ctx);
-      builder.getContractBuilder().addSpendDescription(spendDescriptionCapsule.getInstance());
-    }
-
-    // Create Sapling OutputDescriptions
-    for (ReceiveDescriptionInfo receive : builder.getReceives()) {
-      ReceiveDescriptionCapsule receiveDescriptionCapsule = builder
-          .generateOutputProof(receive, ctx);
-      builder.getContractBuilder().addReceiveDescription(receiveDescriptionCapsule.getInstance());
-    }
-
-    // Empty output script
-    TransactionCapsule transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
-        builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
-    //replace with interface
-    //System.out.println(JsonFormat.printToString(transactionCapsule.getInstance()));
-    BytesMessage transactionHash = wallet
-        .getShieldTransactionHash(transactionCapsule.getInstance());
-
-    if (transactionHash == null) {
-      throw new ZksnarkException("cal transaction hash failed");
-    }
-    dataHashToBeSigned.setHash(transactionHash.getValue().toByteArray());
-
-    // Create binding signatures
-    byte[] bindingSig = new byte[64];
-    JLibrustzcash.librustzcashSaplingBindingSig(
-        new BindingSigParams(ctx,
-            builder.getValueBalance(),
-            dataHashToBeSigned.getHash(),
-            bindingSig)
-    );
-    builder.getContractBuilder().setBindingSignature(ByteString.copyFrom(bindingSig));
-    return transactionCapsule;
-  }
-
-  @Test
-  public void testMemoTooLong() throws ContractValidateException, TooBigTransactionException,
-      TooBigTransactionResultException, TaposException, TransactionExpirationException,
-      ReceiptCheckErrException, DupTransactionException, VMIllegalException,
-      ValidateSignatureException, BadItemException, ContractExeException,
-      AccountResourceInsufficientException, InvalidProtocolBufferException, ZksnarkException {
-    long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
-
-    librustzcashInitZksnarkParams();
-    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-
-    // generate spend proof
-    SpendingKey sk = SpendingKey
-        .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
-    ExpandedSpendingKey expsk = sk.expandedSpendingKey();
-    PaymentAddress address = sk.defaultAddress();
-    Note note = new Note(address, 100 * 1000000L);
-    IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
-    byte[] anchor = voucher.root().getContent().toByteArray();
-    chainBaseManager.getMerkleContainer()
-        .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
-    builder.addSpend(expsk, note, anchor, voucher);
-
-    // generate output proof
-    SpendingKey spendingKey = SpendingKey.random();
-    FullViewingKey fullViewingKey = spendingKey.fullViewingKey();
-    IncomingViewingKey incomingViewingKey = fullViewingKey.inViewingKey();
-    PaymentAddress paymentAddress = incomingViewingKey.address(new DiversifierT()).get();
-    byte[] memo = org.tron.keystore.Wallet.generateRandomBytes(1024);
-    builder.addOutput(expsk.getOvk(), paymentAddress,
-        100 * 1000000L - wallet.getShieldedTransactionFee(), memo);
-
-    TransactionCapsule transactionCap = builder.build();
-
-    boolean ok = dbManager.pushTransaction(transactionCap);
-    Assert.assertTrue(ok);
-
-    // add here
-    byte[] ivk = fullViewingKey.inViewingKey().getValue();
-    Protocol.Transaction t = transactionCap.getInstance();
-
-    for (org.tron.protos.Protocol.Transaction.Contract c : t.getRawData().getContractList()) {
-      if (c.getType() != ContractType.ShieldedTransferContract) {
-        continue;
-      }
-      ShieldedTransferContract stContract = c.getParameter()
-          .unpack(ShieldedTransferContract.class);
-      ReceiveDescription receiveDescription = stContract.getReceiveDescription(0);
-
-      Optional<Note> ret1 = Note.decrypt(
-          receiveDescription.getCEnc().toByteArray(),//ciphertext
-          ivk,
-          receiveDescription.getEpk().toByteArray(),//epk
-          receiveDescription.getNoteCommitment().toByteArray() //cm
-      );
-
-      if (ret1.isPresent()) {
-        Note noteText = ret1.get();
-        byte[] pkD = new byte[32];
-        if (!JLibrustzcash.librustzcashIvkToPkd(
-            new IvkToPkdParams(incomingViewingKey.getValue(),
-                noteText.getD().getData(), pkD))) {
-          JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
-          return;
+        // Create Sapling OutputDescriptions
+        for (ReceiveDescriptionInfo receive : builder.getReceives()) {
+            ReceiveDescriptionCapsule receiveDescriptionCapsule = builder
+                    .generateOutputProof(receive, ctx);
+            builder.getContractBuilder().addReceiveDescription(receiveDescriptionCapsule.getInstance());
         }
-        Assert.assertArrayEquals(paymentAddress.getPkD(), pkD);
-        Assert.assertEquals(100 * 1000000L - wallet.getShieldedTransactionFee(),
-            noteText.getValue());
 
-        byte[] resultMemo = new byte[512];
-        System.arraycopy(memo, 0, resultMemo, 0, 512);
-        Assert.assertArrayEquals(resultMemo, noteText.getMemo());
-      } else {
-        Assert.assertFalse(true);
-      }
+        // begin to generate dataToBeSigned
+        TransactionCapsule transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
+                builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
+        byte[] dataToBeSigned = TransactionCapsule
+                .getShieldTransactionHashIgnoreTypeException(transactionCapsule.getInstance());
+        TransactionCapsule transactionCap = generateTransactionCapsule(builder, ctx, dataToBeSigned,
+                transactionCapsule);
+
+        // generate checkSpendParams
+        SpendDescription spendDescription = builder.getContractBuilder().getSpendDescription(0);
+        CheckSpendParams checkSpendParams = new CheckSpendParams(ctx,
+                spendDescription.getValueCommitment().toByteArray(),
+                spendDescription.getAnchor().toByteArray(),
+                spendDescription.getNullifier().toByteArray(),
+                spendDescription.getRk().toByteArray(),
+                spendDescription.getZkproof().toByteArray(),
+                spendDescription.getSpendAuthoritySignature().toByteArray(),
+                dataToBeSigned);
+
+        boolean ok1 = JLibrustzcash.librustzcashSaplingCheckSpend(checkSpendParams);
+        Assert.assertTrue(ok1);
+
+        byte[] checkSpendParamsData = new byte[385];
+        System.arraycopy(
+                checkSpendParams.getCv(), 0, checkSpendParamsData, 0, 32);
+        System.arraycopy(
+                checkSpendParams.getAnchor(), 0, checkSpendParamsData, 32, 32);
+        System.arraycopy(
+                checkSpendParams.getNullifier(), 0, checkSpendParamsData, 64, 32);
+        System.arraycopy(
+                checkSpendParams.getRk(), 0, checkSpendParamsData, 96, 32);
+        System.arraycopy(
+                checkSpendParams.getZkproof(), 0, checkSpendParamsData, 128, 192);
+        System.arraycopy(
+                checkSpendParams.getSpendAuthSig(), 0, checkSpendParamsData, 320, 64);
+
+        // generate CheckOutputParams
+        ReceiveDescription receiveDescription =
+                builder.getContractBuilder().getReceiveDescription(0);
+        CheckOutputParams checkOutputParams = new CheckOutputParams(ctx,
+                receiveDescription.getValueCommitment().toByteArray(),
+                receiveDescription.getNoteCommitment().toByteArray(),
+                receiveDescription.getEpk().toByteArray(),
+                receiveDescription.getZkproof().toByteArray()
+        );
+
+        boolean ok2 = JLibrustzcash.librustzcashSaplingCheckOutput(checkOutputParams);
+        Assert.assertTrue(ok2);
+
+        return new String[]{ByteArray.toHexString(checkSpendParamsData),
+                ByteArray.toHexString(dataToBeSigned),
+                ByteArray.toHexString(checkOutputParams.encode())};
     }
-    // end here
-    JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
-    Assert.assertTrue(ok);
-  }
 
-  @Test
-  public void testMemoNotEnough() throws ContractValidateException, TooBigTransactionException,
-      TooBigTransactionResultException, TaposException, TransactionExpirationException,
-      ReceiptCheckErrException, DupTransactionException, VMIllegalException,
-      ValidateSignatureException, BadItemException, ContractExeException,
-      AccountResourceInsufficientException, InvalidProtocolBufferException, ZksnarkException {
-    long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
+    private long benchmarkVerifySpend(String spend, String dataToBeSigned) throws ZksnarkException {
+        long startTime = System.currentTimeMillis();
+        long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
 
-    librustzcashInitZksnarkParams();
-    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+        CheckSpendParams checkSpendParams = CheckSpendParams.decode(ctx,
+                ByteArray.fromHexString(spend),
+                ByteArray.fromHexString(dataToBeSigned));
 
-    // generate spend proof
-    SpendingKey sk = SpendingKey
-        .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
-    ExpandedSpendingKey expsk = sk.expandedSpendingKey();
-    PaymentAddress address = sk.defaultAddress();
-    Note note = new Note(address, 100 * 1000000L);
-    IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
-    byte[] anchor = voucher.root().getContent().toByteArray();
-    chainBaseManager.getMerkleContainer()
-        .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
-    builder.addSpend(expsk, note, anchor, voucher);
+        boolean ok = JLibrustzcash.librustzcashSaplingCheckSpend(checkSpendParams);
 
-    // generate output proof
-    SpendingKey spendingKey = SpendingKey.random();
-    FullViewingKey fullViewingKey = spendingKey.fullViewingKey();
-    IncomingViewingKey incomingViewingKey = fullViewingKey.inViewingKey();
-    PaymentAddress paymentAddress = incomingViewingKey.address(new DiversifierT()).get();
-    byte[] memo = org.tron.keystore.Wallet.generateRandomBytes(128);
-    builder.addOutput(expsk.getOvk(), paymentAddress,
-        100 * 1000000L - wallet.getShieldedTransactionFee(), memo);
+        JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
+        Assert.assertTrue(ok);
 
-    TransactionCapsule transactionCap = builder.build();
+        long endTime = System.currentTimeMillis();
+        long time = endTime - startTime;
 
-    boolean ok = dbManager.pushTransaction(transactionCap);
-    Assert.assertTrue(ok);
+        System.out.println("--- time is: " + time + ", result is " + ok);
+        return time;
+    }
 
-    // add here
-    byte[] ivk = fullViewingKey.inViewingKey().getValue();
-    Protocol.Transaction t = transactionCap.getInstance();
+    private long benchmarkVerifyOutput(String outputParams) throws ZksnarkException {
+        // expect true
+        long startTime = System.currentTimeMillis();
+        long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
 
-    for (org.tron.protos.Protocol.Transaction.Contract c : t.getRawData().getContractList()) {
-      if (c.getType() != ContractType.ShieldedTransferContract) {
-        continue;
-      }
-      ShieldedTransferContract stContract = c.getParameter()
-          .unpack(ShieldedTransferContract.class);
-      ReceiveDescription receiveDescription = stContract.getReceiveDescription(0);
+        CheckOutputParams checkOutputParams = CheckOutputParams.decode(ctx,
+                ByteArray.fromHexString(outputParams));
 
-      Optional<Note> ret1 = Note.decrypt(
-          receiveDescription.getCEnc().toByteArray(),//ciphertext
-          ivk,
-          receiveDescription.getEpk().toByteArray(),//epk
-          receiveDescription.getNoteCommitment().toByteArray() //cm
-      );
+        boolean ok = JLibrustzcash.librustzcashSaplingCheckOutput(checkOutputParams);
 
-      if (ret1.isPresent()) {
-        Note noteText = ret1.get();
-        byte[] pkD = new byte[32];
-        if (!JLibrustzcash.librustzcashIvkToPkd(
-            new IvkToPkdParams(incomingViewingKey.getValue(),
-                noteText.getD().getData(), pkD))) {
-          JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
-          return;
+        JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
+        Assert.assertTrue(ok);
+
+        long endTime = System.currentTimeMillis();
+        long time = endTime - startTime;
+
+        System.out.println("--- time is: " + time + ", result is " + ok);
+        return time;
+    }
+
+    @Test
+    public void calBenchmarkVerifySpend() throws ZksnarkException, BadItemException {
+        librustzcashInitZksnarkParams();
+        System.out.println("--- load ok ---");
+
+        int count = 10;
+        long minTime = 500;
+        long maxTime = 0;
+        double totalTime = 0.0;
+
+        String[] result = generateSpendAndOutputParams();
+        String spend = result[0];
+        String dataToBeSigned = result[1];
+
+        for (int i = 0; i < count; i++) {
+            long time = benchmarkVerifySpend(spend, dataToBeSigned);
+            if (time < minTime) {
+                minTime = time;
+            }
+            if (time > maxTime) {
+                maxTime = time;
+            }
+            totalTime += time;
         }
-        Assert.assertArrayEquals(paymentAddress.getPkD(), pkD);
-        Assert.assertEquals(100 * 1000000L - wallet.getShieldedTransactionFee(),
-            noteText.getValue());
 
-        byte[] resultMemo = new byte[512];
-        System.arraycopy(memo, 0, resultMemo, 0, 128);
-        Assert.assertArrayEquals(resultMemo, noteText.getMemo());
-      } else {
-        Assert.assertFalse(true);
-      }
-    }
-    // end here
-    JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
-    Assert.assertTrue(ok);
-  }
+        System.out.println("---- result ----");
+        System.out.println("---- maxTime is: " + maxTime);
+        System.out.println("---- minTime is: " + minTime);
+        System.out.println("---- avgTime is: " + totalTime / count);
 
-  /*
-  send coin to 2 different address generated by same sk, scan note by ivk; spend this note again
-   */
-  @Test
-  public void pushSameSkAndScanAndSpend() throws Exception {
-
-    byte[] privateKey = ByteArray
-        .fromHexString("f4df789d3210ac881cb900464dd30409453044d2777060a0c391cbdf4c6a4f57");
-    final ECKey ecKey = ECKey.fromPrivate(privateKey);
-    byte[] witnessAddress = ecKey.getAddress();
-    WitnessCapsule witnessCapsule = new WitnessCapsule(ByteString.copyFrom(witnessAddress));
-    chainBaseManager.addWitness(ByteString.copyFrom(witnessAddress));
-
-    //sometimes generate block failed, try several times.
-
-    Block block = getSignedBlock(witnessCapsule.getAddress(), 0, privateKey);
-    dbManager.pushBlock(new BlockCapsule(block));
-
-    //create transactions
-    librustzcashInitZksnarkParams();
-    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(1000 * 1000000L);
-    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-
-    // generate spend proof
-    SpendingKey sk = SpendingKey
-        .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
-    ExpandedSpendingKey expsk = sk.expandedSpendingKey();
-    byte[] senderOvk = expsk.getOvk();
-    PaymentAddress address = sk.defaultAddress();
-    Note note = new Note(address, 1000 * 1000000L);
-    IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
-    byte[] anchor = voucher.root().getContent().toByteArray();
-    chainBaseManager.getMerkleContainer()
-        .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
-    builder.addSpend(expsk, note, anchor, voucher);
-
-    // generate output proof
-    SpendingKey sk2 = SpendingKey.random();
-    FullViewingKey fullViewingKey = sk2.fullViewingKey();
-    IncomingViewingKey incomingViewingKey = fullViewingKey.inViewingKey();
-
-    byte[] memo = org.tron.keystore.Wallet.generateRandomBytes(512);
-
-    //send coin to 2 different address generated by same sk
-    DiversifierT d1 = DiversifierT.random();
-    PaymentAddress paymentAddress1 = incomingViewingKey.address(d1).get();
-    builder.addOutput(senderOvk, paymentAddress1,
-        (1000 * 1000000L - wallet.getShieldedTransactionFee()) / 2, memo);
-
-    DiversifierT d2 = DiversifierT.random();
-    PaymentAddress paymentAddress2 = incomingViewingKey.address(d2).get();
-    builder.addOutput(senderOvk, paymentAddress2,
-        (1000 * 1000000L - wallet.getShieldedTransactionFee()) / 2, memo);
-
-    TransactionCapsule transactionCap = builder.build();
-
-    byte[] trxId = transactionCap.getTransactionId().getBytes();
-    boolean ok = dbManager.pushTransaction(transactionCap);
-    Assert.assertTrue(ok);
-
-    Thread.sleep(500);
-    //package transaction to block
-    block = getSignedBlock(witnessCapsule.getAddress(), 0, privateKey);
-    dbManager.pushBlock(new BlockCapsule(block));
-
-    BlockCapsule blockCapsule3 = new BlockCapsule(wallet.getNowBlock());
-    Assert.assertEquals("blocknum != 2", 2, blockCapsule3.getNum());
-
-    // scan note by ivk
-    byte[] receiverIvk = incomingViewingKey.getValue();
-    DecryptNotes notes1 = wallet.scanNoteByIvk(0, 100, receiverIvk);
-    Assert.assertEquals(2, notes1.getNoteTxsCount());
-
-    // scan note by ovk
-    DecryptNotes notes2 = wallet.scanNoteByOvk(0, 100, senderOvk);
-    Assert.assertEquals(2, notes2.getNoteTxsCount());
-
-    // to spend received note above.
-    ZenTransactionBuilder builder2 = new ZenTransactionBuilder(wallet);
-
-    //query merkleinfo
-    OutputPointInfo.Builder request = OutputPointInfo.newBuilder();
-    for (int i = 0; i < notes1.getNoteTxsCount(); i++) {
-      OutputPoint.Builder outPointBuild = OutputPoint.newBuilder();
-      outPointBuild.setHash(ByteString.copyFrom(trxId));
-      outPointBuild.setIndex(i);
-      request.addOutPoints(outPointBuild.build());
-    }
-    IncrementalMerkleVoucherInfo merkleVoucherInfo = wallet
-        .getMerkleTreeVoucherInfo(request.build());
-
-    //build spend proof. allow only one note in spend
-    ExpandedSpendingKey expsk2 = sk2.expandedSpendingKey();
-    for (int i = 0; i < 1; i++) {
-      org.tron.api.GrpcAPI.Note grpcNote = notes1.getNoteTxs(i).getNote();
-      PaymentAddress paymentAddress = KeyIo.decodePaymentAddress(grpcNote.getPaymentAddress());
-      Note note2 = new Note(paymentAddress.getD(),
-          paymentAddress.getPkD(),
-          grpcNote.getValue(),
-          grpcNote.getRcm().toByteArray()
-      );
-
-      IncrementalMerkleVoucherContainer voucher2 =
-          new IncrementalMerkleVoucherContainer(
-              new IncrementalMerkleVoucherCapsule(merkleVoucherInfo.getVouchers(i)));
-      byte[] anchor2 = voucher2.root().getContent().toByteArray();
-      builder2.addSpend(expsk2, note2, anchor2, voucher2);
     }
 
-    //build output proof
-    SpendingKey sk3 = SpendingKey.random();
-    FullViewingKey fvk3 = sk3.fullViewingKey();
-    IncomingViewingKey ivk3 = fvk3.inViewingKey();
+    @Test
+    public void calBenchmarkVerifyOutput() throws ZksnarkException, BadItemException {
+        librustzcashInitZksnarkParams();
+        System.out.println("--- load ok ---");
 
-    DiversifierT d3 = DiversifierT.random();
-    PaymentAddress paymentAddress3 = incomingViewingKey.address(d3).get();
-    byte[] memo3 = org.tron.keystore.Wallet.generateRandomBytes(512);
-    builder2.addOutput(expsk2.getOvk(), paymentAddress3,
-        (1000 * 1000000L - wallet.getShieldedTransactionFee()) / 2 - wallet
-            .getShieldedTransactionFee(), memo3);
+        int count = 2;
+        long minTime = 500;
+        long maxTime = 0;
+        double totalTime = 0.0;
 
-    TransactionCapsule transactionCap2 = builder2.build();
-    boolean ok2 = dbManager.pushTransaction(transactionCap2);
-    Assert.assertTrue(ok2);
-  }
+        String[] result = generateSpendAndOutputParams();
+        String outputParams = result[2];
 
-  @Test
-  public void decodePaymentAddressIgnoreCase() {
-    String addressLower =
-        "ztron1975m0wyg8f30cgf2l5fgndhzqzkzgkgnxge8cwx2wr7m3q7chsuwewh2e6u24yykum0hq8ue99u";
-    String addressUpper = addressLower.toUpperCase();
+        for (int i = 0; i < count; i++) {
+            long time = benchmarkVerifyOutput(outputParams);
+            if (time < minTime) {
+                minTime = time;
+            }
+            if (time > maxTime) {
+                maxTime = time;
+            }
+            totalTime += time;
+        }
 
-    PaymentAddress paymentAddress1 = KeyIo.decodePaymentAddress(addressLower);
-    PaymentAddress paymentAddress2 = KeyIo.decodePaymentAddress(addressUpper);
+        System.out.println("---- result ----");
+        System.out.println("---- maxTime is: " + maxTime);
+        System.out.println("---- minTime is: " + minTime);
+        System.out.println("---- avgTime is: " + totalTime / count);
 
-    Assert.assertEquals(ByteArray.toHexString(paymentAddress1.getD().getData()),
-        ByteArray.toHexString(paymentAddress2.getD().getData()));
-    Assert.assertEquals(ByteArray.toHexString(paymentAddress1.getPkD()),
-        ByteArray.toHexString(paymentAddress2.getPkD()));
+    }
 
-  }
+    private ZenTransactionBuilder generateBuilderWithoutColumnInDescription(
+            ZenTransactionBuilder builder, long ctx, TestReceiveMissingColumn column)
+            throws ZksnarkException, BadItemException {
+        //generate input
+        SpendingKey sk = SpendingKey.random();
+        ExpandedSpendingKey expsk = sk.expandedSpendingKey();
+        PaymentAddress address = sk.defaultAddress();
 
-  @Test
-  public void testCreateReceiveNoteRandom() throws ZksnarkException, BadItemException {
-    ReceiveNote receiveNote1 = wallet.createReceiveNoteRandom(0);
-    Assert.assertEquals(0, receiveNote1.getNote().getValue());
+        Note note = new Note(address, 100 * 1000000L);
+        IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
+        byte[] anchor = voucher.root().getContent().toByteArray();
+        chainBaseManager.getMerkleContainer()
+                .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
+        builder.addSpend(expsk, note, anchor, voucher);
 
-    ReceiveNote receiveNote2 = wallet.createReceiveNoteRandom(0);
-    Assert.assertNotEquals(receiveNote1.getNote().getPaymentAddress(),
-        receiveNote2.getNote().getPaymentAddress());
-  }
+        // generate output
+        SpendingKey sk1 = SpendingKey.random();
+        FullViewingKey fullViewingKey1 = sk1.fullViewingKey();
+        IncomingViewingKey ivk1 = fullViewingKey1.inViewingKey();
+        PaymentAddress paymentAddress1 = ivk1.address(new DiversifierT()).get();
+        builder.addOutput(expsk.getOvk(), paymentAddress1,
+                100 * 1000000 - wallet.getShieldedTransactionFee(), new byte[512]);
 
-  public enum TestColumn {
-    CV,
-    ZKPOOF,
-    D_CM,
-    PKD_CM,
-    VALUE_CM,
-    R_CM
-  }
+        // Create Sapling SpendDescriptions
+        for (SpendDescriptionInfo spend : builder.getSpends()) {
+            SpendDescriptionCapsule spendDescriptionCapsule = builder.generateSpendProof(spend, ctx);
+            builder.getContractBuilder().addSpendDescription(spendDescriptionCapsule.getInstance());
+        }
 
-  public enum TestSignMissingColumn {
-    FROM_ADDRESS, FROM_AMOUNT, SPEND_DESCRITPION,
-    RECEIVE_DESCRIPTION, TO_ADDRESS, TO_AMOUNT
-  }
+        // Create Sapling OutputDescriptions
+        for (ReceiveDescriptionInfo receive : builder.getReceives()) {
+            ReceiveDescriptionCapsule receiveDescriptionCapsule = builder
+                    .generateOutputProof(receive, ctx);
+            switch (column) {
+                case CV:
+                    receiveDescriptionCapsule.setValueCommitment(ByteString.EMPTY);
+                    break;
+                case CM:
+                    receiveDescriptionCapsule.setNoteCommitment(ByteString.EMPTY);
+                    break;
+                case EPK:
+                    receiveDescriptionCapsule.setEpk(ByteString.EMPTY);
+                    break;
+                case ZKPROOF:
+                    receiveDescriptionCapsule.setZkproof(ByteString.EMPTY);
+                    break;
+                case C_ENC:
+                    receiveDescriptionCapsule.setCEnc(ByteString.EMPTY);
+                    break;
+                case C_OUT:
+                    receiveDescriptionCapsule.setCOut(ByteString.EMPTY);
+                    break;
+                default:
+                    break;
+            }
+            builder.getContractBuilder().addReceiveDescription(receiveDescriptionCapsule.getInstance());
+        }
 
-  public enum TestReceiveMissingColumn {
-    CV, CM, EPK, C_ENC, C_OUT, ZKPROOF
-  }
+        return builder;
+    }
 
-  @AllArgsConstructor
-  class TransactionHash {
+    /*
+     * test of empty CV in receive description
+     */
+    @Test
+    public void testReceiveDescriptionWithEmptyCv()
+            throws BadItemException, RuntimeException, ZksnarkException {
+        librustzcashInitZksnarkParams();
+        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+        long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
 
-    @Setter
-    @Getter
-    byte[] hash;
-  }
+        builder = generateBuilderWithoutColumnInDescription(builder, ctx, TestReceiveMissingColumn.CV);
+
+        // Empty output script.
+        byte[] dataToBeSigned;//256
+        TransactionCapsule transactionCapsule;
+        try {
+            transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
+                    builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
+            TransactionExtention transactionExtention = TransactionExtention.newBuilder()
+                    .setTransaction(transactionCapsule.getInstance()).build();
+
+            dataToBeSigned = TransactionCapsule.hashShieldTransaction(transactionCapsule.getInstance(),
+                    CommonParameter.getInstance().getZenTokenId());
+        } catch (Exception ex) {
+            JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
+            throw new RuntimeException("Could not construct signature hash: " + ex.getMessage());
+        }
+
+        TransactionCapsule transactionCap = generateTransactionCapsule(builder, ctx, dataToBeSigned,
+                transactionCapsule);
+
+        try {
+            //validate
+            List<Actuator> actuator = ActuatorCreator
+                    .getINSTANCE().createActuator(transactionCap);
+            actuator.get(0).validate();
+            Assert.assertTrue(false);
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof ContractValidateException);
+            Assert.assertEquals("param is null", e.getMessage());
+        }
+        JLibrustzcash.librustzcashSaplingVerificationCtxFree(ctx);
+    }
+
+    /*
+     * test of empty cm in receive description
+     */
+    @Test
+    public void testReceiveDescriptionWithEmptyCm()
+            throws BadItemException, RuntimeException, ZksnarkException {
+        librustzcashInitZksnarkParams();
+        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+        long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
+
+        builder = generateBuilderWithoutColumnInDescription(builder, ctx, TestReceiveMissingColumn.CM);
+
+        // Empty output script.
+        byte[] dataToBeSigned;//256
+        TransactionCapsule transactionCapsule;
+        try {
+            transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
+                    builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
+            dataToBeSigned = TransactionCapsule.hashShieldTransaction(transactionCapsule.getInstance(),
+                    CommonParameter.getInstance().getZenTokenId());
+        } catch (Exception ex) {
+            JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
+            throw new RuntimeException("Could not construct signature hash: " + ex.getMessage());
+        }
+
+        TransactionCapsule transactionCap = generateTransactionCapsule(builder, ctx, dataToBeSigned,
+                transactionCapsule);
+
+        try {
+            //validate
+            List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
+            actuator.get(0).validate();
+
+            Assert.assertTrue(false);
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof ContractValidateException);
+            Assert.assertEquals("param is null", e.getMessage());
+        }
+        JLibrustzcash.librustzcashSaplingVerificationCtxFree(ctx);
+    }
+
+    /*
+     * test of empty epk in receive description
+     */
+    @Test
+    public void testReceiveDescriptionWithEmptyEpk()
+            throws BadItemException, RuntimeException, ZksnarkException {
+        librustzcashInitZksnarkParams();
+        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+        long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
+
+        builder = generateBuilderWithoutColumnInDescription(builder, ctx, TestReceiveMissingColumn.EPK);
+
+        // Empty output script.
+        byte[] dataToBeSigned;//256
+        TransactionCapsule transactionCapsule;
+        try {
+            transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
+                    builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
+            dataToBeSigned = TransactionCapsule.hashShieldTransaction(transactionCapsule.getInstance(),
+                    CommonParameter.getInstance().getZenTokenId());
+        } catch (Exception ex) {
+            JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
+            throw new RuntimeException("Could not construct signature hash: " + ex.getMessage());
+        }
+
+        TransactionCapsule transactionCap = generateTransactionCapsule(builder, ctx, dataToBeSigned,
+                transactionCapsule);
+
+        try {
+            //validate
+            List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
+            actuator.get(0).validate();
+            Assert.assertTrue(false);
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof ContractValidateException);
+            Assert.assertEquals("param is null", e.getMessage());
+        }
+        JLibrustzcash.librustzcashSaplingVerificationCtxFree(ctx);
+    }
+
+    /*
+     * test of empty zkproof in receive description
+     */
+    @Test
+    public void testReceiveDescriptionWithEmptyZkproof()
+            throws BadItemException, RuntimeException, ZksnarkException {
+        librustzcashInitZksnarkParams();
+        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+        long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
+
+        builder = generateBuilderWithoutColumnInDescription(builder, ctx,
+                TestReceiveMissingColumn.ZKPROOF);
+
+        // Empty output script.
+        byte[] dataToBeSigned;//256
+        TransactionCapsule transactionCapsule;
+        try {
+            transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
+                    builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
+            dataToBeSigned = TransactionCapsule.hashShieldTransaction(transactionCapsule.getInstance(),
+                    CommonParameter.getInstance().getZenTokenId());
+        } catch (Exception ex) {
+            JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
+            throw new RuntimeException("Could not construct signature hash: " + ex.getMessage());
+        }
+
+        TransactionCapsule transactionCap = generateTransactionCapsule(builder, ctx, dataToBeSigned,
+                transactionCapsule);
+
+        try {
+            //validate
+            List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
+            actuator.get(0).validate();
+            Assert.assertTrue(false);
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof ContractValidateException);
+            Assert.assertEquals("param is null", e.getMessage());
+        }
+        JLibrustzcash.librustzcashSaplingVerificationCtxFree(ctx);
+    }
+
+    /*
+     * test of empty c_enc in receive description
+     */
+    @Test
+    public void testReceiveDescriptionWithEmptyCenc()
+            throws BadItemException, RuntimeException, ZksnarkException {
+        librustzcashInitZksnarkParams();
+        dbManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+        dbManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+        long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
+
+        builder = generateBuilderWithoutColumnInDescription(builder, ctx,
+                TestReceiveMissingColumn.C_ENC);
+
+        // Empty output script.
+        byte[] dataToBeSigned;//256
+        TransactionCapsule transactionCapsule;
+        try {
+            transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
+                    builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
+            dataToBeSigned = TransactionCapsule.hashShieldTransaction(transactionCapsule.getInstance(),
+                    CommonParameter.getInstance().getZenTokenId());
+        } catch (Exception ex) {
+            JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
+            throw new RuntimeException("Could not construct signature hash: " + ex.getMessage());
+        }
+
+        TransactionCapsule transactionCap = generateTransactionCapsule(builder, ctx, dataToBeSigned,
+                transactionCapsule);
+
+        try {
+            //validate
+            List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
+            actuator.get(0).validate();
+            Assert.assertTrue(false);
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof ContractValidateException);
+            Assert.assertEquals("Cout or CEnc size error", e.getMessage());
+        }
+        JLibrustzcash.librustzcashSaplingVerificationCtxFree(ctx);
+    }
+
+    /*
+     * test of empty c_out in receive description
+     */
+    @Test
+    public void testReceiveDescriptionWithEmptyCout()
+            throws BadItemException, RuntimeException, ZksnarkException {
+        librustzcashInitZksnarkParams();
+        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+        long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
+
+        builder = generateBuilderWithoutColumnInDescription(builder, ctx,
+                TestReceiveMissingColumn.C_OUT);
+
+        // Empty output script.
+        byte[] dataToBeSigned;//256
+        TransactionCapsule transactionCapsule;
+        try {
+            transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
+                    builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
+            dataToBeSigned = TransactionCapsule.hashShieldTransaction(transactionCapsule.getInstance(),
+                    CommonParameter.getInstance().getZenTokenId());
+        } catch (Exception ex) {
+            JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
+            throw new RuntimeException("Could not construct signature hash: " + ex.getMessage());
+        }
+
+        TransactionCapsule transactionCap = generateTransactionCapsule(builder, ctx, dataToBeSigned,
+                transactionCapsule);
+
+        try {
+            //validate
+            List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
+            actuator.get(0).validate();
+            Assert.assertTrue(false);
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof ContractValidateException);
+            Assert.assertEquals("Cout or CEnc size error", e.getMessage());
+        }
+        JLibrustzcash.librustzcashSaplingVerificationCtxFree(ctx);
+    }
+
+    /*
+     * test some column in ReceiveDescription is wrong
+     */
+    private ReceiveDescriptionCapsule changeGenerateOutputProof(ReceiveDescriptionInfo output,
+                                                                long ctx, TestColumn testColumn)
+            throws ZksnarkException {
+        byte[] cm = output.getNote().cm();
+        if (ByteArray.isEmpty(cm)) {
+            JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
+            throw new ZksnarkException("Output is invalid");
+        }
+
+        Optional<NotePlaintextEncryptionResult> res = output.getNote()
+                .encrypt(output.getNote().getPkD());
+        if (!res.isPresent()) {
+            JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
+            throw new ZksnarkException("Failed to encrypt note");
+        }
+
+        NotePlaintextEncryptionResult enc = res.get();
+        NoteEncryption encryptor = enc.getNoteEncryption();
+
+        byte[] cv = new byte[32];
+        byte[] zkProof = new byte[192];
+        if (!JLibrustzcash.librustzcashSaplingOutputProof(
+                new OutputProofParams(ctx,
+                        encryptor.getEsk(),
+                        output.getNote().getD().getData(),
+                        output.getNote().getPkD(),
+                        output.getNote().getRcm(),
+                        output.getNote().getValue(),
+                        cv,
+                        zkProof))) {
+            JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
+            throw new ZksnarkException("Output proof failed");
+        }
+
+        ReceiveDescriptionCapsule receiveDescriptionCapsule = new ReceiveDescriptionCapsule();
+        receiveDescriptionCapsule.setValueCommitment(cv);
+        receiveDescriptionCapsule.setNoteCommitment(cm);
+        receiveDescriptionCapsule.setEpk(encryptor.getEpk());
+        receiveDescriptionCapsule.setCEnc(enc.getEncCiphertext());
+        receiveDescriptionCapsule.setZkproof(zkProof);
+
+        OutgoingPlaintext outPlaintext =
+                new OutgoingPlaintext(output.getNote().getPkD(), encryptor.getEsk());
+        receiveDescriptionCapsule.setCOut(outPlaintext
+                .encrypt(output.getOvk(), receiveDescriptionCapsule.getValueCommitment().toByteArray(),
+                        receiveDescriptionCapsule.getCm().toByteArray(),
+                        encryptor).getData());
+
+        Note newNote = output.getNote();
+        byte[] newCm;
+        switch (testColumn) {
+            case CV:
+                receiveDescriptionCapsule.setValueCommitment(randomUint256());
+                break;
+            case ZKPOOF:
+                receiveDescriptionCapsule.setZkproof(randomUint1536());
+                break;
+            case D_CM:
+                newNote.setD(DiversifierT.random());
+                newCm = newNote.cm();
+                if (newCm == null) {
+                    receiveDescriptionCapsule.setNoteCommitment(ByteString.EMPTY);
+                } else {
+                    receiveDescriptionCapsule.setNoteCommitment(newCm);
+                }
+                break;
+            case PKD_CM:
+                newNote.setPkD(randomUint256());
+                newCm = newNote.cm();
+                if (newCm == null) {
+                    receiveDescriptionCapsule.setNoteCommitment(ByteString.EMPTY);
+                } else {
+                    receiveDescriptionCapsule.setNoteCommitment(newCm);
+                }
+                break;
+            case VALUE_CM:
+                newNote.setValue(newNote.getValue() + 10000);
+                newCm = newNote.cm();
+                if (newCm == null) {
+                    receiveDescriptionCapsule.setNoteCommitment(ByteString.EMPTY);
+                } else {
+                    receiveDescriptionCapsule.setNoteCommitment(newCm);
+                }
+                break;
+            case R_CM:
+                newNote.setRcm(Note.generateR());
+                newCm = newNote.cm();
+                if (newCm == null) {
+                    receiveDescriptionCapsule.setNoteCommitment(ByteString.EMPTY);
+                } else {
+                    receiveDescriptionCapsule.setNoteCommitment(newCm);
+                }
+                break;
+
+            default:
+                break;
+        }
+
+        return receiveDescriptionCapsule;
+    }
+
+    private TransactionCapsule changeBuildOutputProof(ZenTransactionBuilder builder, long ctx,
+                                                      TestColumn testColumn)
+            throws ZksnarkException {
+        ShieldedTransferContract.Builder contractBuilder = builder.getContractBuilder();
+
+        // Create Sapling SpendDescriptions
+        for (SpendDescriptionInfo spend : builder.getSpends()) {
+            SpendDescriptionCapsule spendDescriptionCapsule = builder.generateSpendProof(spend, ctx);
+            contractBuilder.addSpendDescription(spendDescriptionCapsule.getInstance());
+        }
+
+        // Create Sapling OutputDescriptions
+        for (ReceiveDescriptionInfo receive : builder.getReceives()) {
+            //test case
+            ReceiveDescriptionCapsule receiveDescriptionCapsule = changeGenerateOutputProof(receive, ctx,
+                    testColumn);
+            //end of test case
+            contractBuilder.addReceiveDescription(receiveDescriptionCapsule.getInstance());
+        }
+
+        // Empty output script.
+        byte[] dataToBeSigned;//256
+        TransactionCapsule transactionCapsule;
+        try {
+            transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
+                    contractBuilder.build(), ContractType.ShieldedTransferContract);
+
+            dataToBeSigned = TransactionCapsule.hashShieldTransaction(transactionCapsule.getInstance(),
+                    CommonParameter.getInstance().getZenTokenId());
+        } catch (Exception ex) {
+            JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
+            throw new ZksnarkException("Could not construct signature hash: " + ex.getMessage());
+        }
+
+        // Create Sapling spendAuth and binding signatures
+        builder.createSpendAuth(dataToBeSigned);
+        byte[] bindingSig = new byte[64];
+        JLibrustzcash.librustzcashSaplingBindingSig(
+                new BindingSigParams(ctx,
+                        builder.getValueBalance(),
+                        dataToBeSigned,
+                        bindingSig)
+        );
+        contractBuilder.setBindingSignature(ByteString.copyFrom(bindingSig));
+        JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
+
+        Transaction.raw.Builder rawBuilder = transactionCapsule.getInstance().toBuilder()
+                .getRawDataBuilder()
+                .clearContract()
+                .addContract(
+                        Transaction.Contract.newBuilder().setType(ContractType.ShieldedTransferContract)
+                                .setParameter(
+                                        Any.pack(contractBuilder.build())).build());
+
+        Transaction transaction = transactionCapsule.getInstance().toBuilder().clearRawData()
+                .setRawData(rawBuilder).build();
+        return new TransactionCapsule(transaction);
+    }
+
+    private ZenTransactionBuilder generateBuilder(ZenTransactionBuilder builder, long ctx)
+            throws ZksnarkException, BadItemException {
+        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+
+        // generate input
+        SpendingKey sk = SpendingKey.random();
+        ExpandedSpendingKey expsk = sk.expandedSpendingKey();
+        PaymentAddress address = sk.defaultAddress();
+        Note note = new Note(address, 100 * 1000000L);
+        IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
+        byte[] anchor = voucher.root().getContent().toByteArray();
+        //put the voucher and anchor into db
+        chainBaseManager.getMerkleContainer()
+                .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
+        builder.addSpend(expsk, note, anchor, voucher);
+
+        // generate output
+        SpendingKey sk1 = SpendingKey.random();
+        FullViewingKey fullViewingKey1 = sk1.fullViewingKey();
+        IncomingViewingKey ivk1 = fullViewingKey1.inViewingKey();
+        PaymentAddress paymentAddress1 = ivk1.address(new DiversifierT()).get();
+        Note note2 = new Note(paymentAddress1, 100 * 1000000L - wallet.getShieldedTransactionFee());
+        builder
+                .addOutput(expsk.getOvk(), note2.getD(), note2.getPkD(), note2.getValue(), note2.getRcm(),
+                        new byte[512]);
+
+        return builder;
+    }
+
+    /*
+     * test wrong value_commitment in ReceiveDescription
+     */
+    @Test
+    public void testReceiveDescriptionWithWrongCv()
+            throws BadItemException, RuntimeException, ZksnarkException {
+        librustzcashInitZksnarkParams();
+        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+        long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
+
+        builder = generateBuilder(builder, ctx);
+
+        TestColumn testColumn = TestColumn.CV;
+        TransactionCapsule transactionCap = changeBuildOutputProof(builder, ctx, testColumn);
+
+        updateTotalShieldedPoolValue(builder.getValueBalance());
+
+        try {
+            List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
+            actuator.get(0).validate();
+            Assert.assertFalse(true);
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof ContractValidateException);
+            Assert.assertEquals("librustzcashSaplingCheckOutput error", e.getMessage());
+        }
+    }
+
+    /*
+     * test wrong zkproof in ReceiveDescription
+     */
+    @Test
+    public void testReceiveDescriptionWithWrongZkproof()
+            throws BadItemException, RuntimeException, ZksnarkException {
+        librustzcashInitZksnarkParams();
+        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+        long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
+
+        builder = generateBuilder(builder, ctx);
+
+        TestColumn testColumn = TestColumn.ZKPOOF;
+        TransactionCapsule transactionCap = changeBuildOutputProof(builder, ctx, testColumn);
+
+        updateTotalShieldedPoolValue(builder.getValueBalance());
+
+        try {
+            List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
+            actuator.get(0).validate();
+            Assert.assertFalse(true);
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof ContractValidateException);
+            Assert.assertEquals("librustzcashSaplingCheckOutput error", e.getMessage());
+        }
+    }
+
+    /*
+     * test note_commitment in ReceiveDescription generated by wrong d
+     */
+    @Test
+    public void testReceiveDescriptionWithWrongD()
+            throws BadItemException, RuntimeException, ZksnarkException {
+        librustzcashInitZksnarkParams();
+        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+        long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
+
+        builder = generateBuilder(builder, ctx);
+
+        TestColumn testColumn = TestColumn.D_CM;
+        TransactionCapsule transactionCap = changeBuildOutputProof(builder, ctx, testColumn);
+
+        updateTotalShieldedPoolValue(builder.getValueBalance());
+
+        try {
+            List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
+            actuator.get(0).validate();
+            Assert.assertFalse(true);
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof ContractValidateException);
+            //if generate cm successful, checkout error; else param is null because of cm is null
+            Assert.assertTrue("librustzcashSaplingCheckOutput error".equalsIgnoreCase(e.getMessage())
+                    || "param is null".equalsIgnoreCase(e.getMessage()));
+        }
+    }
+
+    /*
+     * test note_commitment in ReceiveDescription generated by wrong pkd
+     */
+    @Test
+    public void testReceiveDescriptionWithWrongPkd()
+            throws BadItemException, RuntimeException, ZksnarkException {
+        librustzcashInitZksnarkParams();
+        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+        long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
+
+        builder = generateBuilder(builder, ctx);
+
+        TestColumn testColumn = TestColumn.PKD_CM;
+        TransactionCapsule transactionCap = changeBuildOutputProof(builder, ctx, testColumn);
+
+        updateTotalShieldedPoolValue(builder.getValueBalance());
+
+        try {
+            List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
+            actuator.get(0).validate();
+            Assert.assertFalse(true);
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof ContractValidateException);
+            //if generate cm successful, checkout error; else param is null because of cm is null
+            Assert.assertTrue("librustzcashSaplingCheckOutput error".equalsIgnoreCase(e.getMessage())
+                    || "param is null".equalsIgnoreCase(e.getMessage()));
+        }
+    }
+
+    /*
+     * test note_commitment in ReceiveDescription generated by wrong value
+     */
+    @Test
+    public void testReceiveDescriptionWithWrongValue()
+            throws BadItemException, RuntimeException, ZksnarkException {
+        librustzcashInitZksnarkParams();
+        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+        long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
+
+        builder = generateBuilder(builder, ctx);
+
+        TestColumn testColumn = TestColumn.VALUE_CM;
+        TransactionCapsule transactionCap = changeBuildOutputProof(builder, ctx, testColumn);
+
+        updateTotalShieldedPoolValue(builder.getValueBalance());
+
+        try {
+            List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
+            actuator.get(0).validate();
+            Assert.assertFalse(true);
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof ContractValidateException);
+            Assert.assertTrue(e.getMessage().equalsIgnoreCase("librustzcashSaplingCheckOutput error"));
+        }
+    }
+
+    /*
+     * test note_commitment in ReceiveDescription generated by wrong r
+     */
+    @Test
+    public void testReceiveDescriptionWithWrongRcm()
+            throws BadItemException, RuntimeException, ZksnarkException {
+        librustzcashInitZksnarkParams();
+        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+        long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
+
+        builder = generateBuilder(builder, ctx);
+
+        TestColumn testColumn = TestColumn.R_CM;
+        TransactionCapsule transactionCap = changeBuildOutputProof(builder, ctx, testColumn);
+
+        updateTotalShieldedPoolValue(builder.getValueBalance());
+
+        try {
+            List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
+            actuator.get(0).validate();
+            Assert.assertFalse(true);
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof ContractValidateException);
+            Assert.assertEquals("librustzcashSaplingCheckOutput error", e.getMessage());
+        }
+    }
+
+    /**
+     * use ask or nsk not belongs to sk.
+     */
+    @Test
+    public void testNotMatchAskAndNsk()
+            throws BadItemException, RuntimeException, ZksnarkException {
+        librustzcashInitZksnarkParams();
+        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+
+        // generate sk
+        SpendingKey sk = SpendingKey
+                .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
+        ExpandedSpendingKey expsk = sk.expandedSpendingKey();
+        PaymentAddress address = sk.defaultAddress();
+
+        //generate a note belongs to this sk
+        Note note = new Note(address, 100 * 1000000L);
+        IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
+        byte[] anchor = voucher.root().getContent().toByteArray();
+        //put the voucher and anchor into db
+        chainBaseManager.getMerkleContainer()
+                .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
+
+        //test case: give a random Ask or nsk
+        expsk.setAsk(randomUint256());
+        //expsk.setNsk(randomUint256());
+        //end of test case
+
+        builder.addSpend(expsk, note, anchor, voucher);
+
+        // generate output
+        SpendingKey sk1 = SpendingKey.random();
+        FullViewingKey fullViewingKey1 = sk1.fullViewingKey();
+        IncomingViewingKey ivk1 = fullViewingKey1.inViewingKey();
+        PaymentAddress paymentAddress1 = ivk1.address(new DiversifierT()).get();
+        builder.addOutput(expsk.getOvk(), paymentAddress1,
+                100 * 1000000L - wallet.getShieldedTransactionFee(), new byte[512]);
+
+        updateTotalShieldedPoolValue(builder.getValueBalance());
+        try {
+            TransactionCapsule transactionCap = builder.build();
+            Assert.assertFalse(true);
+
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof ZksnarkException);
+            Assert.assertEquals("Spend proof failed", e.getMessage());
+        }
+    }
+
+    /**
+     * use random ovk not related to sk.
+     */
+    @Test
+    public void testRandomOvk()
+            throws BadItemException, RuntimeException, ZksnarkException {
+        librustzcashInitZksnarkParams();
+        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+
+        // generate sk
+        SpendingKey sk = SpendingKey
+                .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
+        ExpandedSpendingKey expsk = sk.expandedSpendingKey();
+        PaymentAddress address = sk.defaultAddress();
+
+        //generate a note belongs to this sk
+        Note note = new Note(address, 100 * 1000000L);
+        IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
+        byte[] anchor = voucher.root().getContent().toByteArray();
+        //put the voucher and anchor into db
+        chainBaseManager.getMerkleContainer()
+                .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
+
+        //test case: give a random Ovk
+        expsk.setOvk(randomUint256());
+        //end of test case
+
+        builder.addSpend(expsk, note, anchor, voucher);
+
+        // generate output
+        SpendingKey sk1 = SpendingKey.random();
+        FullViewingKey fullViewingKey1 = sk1.fullViewingKey();
+        IncomingViewingKey ivk1 = fullViewingKey1.inViewingKey();
+        PaymentAddress paymentAddress1 = ivk1.address(new DiversifierT()).get();
+        builder.addOutput(expsk.getOvk(), paymentAddress1,
+                100 * 1000000L - wallet.getShieldedTransactionFee(), new byte[512]);
+
+        updateTotalShieldedPoolValue(builder.getValueBalance());
+        TransactionCapsule transactionCap = builder.build();
+        Assert.assertTrue(true);
+    }
+
+    /*
+     * test add two same cm into spend
+     */
+    //@Test not used
+    public void testSameInputCm()
+            throws BadItemException, RuntimeException, ZksnarkException {
+        librustzcashInitZksnarkParams();
+        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+
+        // generate input
+        SpendingKey sk = SpendingKey
+                .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
+        ExpandedSpendingKey expsk = sk.expandedSpendingKey();
+        PaymentAddress address = sk.defaultAddress();
+        Note note = new Note(address, 100 * 1000000L);
+        IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
+        byte[] anchor = voucher.root().getContent().toByteArray();
+        //put the voucher and anchor into db
+        chainBaseManager.getMerkleContainer()
+                .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
+
+        //add two same cm
+        builder.addSpend(expsk, note, anchor, voucher);
+        builder.addSpend(expsk, note, anchor, voucher);
+
+        // generate output
+        SpendingKey sk1 = SpendingKey.random();
+        FullViewingKey fullViewingKey1 = sk1.fullViewingKey();
+        IncomingViewingKey ivk1 = fullViewingKey1.inViewingKey();
+        PaymentAddress paymentAddress1 = ivk1.address(new DiversifierT()).get();
+        builder.addOutput(expsk.getOvk(), paymentAddress1,
+                200 * 1000000L - wallet.getShieldedTransactionFee(), new byte[512]);
+
+        updateTotalShieldedPoolValue(builder.getValueBalance());
+        TransactionCapsule transactionCap = builder.build();
+
+        try {
+            //validate
+            List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
+            actuator.get(0).validate();
+            Assert.assertFalse(true);
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof ContractValidateException);
+            Assert.assertEquals("duplicate sapling nullifiers in this transaction", e.getMessage());
+        }
+    }
+
+    /*
+     * test add two same cm into output
+     */
+    @Test
+    public void testSameOutputCm()
+            throws BadItemException, RuntimeException, ZksnarkException {
+        librustzcashInitZksnarkParams();
+        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+
+        // generate input
+        SpendingKey sk = SpendingKey
+                .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
+        ExpandedSpendingKey expsk = sk.expandedSpendingKey();
+        PaymentAddress address = sk.defaultAddress();
+        Note note = new Note(address, 100 * 1000000L);
+        IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
+        byte[] anchor = voucher.root().getContent().toByteArray();
+        //put the voucher and anchor into db
+        chainBaseManager.getMerkleContainer()
+                .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
+        builder.addSpend(expsk, note, anchor, voucher);
+
+        // generate output
+        SpendingKey sk1 = SpendingKey.random();
+        FullViewingKey fullViewingKey1 = sk1.fullViewingKey();
+        IncomingViewingKey ivk1 = fullViewingKey1.inViewingKey();
+        PaymentAddress paymentAddress1 = ivk1.address(new DiversifierT()).get();
+        Note note2 = new Note(address, (100 * 1000000L - wallet.getShieldedTransactionFee()) / 2);
+        //add two same output note
+        builder
+                .addOutput(expsk.getOvk(), note2.getD(), note2.getPkD(), note2.getValue(), note2.getRcm(),
+                        new byte[512]);
+        builder
+                .addOutput(expsk.getOvk(), note2.getD(), note2.getPkD(), note2.getValue(), note2.getRcm(),
+                        new byte[512]);//same output cm
+
+        updateTotalShieldedPoolValue(builder.getValueBalance());
+        TransactionCapsule transactionCap = builder.build();
+
+        try {
+            //validate
+            List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
+            actuator.get(0).validate();
+            Assert.assertFalse(true);
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof ContractValidateException);
+            Assert.assertEquals("duplicate cm in receive_description", e.getMessage());
+        }
+    }
+
+    /**
+     * test of transferring insufficient money from shield address to shield address.
+     */
+    @Test
+    public void testShieldInputInsufficient()
+            throws BadItemException, RuntimeException, ZksnarkException {
+        librustzcashInitZksnarkParams();
+        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+
+        // generate input
+        SpendingKey sk = SpendingKey
+                .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
+        ExpandedSpendingKey expsk = sk.expandedSpendingKey();
+        PaymentAddress address = sk.defaultAddress();
+        Note note = new Note(address, 100 * 1000000L);
+        IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
+        byte[] anchor = voucher.root().getContent().toByteArray();
+        chainBaseManager.getMerkleContainer()
+                .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
+
+        //set value that's bigger than own
+        note.setValue(note.getValue() + 10 * 1000000L); //test case of insufficient money
+
+        builder.addSpend(expsk, note, anchor, voucher);
+
+        // generate output
+        SpendingKey sk1 = SpendingKey.random();
+        FullViewingKey fullViewingKey1 = sk1.fullViewingKey();
+        IncomingViewingKey ivk1 = fullViewingKey1.inViewingKey();
+        PaymentAddress paymentAddress1 = ivk1.address(new DiversifierT()).get();
+        builder.addOutput(expsk.getOvk(), paymentAddress1,
+                100 * 1000000L - wallet.getShieldedTransactionFee(), new byte[512]);
+
+        updateTotalShieldedPoolValue(builder.getValueBalance());
+
+        try {
+            TransactionCapsule transactionCap = builder.build();
+            Assert.assertFalse(true);
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof ZksnarkException);
+            Assert.assertEquals("Spend proof failed", e.getMessage());
+        }
+    }
+
+    /**
+     * test of transferring insufficient money from transparent address to shield address.
+     */
+    @Test
+    public void testTransparentInputInsufficient() throws RuntimeException, ZksnarkException {
+        librustzcashInitZksnarkParams();
+        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+        long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
+        createCapsule();
+        createAccountAssetIssue();
+        //generate input
+        builder.setTransparentInput(ByteArray.fromHexString(FROM_ADDRESS), FROM_AMOUNT); // fail
+        //builder.setTransparentInput(ByteArray.fromHexString(FROM_ADDRESS), OWNER_BALANCE); //success
+        byte[] senderOvk = randomUint256();
+
+        //generate output
+        SpendingKey sk = SpendingKey.random();
+        FullViewingKey fullViewingKey12 = sk.fullViewingKey();
+        IncomingViewingKey ivk = fullViewingKey12.inViewingKey();
+        PaymentAddress paymentAddress = ivk.address(new DiversifierT()).get();
+        builder.addOutput(senderOvk, paymentAddress,
+                FROM_AMOUNT - wallet.getShieldedTransactionFee(), new byte[512]); // fail
+        //builder.addOutput(senderOvk, paymentAddress,
+        //        OWNER_BALANCE - wallet.getShieldedTransactionFee(), new byte[512]); //success
+
+        updateTotalShieldedPoolValue(builder.getValueBalance());
+        TransactionCapsule transactionCap = builder.build();
+
+        try {
+            //valdiate
+            List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
+            actuator.get(0).validate();
+            Assert.assertFalse(true);
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof ContractValidateException);
+            Assert.assertEquals("Validate ShieldedTransferContract error, balance is not sufficient",
+                    e.getMessage());
+        }
+    }
+
+    /*
+    test if random DiversifierT is valid.
+  */
+    @Test
+    public void testDiversifierT() throws ZksnarkException {
+        //byte[] data = org.tron.keystore.Wallet.generateRandomBytes(Constant.ZC_DIVERSIFIER_SIZE);
+        byte[] data1 = ByteArray.fromHexString("93c9e5679850252b37a991");
+        byte[] data2 = ByteArray.fromHexString("c50124c6a9a2e1700fc0b5");
+        Assert.assertFalse(JLibrustzcash.librustzcashCheckDiversifier(data1));
+        Assert.assertTrue(JLibrustzcash.librustzcashCheckDiversifier(data2));
+    }
+
+    private byte[] hashWithMissingColumn(TransactionCapsule tx, TestSignMissingColumn column)
+            throws InvalidProtocolBufferException {
+        Any contractParameter = tx.getInstance().getRawData().getContract(0).getParameter();
+        ShieldedTransferContract shieldedTransferContract = contractParameter
+                .unpack(ShieldedTransferContract.class);
+        ShieldedTransferContract.Builder newContract = ShieldedTransferContract.newBuilder();
+
+        if (column != null) {
+            switch (column) {
+                case FROM_ADDRESS:
+                    newContract.setFromAmount(shieldedTransferContract.getFromAmount());
+                    newContract
+                            .addAllReceiveDescription(shieldedTransferContract.getReceiveDescriptionList());
+                    newContract.setToAmount(shieldedTransferContract.getToAmount());
+                    newContract.setTransparentToAddress(shieldedTransferContract.getTransparentToAddress());
+                    for (SpendDescription spendDescription : shieldedTransferContract
+                            .getSpendDescriptionList()) {
+                        newContract
+                                .addSpendDescription(
+                                        spendDescription.toBuilder().clearSpendAuthoritySignature().build());
+                    }
+                    break;
+                case FROM_AMOUNT:
+                    //newContract.setFromAmount(shieldedTransferContract.getFromAmount());
+                    newContract
+                            .addAllReceiveDescription(shieldedTransferContract.getReceiveDescriptionList());
+                    newContract.setToAmount(shieldedTransferContract.getToAmount());
+                    newContract
+                            .setTransparentFromAddress(shieldedTransferContract.getTransparentFromAddress());
+                    newContract.setTransparentToAddress(shieldedTransferContract.getTransparentToAddress());
+                    for (SpendDescription spendDescription : shieldedTransferContract
+                            .getSpendDescriptionList()) {
+                        newContract
+                                .addSpendDescription(
+                                        spendDescription.toBuilder().clearSpendAuthoritySignature().build());
+                    }
+                    break;
+                case SPEND_DESCRITPION:
+                    newContract.setFromAmount(shieldedTransferContract.getFromAmount());
+                    newContract
+                            .addAllReceiveDescription(shieldedTransferContract.getReceiveDescriptionList());
+                    newContract.setToAmount(shieldedTransferContract.getToAmount());
+                    newContract
+                            .setTransparentFromAddress(shieldedTransferContract.getTransparentFromAddress());
+                    newContract.setTransparentToAddress(shieldedTransferContract.getTransparentToAddress());
+                    break;
+                case RECEIVE_DESCRIPTION:
+                    newContract.setFromAmount(shieldedTransferContract.getFromAmount());
+                    newContract.setToAmount(shieldedTransferContract.getToAmount());
+                    newContract
+                            .setTransparentFromAddress(shieldedTransferContract.getTransparentFromAddress());
+                    newContract.setTransparentToAddress(shieldedTransferContract.getTransparentToAddress());
+                    for (SpendDescription spendDescription : shieldedTransferContract
+                            .getSpendDescriptionList()) {
+                        newContract
+                                .addSpendDescription(
+                                        spendDescription.toBuilder().clearSpendAuthoritySignature().build());
+                    }
+                    break;
+                case TO_ADDRESS:
+                    newContract.setFromAmount(shieldedTransferContract.getFromAmount());
+                    newContract
+                            .addAllReceiveDescription(shieldedTransferContract.getReceiveDescriptionList());
+                    newContract.setToAmount(shieldedTransferContract.getToAmount());
+                    newContract
+                            .setTransparentFromAddress(shieldedTransferContract.getTransparentFromAddress());
+                    //newContract.setTransparentToAddress(shieldedTransferContract.getTransparentToAddress());
+                    for (SpendDescription spendDescription : shieldedTransferContract
+                            .getSpendDescriptionList()) {
+                        newContract
+                                .addSpendDescription(
+                                        spendDescription.toBuilder().clearSpendAuthoritySignature().build());
+                    }
+                    break;
+                case TO_AMOUNT:
+                    newContract.setFromAmount(shieldedTransferContract.getFromAmount());
+                    newContract
+                            .addAllReceiveDescription(shieldedTransferContract.getReceiveDescriptionList());
+                    //newContract.setToAmount(shieldedTransferContract.getToAmount());
+                    newContract
+                            .setTransparentFromAddress(shieldedTransferContract.getTransparentFromAddress());
+                    newContract.setTransparentToAddress(shieldedTransferContract.getTransparentToAddress());
+                    for (SpendDescription spendDescription : shieldedTransferContract
+                            .getSpendDescriptionList()) {
+                        newContract
+                                .addSpendDescription(
+                                        spendDescription.toBuilder().clearSpendAuthoritySignature().build());
+                    }
+                    break;
+                default:
+                    break;
+            }
+        }
+        Transaction.raw.Builder rawBuilder = tx.getInstance().toBuilder()
+                .getRawDataBuilder()
+                .clearContract()
+                .addContract(
+                        Transaction.Contract.newBuilder().setType(ContractType.ShieldedTransferContract)
+                                .setParameter(
+                                        Any.pack(newContract.build())).build());
+
+        Transaction transaction = tx.getInstance().toBuilder().clearRawData()
+                .setRawData(rawBuilder).build();
+
+        byte[] mergedByte = Bytes.concat(
+                Sha256Hash.of(
+                        CommonParameter
+                                .getInstance().isECKeyCryptoEngine(),
+                        CommonParameter.getInstance().getZenTokenId().getBytes()).getBytes(),
+                transaction.getRawData().toByteArray());
+        return Sha256Hash.of(CommonParameter
+                .getInstance().isECKeyCryptoEngine(), mergedByte).getBytes();
+    }
+
+    private ZenTransactionBuilder generateShield2ShieldBuilder(ZenTransactionBuilder builder,
+                                                               long ctx)
+            throws ZksnarkException, BadItemException {
+        //generate input
+        SpendingKey sk = SpendingKey.random();
+        ExpandedSpendingKey expsk = sk.expandedSpendingKey();
+        PaymentAddress address = sk.defaultAddress();
+        Note note = new Note(address, 100 * 1000000L);
+        IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
+        byte[] anchor = voucher.root().getContent().toByteArray();
+        chainBaseManager.getMerkleContainer()
+                .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
+        builder.addSpend(expsk, note, anchor, voucher);
+
+        // generate output
+        SpendingKey sk1 = SpendingKey.random();
+        FullViewingKey fullViewingKey1 = sk1.fullViewingKey();
+        IncomingViewingKey ivk1 = fullViewingKey1.inViewingKey();
+        PaymentAddress paymentAddress1 = ivk1.address(new DiversifierT()).get();
+        builder.addOutput(expsk.getOvk(), paymentAddress1,
+                100 * 1000000L - wallet.getShieldedTransactionFee(), new byte[512]);
+
+        // Create Sapling SpendDescriptions
+        for (SpendDescriptionInfo spend : builder.getSpends()) {
+            SpendDescriptionCapsule spendDescriptionCapsule = builder.generateSpendProof(spend, ctx);
+            builder.getContractBuilder().addSpendDescription(spendDescriptionCapsule.getInstance());
+        }
+
+        // Create Sapling OutputDescriptions
+        for (ReceiveDescriptionInfo receive : builder.getReceives()) {
+            ReceiveDescriptionCapsule receiveDescriptionCapsule = builder
+                    .generateOutputProof(receive, ctx);
+            builder.getContractBuilder().addReceiveDescription(receiveDescriptionCapsule.getInstance());
+        }
+
+        return builder;
+    }
+
+    public TransactionCapsule generateTransactionCapsule(ZenTransactionBuilder builder,
+                                                         long ctx, byte[] hashOfTransaction, TransactionCapsule transactionCapsule)
+            throws ZksnarkException {
+        // Create Sapling spendAuth
+        for (int i = 0; i < builder.getSpends().size(); i++) {
+            byte[] result = new byte[64];
+            JLibrustzcash.librustzcashSaplingSpendSig(
+                    new SpendSigParams(builder.getSpends().get(i).getExpsk().getAsk(),
+                            builder.getSpends().get(i).getAlpha(),
+                            hashOfTransaction,
+                            result));
+            builder.getContractBuilder().getSpendDescriptionBuilder(i)
+                    .setSpendAuthoritySignature(ByteString.copyFrom(result));
+        }
+
+        //create binding signatures
+        byte[] bindingSig = new byte[64];
+        JLibrustzcash.librustzcashSaplingBindingSig(
+                new BindingSigParams(ctx,
+                        builder.getValueBalance(),
+                        hashOfTransaction,
+                        bindingSig)
+        );
+        builder.getContractBuilder().setBindingSignature(ByteString.copyFrom(bindingSig));
+
+        Transaction.raw.Builder rawBuilder = transactionCapsule.getInstance().toBuilder()
+                .getRawDataBuilder()
+                .clearContract()
+                .addContract(Transaction.Contract.newBuilder()
+                        .setType(ContractType.ShieldedTransferContract)
+                        .setParameter(Any.pack(builder.getContractBuilder().build()))
+                        .build());
+
+        Transaction transaction = transactionCapsule.getInstance().toBuilder().clearRawData()
+                .setRawData(rawBuilder).build();
+        TransactionCapsule transactionCap = new TransactionCapsule(transaction);
+
+        updateTotalShieldedPoolValue(builder.getValueBalance());
+
+        return transactionCap;
+    }
+
+    /*
+     * test signature for shield to shield transaction with some column missing
+     */
+    @Test
+    public void testSignWithoutFromAddress()
+            throws BadItemException, ContractValidateException, RuntimeException,
+            ZksnarkException {
+        librustzcashInitZksnarkParams();
+        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+        long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
+
+        builder = generateShield2ShieldBuilder(builder, ctx);
+
+        // Empty output script.
+        byte[] hashOfTransaction;//256
+        TransactionCapsule transactionCapsule;
+        try {
+            transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
+                    builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
+
+            //test case
+            hashOfTransaction = hashWithMissingColumn(transactionCapsule,
+                    TestSignMissingColumn.FROM_ADDRESS);
+            //end of test case
+
+        } catch (Exception ex) {
+            JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
+            throw new RuntimeException("Could not construct signature hash: " + ex.getMessage());
+        }
+
+        TransactionCapsule transactionCap = generateTransactionCapsule(builder, ctx, hashOfTransaction,
+                transactionCapsule);
+
+        List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
+        actuator.get(0).validate(); //there is hash(transaction) in librustzcashSaplingFinalCheck
+        Assert.assertTrue(true);
+    }
+
+    /*
+     * test signature for shield to shield transaction with some column missing
+     */
+    @Test
+    public void testSignWithoutFromAmout()
+            throws BadItemException, ContractValidateException, RuntimeException,
+            ZksnarkException {
+        librustzcashInitZksnarkParams();
+        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+        long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
+
+        builder = generateShield2ShieldBuilder(builder, ctx);
+
+        // Empty output script.
+        byte[] hashOfTransaction;//256
+        TransactionCapsule transactionCapsule;
+        try {
+            transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
+                    builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
+
+            //test case
+            hashOfTransaction = hashWithMissingColumn(transactionCapsule,
+                    TestSignMissingColumn.FROM_AMOUNT);
+            //end of test case
+
+        } catch (Exception ex) {
+            JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
+            throw new RuntimeException("Could not construct signature hash: " + ex.getMessage());
+        }
+
+        TransactionCapsule transactionCap = generateTransactionCapsule(builder, ctx, hashOfTransaction,
+                transactionCapsule);
+
+        List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
+        actuator.get(0).validate(); //there is hash(transaction) in librustzcashSaplingFinalCheck
+        Assert.assertTrue(true);
+    }
+
+    /*
+     * test signature for shield to shield transaction with some column missing
+     */
+    @Test
+    public void testSignWithoutSpendDescription()
+            throws BadItemException, RuntimeException, ZksnarkException {
+        librustzcashInitZksnarkParams();
+        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+        long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
+
+        builder = generateShield2ShieldBuilder(builder, ctx);
+
+        // Empty output script.
+        byte[] hashOfTransaction;//256
+        TransactionCapsule transactionCapsule;
+        try {
+            transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
+                    builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
+
+            //test case
+            hashOfTransaction = hashWithMissingColumn(transactionCapsule,
+                    TestSignMissingColumn.SPEND_DESCRITPION);
+            //end of test case
+
+        } catch (Exception ex) {
+            JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
+            throw new RuntimeException("Could not construct signature hash: " + ex.getMessage());
+        }
+
+        TransactionCapsule transactionCap = generateTransactionCapsule(builder, ctx, hashOfTransaction,
+                transactionCapsule);
+
+        try {
+            //validate
+            List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
+            actuator.get(0).validate(); //there is hash(transaction) in librustzcashSaplingFinalCheck
+            Assert.assertFalse(true);
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof ContractValidateException);
+            Assert.assertEquals("librustzcashSaplingCheckSpend error", e.getMessage());
+        }
+        JLibrustzcash.librustzcashSaplingVerificationCtxFree(ctx);
+    }
+
+    /*
+     * test signature for shield to shield transaction with some column missing
+     */
+    @Test
+    public void testSignWithoutReceiveDescription()
+            throws BadItemException, RuntimeException, ZksnarkException {
+        librustzcashInitZksnarkParams();
+        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+        long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
+
+        builder = generateShield2ShieldBuilder(builder, ctx);
+
+        // Empty output script.
+        byte[] hashOfTransaction;//256
+        TransactionCapsule transactionCapsule;
+        try {
+            transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
+                    builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
+
+            //test case
+            hashOfTransaction = hashWithMissingColumn(transactionCapsule,
+                    TestSignMissingColumn.RECEIVE_DESCRIPTION);
+            //end of test case
+
+        } catch (Exception ex) {
+            JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
+            throw new RuntimeException("Could not construct signature hash: " + ex.getMessage());
+        }
+
+        TransactionCapsule transactionCap = generateTransactionCapsule(builder, ctx, hashOfTransaction,
+                transactionCapsule);
+
+        try {
+            //validate
+            List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
+            actuator.get(0).validate(); //there is hash(transaction) in librustzcashSaplingFinalCheck
+            Assert.assertFalse(true);
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof ContractValidateException);
+            Assert.assertEquals("librustzcashSaplingCheckSpend error", e.getMessage());
+        }
+        JLibrustzcash.librustzcashSaplingVerificationCtxFree(ctx);
+    }
+
+    /*
+     * test signature for shield to shield transaction with some column missing
+     */
+    @Test
+    public void testSignWithoutToAddress()
+            throws BadItemException, ContractValidateException, RuntimeException,
+            ZksnarkException {
+        librustzcashInitZksnarkParams();
+        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+        long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
+
+        builder = generateShield2ShieldBuilder(builder, ctx);
+
+        // Empty output script.
+        byte[] hashOfTransaction;//256
+        TransactionCapsule transactionCapsule;
+        try {
+            transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
+                    builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
+
+            //test case
+            hashOfTransaction = hashWithMissingColumn(transactionCapsule,
+                    TestSignMissingColumn.TO_ADDRESS);
+            //end of test case
+
+        } catch (Exception ex) {
+            JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
+            throw new RuntimeException("Could not construct signature hash: " + ex.getMessage());
+        }
+
+        TransactionCapsule transactionCap = generateTransactionCapsule(builder, ctx, hashOfTransaction,
+                transactionCapsule);
+
+        List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
+        actuator.get(0).validate(); //there is hash(transaction) in librustzcashSaplingFinalCheck
+        Assert.assertTrue(true);
+    }
+
+    /*
+     * test signature for shield to shield transaction with some column missing
+     */
+    @Test
+    public void testSignWithoutToAmount()
+            throws BadItemException, ContractValidateException, RuntimeException,
+            ZksnarkException {
+        librustzcashInitZksnarkParams();
+        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+        long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
+
+        builder = generateShield2ShieldBuilder(builder, ctx);
+
+        // Empty output script.
+        byte[] hashOfTransaction;//256
+        TransactionCapsule transactionCapsule;
+        try {
+            transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
+                    builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
+
+            //test case
+            hashOfTransaction = hashWithMissingColumn(transactionCapsule,
+                    TestSignMissingColumn.TO_AMOUNT);
+            //end of test case
+
+        } catch (Exception ex) {
+            JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
+            throw new RuntimeException("Could not construct signature hash: " + ex.getMessage());
+        }
+
+        TransactionCapsule transactionCap = generateTransactionCapsule(builder, ctx, hashOfTransaction,
+                transactionCapsule);
+
+        List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
+        actuator.get(0).validate(); //there is hash(transaction) in librustzcashSaplingFinalCheck
+        Assert.assertTrue(true);
+    }
+
+    /*
+     * test spend authorize signature with some wrong column
+     */
+    @Test
+    public void testSpendSignatureWithWrongColumn()
+            throws BadItemException, RuntimeException, ZksnarkException {
+        librustzcashInitZksnarkParams();
+        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+        long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
+
+        // generate input
+        SpendingKey sk = SpendingKey
+                .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
+        ExpandedSpendingKey expsk = sk.expandedSpendingKey();
+        PaymentAddress address = sk.defaultAddress();
+        Note note = new Note(address, 100 * 1000000L);
+        IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
+        byte[] anchor = voucher.root().getContent().toByteArray();
+        chainBaseManager.getMerkleContainer()
+                .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
+        builder.addSpend(expsk, note, anchor, voucher);
+
+        //shield transparent input
+        //createCapsule();
+        //builder.setTransparentInput(ByteArray.fromHexString(FROM_ADDRESS), OWNER_BALANCE);
+
+        // generate output
+        SpendingKey sk1 = SpendingKey.random();
+        FullViewingKey fullViewingKey1 = sk1.fullViewingKey();
+        IncomingViewingKey ivk1 = fullViewingKey1.inViewingKey();
+        PaymentAddress paymentAddress1 = ivk1.address(new DiversifierT()).get();
+        builder.addOutput(expsk.getOvk(), paymentAddress1,
+                100 * 1000000L - wallet.getShieldedTransactionFee(), new byte[512]);
+
+        // Create Sapling SpendDescriptions
+        for (SpendDescriptionInfo spend : builder.getSpends()) {
+            SpendDescriptionCapsule spendDescriptionCapsule = builder.generateSpendProof(spend, ctx);
+            builder.getContractBuilder().addSpendDescription(spendDescriptionCapsule.getInstance());
+        }
+
+        // Create Sapling OutputDescriptions
+        for (ReceiveDescriptionInfo receive : builder.getReceives()) {
+            ReceiveDescriptionCapsule receiveDescriptionCapsule = builder
+                    .generateOutputProof(receive, ctx);
+            builder.getContractBuilder().addReceiveDescription(receiveDescriptionCapsule.getInstance());
+        }
+
+        // Empty output script.
+        byte[] hashOfTransaction;//256
+        TransactionCapsule transactionCapsule;
+        try {
+            transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
+                    builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
+
+            hashOfTransaction = TransactionCapsule
+                    .hashShieldTransaction(transactionCapsule.getInstance(),
+                            CommonParameter.getInstance().getZenTokenId());
+
+        } catch (Exception ex) {
+            JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
+            throw new RuntimeException("Could not construct signature hash: " + ex.getMessage());
+        }
+
+        // Create Sapling spendAuth
+        for (int i = 0; i < builder.getSpends().size(); i++) {
+            byte[] result = new byte[64];
+            JLibrustzcash.librustzcashSaplingSpendSig(
+                    new SpendSigParams(builder.getSpends().get(i).getExpsk().getAsk(),
+                            Note.generateR(),
+                            //replace builder.getSpends().get(i).alpha with random alpha, should fail
+                            hashOfTransaction,
+                            result));
+            builder.getContractBuilder().getSpendDescriptionBuilder(i)
+                    .setSpendAuthoritySignature(ByteString.copyFrom(result));
+        }
+
+        //create binding signatures
+        byte[] bindingSig = new byte[64];
+        JLibrustzcash.librustzcashSaplingBindingSig(
+                new BindingSigParams(ctx,
+                        builder.getValueBalance(),
+                        hashOfTransaction,
+                        bindingSig)
+        );
+        builder.getContractBuilder().setBindingSignature(ByteString.copyFrom(bindingSig));
+
+        Transaction.raw.Builder rawBuilder = transactionCapsule.getInstance().toBuilder()
+                .getRawDataBuilder()
+                .clearContract()
+                .addContract(Transaction.Contract.newBuilder()
+                        .setType(ContractType.ShieldedTransferContract)
+                        .setParameter(Any.pack(builder.getContractBuilder().build()))
+                        .build());
+
+        Transaction transaction = transactionCapsule.getInstance().toBuilder().clearRawData()
+                .setRawData(rawBuilder).build();
+        TransactionCapsule transactionCap = new TransactionCapsule(transaction);
+
+        updateTotalShieldedPoolValue(builder.getValueBalance());
+
+        try {
+            //validate
+            List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
+            actuator.get(0)
+                    .validate(); //there is getSpendAuthoritySignature in librustzcashSaplingCheckSpend
+            Assert.assertFalse(true);
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof ContractValidateException);
+            //signature for spend with some wrong column
+            //if transparent to shield, ok
+            //if shield to shield or shield to transparent, librustzcashSaplingFinalCheck error
+            Assert.assertTrue(e.getMessage().equalsIgnoreCase("librustzcashSaplingCheckSpend error"));
+        }
+        JLibrustzcash.librustzcashSaplingVerificationCtxFree(ctx);
+    }
+
+    /*
+     * test use isolate method to build the signature
+     */
+    @Test
+    public void testIsolateSignature()
+            throws ZksnarkException, BadItemException, ContractValidateException, ContractExeException {
+        librustzcashInitZksnarkParams();
+        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+        long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
+
+        // generate shield spend
+        SpendingKey sk = SpendingKey
+                .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
+        ExpandedSpendingKey expsk = sk.expandedSpendingKey();
+
+        //build transaction without spend signature and get transactionHash
+        TransactionHash transactionHash = new TransactionHash(new byte[32]);
+        TransactionCapsule transactionCapsule = buildShieldedTransactionWithoutSpendAuthSig(
+                sk.defaultAddress(),
+                sk.fullViewingKey().getAk(),
+                expsk.getNsk(),
+                expsk.getOvk(),
+                transactionHash,
+                builder,
+                ctx);
+        //filled with Sapling spendAuth in builder
+        List<SpendDescriptionInfo> spends = builder.getSpends();
+        for (int i = 0; i < spends.size(); i++) {
+            //replace with interface
+            SpendAuthSigParameters spendAuthSigParameters = SpendAuthSigParameters.newBuilder()
+                    .setAsk(ByteString.copyFrom(expsk.getAsk())) //ask => ak
+                    .setAlpha(ByteString.copyFrom(spends.get(i).getAlpha()))
+                    .setTxHash(ByteString.copyFrom(transactionHash.getHash()))
+                    .build();
+            BytesMessage spendAuthSig = wallet.createSpendAuthSig(spendAuthSigParameters);
+            builder.getContractBuilder().getSpendDescriptionBuilder(i)
+                    .setSpendAuthoritySignature(spendAuthSig.getValue());
+        }
+
+        Transaction.raw.Builder rawBuilder = transactionCapsule.getInstance().toBuilder()
+                .getRawDataBuilder()
+                .clearContract()
+                .addContract(Transaction.Contract.newBuilder()
+                        .setType(ContractType.ShieldedTransferContract)
+                        .setParameter(Any.pack(builder.getContractBuilder().build()))
+                        .build());
+        Transaction transaction = transactionCapsule.getInstance().toBuilder().clearRawData()
+                .setRawData(rawBuilder).build();
+
+        TransactionCapsule transactionCap = new TransactionCapsule(transaction);
+        //validate
+        List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
+        actuator.get(0).validate();
+        //execute
+        TransactionResultCapsule resultCapsule = new TransactionResultCapsule();
+        boolean executeResult = actuator.get(0).execute(resultCapsule);
+        Assert.assertTrue(executeResult);
+    }
+
+    /*
+     * build ShieldedTransaction Without SpendAuthSig
+     */
+    public TransactionCapsule buildShieldedTransactionWithoutSpendAuthSig(PaymentAddress address,
+                                                                          byte[] ak,
+                                                                          byte[] nsk, byte[] ovk, TransactionHash dataHashToBeSigned, ZenTransactionBuilder builder,
+                                                                          long ctx)
+            throws ZksnarkException, BadItemException, ContractValidateException {
+        // generate input
+        Note note = new Note(address, 100 * 1000000L);
+        note.setRcm(ByteArray.fromHexString(
+                "eb1aa5dd257b9da4e4064a853dec94651be38078e29fe441a9a8075016cfa701"));
+        IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
+        byte[] anchor = voucher.root().getContent().toByteArray();
+        chainBaseManager.getMerkleContainer()
+                .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
+        SpendDescriptionInfo skSpend = new SpendDescriptionInfo(ak,
+                nsk,
+                ovk,
+                note,
+                Note.generateR(),
+                anchor,
+                voucher
+        );
+        builder.addSpend(skSpend);
+
+        // generate output
+        SpendingKey sk1 = SpendingKey.random();
+        FullViewingKey fullViewingKey1 = sk1.fullViewingKey();
+        IncomingViewingKey ivk1 = fullViewingKey1.inViewingKey();
+        PaymentAddress paymentAddress1 = ivk1.address(new DiversifierT()).get();
+        builder.addOutput(ovk, paymentAddress1,
+                100 * 1000000L - wallet.getShieldedTransactionFee(), new byte[512]);
+
+        // Create Sapling SpendDescriptions
+        for (SpendDescriptionInfo spend : builder.getSpends()) {
+            SpendDescriptionCapsule spendDescriptionCapsule = builder.generateSpendProof(spend, ctx);
+            builder.getContractBuilder().addSpendDescription(spendDescriptionCapsule.getInstance());
+        }
+
+        // Create Sapling OutputDescriptions
+        for (ReceiveDescriptionInfo receive : builder.getReceives()) {
+            ReceiveDescriptionCapsule receiveDescriptionCapsule = builder
+                    .generateOutputProof(receive, ctx);
+            builder.getContractBuilder().addReceiveDescription(receiveDescriptionCapsule.getInstance());
+        }
+
+        // Empty output script
+        TransactionCapsule transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
+                builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
+        //replace with interface
+        //System.out.println(JsonFormat.printToString(transactionCapsule.getInstance()));
+        BytesMessage transactionHash = wallet
+                .getShieldTransactionHash(transactionCapsule.getInstance());
+
+        if (transactionHash == null) {
+            throw new ZksnarkException("cal transaction hash failed");
+        }
+        dataHashToBeSigned.setHash(transactionHash.getValue().toByteArray());
+
+        // Create binding signatures
+        byte[] bindingSig = new byte[64];
+        JLibrustzcash.librustzcashSaplingBindingSig(
+                new BindingSigParams(ctx,
+                        builder.getValueBalance(),
+                        dataHashToBeSigned.getHash(),
+                        bindingSig)
+        );
+        builder.getContractBuilder().setBindingSignature(ByteString.copyFrom(bindingSig));
+        return transactionCapsule;
+    }
+
+    @Test
+    public void testMemoTooLong() throws ContractValidateException, TooBigTransactionException,
+            TooBigTransactionResultException, TaposException, TransactionExpirationException,
+            ReceiptCheckErrException, DupTransactionException, VMIllegalException,
+            ValidateSignatureException, BadItemException, ContractExeException,
+            AccountResourceInsufficientException, InvalidProtocolBufferException, ZksnarkException {
+        long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
+
+        librustzcashInitZksnarkParams();
+        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+
+        // generate spend proof
+        SpendingKey sk = SpendingKey
+                .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
+        ExpandedSpendingKey expsk = sk.expandedSpendingKey();
+        PaymentAddress address = sk.defaultAddress();
+        Note note = new Note(address, 100 * 1000000L);
+        IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
+        byte[] anchor = voucher.root().getContent().toByteArray();
+        chainBaseManager.getMerkleContainer()
+                .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
+        builder.addSpend(expsk, note, anchor, voucher);
+
+        // generate output proof
+        SpendingKey spendingKey = SpendingKey.random();
+        FullViewingKey fullViewingKey = spendingKey.fullViewingKey();
+        IncomingViewingKey incomingViewingKey = fullViewingKey.inViewingKey();
+        PaymentAddress paymentAddress = incomingViewingKey.address(new DiversifierT()).get();
+        byte[] memo = org.tron.keystore.Wallet.generateRandomBytes(1024);
+        builder.addOutput(expsk.getOvk(), paymentAddress,
+                100 * 1000000L - wallet.getShieldedTransactionFee(), memo);
+
+        TransactionCapsule transactionCap = builder.build();
+
+        boolean ok = dbManager.pushTransaction(transactionCap);
+        Assert.assertTrue(ok);
+
+        // add here
+        byte[] ivk = fullViewingKey.inViewingKey().getValue();
+        Protocol.Transaction t = transactionCap.getInstance();
+
+        for (org.tron.protos.Protocol.Transaction.Contract c : t.getRawData().getContractList()) {
+            if (c.getType() != ContractType.ShieldedTransferContract) {
+                continue;
+            }
+            ShieldedTransferContract stContract = c.getParameter()
+                    .unpack(ShieldedTransferContract.class);
+            ReceiveDescription receiveDescription = stContract.getReceiveDescription(0);
+
+            Optional<Note> ret1 = Note.decrypt(
+                    receiveDescription.getCEnc().toByteArray(),//ciphertext
+                    ivk,
+                    receiveDescription.getEpk().toByteArray(),//epk
+                    receiveDescription.getNoteCommitment().toByteArray() //cm
+            );
+
+            if (ret1.isPresent()) {
+                Note noteText = ret1.get();
+                byte[] pkD = new byte[32];
+                if (!JLibrustzcash.librustzcashIvkToPkd(
+                        new IvkToPkdParams(incomingViewingKey.getValue(),
+                                noteText.getD().getData(), pkD))) {
+                    JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
+                    return;
+                }
+                Assert.assertArrayEquals(paymentAddress.getPkD(), pkD);
+                Assert.assertEquals(100 * 1000000L - wallet.getShieldedTransactionFee(),
+                        noteText.getValue());
+
+                byte[] resultMemo = new byte[512];
+                System.arraycopy(memo, 0, resultMemo, 0, 512);
+                Assert.assertArrayEquals(resultMemo, noteText.getMemo());
+            } else {
+                Assert.assertFalse(true);
+            }
+        }
+        // end here
+        JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
+        Assert.assertTrue(ok);
+    }
+
+    @Test
+    public void testMemoNotEnough() throws ContractValidateException, TooBigTransactionException,
+            TooBigTransactionResultException, TaposException, TransactionExpirationException,
+            ReceiptCheckErrException, DupTransactionException, VMIllegalException,
+            ValidateSignatureException, BadItemException, ContractExeException,
+            AccountResourceInsufficientException, InvalidProtocolBufferException, ZksnarkException {
+        long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
+
+        librustzcashInitZksnarkParams();
+        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+
+        // generate spend proof
+        SpendingKey sk = SpendingKey
+                .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
+        ExpandedSpendingKey expsk = sk.expandedSpendingKey();
+        PaymentAddress address = sk.defaultAddress();
+        Note note = new Note(address, 100 * 1000000L);
+        IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
+        byte[] anchor = voucher.root().getContent().toByteArray();
+        chainBaseManager.getMerkleContainer()
+                .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
+        builder.addSpend(expsk, note, anchor, voucher);
+
+        // generate output proof
+        SpendingKey spendingKey = SpendingKey.random();
+        FullViewingKey fullViewingKey = spendingKey.fullViewingKey();
+        IncomingViewingKey incomingViewingKey = fullViewingKey.inViewingKey();
+        PaymentAddress paymentAddress = incomingViewingKey.address(new DiversifierT()).get();
+        byte[] memo = org.tron.keystore.Wallet.generateRandomBytes(128);
+        builder.addOutput(expsk.getOvk(), paymentAddress,
+                100 * 1000000L - wallet.getShieldedTransactionFee(), memo);
+
+        TransactionCapsule transactionCap = builder.build();
+
+        boolean ok = dbManager.pushTransaction(transactionCap);
+        Assert.assertTrue(ok);
+
+        // add here
+        byte[] ivk = fullViewingKey.inViewingKey().getValue();
+        Protocol.Transaction t = transactionCap.getInstance();
+
+        for (org.tron.protos.Protocol.Transaction.Contract c : t.getRawData().getContractList()) {
+            if (c.getType() != ContractType.ShieldedTransferContract) {
+                continue;
+            }
+            ShieldedTransferContract stContract = c.getParameter()
+                    .unpack(ShieldedTransferContract.class);
+            ReceiveDescription receiveDescription = stContract.getReceiveDescription(0);
+
+            Optional<Note> ret1 = Note.decrypt(
+                    receiveDescription.getCEnc().toByteArray(),//ciphertext
+                    ivk,
+                    receiveDescription.getEpk().toByteArray(),//epk
+                    receiveDescription.getNoteCommitment().toByteArray() //cm
+            );
+
+            if (ret1.isPresent()) {
+                Note noteText = ret1.get();
+                byte[] pkD = new byte[32];
+                if (!JLibrustzcash.librustzcashIvkToPkd(
+                        new IvkToPkdParams(incomingViewingKey.getValue(),
+                                noteText.getD().getData(), pkD))) {
+                    JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
+                    return;
+                }
+                Assert.assertArrayEquals(paymentAddress.getPkD(), pkD);
+                Assert.assertEquals(100 * 1000000L - wallet.getShieldedTransactionFee(),
+                        noteText.getValue());
+
+                byte[] resultMemo = new byte[512];
+                System.arraycopy(memo, 0, resultMemo, 0, 128);
+                Assert.assertArrayEquals(resultMemo, noteText.getMemo());
+            } else {
+                Assert.assertFalse(true);
+            }
+        }
+        // end here
+        JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
+        Assert.assertTrue(ok);
+    }
+
+    /*
+    send coin to 2 different address generated by same sk, scan note by ivk; spend this note again
+     */
+    @Test
+    public void pushSameSkAndScanAndSpend() throws Exception {
+
+        byte[] privateKey = ByteArray
+                .fromHexString("f4df789d3210ac881cb900464dd30409453044d2777060a0c391cbdf4c6a4f57");
+        final ECKey ecKey = ECKey.fromPrivate(privateKey);
+        byte[] witnessAddress = ecKey.getAddress();
+        WitnessCapsule witnessCapsule = new WitnessCapsule(ByteString.copyFrom(witnessAddress));
+        chainBaseManager.addWitness(ByteString.copyFrom(witnessAddress));
+
+        createAccountAssetIssue();
+        //sometimes generate block failed, try several times.
+
+        Block block = getSignedBlock(witnessCapsule.getAddress(), 0, privateKey);
+        dbManager.pushBlock(new BlockCapsule(block));
+
+        //create transactions
+        librustzcashInitZksnarkParams();
+        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(1000 * 1000000L);
+        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+
+        // generate spend proof
+        SpendingKey sk = SpendingKey
+                .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
+        ExpandedSpendingKey expsk = sk.expandedSpendingKey();
+        byte[] senderOvk = expsk.getOvk();
+        PaymentAddress address = sk.defaultAddress();
+        Note note = new Note(address, 1000 * 1000000L);
+        IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
+        byte[] anchor = voucher.root().getContent().toByteArray();
+        chainBaseManager.getMerkleContainer()
+                .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
+        builder.addSpend(expsk, note, anchor, voucher);
+
+        // generate output proof
+        SpendingKey sk2 = SpendingKey.random();
+        FullViewingKey fullViewingKey = sk2.fullViewingKey();
+        IncomingViewingKey incomingViewingKey = fullViewingKey.inViewingKey();
+
+        byte[] memo = org.tron.keystore.Wallet.generateRandomBytes(512);
+
+        //send coin to 2 different address generated by same sk
+        DiversifierT d1 = DiversifierT.random();
+        PaymentAddress paymentAddress1 = incomingViewingKey.address(d1).get();
+        builder.addOutput(senderOvk, paymentAddress1,
+                (1000 * 1000000L - wallet.getShieldedTransactionFee()) / 2, memo);
+
+        DiversifierT d2 = DiversifierT.random();
+        PaymentAddress paymentAddress2 = incomingViewingKey.address(d2).get();
+        builder.addOutput(senderOvk, paymentAddress2,
+                (1000 * 1000000L - wallet.getShieldedTransactionFee()) / 2, memo);
+
+        TransactionCapsule transactionCap = builder.build();
+
+        byte[] trxId = transactionCap.getTransactionId().getBytes();
+//        chainBaseManager.getAccountAssetIssueStore().getBlackhole().getAssetMapV2();
+        boolean ok = dbManager.pushTransaction(transactionCap);
+        Assert.assertTrue(ok);
+
+        Thread.sleep(500);
+        //package transaction to block
+        block = getSignedBlock(witnessCapsule.getAddress(), 0, privateKey);
+        dbManager.pushBlock(new BlockCapsule(block));
+
+        BlockCapsule blockCapsule3 = new BlockCapsule(wallet.getNowBlock());
+        Assert.assertEquals("blocknum != 2", 2, blockCapsule3.getNum());
+
+        // scan note by ivk
+        byte[] receiverIvk = incomingViewingKey.getValue();
+        DecryptNotes notes1 = wallet.scanNoteByIvk(0, 100, receiverIvk);
+        Assert.assertEquals(2, notes1.getNoteTxsCount());
+
+        // scan note by ovk
+        DecryptNotes notes2 = wallet.scanNoteByOvk(0, 100, senderOvk);
+        Assert.assertEquals(2, notes2.getNoteTxsCount());
+
+        // to spend received note above.
+        ZenTransactionBuilder builder2 = new ZenTransactionBuilder(wallet);
+
+        //query merkleinfo
+        OutputPointInfo.Builder request = OutputPointInfo.newBuilder();
+        for (int i = 0; i < notes1.getNoteTxsCount(); i++) {
+            OutputPoint.Builder outPointBuild = OutputPoint.newBuilder();
+            outPointBuild.setHash(ByteString.copyFrom(trxId));
+            outPointBuild.setIndex(i);
+            request.addOutPoints(outPointBuild.build());
+        }
+        IncrementalMerkleVoucherInfo merkleVoucherInfo = wallet
+                .getMerkleTreeVoucherInfo(request.build());
+
+        //build spend proof. allow only one note in spend
+        ExpandedSpendingKey expsk2 = sk2.expandedSpendingKey();
+        for (int i = 0; i < 1; i++) {
+            org.tron.api.GrpcAPI.Note grpcNote = notes1.getNoteTxs(i).getNote();
+            PaymentAddress paymentAddress = KeyIo.decodePaymentAddress(grpcNote.getPaymentAddress());
+            Note note2 = new Note(paymentAddress.getD(),
+                    paymentAddress.getPkD(),
+                    grpcNote.getValue(),
+                    grpcNote.getRcm().toByteArray()
+            );
+
+            IncrementalMerkleVoucherContainer voucher2 =
+                    new IncrementalMerkleVoucherContainer(
+                            new IncrementalMerkleVoucherCapsule(merkleVoucherInfo.getVouchers(i)));
+            byte[] anchor2 = voucher2.root().getContent().toByteArray();
+            builder2.addSpend(expsk2, note2, anchor2, voucher2);
+        }
+
+        //build output proof
+        SpendingKey sk3 = SpendingKey.random();
+        FullViewingKey fvk3 = sk3.fullViewingKey();
+        IncomingViewingKey ivk3 = fvk3.inViewingKey();
+
+        DiversifierT d3 = DiversifierT.random();
+        PaymentAddress paymentAddress3 = incomingViewingKey.address(d3).get();
+        byte[] memo3 = org.tron.keystore.Wallet.generateRandomBytes(512);
+        builder2.addOutput(expsk2.getOvk(), paymentAddress3,
+                (1000 * 1000000L - wallet.getShieldedTransactionFee()) / 2 - wallet
+                        .getShieldedTransactionFee(), memo3);
+
+        TransactionCapsule transactionCap2 = builder2.build();
+        boolean ok2 = dbManager.pushTransaction(transactionCap2);
+        Assert.assertTrue(ok2);
+    }
+
+    @Test
+    public void decodePaymentAddressIgnoreCase() {
+        String addressLower =
+                "ztron1975m0wyg8f30cgf2l5fgndhzqzkzgkgnxge8cwx2wr7m3q7chsuwewh2e6u24yykum0hq8ue99u";
+        String addressUpper = addressLower.toUpperCase();
+
+        PaymentAddress paymentAddress1 = KeyIo.decodePaymentAddress(addressLower);
+        PaymentAddress paymentAddress2 = KeyIo.decodePaymentAddress(addressUpper);
+
+        Assert.assertEquals(ByteArray.toHexString(paymentAddress1.getD().getData()),
+                ByteArray.toHexString(paymentAddress2.getD().getData()));
+        Assert.assertEquals(ByteArray.toHexString(paymentAddress1.getPkD()),
+                ByteArray.toHexString(paymentAddress2.getPkD()));
+
+    }
+
+    @Test
+    public void testCreateReceiveNoteRandom() throws ZksnarkException, BadItemException {
+        ReceiveNote receiveNote1 = wallet.createReceiveNoteRandom(0);
+        Assert.assertEquals(0, receiveNote1.getNote().getValue());
+
+        ReceiveNote receiveNote2 = wallet.createReceiveNoteRandom(0);
+        Assert.assertNotEquals(receiveNote1.getNote().getPaymentAddress(),
+                receiveNote2.getNote().getPaymentAddress());
+    }
+
+    public enum TestColumn {
+        CV,
+        ZKPOOF,
+        D_CM,
+        PKD_CM,
+        VALUE_CM,
+        R_CM
+    }
+
+    public enum TestSignMissingColumn {
+        FROM_ADDRESS, FROM_AMOUNT, SPEND_DESCRITPION,
+        RECEIVE_DESCRIPTION, TO_ADDRESS, TO_AMOUNT
+    }
+
+    public enum TestReceiveMissingColumn {
+        CV, CM, EPK, C_ENC, C_OUT, ZKPROOF
+    }
+
+    @AllArgsConstructor
+    class TransactionHash {
+
+        @Setter
+        @Getter
+        byte[] hash;
+    }
 
 }


### PR DESCRIPTION
### 1. What did you do?
Optimize your Account account. Create a new store of account assets.

Compare with [release_4.1.2](https://github.com/tronprotocol/java-tron/releases/tag/GreatVoyage-v4.1.2) and  [optimized version](https://github.com/tronprotocol/java-tron/tree/feature/account_asset_optimization) 



The serialization speed is optimized on the original side according to the Account account volume, and as much as possible, other than the necessary fields of the account, such as address, balance, accountName and other related fields are kept, other business fields that can be taken out separately are extracted.

This time, the Asset asset-related storage is optimized, stripped from the Account and moved to the new Asset-related storage.


### 2. What did you expect to see?
Account transfer speed further optimized
**1. Serialization speed**
Account reduces Asset-related fields during serialization, and after serialization fields are performed, a performance comparison of 1 million serializations is performed:

**Results of comparing the results of 4 tests**
|    version   |  improvements  |
| ---- | ---- |
|   1      |  14.77%  |
|    2    |  37.31%  |
|    3    |  28.69%  |
|    4     |  23.15%  |

**2.Transaction processing speed**
Account deserialization 1 million times compared, the optimized version will be slightly faster in deserialization about 16%

**Results of comparing the results of 4 tests**
|    version |  improvements  |
| ---- | ---- |
|    1    |  28.75% |
|    2    |  39.35% |
|    3   |  37.92%  |
|    4   |  30.04%  |


**3.Transaction processing speed**
There is a significant increase in average speed when comparing both transaction and block processing speeds


|    version  |  txs/ms   |  block/ms    |  
| ---- | ---- | ---- |
|    optimized   |  23.26%| 33.91% |





### 3. What did you see instead?
Account transfer speeds have improved, as have transaction and block packing speeds
Based on the above comparison, it can be determined that the version that extracts the fields will be faster in the serialization operation.

