### PR TITLE
account asset optimization

### DIFF
--- a/actuator/src/main/java/org/tron/core/actuator/ShieldedTransferActuator.java
+++ b/actuator/src/main/java/org/tron/core/actuator/ShieldedTransferActuator.java
@@ -117,10 +117,7 @@ public class ShieldedTransferActuator extends AbstractActuator {
   private void executeTransparentFrom(byte[] ownerAddress, long amount,
       TransactionResultCapsule ret, long fee)
       throws ContractExeException {
-    AccountStore accountStore = chainBaseManager.getAccountStore();
     AccountAssetIssueStore accountAssetIssueStore = chainBaseManager.getAccountAssetIssueStore();
-
-
     AssetIssueStore assetIssueStore = chainBaseManager.getAssetIssueStore();
     DynamicPropertiesStore dynamicStore = chainBaseManager.getDynamicPropertiesStore();
     try {

--- a/chainbase/src/main/java/org/tron/core/db/TransactionTrace.java
+++ b/chainbase/src/main/java/org/tron/core/db/TransactionTrace.java
@@ -60,8 +60,6 @@ public class TransactionTrace {
 
   private TrxType trxType;
 
-  private long txStartTimeInMs;
-
   private Runtime runtime;
 
   private ForkController forkController;
@@ -126,7 +124,6 @@ public class TransactionTrace {
 
   //pre transaction check
   public void init(BlockCapsule blockCap, boolean eventPluginLoaded) {
-    txStartTimeInMs = System.currentTimeMillis();
     transactionContext = new TransactionContext(blockCap, trx, storeFactory, false,
         eventPluginLoaded);
   }

--- a/chainbase/src/main/java/org/tron/core/store/AccountAssetIssueStore.java
+++ b/chainbase/src/main/java/org/tron/core/store/AccountAssetIssueStore.java
@@ -1,5 +1,6 @@
 package org.tron.core.store;
 
+import com.google.protobuf.ByteString;
 import com.typesafe.config.ConfigObject;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.ArrayUtils;
@@ -176,7 +177,6 @@ public class AccountAssetIssueStore extends TronStoreWithRevoking<AccountAssetIs
                     try {
                         while (true) {
                             Map.Entry<byte[], byte[]> accountEntry = convertQueue.take();
-                            AccountAssetIssueCapsule accountAssetIssueCapsule = new AccountAssetIssueCapsule();
                             AccountCapsule accountCapsule = new AccountCapsule(accountEntry.getValue());
                             AccountAssetIssue accountAssetIssue = AccountAssetIssue.newBuilder()
                                     .setAddress(accountCapsule.getAddress())
@@ -190,9 +190,8 @@ public class AccountAssetIssueStore extends TronStoreWithRevoking<AccountAssetIs
                                     .putAllLatestAssetOperationTime(accountCapsule.getLatestAssetOperationTimeMap())
                                     .putAllLatestAssetOperationTimeV2(accountCapsule.getLatestAssetOperationTimeMapV2())
                                     .build();
-                            accountAssetIssueCapsule.setInstance(accountAssetIssue);
-                            accountAssetIssueStore.put(accountCapsule.getAddress().toByteArray(), accountAssetIssueCapsule);
-
+                            accountAssetIssueStore.put(accountCapsule.getAddress().toByteArray(),
+                                    new AccountAssetIssueCapsule(accountAssetIssue));
                             Protocol.Account account = accountCapsule.getInstance();
                             account = account.toBuilder()
                                     .clearAssetIssuedID()

--- a/framework/src/main/java/org/tron/common/storage/Deposit.java
+++ b/framework/src/main/java/org/tron/common/storage/Deposit.java
@@ -1,6 +1,7 @@
 package org.tron.common.storage;
 
 import org.tron.common.runtime.vm.DataWord;
+import org.tron.core.capsule.AccountAssetIssueCapsule;
 import org.tron.core.capsule.AccountCapsule;
 import org.tron.core.capsule.AssetIssueCapsule;
 import org.tron.core.capsule.BlockCapsule;
@@ -10,7 +11,6 @@ import org.tron.core.capsule.ProposalCapsule;
 import org.tron.core.capsule.TransactionCapsule;
 import org.tron.core.capsule.VotesCapsule;
 import org.tron.core.capsule.WitnessCapsule;
-import org.tron.core.capsule.AccountAssetIssueCapsule;
 import org.tron.core.db.Manager;
 import org.tron.core.vm.program.Storage;
 import org.tron.core.vm.repository.Key;
@@ -23,9 +23,9 @@ public interface Deposit {
 
   AccountCapsule createAccount(byte[] address, Protocol.AccountType type);
 
-  AccountAssetIssueCapsule createAccountAssetIssue(byte[] address);
-
   AccountCapsule createAccount(byte[] address, String accountName, Protocol.AccountType type);
+
+  AccountAssetIssueCapsule createAccountAssetIssue(byte[] address);
 
   AccountCapsule getAccount(byte[] address);
 

--- a/framework/src/main/java/org/tron/core/Wallet.java
+++ b/framework/src/main/java/org/tron/core/Wallet.java
@@ -120,11 +120,11 @@ import org.tron.consensus.ConsensusDelegate;
 import org.tron.core.actuator.Actuator;
 import org.tron.core.actuator.ActuatorFactory;
 import org.tron.core.actuator.VMActuator;
+import org.tron.core.capsule.AccountAssetIssueCapsule;
 import org.tron.core.capsule.AccountCapsule;
 import org.tron.core.capsule.AssetIssueCapsule;
 import org.tron.core.capsule.BlockBalanceTraceCapsule;
 import org.tron.core.capsule.BlockCapsule;
-import org.tron.core.capsule.AccountAssetIssueCapsule;
 import org.tron.core.capsule.BlockCapsule.BlockId;
 import org.tron.core.capsule.BytesCapsule;
 import org.tron.core.capsule.CodeCapsule;
@@ -171,7 +171,16 @@ import org.tron.core.exception.ZksnarkException;
 import org.tron.core.net.TronNetDelegate;
 import org.tron.core.net.TronNetService;
 import org.tron.core.net.message.TransactionMessage;
-import org.tron.core.store.*;
+import org.tron.core.store.AccountAssetIssueStore;
+import org.tron.core.store.AccountIdIndexStore;
+import org.tron.core.store.AccountStore;
+import org.tron.core.store.AccountTraceStore;
+import org.tron.core.store.BalanceTraceStore;
+import org.tron.core.store.ContractStore;
+import org.tron.core.store.MarketOrderStore;
+import org.tron.core.store.MarketPairPriceToOrderStore;
+import org.tron.core.store.MarketPairToPriceStore;
+import org.tron.core.store.StoreFactory;
 import org.tron.core.utils.TransactionUtil;
 import org.tron.core.zen.ShieldedTRC20ParametersBuilder;
 import org.tron.core.zen.ShieldedTRC20ParametersBuilder.ShieldedTRC20ParametersType;
@@ -372,7 +381,8 @@ public class Wallet {
 
   public AccountAssetIssue getAccountAssetIssueById(Account account) {
     AccountAssetIssueStore accountAssetIssueStore = chainBaseManager.getAccountAssetIssueStore();
-    AccountAssetIssueCapsule accountAssetIssueCapsule = accountAssetIssueStore.get(account.getAddress().toByteArray());
+    AccountAssetIssueCapsule accountAssetIssueCapsule =
+            accountAssetIssueStore.get(account.getAddress().toByteArray());
     if (accountAssetIssueCapsule == null) {
       return null;
     }
@@ -1049,7 +1059,8 @@ public class Wallet {
   }
 
   private Map<String, Long> setAssetNetLimit(Map<String, Long> assetNetLimitMap,
-                                             AccountCapsule accountCapsule, AccountAssetIssueCapsule accountAssetIssueCapsule) {
+                                             AccountCapsule accountCapsule,
+                                             AccountAssetIssueCapsule accountAssetIssueCapsule) {
     Map<String, Long> allFreeAssetNetUsage;
     if (chainBaseManager.getDynamicPropertiesStore().getAllowSameTokenName() == 0) {
       allFreeAssetNetUsage = accountAssetIssueCapsule.getAllFreeAssetNetUsage();
@@ -1093,7 +1104,8 @@ public class Wallet {
     long totalNetWeight = chainBaseManager.getDynamicPropertiesStore().getTotalNetWeight();
 
     Map<String, Long> assetNetLimitMap = new HashMap<>();
-    Map<String, Long> allFreeAssetNetUsage = setAssetNetLimit(assetNetLimitMap, accountCapsule, accountAssetIssueCapsule);
+    Map<String, Long> allFreeAssetNetUsage =
+            setAssetNetLimit(assetNetLimitMap, accountCapsule, accountAssetIssueCapsule);
 
     builder.setFreeNetUsed(accountCapsule.getFreeNetUsage())
         .setFreeNetLimit(freeNetLimit)
@@ -1144,7 +1156,8 @@ public class Wallet {
     long storageUsage = accountCapsule.getAccountResource().getStorageUsage();
 
     Map<String, Long> assetNetLimitMap = new HashMap<>();
-    Map<String, Long> allFreeAssetNetUsage = setAssetNetLimit(assetNetLimitMap, accountCapsule, accountAssetIssueCapsule);
+    Map<String, Long> allFreeAssetNetUsage =
+            setAssetNetLimit(assetNetLimitMap, accountCapsule, accountAssetIssueCapsule);
 
     builder.setFreeNetUsed(accountCapsule.getFreeNetUsage())
         .setFreeNetLimit(freeNetLimit)

--- a/framework/src/main/java/org/tron/core/config/args/Args.java
+++ b/framework/src/main/java/org/tron/core/config/args/Args.java
@@ -748,10 +748,11 @@ public class Args extends CommonParameter {
     PARAMETER.historyBalanceLookup = config.hasPath(Constant.HISTORY_BALANCE_LOOKUP) && config
         .getBoolean(Constant.HISTORY_BALANCE_LOOKUP);
 
-    PARAMETER.openPrintLog = config.hasPath(Constant.OPEN_PRINT_LOG) ? config
-        .getBoolean(Constant.OPEN_PRINT_LOG) : true;
-    PARAMETER.openTransactionSort = config.hasPath(Constant.OPEN_TRANSACTION_SORT) ? config
-        .getBoolean(Constant.OPEN_TRANSACTION_SORT) : false;
+    PARAMETER.openPrintLog = !config.hasPath(Constant.OPEN_PRINT_LOG) || config
+            .getBoolean(Constant.OPEN_PRINT_LOG);
+
+    PARAMETER.openTransactionSort = config.hasPath(Constant.OPEN_TRANSACTION_SORT) && config
+            .getBoolean(Constant.OPEN_TRANSACTION_SORT);
 
     logConfig();
   }

--- a/framework/src/main/java/org/tron/core/db/BandwidthProcessor.java
+++ b/framework/src/main/java/org/tron/core/db/BandwidthProcessor.java
@@ -40,7 +40,9 @@ public class BandwidthProcessor extends ResourceProcessor {
   }
 
   private void updateUsage(AccountCapsule accountCapsule, long now) {
-    AccountAssetIssueCapsule accountAssetIssueCapsule = chainBaseManager.getAccountAssetIssueStore().get(accountCapsule.getAddress().toByteArray());
+    AccountAssetIssueCapsule accountAssetIssueCapsule =
+            chainBaseManager.getAccountAssetIssueStore()
+            .get(accountCapsule.getAddress().toByteArray());
     long oldNetUsage = accountCapsule.getNetUsage();
     long latestConsumeTime = accountCapsule.getLatestConsumeTime();
     accountCapsule.setNetUsage(increase(oldNetUsage, 0, latestConsumeTime, now));
@@ -52,15 +54,18 @@ public class BandwidthProcessor extends ResourceProcessor {
       Map<String, Long> assetMap = accountAssetIssueCapsule.getAssetMap();
       assetMap.forEach((assetName, balance) -> {
         long oldFreeAssetNetUsage = accountAssetIssueCapsule.getFreeAssetNetUsage(assetName);
-        long latestAssetOperationTime = accountAssetIssueCapsule.getLatestAssetOperationTime(assetName);
+        long latestAssetOperationTime = accountAssetIssueCapsule
+                .getLatestAssetOperationTime(assetName);
         accountAssetIssueCapsule.putFreeAssetNetUsage(assetName,
             increase(oldFreeAssetNetUsage, 0, latestAssetOperationTime, now));
       });
     }
     Map<String, Long> assetMapV2 = accountAssetIssueCapsule.getAssetMapV2();
     assetMapV2.forEach((assetName, balance) -> {
-      long oldFreeAssetNetUsage = accountAssetIssueCapsule.getFreeAssetNetUsageV2(assetName);
-      long latestAssetOperationTime = accountAssetIssueCapsule.getLatestAssetOperationTimeV2(assetName);
+      long oldFreeAssetNetUsage = accountAssetIssueCapsule
+              .getFreeAssetNetUsageV2(assetName);
+      long latestAssetOperationTime = accountAssetIssueCapsule
+              .getLatestAssetOperationTimeV2(assetName);
       accountAssetIssueCapsule.putFreeAssetNetUsageV2(assetName,
           increase(oldFreeAssetNetUsage, 0, latestAssetOperationTime, now));
     });
@@ -244,7 +249,9 @@ public class BandwidthProcessor extends ResourceProcessor {
       throw new ContractValidateException("asset does not exist");
     }
 
-    AccountAssetIssueCapsule accountAssetIssueCapsule = chainBaseManager.getAccountAssetIssueStore().get(accountCapsule.getAddress().toByteArray());
+    AccountAssetIssueCapsule accountAssetIssueCapsule = chainBaseManager
+            .getAccountAssetIssueStore()
+            .get(accountCapsule.getAddress().toByteArray());
     String tokenName = ByteArray.toStr(assetName.toByteArray());
     String tokenID = assetIssueCapsule.getId();
     if (assetIssueCapsule.getOwnerAddress() == accountCapsule.getAddress()) {
@@ -344,7 +351,8 @@ public class BandwidthProcessor extends ResourceProcessor {
     chainBaseManager.getAccountStore().put(accountCapsule.createDbKey(), accountCapsule);
     chainBaseManager.getAccountStore().put(issuerAccountCapsule.createDbKey(),
         issuerAccountCapsule);
-    chainBaseManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.getAddress().toByteArray(), accountAssetIssueCapsule);
+    chainBaseManager.getAccountAssetIssueStore()
+            .put(accountAssetIssueCapsule.getAddress().toByteArray(), accountAssetIssueCapsule);
     return true;
 
   }

--- a/framework/src/main/java/org/tron/core/db/Manager.java
+++ b/framework/src/main/java/org/tron/core/db/Manager.java
@@ -344,7 +344,7 @@ public class Manager {
     isRunTriggerCapsuleProcessThread = false;
   }
 
-  Comparator downComparator = (Comparator<TransactionCapsule>) (o1, o2) -> Long
+  private Comparator downComparator = (Comparator<TransactionCapsule>) (o1, o2) -> Long
       .compare(o2.getOrder(), o1.getOrder());
 
   @PostConstruct

--- a/framework/src/main/java/org/tron/core/db/Manager.java
+++ b/framework/src/main/java/org/tron/core/db/Manager.java
@@ -73,8 +73,8 @@ import org.tron.consensus.base.Param.Miner;
 import org.tron.core.ChainBaseManager;
 import org.tron.core.Constant;
 import org.tron.core.actuator.ActuatorCreator;
-import org.tron.core.capsule.AccountCapsule;
 import org.tron.core.capsule.AccountAssetIssueCapsule;
+import org.tron.core.capsule.AccountCapsule;
 import org.tron.core.capsule.BlockBalanceTraceCapsule;
 import org.tron.core.capsule.BlockCapsule;
 import org.tron.core.capsule.BlockCapsule.BlockId;
@@ -119,6 +119,7 @@ import org.tron.core.exception.ZksnarkException;
 import org.tron.core.metrics.MetricsKey;
 import org.tron.core.metrics.MetricsUtil;
 import org.tron.core.service.MortgageService;
+import org.tron.core.store.AccountAssetIssueStore;
 import org.tron.core.store.AccountIdIndexStore;
 import org.tron.core.store.AccountIndexStore;
 import org.tron.core.store.AccountStore;
@@ -142,7 +143,6 @@ import org.tron.core.store.TransactionRetStore;
 import org.tron.core.store.VotesStore;
 import org.tron.core.store.WitnessScheduleStore;
 import org.tron.core.store.WitnessStore;
-import org.tron.core.store.AccountAssetIssueStore;
 import org.tron.core.utils.TransactionRegister;
 import org.tron.protos.Protocol.AccountType;
 import org.tron.protos.Protocol.Transaction;
@@ -366,7 +366,7 @@ public class Manager {
       this.rePushTransactions = new PriorityBlockingQueue<>(2000, downComparator);
     } else {
       this.pendingTransactions = new LinkedBlockingQueue<>();
-      this.rePushTransactions =new LinkedBlockingQueue<>();
+      this.rePushTransactions = new LinkedBlockingQueue<>();
     }
     this.triggerCapsuleQueue = new LinkedBlockingQueue<>();
     chainBaseManager.setMerkleContainer(getMerkleContainer());
@@ -485,7 +485,8 @@ public class Manager {
               chainBaseManager.getAccountStore().put(account.getAddress(), accountCapsule);
               chainBaseManager.getAccountIdIndexStore().put(accountCapsule);
               chainBaseManager.getAccountIndexStore().put(accountCapsule);
-              chainBaseManager.getAccountAssetIssueStore().put(account.getAddress(), accountAssetIssueCapsule);
+              chainBaseManager.getAccountAssetIssueStore()
+                      .put(account.getAddress(), accountAssetIssueCapsule);
             });
   }
 

--- a/framework/src/main/java/org/tron/core/db/api/AssetUpdateHelper.java
+++ b/framework/src/main/java/org/tron/core/db/api/AssetUpdateHelper.java
@@ -12,11 +12,11 @@ import java.util.Map.Entry;
 import lombok.extern.slf4j.Slf4j;
 import org.tron.common.utils.ByteArray;
 import org.tron.core.ChainBaseManager;
+import org.tron.core.capsule.AccountAssetIssueCapsule;
 import org.tron.core.capsule.AssetIssueCapsule;
 import org.tron.core.capsule.BlockCapsule;
 import org.tron.core.capsule.ExchangeCapsule;
 import org.tron.core.capsule.TransactionCapsule;
-import org.tron.core.capsule.AccountAssetIssueCapsule;
 import org.tron.protos.Protocol.Transaction.Contract.ContractType;
 import org.tron.protos.contract.AssetIssueContractOuterClass.AssetIssueContract;
 
@@ -166,7 +166,8 @@ public class AssetUpdateHelper {
       accountAssetIssueCapsule.clearFreeAssetNetUsageV2();
       if (accountAssetIssueCapsule.getAllFreeAssetNetUsage().size() != 0) {
         HashMap<String, Long> map = new HashMap<>();
-        for (Map.Entry<String, Long> entry : accountAssetIssueCapsule.getAllFreeAssetNetUsage().entrySet()) {
+        for (Map.Entry<String, Long> entry :
+                accountAssetIssueCapsule.getAllFreeAssetNetUsage().entrySet()) {
           map.put(ByteArray.toStr(assetNameToIdMap.get(entry.getKey())), entry.getValue());
         }
         accountAssetIssueCapsule.addAllFreeAssetNetUsageV2(map);
@@ -185,10 +186,12 @@ public class AssetUpdateHelper {
       if (!accountAssetIssueCapsule.getAssetIssuedName().isEmpty()) {
         accountAssetIssueCapsule.setAssetIssuedID(
                 assetNameToIdMap.get(
-                        ByteArray.toStr(accountAssetIssueCapsule.getAssetIssuedName().toByteArray())));
+                        ByteArray.toStr(
+                                accountAssetIssueCapsule.getAssetIssuedName().toByteArray())));
       }
 
-      chainBaseManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.createDbKey(), accountAssetIssueCapsule);
+      chainBaseManager.getAccountAssetIssueStore()
+              .put(accountAssetIssueCapsule.createDbKey(), accountAssetIssueCapsule);
 
       if (count % 50000 == 0) {
         logger.info("The number of accounts that have completed the update: {}", count);

--- a/framework/src/main/java/org/tron/core/services/http/FullNodeHttpApiService.java
+++ b/framework/src/main/java/org/tron/core/services/http/FullNodeHttpApiService.java
@@ -524,8 +524,10 @@ public class FullNodeHttpApiService implements Service {
       context.addServlet(new ServletHolder(getBlockBalanceServlet),
           "/wallet/getblockbalance");
       context.addServlet(new ServletHolder(getBurnTrxServlet), "/wallet/getburntrx");
-      context.addServlet(new ServletHolder(getTransactionFromPendingServlet), "/wallet/gettransactionfrompending");
-      context.addServlet(new ServletHolder(getTransactionListFromPendingServlet), "/wallet/gettransactionlistfrompending");
+      context.addServlet(new ServletHolder(getTransactionFromPendingServlet),
+              "/wallet/gettransactionfrompending");
+      context.addServlet(new ServletHolder(getTransactionListFromPendingServlet),
+              "/wallet/gettransactionlistfrompending");
       context.addServlet(new ServletHolder(getPendingSizeServlet), "/wallet/getpendingsize");
 
       int maxHttpConnectNumber = Args.getInstance().getMaxHttpConnectNumber();

--- a/framework/src/main/java/org/tron/core/services/http/GetAccountByIdServlet.java
+++ b/framework/src/main/java/org/tron/core/services/http/GetAccountByIdServlet.java
@@ -48,7 +48,6 @@ public class GetAccountByIdServlet extends RateLimiterServlet {
       throws IOException {
     Account reply = wallet.getAccountById(account);
     AccountAssetIssue accountAssetIssue = wallet.getAccountAssetIssueById(account);
-//    Util.printAccount(reply, response, visible);
     Util.printAccount(reply, accountAssetIssue, response, visible);
   }
 }

--- a/framework/src/main/java/org/tron/core/services/http/Util.java
+++ b/framework/src/main/java/org/tron/core/services/http/Util.java
@@ -61,6 +61,7 @@ public class Util {
   public static final String CONTRACT_TYPE = "contractType";
   public static final String EXTRA_DATA = "extra_data";
   public static final String PARAMETER = "parameter";
+  public static final String ASSET_ISSUED_ID = "asset_issued_ID";
 
   public static String printTransactionFee(String transactionFee) {
     JSONObject jsonObject = new JSONObject();
@@ -431,8 +432,8 @@ public class Util {
       return JsonFormat.printToString(account, false);
     } else {
       JSONObject accountJson = JSONObject.parseObject(JsonFormat.printToString(account, false));
-      String assetId = accountJson.get("asset_issued_ID").toString();
-      accountJson.put("asset_issued_ID",
+      String assetId = accountJson.get(ASSET_ISSUED_ID).toString();
+      accountJson.put(ASSET_ISSUED_ID,
           ByteString.copyFrom(ByteArray.fromHexString(assetId)).toStringUtf8());
       return accountJson.toJSONString();
     }
@@ -445,8 +446,8 @@ public class Util {
     } else {
       account = convertAccount(account, accountAssetIssue);
       JSONObject accountJson = JSONObject.parseObject(JsonFormat.printToString(account, false));
-      String assetId = accountJson.get("asset_issued_ID").toString();
-      accountJson.put("asset_issued_ID",
+      String assetId = accountJson.get(ASSET_ISSUED_ID).toString();
+      accountJson.put(ASSET_ISSUED_ID,
           ByteString.copyFrom(ByteArray.fromHexString(assetId)).toStringUtf8());
       return accountJson.toJSONString();
     }

--- a/framework/src/main/java/org/tron/core/services/http/Util.java
+++ b/framework/src/main/java/org/tron/core/services/http/Util.java
@@ -481,11 +481,13 @@ public class Util {
     }
   }
 
-  public static void printAccount(Account reply, AccountAssetIssue accountAssetIssue, HttpServletResponse response, Boolean visible)
+  public static void printAccount(Account reply, AccountAssetIssue accountAssetIssue,
+                                  HttpServletResponse response, Boolean visible)
           throws java.io.IOException {
     if (reply != null) {
       if (visible) {
-        response.getWriter().println(JsonFormat.printToString(convertAccount(reply, accountAssetIssue), true));
+        response.getWriter().println(
+                JsonFormat.printToString(convertAccount(reply, accountAssetIssue), true));
       } else {
         response.getWriter().println(convertOutput(reply, accountAssetIssue));
       }

--- a/framework/src/test/java/org/tron/common/runtime/vm/TransferToAccountTest.java
+++ b/framework/src/test/java/org/tron/common/runtime/vm/TransferToAccountTest.java
@@ -23,11 +23,11 @@ import org.tron.core.ChainBaseManager;
 import org.tron.core.Constant;
 import org.tron.core.Wallet;
 import org.tron.core.actuator.VMActuator;
+import org.tron.core.capsule.AccountAssetIssueCapsule;
 import org.tron.core.capsule.AccountCapsule;
 import org.tron.core.capsule.AssetIssueCapsule;
 import org.tron.core.capsule.BlockCapsule;
 import org.tron.core.capsule.TransactionCapsule;
-import org.tron.core.capsule.AccountAssetIssueCapsule;
 import org.tron.core.config.DefaultConfig;
 import org.tron.core.config.args.Args;
 import org.tron.core.db.Manager;
@@ -129,13 +129,12 @@ public class TransferToAccountTest {
     AssetIssueCapsule assetIssueCapsule = new AssetIssueCapsule(assetIssueContract);
     chainBaseManager.getAssetIssueV2Store()
         .put(assetIssueCapsule.createDbV2Key(), assetIssueCapsule);
-
-//    ownerCapsule.addAssetV2(ByteArray.fromString(String.valueOf(id)), 100_000_000);
     chainBaseManager.getAccountStore().put(ownerCapsule.getAddress().toByteArray(), ownerCapsule);
 
     ownerAccountAssetIssueCapsule.addAssetV2(ByteArray.fromString(String.valueOf(id)), 100_000_000);
     dbManager.getAccountAssetIssueStore()
-            .put(ownerAccountAssetIssueCapsule.getAddress().toByteArray(), ownerAccountAssetIssueCapsule);
+            .put(ownerAccountAssetIssueCapsule.getAddress().toByteArray(),
+                    ownerAccountAssetIssueCapsule);
     return id;
   }
 

--- a/framework/src/test/java/org/tron/common/runtime/vm/TransferTokenTest.java
+++ b/framework/src/test/java/org/tron/common/runtime/vm/TransferTokenTest.java
@@ -113,13 +113,12 @@ public class TransferTokenTest {
             .build();
     AssetIssueCapsule assetIssueCapsule = new AssetIssueCapsule(assetIssueContract);
     dbManager.getAssetIssueV2Store().put(assetIssueCapsule.createDbV2Key(), assetIssueCapsule);
-
-//    ownerCapsule.addAssetV2(ByteArray.fromString(String.valueOf(id)), 100_000_000);
     dbManager.getAccountStore().put(ownerCapsule.getAddress().toByteArray(), ownerCapsule);
 
     ownerAccountAssetIssueCapsule.addAssetV2(ByteArray.fromString(String.valueOf(id)), 100_000_000);
     dbManager.getAccountAssetIssueStore()
-            .put(ownerAccountAssetIssueCapsule.getAddress().toByteArray(), ownerAccountAssetIssueCapsule);
+            .put(ownerAccountAssetIssueCapsule.getAddress()
+                    .toByteArray(), ownerAccountAssetIssueCapsule);
     return id;
   }
 
@@ -143,9 +142,11 @@ public class TransferTokenTest {
     byte[] contractAddress = deployTransferTokenContract(id);
     deposit.commit();
     Assert.assertEquals(100,
-        dbManager.getAccountAssetIssueStore().get(contractAddress).getAssetMapV2().get(String.valueOf(id))
+        dbManager.getAccountAssetIssueStore()
+                .get(contractAddress).getAssetMapV2().get(String.valueOf(id))
             .longValue());
-    Assert.assertEquals(1000, dbManager.getAccountStore().get(contractAddress).getBalance());
+    Assert.assertEquals(1000,
+            dbManager.getAccountStore().get(contractAddress).getBalance());
 
     String selectorStr = "TransferTokenTo(address,trcToken,uint256)";
     String params = "000000000000000000000000548794500882809695a8a687866e76d4271a1abc"
@@ -167,9 +168,12 @@ public class TransferTokenTest {
 
     org.testng.Assert.assertNull(runtime.getRuntimeError());
     Assert.assertEquals(100 + tokenValue - 9,
-        dbManager.getAccountAssetIssueStore().get(contractAddress).getAssetMapV2().get(String.valueOf(id))
+        dbManager.getAccountAssetIssueStore()
+                .get(contractAddress).getAssetMapV2().get(String.valueOf(id))
             .longValue());
-    Assert.assertEquals(9, dbManager.getAccountAssetIssueStore().get(Hex.decode(TRANSFER_TO)).getAssetMapV2()
+    Assert.assertEquals(9,
+            dbManager.getAccountAssetIssueStore()
+                    .get(Hex.decode(TRANSFER_TO)).getAssetMapV2()
         .get(String.valueOf(id)).longValue());
 
     /*   suicide test  */
@@ -196,7 +200,8 @@ public class TransferTokenTest {
     Assert.assertEquals(100 + tokenValue - 9 + 9,
         dbManager.getAccountAssetIssueStore().get(Hex.decode(TRANSFER_TO)).getAssetMapV2()
             .get(String.valueOf(id)).longValue());
-    Assert.assertEquals(99, dbManager.getAccountAssetIssueStore().get(Hex.decode(TRANSFER_TO)).getAssetMapV2()
+    Assert.assertEquals(99,
+            dbManager.getAccountAssetIssueStore().get(Hex.decode(TRANSFER_TO)).getAssetMapV2()
         .get(String.valueOf(id2)).longValue());
   }
 

--- a/framework/src/test/java/org/tron/core/BandwidthProcessorTest.java
+++ b/framework/src/test/java/org/tron/core/BandwidthProcessorTest.java
@@ -14,7 +14,11 @@ import org.tron.common.application.TronApplicationContext;
 import org.tron.common.runtime.RuntimeImpl;
 import org.tron.common.utils.ByteArray;
 import org.tron.common.utils.FileUtil;
-import org.tron.core.capsule.*;
+import org.tron.core.capsule.AccountAssetIssueCapsule;
+import org.tron.core.capsule.AccountCapsule;
+import org.tron.core.capsule.AssetIssueCapsule;
+import org.tron.core.capsule.TransactionCapsule;
+import org.tron.core.capsule.TransactionResultCapsule;
 import org.tron.core.config.DefaultConfig;
 import org.tron.core.config.args.Args;
 import org.tron.core.db.BandwidthProcessor;
@@ -120,8 +124,6 @@ public class BandwidthProcessorTest {
             ByteString.copyFrom(ByteArray.fromHexString(OWNER_ADDRESS)),
             AccountType.Normal,
             0L);
-//    ownerCapsule.addAsset(ASSET_NAME.getBytes(), 100L);
-//    ownerCapsule.addAsset(ASSET_NAME_V2.getBytes(), 100L);
 
     AccountAssetIssueCapsule ownerAssetIssueCapsule =
             new AccountAssetIssueCapsule(
@@ -169,21 +171,28 @@ public class BandwidthProcessorTest {
 
     chainBaseManager.getAccountStore().reset();
     chainBaseManager.getAccountStore().put(ownerCapsule.getAddress().toByteArray(), ownerCapsule);
-    chainBaseManager.getAccountAssetIssueStore().put(ownerAssetIssueCapsule.getAddress().toByteArray(),
+    chainBaseManager.getAccountAssetIssueStore()
+            .put(ownerAssetIssueCapsule.getAddress().toByteArray(),
             ownerAssetIssueCapsule);
 
-    chainBaseManager.getAccountAssetIssueStore().put(toAccountAssetIssueCapsule.getAddress().toByteArray(),
+    chainBaseManager.getAccountAssetIssueStore()
+            .put(toAccountAssetIssueCapsule.getAddress().toByteArray(),
             toAccountAssetIssueCapsule);
-    chainBaseManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.getAddress().toByteArray(),
+    chainBaseManager.getAccountAssetIssueStore()
+            .put(accountAssetIssueCapsule.getAddress().toByteArray(),
             accountAssetIssueCapsule);
-    chainBaseManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule2.getAddress().toByteArray(),
+    chainBaseManager.getAccountAssetIssueStore()
+            .put(accountAssetIssueCapsule2.getAddress().toByteArray(),
             accountAssetIssueCapsule2);
 
     chainBaseManager.getAccountStore()
         .put(toAccountCapsule.getAddress().toByteArray(), toAccountCapsule);
 
-    chainBaseManager.getAccountStore().put(assetCapsule.getAddress().toByteArray(), assetCapsule);
-    chainBaseManager.getAccountStore().put(assetCapsule2.getAddress().toByteArray(), assetCapsule2);
+    chainBaseManager.getAccountStore()
+            .put(assetCapsule.getAddress().toByteArray(), assetCapsule);
+    chainBaseManager.getAccountStore()
+            .put(assetCapsule2.getAddress().toByteArray(), assetCapsule2);
+
   }
 
   private TransferAssetContract getTransferAssetContract() {
@@ -243,12 +252,14 @@ public class BandwidthProcessorTest {
     AssetIssueCapsule assetIssueCapsule = new AssetIssueCapsule(assetIssueContract);
     AccountCapsule toAccountCapsule = chainBaseManager.getAccountStore()
         .get(ByteArray.fromHexString(TO_ADDRESS));
-    AccountAssetIssueCapsule toAccountAssetIssueCapsule = chainBaseManager.getAccountAssetIssueStore()
+    AccountAssetIssueCapsule toAccountAssetIssueCapsule =
+            chainBaseManager.getAccountAssetIssueStore()
             .get(ByteArray.fromHexString(TO_ADDRESS));
     if (chainBaseManager.getDynamicPropertiesStore().getAllowSameTokenName() == 1) {
       chainBaseManager.getAssetIssueV2Store()
           .put(assetIssueCapsule.createDbV2Key(), assetIssueCapsule);
-      toAccountAssetIssueCapsule.addAssetV2(ByteArray.fromString(String.valueOf(id)), TOTAL_SUPPLY);
+      toAccountAssetIssueCapsule
+              .addAssetV2(ByteArray.fromString(String.valueOf(id)), TOTAL_SUPPLY);
     } else {
       chainBaseManager.getAssetIssueStore()
           .put(assetIssueCapsule.createDbKey(), assetIssueCapsule);
@@ -377,7 +388,8 @@ public class BandwidthProcessorTest {
         .get(ByteArray.fromHexString(ASSET_ADDRESS));
 
     AccountAssetIssueCapsule ownerAssetIssueCapsuleNew =
-            chainBaseManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
+            chainBaseManager.getAccountAssetIssueStore()
+                    .get(ByteArray.fromHexString(OWNER_ADDRESS));
 
     Assert.assertEquals(508882612L, assetCapsuleNew.getLatestConsumeTime());
     Assert.assertEquals(1526647838000L, ownerCapsuleNew.getLatestOperationTime());
@@ -448,10 +460,12 @@ public class BandwidthProcessorTest {
     chainBaseManager.getAccountStore().put(issuerCapsuleV2.getAddress().toByteArray(),
         issuerCapsuleV2);
 
-    AccountAssetIssueCapsule issuerAccountAsstCapsuleV2 = chainBaseManager.getAccountAssetIssueStore()
+    AccountAssetIssueCapsule issuerAccountAsstCapsuleV2 =
+            chainBaseManager.getAccountAssetIssueStore()
             .get(ByteArray.fromHexString(ASSET_ADDRESS_V2));
 
-    chainBaseManager.getAccountAssetIssueStore().put(issuerAccountAsstCapsuleV2.getAddress().toByteArray(),
+    chainBaseManager.getAccountAssetIssueStore()
+            .put(issuerAccountAsstCapsuleV2.getAddress().toByteArray(),
             issuerAccountAsstCapsuleV2);
 
     TransactionResultCapsule ret = new TransactionResultCapsule();
@@ -464,13 +478,17 @@ public class BandwidthProcessorTest {
     AccountCapsule issuerCapsuleNew = chainBaseManager.getAccountStore()
         .get(ByteArray.fromHexString(ASSET_ADDRESS_V2));
 
-    AccountAssetIssueCapsule ownerAssetIssueCapsule = chainBaseManager.getAccountAssetIssueStore()
+    AccountAssetIssueCapsule ownerAssetIssueCapsule =
+            chainBaseManager.getAccountAssetIssueStore()
             .get(ByteArray.fromHexString(OWNER_ADDRESS));
-    AccountAssetIssueCapsule issueAssetIssueCapsule = chainBaseManager.getAccountAssetIssueStore()
+    AccountAssetIssueCapsule issueAssetIssueCapsule =
+            chainBaseManager.getAccountAssetIssueStore()
             .get(ByteArray.fromHexString(ASSET_ADDRESS_V2));
 
-    Assert.assertEquals(508882612L, issuerCapsuleNew.getLatestConsumeTime());
-    Assert.assertEquals(1526647838000L, ownerCapsuleNew.getLatestOperationTime());
+    Assert.assertEquals(508882612L,
+            issuerCapsuleNew.getLatestConsumeTime());
+    Assert.assertEquals(1526647838000L,
+            ownerCapsuleNew.getLatestOperationTime());
 
     Assert.assertEquals(508882612L,
             ownerAssetIssueCapsule.getLatestAssetOperationTimeV2(ASSET_NAME_V2));
@@ -669,7 +687,8 @@ public class BandwidthProcessorTest {
             ByteString.copyFromUtf8("owner"),
             ByteString.copyFrom(ByteArray.fromHexString(OWNER_ADDRESS)));
     chainBaseManager.getAccountAssetIssueStore()
-            .put(ownerAccountAssetIssueCapsule.getAddress().toByteArray(), ownerAccountAssetIssueCapsule);
+            .put(ownerAccountAssetIssueCapsule.getAddress().toByteArray(),
+                    ownerAccountAssetIssueCapsule);
 
     AccountCapsule toAddressCapsule =
         new AccountCapsule(
@@ -858,10 +877,13 @@ public class BandwidthProcessorTest {
       Assert.assertNotNull(fromAccount);
 
       AccountAssetIssueCapsule fromAccountAssetIssue =
-              chainBaseManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
+              chainBaseManager.getAccountAssetIssueStore()
+                      .get(ByteArray.fromHexString(OWNER_ADDRESS));
 
-      Assert.assertEquals(fromAccountAssetIssue.getFreeAssetNetUsageV2(String.valueOf(id)), byteSize);
-      Assert.assertEquals(fromAccountAssetIssue.getFreeAssetNetUsageV2(String.valueOf(id)), byteSize);
+      Assert.assertEquals(fromAccountAssetIssue
+              .getFreeAssetNetUsageV2(String.valueOf(id)), byteSize);
+      Assert.assertEquals(fromAccountAssetIssue
+              .getFreeAssetNetUsageV2(String.valueOf(id)), byteSize);
 
     } catch (ContractValidateException e) {
       Assert.assertFalse(e instanceof ContractValidateException);

--- a/framework/src/test/java/org/tron/core/ShieldedTRC20BuilderTest.java
+++ b/framework/src/test/java/org/tron/core/ShieldedTRC20BuilderTest.java
@@ -132,7 +132,7 @@ public class ShieldedTRC20BuilderTest extends BlockGenerate {
       Assert.assertEquals(1, result[31]);
 
       //update frontier and leafCount
-      
+
       int slot = result[63];
       if (slot == 0) {
         System.arraycopy(inputData, 0, frontier, 0, 32);

--- a/framework/src/test/java/org/tron/core/actuator/AssetIssueActuatorTest.java
+++ b/framework/src/test/java/org/tron/core/actuator/AssetIssueActuatorTest.java
@@ -101,7 +101,8 @@ public class AssetIssueActuatorTest {
         ByteString.copyFrom(ByteArray.fromHexString(OWNER_ADDRESS_SECOND)), AccountType.Normal,
         dbManager.getDynamicPropertiesStore().getAssetIssueFee());
     dbManager.getAccountStore().put(ownerCapsule.getAddress().toByteArray(), ownerCapsule);
-    dbManager.getAccountStore().put(ownerSecondCapsule.getAddress().toByteArray(), ownerSecondCapsule);
+    dbManager.getAccountStore()
+            .put(ownerSecondCapsule.getAddress().toByteArray(), ownerSecondCapsule);
 
     AccountAssetIssueCapsule ownerAssetIssueCapsule = new AccountAssetIssueCapsule(
             ByteString.copyFrom(ByteArray.fromHexString(OWNER_ADDRESS)));
@@ -111,7 +112,8 @@ public class AssetIssueActuatorTest {
     dbManager.getAccountAssetIssueStore()
             .put(ownerAssetIssueCapsule.getAddress().toByteArray(), ownerAssetIssueCapsule);
     dbManager.getAccountAssetIssueStore()
-            .put(ownerAssetIssueSecondCapsule.getAddress().toByteArray(), ownerAssetIssueSecondCapsule);
+            .put(ownerAssetIssueSecondCapsule.getAddress()
+                    .toByteArray(), ownerAssetIssueSecondCapsule);
 
     dbManager.getDynamicPropertiesStore().saveLatestBlockHeaderTimestamp(24 * 3600 * 1000);
     dbManager.getDynamicPropertiesStore().saveAllowSameTokenName(0);
@@ -180,7 +182,8 @@ public class AssetIssueActuatorTest {
       Assert.assertEquals(0, assetIssueCapsuleV2.getPrecision());
       Assert.assertEquals(NUM, assetIssueCapsuleV2.getNum());
       Assert.assertEquals(TRX_NUM, assetIssueCapsuleV2.getTrxNum());
-      Assert.assertEquals(ownerAccountAssetIssue.getAssetMapV2().get(String.valueOf(tokenIdNum)).longValue(),
+      Assert.assertEquals(ownerAccountAssetIssue.getAssetMapV2()
+                      .get(String.valueOf(tokenIdNum)).longValue(),
           TOTAL_SUPPLY);
 
     } catch (ContractValidateException e) {
@@ -227,7 +230,8 @@ public class AssetIssueActuatorTest {
       Assert.assertEquals(6, assetIssueCapsuleV2.getPrecision());
       Assert.assertEquals(NUM, assetIssueCapsuleV2.getNum());
       Assert.assertEquals(TRX_NUM, assetIssueCapsuleV2.getTrxNum());
-      Assert.assertEquals(ownerAccountAssetIssue.getAssetMapV2().get(String.valueOf(tokenIdNum)).longValue(),
+      Assert.assertEquals(ownerAccountAssetIssue.getAssetMapV2()
+                      .get(String.valueOf(tokenIdNum)).longValue(),
           TOTAL_SUPPLY);
 
     } catch (ContractValidateException e) {
@@ -273,7 +277,8 @@ public class AssetIssueActuatorTest {
       Assert.assertEquals(6, assetIssueCapsuleV2.getPrecision());
       Assert.assertEquals(NUM, assetIssueCapsuleV2.getNum());
       Assert.assertEquals(TRX_NUM, assetIssueCapsuleV2.getTrxNum());
-      Assert.assertEquals(ownerAccountAssetIssue.getAssetMapV2().get(String.valueOf(tokenIdNum)).longValue(),
+      Assert.assertEquals(ownerAccountAssetIssue.getAssetMapV2()
+                      .get(String.valueOf(tokenIdNum)).longValue(),
           TOTAL_SUPPLY);
 
     } catch (ContractValidateException e) {
@@ -745,7 +750,8 @@ public class AssetIssueActuatorTest {
       Assert.assertEquals(owner.getBalance(), 0L);
       Assert.assertEquals(dbManager.getAccountStore().getBlackhole().getBalance(),
           blackholeBalance + dbManager.getDynamicPropertiesStore().getAssetIssueFee());
-      Assert.assertEquals(ownerAccountAssetIssue.getAssetMap().get("testname0123456789abcdefghijgklm").longValue(),
+      Assert.assertEquals(ownerAccountAssetIssue.getAssetMap()
+                      .get("testname0123456789abcdefghijgklm").longValue(),
           TOTAL_SUPPLY);
     } catch (ContractValidateException e) {
       Assert.assertFalse(e instanceof ContractValidateException);
@@ -1810,12 +1816,11 @@ public class AssetIssueActuatorTest {
             ByteString.copyFromUtf8("owner11"),
             ByteString.copyFrom(ByteArray.fromHexString(ownerAddress)));
     ownerAccountAssetIssue.addAsset(NAME.getBytes(), 1000L);
-    dbManager.getAccountAssetIssueStore().put(ownerAccountAssetIssue.getAddress().toByteArray(), ownerAccountAssetIssue);
+    dbManager.getAccountAssetIssueStore()
+            .put(ownerAccountAssetIssue.getAddress().toByteArray(), ownerAccountAssetIssue);
 
     AssetIssueActuator actuator = new AssetIssueActuator();
     actuator.setChainBaseManager(dbManager.getChainBaseManager()).setAny(getContract());
-//    ownerAccountAssetIssue.getAssetIssuedName().toStringUtf8();
-//    ownerCapsule.getAssetIssuedName().toStringUtf8();
 
     TransactionResultCapsule ret = new TransactionResultCapsule();
     Long blackholeBalance = dbManager.getAccountStore().getBlackhole().getBalance();
@@ -1842,7 +1847,8 @@ public class AssetIssueActuatorTest {
       Assert.assertEquals(owner.getBalance(), 0L);
       Assert.assertEquals(dbManager.getAccountStore().getBlackhole().getBalance(),
           blackholeBalance + dbManager.getDynamicPropertiesStore().getAssetIssueFee());
-      Assert.assertEquals(ownerAssetIssue.getAssetMapV2().get(String.valueOf(tokenIdNum)).longValue(),
+      Assert.assertEquals(ownerAssetIssue.getAssetMapV2()
+                      .get(String.valueOf(tokenIdNum)).longValue(),
           TOTAL_SUPPLY);
     } catch (ContractValidateException e) {
       Assert.assertFalse(e instanceof ContractValidateException);

--- a/framework/src/test/java/org/tron/core/actuator/ExchangeCreateActuatorTest.java
+++ b/framework/src/test/java/org/tron/core/actuator/ExchangeCreateActuatorTest.java
@@ -18,7 +18,11 @@ import org.tron.common.utils.ByteArray;
 import org.tron.common.utils.FileUtil;
 import org.tron.core.Constant;
 import org.tron.core.Wallet;
-import org.tron.core.capsule.*;
+import org.tron.core.capsule.AccountAssetIssueCapsule;
+import org.tron.core.capsule.AccountCapsule;
+import org.tron.core.capsule.AssetIssueCapsule;
+import org.tron.core.capsule.ExchangeCapsule;
+import org.tron.core.capsule.TransactionResultCapsule;
 import org.tron.core.config.DefaultConfig;
 import org.tron.core.config.args.Args;
 import org.tron.core.db.Manager;
@@ -172,10 +176,12 @@ public class ExchangeCreateActuatorTest {
     accountCapsule.setBalance(10000_000000L);
     dbManager.getAccountStore().put(ownerAddress, accountCapsule);
 
-    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    AccountAssetIssueCapsule accountAssetIssueCapsule =
+            dbManager.getAccountAssetIssueStore().get(ownerAddress);
     accountAssetIssueCapsule.addAssetAmount(firstTokenId.getBytes(), firstTokenBalance);
     accountAssetIssueCapsule.addAssetAmount(secondTokenId.getBytes(), secondTokenBalance);
-    dbManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.createDbKey(), accountAssetIssueCapsule);
+    dbManager.getAccountAssetIssueStore()
+            .put(accountAssetIssueCapsule.createDbKey(), accountAssetIssueCapsule);
 
     ExchangeCreateActuator actuator = new ExchangeCreateActuator();
     actuator.setChainBaseManager(dbManager.getChainBaseManager()).setAny(getContract(
@@ -267,9 +273,12 @@ public class ExchangeCreateActuatorTest {
     accountCapsule.setBalance(200_000_000_000000L);
     dbManager.getAccountStore().put(ownerAddress, accountCapsule);
 
-    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
-    accountAssetIssueCapsule.addAssetAmount(secondTokenId.getBytes(), 200_000_000L);
-    dbManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.createDbKey(), accountAssetIssueCapsule);
+    AccountAssetIssueCapsule accountAssetIssueCapsule =
+            dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    accountAssetIssueCapsule
+            .addAssetAmount(secondTokenId.getBytes(), 200_000_000L);
+    dbManager.getAccountAssetIssueStore()
+            .put(accountAssetIssueCapsule.createDbKey(), accountAssetIssueCapsule);
 
     ExchangeCreateActuator actuator = new ExchangeCreateActuator();
     actuator.setChainBaseManager(dbManager.getChainBaseManager()).setAny(getContract(
@@ -348,24 +357,28 @@ public class ExchangeCreateActuatorTest {
             .setName(ByteString.copyFrom(secondTokenId.getBytes()))
             .build());
     assetIssueCapsule.setId(String.valueOf(1L));
-    dbManager.getAssetIssueStore().put(assetIssueCapsule.createDbKey(), assetIssueCapsule);
+    dbManager.getAssetIssueStore()
+            .put(assetIssueCapsule.createDbKey(), assetIssueCapsule);
 
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_FIRST);
     AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
     accountCapsule.setBalance(200_000_000_000000L);
     dbManager.getAccountStore().put(ownerAddress, accountCapsule);
 
-    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    AccountAssetIssueCapsule accountAssetIssueCapsule =
+            dbManager.getAccountAssetIssueStore().get(ownerAddress);
     accountAssetIssueCapsule.addAsset(secondTokenId.getBytes(), 200_000_000L);
     accountAssetIssueCapsule.addAssetV2(String.valueOf(1L).getBytes(), 200_000_000L);
-    dbManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.createDbKey(), accountAssetIssueCapsule);
+    dbManager.getAccountAssetIssueStore()
+            .put(accountAssetIssueCapsule.createDbKey(), accountAssetIssueCapsule);
 
     ExchangeCreateActuator actuator = new ExchangeCreateActuator();
     actuator.setChainBaseManager(dbManager.getChainBaseManager()).setAny(getContract(
         OWNER_ADDRESS_FIRST, firstTokenId, firstTokenBalance, String.valueOf(1L),
         secondTokenBalance));
     TransactionResultCapsule ret = new TransactionResultCapsule();
-    Assert.assertEquals(dbManager.getDynamicPropertiesStore().getLatestExchangeNum(), 0);
+    Assert.assertEquals(dbManager.getDynamicPropertiesStore()
+            .getLatestExchangeNum(), 0);
     dbManager.getDynamicPropertiesStore().saveAllowSameTokenName(1);
     try {
       actuator.validate();
@@ -440,12 +453,14 @@ public class ExchangeCreateActuatorTest {
     accountCapsule.setBalance(10000_000000L);
     dbManager.getAccountStore().put(ownerAddress, accountCapsule);
 
-    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    AccountAssetIssueCapsule accountAssetIssueCapsule =
+            dbManager.getAccountAssetIssueStore().get(ownerAddress);
     accountAssetIssueCapsule.addAssetAmountV2(firstTokenId.getBytes(), firstTokenBalance,
             dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
     accountAssetIssueCapsule.addAssetAmountV2(secondTokenId.getBytes(), secondTokenBalance,
             dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
-    dbManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.createDbKey(), accountAssetIssueCapsule);
+    dbManager.getAccountAssetIssueStore()
+            .put(accountAssetIssueCapsule.createDbKey(), accountAssetIssueCapsule);
 
     ExchangeCreateActuator actuator = new ExchangeCreateActuator();
     actuator.setChainBaseManager(dbManager.getChainBaseManager()).setAny(getContract(
@@ -518,10 +533,13 @@ public class ExchangeCreateActuatorTest {
     AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
     accountCapsule.setBalance(200_000_000_000000L);
     dbManager.getAccountStore().put(ownerAddress, accountCapsule);
-    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
-    accountAssetIssueCapsule.addAssetAmountV2(secondTokenId.getBytes(), 200_000_000L,
-            dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
-    dbManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.createDbKey(), accountAssetIssueCapsule);
+    AccountAssetIssueCapsule accountAssetIssueCapsule =
+            dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    accountAssetIssueCapsule
+            .addAssetAmountV2(secondTokenId.getBytes(), 200_000_000L,
+                    dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
+    dbManager.getAccountAssetIssueStore()
+            .put(accountAssetIssueCapsule.createDbKey(), accountAssetIssueCapsule);
 
     ExchangeCreateActuator actuator = new ExchangeCreateActuator();
     actuator.setChainBaseManager(dbManager.getChainBaseManager()).setAny(getContract(
@@ -891,10 +909,14 @@ public class ExchangeCreateActuatorTest {
     accountCapsule.setBalance(10000_000000L);
     dbManager.getAccountStore().put(ownerAddress, accountCapsule);
 
-    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
-    accountAssetIssueCapsule.addAssetAmount(firstTokenId.getBytes(), firstTokenBalance);
-    accountAssetIssueCapsule.addAssetAmount(secondTokenId.getBytes(), secondTokenBalance);
-    dbManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.createDbKey(), accountAssetIssueCapsule);
+    AccountAssetIssueCapsule accountAssetIssueCapsule =
+            dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    accountAssetIssueCapsule
+            .addAssetAmount(firstTokenId.getBytes(), firstTokenBalance);
+    accountAssetIssueCapsule
+            .addAssetAmount(secondTokenId.getBytes(), secondTokenBalance);
+    dbManager.getAccountAssetIssueStore()
+            .put(accountAssetIssueCapsule.createDbKey(), accountAssetIssueCapsule);
 
     ExchangeCreateActuator actuator = new ExchangeCreateActuator();
     actuator.setChainBaseManager(dbManager.getChainBaseManager()).setAny(getContract(
@@ -1154,10 +1176,14 @@ public class ExchangeCreateActuatorTest {
     accountCapsule.setBalance(10000_000000L);
     dbManager.getAccountStore().put(ownerAddress, accountCapsule);
 
-    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
-    accountAssetIssueCapsule.addAssetAmount(firstTokenId.getBytes(), firstTokenBalance - 1000L);
-    accountAssetIssueCapsule.addAssetAmount(secondTokenId.getBytes(), 200_000_000L);
-    dbManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.createDbKey(), accountAssetIssueCapsule);
+    AccountAssetIssueCapsule accountAssetIssueCapsule =
+            dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    accountAssetIssueCapsule
+            .addAssetAmount(firstTokenId.getBytes(), firstTokenBalance - 1000L);
+    accountAssetIssueCapsule
+            .addAssetAmount(secondTokenId.getBytes(), 200_000_000L);
+    dbManager.getAccountAssetIssueStore()
+            .put(accountAssetIssueCapsule.createDbKey(), accountAssetIssueCapsule);
 
     ExchangeCreateActuator actuator = new ExchangeCreateActuator();
     actuator.setChainBaseManager(dbManager.getChainBaseManager()).setAny(getContract(
@@ -1195,10 +1221,13 @@ public class ExchangeCreateActuatorTest {
     accountCapsule.setBalance(10000_000000L);
     dbManager.getAccountStore().put(ownerAddress, accountCapsule);
 
-    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
-    accountAssetIssueCapsule.addAssetAmount(firstTokenId.getBytes(), firstTokenBalance - 1000L);
+    AccountAssetIssueCapsule accountAssetIssueCapsule =
+            dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    accountAssetIssueCapsule
+            .addAssetAmount(firstTokenId.getBytes(), firstTokenBalance - 1000L);
     accountAssetIssueCapsule.addAssetAmount(secondTokenId.getBytes(), 200_000_000L);
-    dbManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.createDbKey(), accountAssetIssueCapsule);
+    dbManager.getAccountAssetIssueStore()
+            .put(accountAssetIssueCapsule.createDbKey(), accountAssetIssueCapsule);
 
     ExchangeCreateActuator actuator = new ExchangeCreateActuator();
     actuator.setChainBaseManager(dbManager.getChainBaseManager()).setAny(getContract(
@@ -1231,16 +1260,20 @@ public class ExchangeCreateActuatorTest {
     long secondTokenBalance = 100_000_000_000000L;
 
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_FIRST);
-    AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
+    AccountCapsule accountCapsule =
+            dbManager.getAccountStore().get(ownerAddress);
     accountCapsule.setBalance(secondTokenBalance + 1000L);
     dbManager.getAccountStore().put(ownerAddress, accountCapsule);
 
-    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    AccountAssetIssueCapsule accountAssetIssueCapsule =
+            dbManager.getAccountAssetIssueStore().get(ownerAddress);
     accountAssetIssueCapsule.addAssetAmount(firstTokenId.getBytes(), 200_000_000L);
-    dbManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.createDbKey(), accountAssetIssueCapsule);
+    dbManager.getAccountAssetIssueStore()
+            .put(accountAssetIssueCapsule.createDbKey(), accountAssetIssueCapsule);
 
     ExchangeCreateActuator actuator = new ExchangeCreateActuator();
-    actuator.setChainBaseManager(dbManager.getChainBaseManager()).setAny(getContract(
+    actuator.setChainBaseManager(dbManager.getChainBaseManager())
+            .setAny(getContract(
         OWNER_ADDRESS_FIRST, firstTokenId, firstTokenBalance, secondTokenId, secondTokenBalance));
 
     TransactionResultCapsule ret = new TransactionResultCapsule();
@@ -1275,9 +1308,11 @@ public class ExchangeCreateActuatorTest {
     accountCapsule.setBalance(secondTokenBalance + 1000L);
     dbManager.getAccountStore().put(ownerAddress, accountCapsule);
 
-    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    AccountAssetIssueCapsule accountAssetIssueCapsule =
+            dbManager.getAccountAssetIssueStore().get(ownerAddress);
     accountAssetIssueCapsule.addAssetAmount(firstTokenId.getBytes(), 200_000_000L);
-    dbManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.createDbKey(), accountAssetIssueCapsule);
+    dbManager.getAccountAssetIssueStore()
+            .put(accountAssetIssueCapsule.createDbKey(), accountAssetIssueCapsule);
 
     ExchangeCreateActuator actuator = new ExchangeCreateActuator();
     actuator.setChainBaseManager(dbManager.getChainBaseManager()).setAny(getContract(
@@ -1315,10 +1350,14 @@ public class ExchangeCreateActuatorTest {
     dbManager.getAccountStore().put(ownerAddress, accountCapsule);
 
 
-    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
-    accountAssetIssueCapsule.addAssetAmount(firstTokenId.getBytes(), firstTokenBalance);
-    accountAssetIssueCapsule.addAssetAmount(secondTokenId.getBytes(), 90_000_000L);
-    dbManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.createDbKey(), accountAssetIssueCapsule);
+    AccountAssetIssueCapsule accountAssetIssueCapsule =
+            dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    accountAssetIssueCapsule
+            .addAssetAmount(firstTokenId.getBytes(), firstTokenBalance);
+    accountAssetIssueCapsule
+            .addAssetAmount(secondTokenId.getBytes(), 90_000_000L);
+    dbManager.getAccountAssetIssueStore()
+            .put(accountAssetIssueCapsule.createDbKey(), accountAssetIssueCapsule);
 
     ExchangeCreateActuator actuator = new ExchangeCreateActuator();
     actuator.setChainBaseManager(dbManager.getChainBaseManager()).setAny(getContract(
@@ -1393,9 +1432,11 @@ public class ExchangeCreateActuatorTest {
     accountCapsule.setBalance(10000_000000L);
     dbManager.getAccountStore().put(ownerAddress, accountCapsule);
 
-    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    AccountAssetIssueCapsule accountAssetIssueCapsule =
+            dbManager.getAccountAssetIssueStore().get(ownerAddress);
     accountAssetIssueCapsule.addAssetAmount(firstTokenId.getBytes(), firstTokenBalance);
-    dbManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.createDbKey(), accountAssetIssueCapsule);
+    dbManager.getAccountAssetIssueStore()
+            .put(accountAssetIssueCapsule.createDbKey(), accountAssetIssueCapsule);
 
     ExchangeCreateActuator actuator = new ExchangeCreateActuator();
     actuator.setChainBaseManager(dbManager.getChainBaseManager()).setAny(getContract(
@@ -1433,9 +1474,11 @@ public class ExchangeCreateActuatorTest {
     accountCapsule.setBalance(10000_000000L);
     dbManager.getAccountStore().put(ownerAddress, accountCapsule);
 
-    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    AccountAssetIssueCapsule accountAssetIssueCapsule =
+            dbManager.getAccountAssetIssueStore().get(ownerAddress);
     accountAssetIssueCapsule.addAssetAmount(firstTokenId.getBytes(), firstTokenBalance);
-    dbManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.createDbKey(), accountAssetIssueCapsule);
+    dbManager.getAccountAssetIssueStore()
+            .put(accountAssetIssueCapsule.createDbKey(), accountAssetIssueCapsule);
 
     ExchangeCreateActuator actuator = new ExchangeCreateActuator();
     actuator.setChainBaseManager(dbManager.getChainBaseManager()).setAny(getContract(
@@ -1484,7 +1527,8 @@ public class ExchangeCreateActuatorTest {
     AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore()
             .get(ownerAddress);
     accountAssetIssueCapsule.addAssetAmount(secondTokenId.getBytes(), 200_000_000L);
-    dbManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.getAddress().toByteArray(), accountAssetIssueCapsule);
+    dbManager.getAccountAssetIssueStore()
+            .put(accountAssetIssueCapsule.getAddress().toByteArray(), accountAssetIssueCapsule);
 
     actuatorTest.setContract(getContract(
         OWNER_ADDRESS_FIRST, firstTokenId, firstTokenBalance, secondTokenId, secondTokenBalance));

--- a/framework/src/test/java/org/tron/core/actuator/ExchangeInjectActuatorTest.java
+++ b/framework/src/test/java/org/tron/core/actuator/ExchangeInjectActuatorTest.java
@@ -19,7 +19,11 @@ import org.tron.common.utils.ByteArray;
 import org.tron.common.utils.FileUtil;
 import org.tron.core.Constant;
 import org.tron.core.Wallet;
-import org.tron.core.capsule.*;
+import org.tron.core.capsule.AccountAssetIssueCapsule;
+import org.tron.core.capsule.AccountCapsule;
+import org.tron.core.capsule.AssetIssueCapsule;
+import org.tron.core.capsule.ExchangeCapsule;
+import org.tron.core.capsule.TransactionResultCapsule;
 import org.tron.core.config.DefaultConfig;
 import org.tron.core.config.args.Args;
 import org.tron.core.db.Manager;
@@ -117,9 +121,11 @@ public class ExchangeInjectActuatorTest {
         .put(ownerAccountSecondCapsule.getAddress().toByteArray(), ownerAccountSecondCapsule);
 
     dbManager.getAccountAssetIssueStore()
-            .put(ownerAccountAssetIssueFirst.getAddress().toByteArray(), ownerAccountAssetIssueFirst);
+            .put(ownerAccountAssetIssueFirst.getAddress().toByteArray(),
+                    ownerAccountAssetIssueFirst);
     dbManager.getAccountAssetIssueStore()
-            .put(ownerAccountSecondCapsule.getAddress().toByteArray(), ownerAccountAssetIssueSecond);
+            .put(ownerAccountSecondCapsule.getAddress().toByteArray(),
+                    ownerAccountAssetIssueSecond);
 
     dbManager.getDynamicPropertiesStore().saveLatestBlockHeaderTimestamp(1000000);
     dbManager.getDynamicPropertiesStore().saveLatestBlockHeaderNumber(10);
@@ -241,7 +247,8 @@ public class ExchangeInjectActuatorTest {
     accountCapsule.setBalance(10000_000000L);
     dbManager.getAccountStore().put(ownerAddress, accountCapsule);
 
-    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    AccountAssetIssueCapsule accountAssetIssueCapsule =
+            dbManager.getAccountAssetIssueStore().get(ownerAddress);
     accountAssetIssueCapsule.addAssetAmount(firstTokenId.getBytes(), firstTokenQuant);
     accountAssetIssueCapsule.addAssetAmount(secondTokenId.getBytes(), secondTokenQuant);
     dbManager.getAccountAssetIssueStore().put(ownerAddress, accountAssetIssueCapsule);
@@ -335,7 +342,8 @@ public class ExchangeInjectActuatorTest {
     accountCapsule.setBalance(10000_000000L);
     dbManager.getAccountStore().put(ownerAddress, accountCapsule);
 
-    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    AccountAssetIssueCapsule accountAssetIssueCapsule =
+            dbManager.getAccountAssetIssueStore().get(ownerAddress);
     accountAssetIssueCapsule.addAsset(firstTokenId.getBytes(), firstTokenQuant);
     accountAssetIssueCapsule.addAsset(secondTokenId.getBytes(), secondTokenQuant);
     accountAssetIssueCapsule.addAssetV2(String.valueOf(1L).getBytes(), firstTokenQuant);
@@ -434,7 +442,8 @@ public class ExchangeInjectActuatorTest {
     accountCapsule.setBalance(10000_000000L);
     dbManager.getAccountStore().put(ownerAddress, accountCapsule);
 
-    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    AccountAssetIssueCapsule accountAssetIssueCapsule =
+            dbManager.getAccountAssetIssueStore().get(ownerAddress);
     accountAssetIssueCapsule.addAssetAmountV2(firstTokenId.getBytes(), firstTokenQuant,
         dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
     accountAssetIssueCapsule.addAssetAmountV2(secondTokenId.getBytes(), secondTokenQuant,
@@ -515,7 +524,8 @@ public class ExchangeInjectActuatorTest {
     accountCapsule.setBalance(firstTokenQuant);
     dbManager.getAccountStore().put(ownerAddress, accountCapsule);
 
-    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    AccountAssetIssueCapsule accountAssetIssueCapsule =
+            dbManager.getAccountAssetIssueStore().get(ownerAddress);
     accountAssetIssueCapsule.addAssetAmount(secondTokenId.getBytes(), secondTokenQuant);
     dbManager.getAccountAssetIssueStore().put(ownerAddress, accountAssetIssueCapsule);
 
@@ -596,14 +606,16 @@ public class ExchangeInjectActuatorTest {
 
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_FIRST);
     AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    AccountAssetIssueCapsule accountAssetIssueCapsule =
+            dbManager.getAccountAssetIssueStore().get(ownerAddress);
 
     accountAssetIssueCapsule.addAssetAmountV2(secondTokenId.getBytes(), secondTokenQuant,
         dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
 
     accountCapsule.setBalance(firstTokenQuant);
     dbManager.getAccountStore().put(ownerAddress, accountCapsule);
-    dbManager.getAccountAssetIssueStore().put(ownerAddress, accountAssetIssueCapsule);
+    dbManager.getAccountAssetIssueStore()
+            .put(ownerAddress, accountAssetIssueCapsule);
 
     ExchangeInjectActuator actuator = new ExchangeInjectActuator();
     actuator.setChainBaseManager(dbManager.getChainBaseManager()).setAny(getContract(
@@ -1514,7 +1526,8 @@ public class ExchangeInjectActuatorTest {
 
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_FIRST);
     AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    AccountAssetIssueCapsule accountAssetIssueCapsule =
+            dbManager.getAccountAssetIssueStore().get(ownerAddress);
     accountCapsule.setBalance(10000_000000L);
     dbManager.getAccountStore().put(ownerAddress, accountCapsule);
 
@@ -1564,7 +1577,8 @@ public class ExchangeInjectActuatorTest {
     accountCapsule.setBalance(10000_000000L);
     dbManager.getAccountStore().put(ownerAddress, accountCapsule);
 
-    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    AccountAssetIssueCapsule accountAssetIssueCapsule =
+            dbManager.getAccountAssetIssueStore().get(ownerAddress);
     accountAssetIssueCapsule.addAssetAmountV2(firstTokenId.getBytes(), firstTokenQuant - 1,
         dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
     accountAssetIssueCapsule.addAssetAmountV2(secondTokenId.getBytes(), secondTokenQuant,
@@ -1611,9 +1625,11 @@ public class ExchangeInjectActuatorTest {
     accountCapsule.setBalance(399_000000L);
     dbManager.getAccountStore().put(ownerAddress, accountCapsule);
 
-    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    AccountAssetIssueCapsule accountAssetIssueCapsule =
+            dbManager.getAccountAssetIssueStore().get(ownerAddress);
     accountAssetIssueCapsule.addAssetAmount(secondTokenId.getBytes(), secondTokenQuant);
-    dbManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.createDbKey(), accountAssetIssueCapsule);
+    dbManager.getAccountAssetIssueStore()
+            .put(accountAssetIssueCapsule.createDbKey(), accountAssetIssueCapsule);
 
     ExchangeInjectActuator actuator = new ExchangeInjectActuator();
     actuator.setChainBaseManager(dbManager.getChainBaseManager()).setAny(getContract(
@@ -1655,7 +1671,8 @@ public class ExchangeInjectActuatorTest {
     accountCapsule.setBalance(399_000000L);
     dbManager.getAccountStore().put(ownerAddress, accountCapsule);
 
-    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    AccountAssetIssueCapsule accountAssetIssueCapsule =
+            dbManager.getAccountAssetIssueStore().get(ownerAddress);
     accountAssetIssueCapsule.addAssetAmountV2(secondTokenId.getBytes(), secondTokenQuant,
             dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
     dbManager.getAccountAssetIssueStore().put(ownerAddress, accountAssetIssueCapsule);
@@ -1702,10 +1719,14 @@ public class ExchangeInjectActuatorTest {
     accountCapsule.setBalance(10000_000000L);
     dbManager.getAccountStore().put(ownerAddress, accountCapsule);
 
-    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
-    accountAssetIssueCapsule.addAssetAmount(firstTokenId.getBytes(), firstTokenQuant - 1);
-    accountAssetIssueCapsule.addAssetAmount(secondTokenId.getBytes(), secondTokenQuant);
-    dbManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.createDbKey(), accountAssetIssueCapsule);
+    AccountAssetIssueCapsule accountAssetIssueCapsule =
+            dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    accountAssetIssueCapsule
+            .addAssetAmount(firstTokenId.getBytes(), firstTokenQuant - 1);
+    accountAssetIssueCapsule
+            .addAssetAmount(secondTokenId.getBytes(), secondTokenQuant);
+    dbManager.getAccountAssetIssueStore()
+            .put(accountAssetIssueCapsule.createDbKey(), accountAssetIssueCapsule);
 
     ExchangeInjectActuator actuator = new ExchangeInjectActuator();
     actuator.setChainBaseManager(dbManager.getChainBaseManager()).setAny(getContract(
@@ -1749,7 +1770,8 @@ public class ExchangeInjectActuatorTest {
     accountCapsule.setBalance(10000_000000L);
     dbManager.getAccountStore().put(ownerAddress, accountCapsule);
 
-    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    AccountAssetIssueCapsule accountAssetIssueCapsule =
+            dbManager.getAccountAssetIssueStore().get(ownerAddress);
     accountAssetIssueCapsule.addAssetAmountV2(firstTokenId.getBytes(), firstTokenQuant - 1,
         dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
     accountAssetIssueCapsule.addAssetAmountV2(secondTokenId.getBytes(), secondTokenQuant,
@@ -1875,7 +1897,8 @@ public class ExchangeInjectActuatorTest {
     accountCapsule.setBalance(10000_000000L);
     dbManager.getAccountStore().put(ownerAddress, accountCapsule);
 
-    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    AccountAssetIssueCapsule accountAssetIssueCapsule =
+            dbManager.getAccountAssetIssueStore().get(ownerAddress);
     accountAssetIssueCapsule.addAssetAmount(firstTokenId.getBytes(), firstTokenQuant);
     accountAssetIssueCapsule.addAssetAmount(secondTokenId.getBytes(), secondTokenQuant);
     dbManager.getAccountAssetIssueStore().put(ownerAddress, accountAssetIssueCapsule);

--- a/framework/src/test/java/org/tron/core/actuator/ExchangeTransactionActuatorTest.java
+++ b/framework/src/test/java/org/tron/core/actuator/ExchangeTransactionActuatorTest.java
@@ -20,7 +20,11 @@ import org.tron.common.utils.ByteArray;
 import org.tron.common.utils.FileUtil;
 import org.tron.core.Constant;
 import org.tron.core.Wallet;
-import org.tron.core.capsule.*;
+import org.tron.core.capsule.AccountAssetIssueCapsule;
+import org.tron.core.capsule.AccountCapsule;
+import org.tron.core.capsule.AssetIssueCapsule;
+import org.tron.core.capsule.ExchangeCapsule;
+import org.tron.core.capsule.TransactionResultCapsule;
 import org.tron.core.config.DefaultConfig;
 import org.tron.core.config.args.Args;
 import org.tron.core.db.Manager;
@@ -236,7 +240,8 @@ public class ExchangeTransactionActuatorTest {
 
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_SECOND);
     AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    AccountAssetIssueCapsule accountAssetIssueCapsule =
+            dbManager.getAccountAssetIssueStore().get(ownerAddress);
 
     Map<String, Long> assetMap = accountAssetIssueCapsule.getAssetMap();
     Assert.assertEquals(20000_000000L, accountCapsule.getBalance());
@@ -317,7 +322,8 @@ public class ExchangeTransactionActuatorTest {
 
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_SECOND);
     AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    AccountAssetIssueCapsule accountAssetIssueCapsule =
+            dbManager.getAccountAssetIssueStore().get(ownerAddress);
     Map<String, Long> assetMap = accountAssetIssueCapsule.getAssetMap();
     Assert.assertEquals(20000_000000L, accountCapsule.getBalance());
     Assert.assertEquals(null, assetMap.get("def"));
@@ -398,7 +404,8 @@ public class ExchangeTransactionActuatorTest {
 
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_SECOND);
     AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    AccountAssetIssueCapsule accountAssetIssueCapsule =
+            dbManager.getAccountAssetIssueStore().get(ownerAddress);
     Map<String, Long> assetV2Map = accountAssetIssueCapsule.getAssetMapV2();
 
     Assert.assertEquals(20000_000000L, accountCapsule.getBalance());
@@ -480,11 +487,13 @@ public class ExchangeTransactionActuatorTest {
     Assert.assertEquals(20000_000000L, accountCapsule.getBalance());
     dbManager.getAccountStore().put(accountCapsule.createDbKey(), accountCapsule);
 
-    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    AccountAssetIssueCapsule accountAssetIssueCapsule =
+            dbManager.getAccountAssetIssueStore().get(ownerAddress);
     accountAssetIssueCapsule.addAssetAmount(tokenId.getBytes(), 10000);
     Map<String, Long> assetMap = accountAssetIssueCapsule.getAssetMap();
     Assert.assertEquals(null, assetMap.get(buyTokenId));
-    dbManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.createDbKey(), accountAssetIssueCapsule);
+    dbManager.getAccountAssetIssueStore()
+            .put(accountAssetIssueCapsule.createDbKey(), accountAssetIssueCapsule);
 
     ExchangeTransactionActuator actuator = new ExchangeTransactionActuator();
     actuator.setChainBaseManager(dbManager.getChainBaseManager()).setAny(getContract(
@@ -527,7 +536,6 @@ public class ExchangeTransactionActuatorTest {
       Assert.assertEquals(firstTokenBalance + quant, exchangeCapsule2.getFirstTokenBalance());
       Assert.assertEquals(199998001L, exchangeCapsule2.getSecondTokenBalance());
 
-//      accountCapsule = dbManager.getAccountStore().get(ownerAddress);
       accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
       assetMap = accountAssetIssueCapsule.getAssetMap();
       Assert.assertEquals(9000L, assetMap.get("abc").longValue());
@@ -562,7 +570,8 @@ public class ExchangeTransactionActuatorTest {
 
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_SECOND);
     AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    AccountAssetIssueCapsule accountAssetIssueCapsule =
+            dbManager.getAccountAssetIssueStore().get(ownerAddress);
 
     accountAssetIssueCapsule.addAssetAmountV2(tokenId.getBytes(), 10000,
         dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
@@ -570,7 +579,8 @@ public class ExchangeTransactionActuatorTest {
     Assert.assertEquals(20000_000000L, accountCapsule.getBalance());
     Assert.assertEquals(null, assetV2Map.get(buyTokenId));
     dbManager.getAccountStore().put(accountCapsule.createDbKey(), accountCapsule);
-    dbManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.createDbKey(), accountAssetIssueCapsule);
+    dbManager.getAccountAssetIssueStore()
+            .put(accountAssetIssueCapsule.createDbKey(), accountAssetIssueCapsule);
 
     ExchangeTransactionActuator actuator = new ExchangeTransactionActuator();
     actuator.setChainBaseManager(dbManager.getChainBaseManager()).setAny(getContract(
@@ -642,14 +652,16 @@ public class ExchangeTransactionActuatorTest {
 
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_SECOND);
     AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    AccountAssetIssueCapsule accountAssetIssueCapsule =
+            dbManager.getAccountAssetIssueStore().get(ownerAddress);
 
     accountAssetIssueCapsule.addAssetAmount(tokenId.getBytes(), 10000);
     Map<String, Long> assetMap = accountAssetIssueCapsule.getAssetMap();
     Assert.assertEquals(20000_000000L, accountCapsule.getBalance());
     Assert.assertEquals(null, assetMap.get(buyTokenId));
     dbManager.getAccountStore().put(accountCapsule.createDbKey(), accountCapsule);
-    dbManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.createDbKey(), accountAssetIssueCapsule);
+    dbManager.getAccountAssetIssueStore()
+            .put(accountAssetIssueCapsule.createDbKey(), accountAssetIssueCapsule);
     ExchangeTransactionActuator actuator = new ExchangeTransactionActuator();
     actuator.setChainBaseManager(dbManager.getChainBaseManager()).setAny(getContract(
         OWNER_ADDRESS_INVALID, exchangeId, tokenId, quant, 1));
@@ -688,7 +700,8 @@ public class ExchangeTransactionActuatorTest {
 
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_SECOND);
     AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    AccountAssetIssueCapsule accountAssetIssueCapsule =
+            dbManager.getAccountAssetIssueStore().get(ownerAddress);
 
     accountAssetIssueCapsule.addAssetAmountV2(tokenId.getBytes(), 10000,
         dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
@@ -697,7 +710,8 @@ public class ExchangeTransactionActuatorTest {
     Assert.assertEquals(20000_000000L, accountCapsule.getBalance());
     Assert.assertEquals(null, assetV2Map.get(buyTokenId));
     dbManager.getAccountStore().put(accountCapsule.createDbKey(), accountCapsule);
-    dbManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.createDbKey(), accountAssetIssueCapsule);
+    dbManager.getAccountAssetIssueStore()
+            .put(accountAssetIssueCapsule.createDbKey(), accountAssetIssueCapsule);
     ExchangeTransactionActuator actuator = new ExchangeTransactionActuator();
     actuator.setChainBaseManager(dbManager.getChainBaseManager()).setAny(getContract(
         OWNER_ADDRESS_INVALID, exchangeId, tokenId, quant, 1));
@@ -1213,13 +1227,15 @@ public class ExchangeTransactionActuatorTest {
 
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_SECOND);
     AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    AccountAssetIssueCapsule accountAssetIssueCapsule =
+            dbManager.getAccountAssetIssueStore().get(ownerAddress);
     accountAssetIssueCapsule.addAssetAmount(tokenId.getBytes(), 10000);
     Map<String, Long> assetMap = accountAssetIssueCapsule.getAssetMap();
     Assert.assertEquals(20000_000000L, accountCapsule.getBalance());
     Assert.assertEquals(null, assetMap.get(buyTokenId));
     dbManager.getAccountStore().put(accountCapsule.createDbKey(), accountCapsule);
-    dbManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.createDbKey(), accountAssetIssueCapsule);
+    dbManager.getAccountAssetIssueStore()
+            .put(accountAssetIssueCapsule.createDbKey(), accountAssetIssueCapsule);
 
     ExchangeTransactionActuator actuator = new ExchangeTransactionActuator();
     actuator.setChainBaseManager(dbManager.getChainBaseManager()).setAny(getContract(
@@ -1263,13 +1279,15 @@ public class ExchangeTransactionActuatorTest {
             .get(ownerAddress);
 
     accountAssetIssueCapsule
-        .addAssetAmountV2(tokenId.getBytes(), 10000, dbManager.getDynamicPropertiesStore(),
+        .addAssetAmountV2(tokenId.getBytes(), 10000,
+                dbManager.getDynamicPropertiesStore(),
             dbManager.getAssetIssueStore());
     Map<String, Long> assetV2Map = accountAssetIssueCapsule.getAssetMapV2();
     Assert.assertEquals(20000_000000L, accountCapsule.getBalance());
     Assert.assertEquals(null, assetV2Map.get(buyTokenId));
     dbManager.getAccountStore().put(accountCapsule.createDbKey(), accountCapsule);
-    dbManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.createDbKey(), accountAssetIssueCapsule);
+    dbManager.getAccountAssetIssueStore()
+            .put(accountAssetIssueCapsule.createDbKey(), accountAssetIssueCapsule);
     ExchangeTransactionActuator actuator = new ExchangeTransactionActuator();
     actuator.setChainBaseManager(dbManager.getChainBaseManager()).setAny(getContract(
         OWNER_ADDRESS_SECOND, exchangeId, tokenId, quant, 1));
@@ -1308,7 +1326,8 @@ public class ExchangeTransactionActuatorTest {
 
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_SECOND);
     AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    AccountAssetIssueCapsule accountAssetIssueCapsule =
+            dbManager.getAccountAssetIssueStore().get(ownerAddress);
     accountAssetIssueCapsule.addAssetAmount(tokenId.getBytes(), 10000);
     Map<String, Long> assetMap = accountAssetIssueCapsule.getAssetMap();
     Assert.assertEquals(20000_000000L, accountCapsule.getBalance());
@@ -1353,7 +1372,8 @@ public class ExchangeTransactionActuatorTest {
 
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_SECOND);
     AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    AccountAssetIssueCapsule accountAssetIssueCapsule =
+            dbManager.getAccountAssetIssueStore().get(ownerAddress);
     accountAssetIssueCapsule
         .addAssetAmountV2(tokenId.getBytes(), 10000, dbManager.getDynamicPropertiesStore(),
             dbManager.getAssetIssueStore());
@@ -1361,7 +1381,8 @@ public class ExchangeTransactionActuatorTest {
     Assert.assertEquals(20000_000000L, accountCapsule.getBalance());
     Assert.assertEquals(null, assetV2Map.get(buyTokenId));
     dbManager.getAccountStore().put(accountCapsule.createDbKey(), accountCapsule);
-    dbManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.createDbKey(), accountAssetIssueCapsule);
+    dbManager.getAccountAssetIssueStore()
+            .put(accountAssetIssueCapsule.createDbKey(), accountAssetIssueCapsule);
     ExchangeTransactionActuator actuator = new ExchangeTransactionActuator();
     actuator.setChainBaseManager(dbManager.getChainBaseManager()).setAny(getContract(
         OWNER_ADDRESS_SECOND, exchangeId, tokenId, quant, 1));
@@ -1400,7 +1421,8 @@ public class ExchangeTransactionActuatorTest {
 
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_SECOND);
     AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    AccountAssetIssueCapsule accountAssetIssueCapsule =
+            dbManager.getAccountAssetIssueStore().get(ownerAddress);
     Map<String, Long> assetMap = accountAssetIssueCapsule.getAssetMap();
     accountCapsule.setBalance(quant - 1);
     Assert.assertEquals(null, assetMap.get(buyTokenId));
@@ -1444,7 +1466,8 @@ public class ExchangeTransactionActuatorTest {
 
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_SECOND);
     AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    AccountAssetIssueCapsule accountAssetIssueCapsule =
+            dbManager.getAccountAssetIssueStore().get(ownerAddress);
 
     Map<String, Long> assetV2Map = accountAssetIssueCapsule.getAssetMapV2();
     accountCapsule.setBalance(quant - 1);
@@ -1489,7 +1512,8 @@ public class ExchangeTransactionActuatorTest {
 
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_SECOND);
     AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    AccountAssetIssueCapsule accountAssetIssueCapsule =
+            dbManager.getAccountAssetIssueStore().get(ownerAddress);
     accountAssetIssueCapsule.addAssetAmount(tokenId.getBytes(), quant - 1);
     Map<String, Long> assetMap = accountAssetIssueCapsule.getAssetMap();
     Assert.assertEquals(20000_000000L, accountCapsule.getBalance());
@@ -1534,7 +1558,8 @@ public class ExchangeTransactionActuatorTest {
 
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_SECOND);
     AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    AccountAssetIssueCapsule accountAssetIssueCapsule =
+            dbManager.getAccountAssetIssueStore().get(ownerAddress);
     accountAssetIssueCapsule.addAssetAmountV2(tokenId.getBytes(), quant - 1,
         dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
     Map<String, Long> assetV2Map = accountAssetIssueCapsule.getAssetMapV2();
@@ -1580,13 +1605,15 @@ public class ExchangeTransactionActuatorTest {
 
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_SECOND);
     AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    AccountAssetIssueCapsule accountAssetIssueCapsule =
+            dbManager.getAccountAssetIssueStore().get(ownerAddress);
     accountAssetIssueCapsule.addAssetAmount(tokenId.getBytes(), quant);
     Map<String, Long> assetMap = accountAssetIssueCapsule.getAssetMap();
     Assert.assertEquals(20000_000000L, accountCapsule.getBalance());
     Assert.assertEquals(null, assetMap.get(buyTokenId));
     dbManager.getAccountStore().put(accountCapsule.createDbKey(), accountCapsule);
-    dbManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.createDbKey(), accountAssetIssueCapsule);
+    dbManager.getAccountAssetIssueStore()
+            .put(accountAssetIssueCapsule.createDbKey(), accountAssetIssueCapsule);
 
     long expected = 0;
     try {
@@ -1635,7 +1662,8 @@ public class ExchangeTransactionActuatorTest {
 
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_SECOND);
     AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    AccountAssetIssueCapsule accountAssetIssueCapsule =
+            dbManager.getAccountAssetIssueStore().get(ownerAddress);
     accountAssetIssueCapsule
         .addAssetAmountV2(tokenId.getBytes(), quant, dbManager.getDynamicPropertiesStore(),
             dbManager.getAssetIssueStore());
@@ -1643,7 +1671,8 @@ public class ExchangeTransactionActuatorTest {
     Assert.assertEquals(20000_000000L, accountCapsule.getBalance());
     Assert.assertEquals(null, assetV2Map.get(buyTokenId));
     dbManager.getAccountStore().put(accountCapsule.createDbKey(), accountCapsule);
-    dbManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.createDbKey(), accountAssetIssueCapsule);
+    dbManager.getAccountAssetIssueStore()
+            .put(accountAssetIssueCapsule.createDbKey(), accountAssetIssueCapsule);
 
     long expected = 0;
     try {

--- a/framework/src/test/java/org/tron/core/actuator/ExchangeWithdrawActuatorTest.java
+++ b/framework/src/test/java/org/tron/core/actuator/ExchangeWithdrawActuatorTest.java
@@ -20,7 +20,11 @@ import org.tron.common.utils.ByteArray;
 import org.tron.common.utils.FileUtil;
 import org.tron.core.Constant;
 import org.tron.core.Wallet;
-import org.tron.core.capsule.*;
+import org.tron.core.capsule.AccountAssetIssueCapsule;
+import org.tron.core.capsule.AccountCapsule;
+import org.tron.core.capsule.AssetIssueCapsule;
+import org.tron.core.capsule.ExchangeCapsule;
+import org.tron.core.capsule.TransactionResultCapsule;
 import org.tron.core.config.DefaultConfig;
 import org.tron.core.config.args.Args;
 import org.tron.core.db.Manager;
@@ -119,8 +123,12 @@ public class ExchangeWithdrawActuatorTest {
     dbManager.getAccountStore()
         .put(ownerAccountSecondCapsule.getAddress().toByteArray(), ownerAccountSecondCapsule);
 
-    dbManager.getAccountAssetIssueStore().put(ownerAccountAssetIssueFirst.getAddress().toByteArray(), ownerAccountAssetIssueFirst);
-    dbManager.getAccountAssetIssueStore().put(ownerAccountAssetIssueSecond.getAddress().toByteArray(), ownerAccountAssetIssueSecond);
+    dbManager.getAccountAssetIssueStore()
+            .put(ownerAccountAssetIssueFirst.getAddress().toByteArray(),
+                    ownerAccountAssetIssueFirst);
+    dbManager.getAccountAssetIssueStore()
+            .put(ownerAccountAssetIssueSecond.getAddress().toByteArray(),
+                    ownerAccountAssetIssueSecond);
 
     dbManager.getDynamicPropertiesStore().saveLatestBlockHeaderTimestamp(1000000);
     dbManager.getDynamicPropertiesStore().saveLatestBlockHeaderNumber(10);
@@ -284,7 +292,8 @@ public class ExchangeWithdrawActuatorTest {
 
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_FIRST);
     AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    AccountAssetIssueCapsule accountAssetIssueCapsule =
+            dbManager.getAccountAssetIssueStore().get(ownerAddress);
 
     Map<String, Long> assetMap = accountAssetIssueCapsule.getAssetMap();
     Assert.assertEquals(10000_000000L, accountCapsule.getBalance());
@@ -361,7 +370,8 @@ public class ExchangeWithdrawActuatorTest {
 
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_FIRST);
     AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    AccountAssetIssueCapsule accountAssetIssueCapsule =
+            dbManager.getAccountAssetIssueStore().get(ownerAddress);
     Map<String, Long> assetMap = accountAssetIssueCapsule.getAssetMap();
     Assert.assertEquals(10000_000000L, accountCapsule.getBalance());
     Assert.assertEquals(null, assetMap.get(firstTokenId));
@@ -437,7 +447,8 @@ public class ExchangeWithdrawActuatorTest {
 
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_FIRST);
     AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    AccountAssetIssueCapsule accountAssetIssueCapsule =
+            dbManager.getAccountAssetIssueStore().get(ownerAddress);
 
     Map<String, Long> assetV2Map = accountAssetIssueCapsule.getAssetMapV2();
     Assert.assertEquals(10000_000000L, accountCapsule.getBalance());
@@ -506,7 +517,8 @@ public class ExchangeWithdrawActuatorTest {
 
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_FIRST);
     AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    AccountAssetIssueCapsule accountAssetIssueCapsule =
+            dbManager.getAccountAssetIssueStore().get(ownerAddress);
 
     Map<String, Long> assetMap = accountAssetIssueCapsule.getAssetMap();
     Assert.assertEquals(10000_000000L, accountCapsule.getBalance());
@@ -580,7 +592,8 @@ public class ExchangeWithdrawActuatorTest {
 
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_FIRST);
     AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-    AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
+    AccountAssetIssueCapsule accountAssetIssueCapsule =
+            dbManager.getAccountAssetIssueStore().get(ownerAddress);
 
     Map<String, Long> assetV2Map = accountAssetIssueCapsule.getAssetMapV2();
     Assert.assertEquals(10000_000000L, accountCapsule.getBalance());

--- a/framework/src/test/java/org/tron/core/actuator/MarketCancelOrderActuatorTest.java
+++ b/framework/src/test/java/org/tron/core/actuator/MarketCancelOrderActuatorTest.java
@@ -18,7 +18,13 @@ import org.tron.common.utils.FileUtil;
 import org.tron.core.ChainBaseManager;
 import org.tron.core.Constant;
 import org.tron.core.Wallet;
-import org.tron.core.capsule.*;
+import org.tron.core.capsule.AccountAssetIssueCapsule;
+import org.tron.core.capsule.AccountCapsule;
+import org.tron.core.capsule.AssetIssueCapsule;
+import org.tron.core.capsule.MarketAccountOrderCapsule;
+import org.tron.core.capsule.MarketOrderCapsule;
+import org.tron.core.capsule.MarketOrderIdListCapsule;
+import org.tron.core.capsule.TransactionResultCapsule;
 import org.tron.core.capsule.utils.MarketUtils;
 import org.tron.core.config.DefaultConfig;
 import org.tron.core.config.args.Args;
@@ -26,7 +32,12 @@ import org.tron.core.db.Manager;
 import org.tron.core.exception.ContractExeException;
 import org.tron.core.exception.ContractValidateException;
 import org.tron.core.exception.ItemNotFoundException;
-import org.tron.core.store.*;
+import org.tron.core.store.AccountAssetIssueStore;
+import org.tron.core.store.AccountStore;
+import org.tron.core.store.MarketAccountStore;
+import org.tron.core.store.MarketOrderStore;
+import org.tron.core.store.MarketPairPriceToOrderStore;
+import org.tron.core.store.MarketPairToPriceStore;
 import org.tron.protos.Protocol.AccountType;
 import org.tron.protos.Protocol.MarketOrder.State;
 import org.tron.protos.Protocol.MarketOrderPair;
@@ -125,10 +136,12 @@ public class MarketCancelOrderActuatorTest {
             new AccountAssetIssueCapsule(
                     ByteString.copyFromUtf8(ACCOUNT_NAME_SECOND),
                     ByteString.copyFrom(ownerAddressSecondBytes));
-    dbManager.getAccountAssetIssueStore().
-            put(ownerAccountAssetIssueFirstCapsule.getAddress().toByteArray(), ownerAccountAssetIssueFirstCapsule);
-    dbManager.getAccountAssetIssueStore().
-            put(ownerAccountAssetIssueSecondCapsule.getAddress().toByteArray(), ownerAccountAssetIssueSecondCapsule);
+    dbManager.getAccountAssetIssueStore()
+            .put(ownerAccountAssetIssueFirstCapsule.getAddress().toByteArray(),
+                    ownerAccountAssetIssueFirstCapsule);
+    dbManager.getAccountAssetIssueStore()
+            .put(ownerAccountAssetIssueSecondCapsule.getAddress().toByteArray(),
+                    ownerAccountAssetIssueSecondCapsule);
 
     // clean
     cleanMarketOrderByAccount(ownerAddressFirstBytes);
@@ -435,8 +448,7 @@ public class MarketCancelOrderActuatorTest {
 
     byte[] ownerAddress = ByteArray.fromHexString(ownAddress);
     AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-//    accountCapsule.addAssetAmountV2(sellTokenId.getBytes(), sellTokenQuant,
-//        dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
+
     dbManager.getAccountStore().put(ownerAddress, accountCapsule);
 
     AccountAssetIssueCapsule accountAssetIssueCapsule =
@@ -518,7 +530,8 @@ public class MarketCancelOrderActuatorTest {
         dbManager.getDynamicPropertiesStore().getMarketCancelFee() + accountCapsule.getBalance());
 
     //check token number return
-    Assert.assertEquals(100L, accountAssetIssueCapsule.getAssetMapV2().get(TOKEN_ID_ONE).longValue());
+    Assert.assertEquals(100L,
+            accountAssetIssueCapsule.getAssetMapV2().get(TOKEN_ID_ONE).longValue());
 
     //check accountOrder
     accountOrderCapsule = marketAccountStore.get(ByteArray.fromHexString(OWNER_ADDRESS_FIRST));
@@ -701,7 +714,8 @@ public class MarketCancelOrderActuatorTest {
         +accountCapsule.getBalance());
 
     //check token number return
-    Assert.assertEquals(100L, accountAssetIssueCapsule.getAssetMapV2().get(TOKEN_ID_ONE).longValue());
+    Assert.assertEquals(100L,
+            accountAssetIssueCapsule.getAssetMapV2().get(TOKEN_ID_ONE).longValue());
 
     //check accountOrder
     accountOrderCapsule = marketAccountStore.get(ByteArray.fromHexString(OWNER_ADDRESS_FIRST));
@@ -791,7 +805,8 @@ public class MarketCancelOrderActuatorTest {
         +accountCapsule.getBalance());
 
     //check token number return
-    Assert.assertEquals(100L,accountAssetIssueCapsule.getAssetMapV2().get(TOKEN_ID_ONE).longValue());
+    Assert.assertEquals(100L,
+            accountAssetIssueCapsule.getAssetMapV2().get(TOKEN_ID_ONE).longValue());
 
     //check accountOrder
     accountOrderCapsule = marketAccountStore.get(ByteArray.fromHexString(OWNER_ADDRESS_FIRST));

--- a/framework/src/test/java/org/tron/core/actuator/MarketSellAssetActuatorTest.java
+++ b/framework/src/test/java/org/tron/core/actuator/MarketSellAssetActuatorTest.java
@@ -19,7 +19,13 @@ import org.tron.common.utils.FileUtil;
 import org.tron.core.ChainBaseManager;
 import org.tron.core.Constant;
 import org.tron.core.Wallet;
-import org.tron.core.capsule.*;
+import org.tron.core.capsule.AccountAssetIssueCapsule;
+import org.tron.core.capsule.AccountCapsule;
+import org.tron.core.capsule.AssetIssueCapsule;
+import org.tron.core.capsule.MarketAccountOrderCapsule;
+import org.tron.core.capsule.MarketOrderCapsule;
+import org.tron.core.capsule.MarketOrderIdListCapsule;
+import org.tron.core.capsule.TransactionResultCapsule;
 import org.tron.core.capsule.utils.MarketUtils;
 import org.tron.core.config.DefaultConfig;
 import org.tron.core.config.args.Args;
@@ -517,7 +523,8 @@ public class MarketSellAssetActuatorTest {
             .get(ownerAddress);
     accountAssetIssueCapsule.addAssetAmountV2(sellTokenId.getBytes(), sellTokenQuant,
             dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
-    dbManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.getAddress().toByteArray(), accountAssetIssueCapsule);
+    dbManager.getAccountAssetIssueStore()
+            .put(accountAssetIssueCapsule.getAddress().toByteArray(), accountAssetIssueCapsule);
 
     MarketSellAssetActuator actuator = new MarketSellAssetActuator();
     actuator.setChainBaseManager(dbManager.getChainBaseManager()).setAny(getContract(
@@ -550,8 +557,10 @@ public class MarketSellAssetActuatorTest {
             .get(ownerAddress);
     accountAssetIssueCapsule.addAssetAmountV2(sellTokenId.getBytes(), sellTokenQuant,
             dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
-    dbManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.getAddress().toByteArray(), accountAssetIssueCapsule);
-    Assert.assertEquals(sellTokenQuant, (long) accountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
+    dbManager.getAccountAssetIssueStore()
+            .put(accountAssetIssueCapsule.getAddress().toByteArray(), accountAssetIssueCapsule);
+    Assert.assertEquals(sellTokenQuant,
+            (long) accountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
 
     // Initialize the order book
 
@@ -599,7 +608,8 @@ public class MarketSellAssetActuatorTest {
             .get(ownerAddress);
     accountAssetIssueCapsule.addAssetAmountV2(sellTokenId.getBytes(), sellTokenQuant,
             dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
-    dbManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.getAddress().toByteArray(), accountAssetIssueCapsule);
+    dbManager.getAccountAssetIssueStore()
+            .put(accountAssetIssueCapsule.getAddress().toByteArray(), accountAssetIssueCapsule);
 
     MarketSellAssetActuator actuator = new MarketSellAssetActuator();
     actuator.setChainBaseManager(dbManager.getChainBaseManager()).setAny(getContract(
@@ -767,7 +777,8 @@ public class MarketSellAssetActuatorTest {
     dbManager.getAccountAssetIssueStore()
             .put(accountAssetIssueCapsule.getAddress().toByteArray(), accountAssetIssueCapsule);
     long balanceBefore = accountCapsule.getBalance();
-    Assert.assertEquals(sellTokenQuant, (long) accountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
+    Assert.assertEquals(sellTokenQuant, (long)
+            accountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
 
     MarketSellAssetActuator actuator = new MarketSellAssetActuator();
     actuator.setChainBaseManager(dbManager.getChainBaseManager()).setAny(getContract(
@@ -849,10 +860,12 @@ public class MarketSellAssetActuatorTest {
             .get(ownerAddress);
     accountAssetIssueCapsule.addAssetAmountV2(sellTokenId.getBytes(), sellTokenQuant,
             dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
-    dbManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.getAddress().toByteArray(), accountAssetIssueCapsule);
+    dbManager.getAccountAssetIssueStore()
+            .put(accountAssetIssueCapsule.getAddress().toByteArray(), accountAssetIssueCapsule);
 
     long balanceBefore = accountCapsule.getBalance();
-    Assert.assertEquals(sellTokenQuant, (long) accountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
+    Assert.assertEquals(sellTokenQuant,
+            (long) accountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
 
     MarketSellAssetActuator actuator = new MarketSellAssetActuator();
     actuator.setChainBaseManager(dbManager.getChainBaseManager()).setAny(getContract(
@@ -935,8 +948,10 @@ public class MarketSellAssetActuatorTest {
             .get(ownerAddress);
     accountAssetIssueCapsule.addAssetAmountV2(sellTokenId.getBytes(), sellTokenQuant,
             dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
-    dbManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.getAddress().toByteArray(), accountAssetIssueCapsule);
-    Assert.assertEquals(sellTokenQuant, (long) accountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
+    dbManager.getAccountAssetIssueStore()
+            .put(accountAssetIssueCapsule.getAddress().toByteArray(), accountAssetIssueCapsule);
+    Assert.assertEquals(sellTokenQuant,
+            (long) accountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
 
     // Initialize the order book
 
@@ -1021,9 +1036,11 @@ public class MarketSellAssetActuatorTest {
             .get(ownerAddress);
     accountAssetIssueCapsule.addAssetAmountV2(sellTokenId.getBytes(), sellTokenQuant,
             dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
-    dbManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.getAddress().toByteArray(), accountAssetIssueCapsule);
-
-    Assert.assertEquals(sellTokenQuant, (long) accountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
+    dbManager.getAccountAssetIssueStore()
+            .put(accountAssetIssueCapsule
+                    .getAddress().toByteArray(), accountAssetIssueCapsule);
+    Assert.assertEquals(sellTokenQuant,
+            (long) accountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
 
     // Initialize the order book
 
@@ -1109,8 +1126,10 @@ public class MarketSellAssetActuatorTest {
             .get(ownerAddress);
     accountAssetIssueCapsule.addAssetAmountV2(sellTokenId.getBytes(), sellTokenQuant,
             dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
-    dbManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.getAddress().toByteArray(), accountAssetIssueCapsule);
-    Assert.assertEquals(sellTokenQuant, (long) accountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
+    dbManager.getAccountAssetIssueStore()
+            .put(accountAssetIssueCapsule.getAddress().toByteArray(), accountAssetIssueCapsule);
+    Assert.assertEquals(sellTokenQuant,
+            (long) accountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
 
 
 
@@ -1210,7 +1229,8 @@ public class MarketSellAssetActuatorTest {
     accountAssetIssueCapsule.addAssetAmountV2(sellTokenId.getBytes(), sellTokenQuant,
         dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
     dbManager.getAccountAssetIssueStore().put(ownerAddress, accountAssetIssueCapsule);
-    Assert.assertEquals(sellTokenQuant, (long) accountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
+    Assert.assertEquals(sellTokenQuant,
+            (long) accountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
 
     // Initialize the order book
 
@@ -1318,18 +1338,14 @@ public class MarketSellAssetActuatorTest {
     long buyTokenQuant = 1000L * num;
 
     byte[] ownerAddress = ByteArray.fromHexString(OWNER_ADDRESS_FIRST);
-//    AccountCapsule accountCapsule = dbManager.getAccountStore().get(ownerAddress);
-//    accountCapsule.addAssetAmountV2(sellTokenId.getBytes(), sellTokenQuant,
-//        dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
-//    dbManager.getAccountStore().put(ownerAddress, accountCapsule);
-//    Assert.assertEquals(sellTokenQuant, (long) accountCapsule.getAssetMapV2().get(sellTokenId));
-
     AccountAssetIssueCapsule accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore()
             .get(ownerAddress);
     accountAssetIssueCapsule.addAssetAmountV2(sellTokenId.getBytes(), sellTokenQuant,
             dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
-    dbManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.getAddress().toByteArray(), accountAssetIssueCapsule);
-    Assert.assertEquals(sellTokenQuant, (long) accountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
+    dbManager.getAccountAssetIssueStore()
+            .put(accountAssetIssueCapsule.getAddress().toByteArray(), accountAssetIssueCapsule);
+    Assert.assertEquals(sellTokenQuant,
+            (long) accountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
 
     // Initialize the order book
 
@@ -1373,8 +1389,10 @@ public class MarketSellAssetActuatorTest {
             .get(ownerAddress);
     accountAssetIssueCapsule.addAssetAmountV2(sellTokenId.getBytes(), sellTokenQuant,
             dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
-    dbManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.getAddress().toByteArray(), accountAssetIssueCapsule);
-    Assert.assertEquals(sellTokenQuant, (long) accountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
+    dbManager.getAccountAssetIssueStore()
+            .put(accountAssetIssueCapsule.getAddress().toByteArray(), accountAssetIssueCapsule);
+    Assert.assertEquals(sellTokenQuant,
+            (long) accountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
 
     // Initialize the order book
 
@@ -1415,12 +1433,16 @@ public class MarketSellAssetActuatorTest {
 
     //check balance and token
     accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
-    Assert.assertEquals(0L, (long) accountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
-    Assert.assertEquals(200L, (long) accountAssetIssueCapsule.getAssetMapV2().get(buyTokenId));
+    Assert.assertEquals(0L,
+            (long) accountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
+    Assert.assertEquals(200L,
+            (long) accountAssetIssueCapsule.getAssetMapV2().get(buyTokenId));
 
     byte[] makerAddress = ByteArray.fromHexString(OWNER_ADDRESS_SECOND);
-    AccountAssetIssueCapsule makerAccountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(makerAddress);
-    Assert.assertEquals(400L, (long) makerAccountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
+    AccountAssetIssueCapsule makerAccountAssetIssueCapsule =
+            dbManager.getAccountAssetIssueStore().get(makerAddress);
+    Assert.assertEquals(400L,
+            (long) makerAccountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
 
     //check accountOrder
     MarketAccountOrderCapsule accountOrderCapsule = marketAccountStore.get(ownerAddress);
@@ -1522,8 +1544,11 @@ public class MarketSellAssetActuatorTest {
             .get(ownerAddress);
     accountAssetIssueCapsule.addAssetAmountV2(sellTokenId.getBytes(), sellTokenQuant,
             dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
-    dbManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.getAddress().toByteArray(), accountAssetIssueCapsule);
-    Assert.assertEquals(sellTokenQuant, (long) accountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
+    dbManager.getAccountAssetIssueStore()
+            .put(accountAssetIssueCapsule.getAddress().toByteArray(),
+                    accountAssetIssueCapsule);
+    Assert.assertEquals(sellTokenQuant,
+            (long) accountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
 
     //get storeDB instance
     ChainBaseManager chainBaseManager = dbManager.getChainBaseManager();
@@ -1558,12 +1583,16 @@ public class MarketSellAssetActuatorTest {
 
     //check balance and token
     accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
-    Assert.assertEquals(0L, (long) accountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
-    Assert.assertEquals(200L, (long) accountAssetIssueCapsule.getAssetMapV2().get(buyTokenId));
+    Assert.assertEquals(0L,
+            (long) accountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
+    Assert.assertEquals(200L,
+            (long) accountAssetIssueCapsule.getAssetMapV2().get(buyTokenId));
 
     byte[] makerAddress = ByteArray.fromHexString(OWNER_ADDRESS_SECOND);
-    AccountAssetIssueCapsule makerAccountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(makerAddress);
-    Assert.assertEquals(500L, (long) makerAccountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
+    AccountAssetIssueCapsule makerAccountAssetIssueCapsule =
+            dbManager.getAccountAssetIssueStore().get(makerAddress);
+    Assert.assertEquals(500L,
+            (long) makerAccountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
 
     //check accountOrder
     MarketAccountOrderCapsule accountOrderCapsule = marketAccountStore.get(ownerAddress);
@@ -1672,7 +1701,8 @@ public class MarketSellAssetActuatorTest {
         dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
     dbManager.getAccountAssetIssueStore().put(ownerAddress, accountAssetIssueCapsule);
 
-    Assert.assertEquals(sellTokenQuant, (long) accountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
+    Assert.assertEquals(sellTokenQuant,
+            (long) accountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
 
     // Initialize the order book
 
@@ -1712,9 +1742,11 @@ public class MarketSellAssetActuatorTest {
     Assert.assertEquals(250L, (long) accountAssetIssueCapsule.getAssetMapV2().get(buyTokenId));
 
     byte[] makerAddress = ByteArray.fromHexString(OWNER_ADDRESS_SECOND);
-    AccountAssetIssueCapsule makerAccountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(makerAddress);
+    AccountAssetIssueCapsule makerAccountAssetIssueCapsule =
+            dbManager.getAccountAssetIssueStore().get(makerAddress);
 
-    Assert.assertEquals(800L, (long) makerAccountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
+    Assert.assertEquals(800L,
+            (long) makerAccountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
 
     //check accountOrder
     MarketAccountOrderCapsule accountOrderCapsule = marketAccountStore.get(ownerAddress);
@@ -1794,8 +1826,10 @@ public class MarketSellAssetActuatorTest {
             .get(ownerAddress);
     accountAssetIssueCapsule.addAssetAmountV2(sellTokenId.getBytes(), sellTokenQuant,
             dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
-    dbManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.getAddress().toByteArray(), accountAssetIssueCapsule);
-    Assert.assertEquals(sellTokenQuant, (long) accountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
+    dbManager.getAccountAssetIssueStore()
+            .put(accountAssetIssueCapsule.getAddress().toByteArray(), accountAssetIssueCapsule);
+    Assert.assertEquals(sellTokenQuant,
+            (long) accountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
 
     // Initialize the order book
 
@@ -1826,14 +1860,17 @@ public class MarketSellAssetActuatorTest {
         .getMarketPairPriceToOrderStore();
 
     //check balance and token
-//    accountCapsule = dbManager.getAccountStore().get(ownerAddress);
     accountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ownerAddress);
-    Assert.assertEquals(1L, (long) accountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
-    Assert.assertEquals(100L, (long) accountAssetIssueCapsule.getAssetMapV2().get(buyTokenId));
+    Assert.assertEquals(1L,
+            (long) accountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
+    Assert.assertEquals(100L,
+            (long) accountAssetIssueCapsule.getAssetMapV2().get(buyTokenId));
 
     byte[] makerAddress = ByteArray.fromHexString(OWNER_ADDRESS_SECOND);
-    AccountAssetIssueCapsule makerAccountAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(makerAddress);
-    Assert.assertEquals(200L, (long) makerAccountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
+    AccountAssetIssueCapsule makerAccountAssetIssueCapsule =
+            dbManager.getAccountAssetIssueStore().get(makerAddress);
+    Assert.assertEquals(200L,
+            (long) makerAccountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
 
     //check accountOrder
     MarketAccountOrderCapsule accountOrderCapsule = marketAccountStore.get(ownerAddress);
@@ -1904,8 +1941,10 @@ public class MarketSellAssetActuatorTest {
             .get(ownerAddress);
     accountAssetIssueCapsule.addAssetAmountV2(sellTokenId.getBytes(), sellTokenQuant,
             dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
-    dbManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.getAddress().toByteArray(), accountAssetIssueCapsule);
-    Assert.assertEquals(sellTokenQuant, (long) accountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
+    dbManager.getAccountAssetIssueStore()
+            .put(accountAssetIssueCapsule.getAddress().toByteArray(), accountAssetIssueCapsule);
+    Assert.assertEquals(sellTokenQuant,
+            (long) accountAssetIssueCapsule.getAssetMapV2().get(sellTokenId));
 
     // Initialize the order book
 

--- a/framework/src/test/java/org/tron/core/actuator/ParticipateAssetIssueActuatorTest.java
+++ b/framework/src/test/java/org/tron/core/actuator/ParticipateAssetIssueActuatorTest.java
@@ -138,7 +138,8 @@ public class ParticipateAssetIssueActuatorTest {
     chainBaseManager.getAccountAssetIssueStore()
             .put(toAccountAssetIssueCapsule.getAddress().toByteArray(), toAccountAssetIssueCapsule);
     chainBaseManager.getAccountAssetIssueStore()
-            .put(toAccountAssetIssueCapsule2.getAddress().toByteArray(), toAccountAssetIssueCapsule2);
+            .put(toAccountAssetIssueCapsule2
+                    .getAddress().toByteArray(), toAccountAssetIssueCapsule2);
   }
 
   private boolean isNullOrZero(Long value) {
@@ -256,7 +257,8 @@ public class ParticipateAssetIssueActuatorTest {
 
     chainBaseManager.getAccountStore().put(toAccountCapsule.getAddress().toByteArray(),
         toAccountCapsule);
-    chainBaseManager.getAccountAssetIssueStore().put(toAccountAssetIssue.getAddress().toByteArray(), toAccountAssetIssue);
+    chainBaseManager.getAccountAssetIssueStore()
+            .put(toAccountAssetIssue.getAddress().toByteArray(), toAccountAssetIssue);
   }
 
   private void initAssetIssue(long startTimestmp, long endTimestmp, String assetName) {
@@ -325,7 +327,8 @@ public class ParticipateAssetIssueActuatorTest {
     AccountCapsule toAccountCapsule = chainBaseManager.getAccountStore()
         .get(ByteArray.fromHexString(TO_ADDRESS));
 
-    AccountAssetIssueCapsule toAccountAssetIssueCapsule = chainBaseManager.getAccountAssetIssueStore()
+    AccountAssetIssueCapsule toAccountAssetIssueCapsule =
+            chainBaseManager.getAccountAssetIssueStore()
             .get(ByteArray.fromHexString(TO_ADDRESS));
     if (chainBaseManager.getDynamicPropertiesStore().getAllowSameTokenName() == 0) {
       chainBaseManager.getAssetIssueStore().put(assetIssueCapsule.createDbKey(),
@@ -334,7 +337,8 @@ public class ParticipateAssetIssueActuatorTest {
       chainBaseManager.getAssetIssueV2Store().put(assetIssueCapsule.createDbV2Key(),
           assetIssueCapsule);
       toAccountAssetIssueCapsule.addAsset(ASSET_NAME.getBytes(), TOTAL_SUPPLY);
-      toAccountAssetIssueCapsule.addAssetV2(ByteArray.fromString(String.valueOf(id)), TOTAL_SUPPLY);
+      toAccountAssetIssueCapsule
+              .addAssetV2(ByteArray.fromString(String.valueOf(id)), TOTAL_SUPPLY);
     } else {
       chainBaseManager.getAssetIssueV2Store().put(assetIssueCapsule.createDbV2Key(),
           assetIssueCapsule);
@@ -343,7 +347,8 @@ public class ParticipateAssetIssueActuatorTest {
 
     chainBaseManager.getAccountStore().put(toAccountCapsule.getAddress().toByteArray(),
         toAccountCapsule);
-    chainBaseManager.getAccountAssetIssueStore().put(toAccountAssetIssueCapsule.getAddress().toByteArray(),
+    chainBaseManager.getAccountAssetIssueStore()
+            .put(toAccountAssetIssueCapsule.getAddress().toByteArray(),
             toAccountAssetIssueCapsule);
   }
 
@@ -370,20 +375,22 @@ public class ParticipateAssetIssueActuatorTest {
       Assert.assertEquals(owner.getBalance(), OWNER_BALANCE - 1000);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE + 1000);
 
-      AccountAssetIssueCapsule ownerAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+      AccountAssetIssueCapsule ownerAccountAsset = chainBaseManager.getAccountAssetIssueStore()
               .get(ByteArray.fromHexString(OWNER_ADDRESS));
       AccountAssetIssueCapsule toAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
               .get(ByteArray.fromHexString(TO_ADDRESS));
       //V1
-      Assert.assertEquals(ownerAccountAssetIssue.getAssetMap().get(ASSET_NAME).longValue(),
+      Assert.assertEquals(ownerAccountAsset.getAssetMap().get(ASSET_NAME).longValue(),
           (1000L) / TRX_NUM * NUM);
       Assert.assertEquals(toAccountAssetIssue.getAssetMap().get(ASSET_NAME).longValue(),
           TOTAL_SUPPLY - (1000L) / TRX_NUM * NUM);
       //V2
       long tokenId = chainBaseManager.getDynamicPropertiesStore().getTokenIdNum();
-      Assert.assertEquals(ownerAccountAssetIssue.getAssetMapV2().get(String.valueOf(tokenId)).longValue(),
+      Assert.assertEquals(ownerAccountAsset
+                      .getAssetMapV2().get(String.valueOf(tokenId)).longValue(),
           (1000L) / TRX_NUM * NUM);
-      Assert.assertEquals(toAccountAssetIssue.getAssetMapV2().get(String.valueOf(tokenId)).longValue(),
+      Assert.assertEquals(toAccountAssetIssue
+                      .getAssetMapV2().get(String.valueOf(tokenId)).longValue(),
           TOTAL_SUPPLY - (1000L) / TRX_NUM * NUM);
 
     } catch (ContractValidateException e) {
@@ -417,7 +424,7 @@ public class ParticipateAssetIssueActuatorTest {
       AccountCapsule toAccount = chainBaseManager.getAccountStore()
           .get(ByteArray.fromHexString(TO_ADDRESS));
 
-      AccountAssetIssueCapsule ownerAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+      AccountAssetIssueCapsule ownerAccountAsset = chainBaseManager.getAccountAssetIssueStore()
               .get(ByteArray.fromHexString(OWNER_ADDRESS));
       AccountAssetIssueCapsule toAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
               .get(ByteArray.fromHexString(TO_ADDRESS));
@@ -425,13 +432,18 @@ public class ParticipateAssetIssueActuatorTest {
       Assert.assertEquals(owner.getBalance(), OWNER_BALANCE - 1000);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE + 1000);
       //V1 data not update
-      Assert.assertNull(ownerAccountAssetIssue.getAssetMap().get(ASSET_NAME));
-      Assert.assertEquals(toAccountAssetIssue.getAssetMap().get(ASSET_NAME).longValue(), TOTAL_SUPPLY);
+      Assert.assertNull(ownerAccountAsset.getAssetMap().get(ASSET_NAME));
+      Assert.assertEquals(
+              toAccountAssetIssue.getAssetMap()
+              .get(ASSET_NAME).longValue(), TOTAL_SUPPLY);
       //V2
       long tokenId = chainBaseManager.getDynamicPropertiesStore().getTokenIdNum();
-      Assert.assertEquals(ownerAccountAssetIssue.getAssetMapV2().get(String.valueOf(tokenId)).longValue(),
+      Assert.assertEquals(ownerAccountAsset
+                      .getAssetMapV2()
+                      .get(String.valueOf(tokenId)).longValue(),
           (1000L) / TRX_NUM * NUM);
-      Assert.assertEquals(toAccountAssetIssue.getAssetMapV2().get(String.valueOf(tokenId)).longValue(),
+      Assert.assertEquals(toAccountAssetIssue
+                      .getAssetMapV2().get(String.valueOf(tokenId)).longValue(),
           TOTAL_SUPPLY - (1000L) / TRX_NUM * NUM);
 
     } catch (ContractValidateException e) {
@@ -462,18 +474,20 @@ public class ParticipateAssetIssueActuatorTest {
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
       AccountCapsule toAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
-      AccountAssetIssueCapsule ownerAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+      AccountAssetIssueCapsule ownerAccountAsset = chainBaseManager.getAccountAssetIssueStore()
               .get(ByteArray.fromHexString(OWNER_ADDRESS));
-      AccountAssetIssueCapsule toAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+      AccountAssetIssueCapsule toAccountAssetIssue =
+              chainBaseManager.getAccountAssetIssueStore()
               .get(ByteArray.fromHexString(TO_ADDRESS));
       Assert.assertEquals(owner.getBalance(), OWNER_BALANCE - 1000);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE + 1000);
       // V1, data is not exist
-      Assert.assertNull(ownerAccountAssetIssue.getAssetMap().get(ASSET_NAME));
+      Assert.assertNull(ownerAccountAsset.getAssetMap().get(ASSET_NAME));
       Assert.assertNull(toAccountAssetIssue.getAssetMap().get(ASSET_NAME));
       //V2
       long id = chainBaseManager.getDynamicPropertiesStore().getTokenIdNum();
-      Assert.assertEquals(ownerAccountAssetIssue.getAssetMapV2().get(String.valueOf(id)).longValue(),
+      Assert.assertEquals(
+              ownerAccountAsset.getAssetMapV2().get(String.valueOf(id)).longValue(),
           (1000L) / TRX_NUM * NUM);
       Assert.assertEquals(
               toAccountAssetIssue.getAssetMapV2().get(String.valueOf(id)).longValue(),
@@ -507,15 +521,19 @@ public class ParticipateAssetIssueActuatorTest {
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
       AccountCapsule toAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
-      AccountAssetIssueCapsule ownerAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+      AccountAssetIssueCapsule ownerAccountAsset =
+              chainBaseManager.getAccountAssetIssueStore()
               .get(ByteArray.fromHexString(OWNER_ADDRESS));
-      AccountAssetIssueCapsule toAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+      AccountAssetIssueCapsule toAccountAssetIssue =
+              chainBaseManager.getAccountAssetIssueStore()
               .get(ByteArray.fromHexString(TO_ADDRESS));
 
       Assert.assertEquals(owner.getBalance(), OWNER_BALANCE);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE);
-      Assert.assertTrue(isNullOrZero(ownerAccountAssetIssue.getAssetMap().get(ASSET_NAME)));
-      Assert.assertEquals(toAccountAssetIssue.getAssetMap().get(ASSET_NAME).longValue(), TOTAL_SUPPLY);
+      Assert.assertTrue(
+              isNullOrZero(ownerAccountAsset.getAssetMap().get(ASSET_NAME)));
+      Assert.assertEquals(
+              toAccountAssetIssue.getAssetMap().get(ASSET_NAME).longValue(), TOTAL_SUPPLY);
     } catch (ContractExeException e) {
       Assert.assertFalse(e instanceof ContractExeException);
     }
@@ -545,7 +563,7 @@ public class ParticipateAssetIssueActuatorTest {
       AccountCapsule toAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
 
-      AccountAssetIssueCapsule ownerAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+      AccountAssetIssueCapsule ownerAccountAsset = chainBaseManager.getAccountAssetIssueStore()
               .get(ByteArray.fromHexString(OWNER_ADDRESS));
       AccountAssetIssueCapsule toAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
               .get(ByteArray.fromHexString(TO_ADDRESS));
@@ -553,7 +571,8 @@ public class ParticipateAssetIssueActuatorTest {
       Assert.assertEquals(owner.getBalance(), OWNER_BALANCE);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE);
       long id = chainBaseManager.getDynamicPropertiesStore().getTokenIdNum();
-      Assert.assertTrue(isNullOrZero(ownerAccountAssetIssue.getAssetMapV2().get(String.valueOf(id))));
+      Assert.assertTrue(
+              isNullOrZero(ownerAccountAsset.getAssetMapV2().get(String.valueOf(id))));
       Assert.assertEquals(toAccountAssetIssue.getAssetMapV2().get(String.valueOf(id)).longValue(),
           TOTAL_SUPPLY);
     } catch (ContractExeException e) {
@@ -584,15 +603,20 @@ public class ParticipateAssetIssueActuatorTest {
       AccountCapsule toAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
 
-      AccountAssetIssueCapsule ownerAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+      AccountAssetIssueCapsule ownerAccountAsset =
+              chainBaseManager.getAccountAssetIssueStore()
               .get(ByteArray.fromHexString(OWNER_ADDRESS));
-      AccountAssetIssueCapsule toAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+      AccountAssetIssueCapsule toAccountAssetIssue =
+              chainBaseManager.getAccountAssetIssueStore()
               .get(ByteArray.fromHexString(TO_ADDRESS));
 
       Assert.assertEquals(owner.getBalance(), OWNER_BALANCE);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE);
-      Assert.assertTrue(isNullOrZero(ownerAccountAssetIssue.getAssetMap().get(ASSET_NAME)));
-      Assert.assertEquals(toAccountAssetIssue.getAssetMap().get(ASSET_NAME).longValue(), TOTAL_SUPPLY);
+      Assert.assertTrue(
+              isNullOrZero(ownerAccountAsset.getAssetMap().get(ASSET_NAME))
+      );
+      Assert.assertEquals(toAccountAssetIssue.getAssetMap()
+              .get(ASSET_NAME).longValue(), TOTAL_SUPPLY);
     } catch (ContractExeException e) {
       Assert.assertFalse(e instanceof ContractExeException);
     }
@@ -621,14 +645,14 @@ public class ParticipateAssetIssueActuatorTest {
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
       AccountCapsule toAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
-      AccountAssetIssueCapsule ownerAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+      AccountAssetIssueCapsule ownerAccountAsset = chainBaseManager.getAccountAssetIssueStore()
               .get(ByteArray.fromHexString(OWNER_ADDRESS));
       AccountAssetIssueCapsule toAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
               .get(ByteArray.fromHexString(TO_ADDRESS));
       Assert.assertEquals(owner.getBalance(), OWNER_BALANCE);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE);
       long id = chainBaseManager.getDynamicPropertiesStore().getTokenIdNum();
-      Assert.assertTrue(isNullOrZero(ownerAccountAssetIssue.getAssetMapV2().get(String.valueOf(id))));
+      Assert.assertTrue(isNullOrZero(ownerAccountAsset.getAssetMapV2().get(String.valueOf(id))));
       Assert.assertEquals(toAccountAssetIssue.getAssetMapV2().get(String.valueOf(id)).longValue(),
           TOTAL_SUPPLY);
     } catch (ContractExeException e) {
@@ -645,19 +669,23 @@ public class ParticipateAssetIssueActuatorTest {
             .getLatestBlockHeaderTimestamp() - 1000,
         chainBaseManager.getDynamicPropertiesStore().getLatestBlockHeaderTimestamp() + 1000);
     ParticipateAssetIssueActuator actuator = new ParticipateAssetIssueActuator(); //no problem
-    actuator.setChainBaseManager(chainBaseManager).setAny(getContract(999L));
+    actuator.setChainBaseManager(chainBaseManager)
+            .setAny(getContract(999L));
 
     TransactionResultCapsule ret = new TransactionResultCapsule();
     try {
       actuator.validate();
       actuator.execute(ret);
 
-      AccountAssetIssueCapsule ownerAccountAssetIssue = dbManager.getAccountAssetIssueStore()
+      AccountAssetIssueCapsule ownerAccountAsset =
+              dbManager.getAccountAssetIssueStore()
               .get(ByteArray.fromHexString(OWNER_ADDRESS));
-      AccountAssetIssueCapsule toAccountAssetIssue = dbManager.getAccountAssetIssueStore()
+      AccountAssetIssueCapsule toAccountAssetIssue =
+              dbManager.getAccountAssetIssueStore()
               .get(ByteArray.fromHexString(TO_ADDRESS));
 
-      Assert.assertEquals(ownerAccountAssetIssue.getAssetMap().get(ASSET_NAME).longValue(),
+      Assert.assertEquals(
+              ownerAccountAsset.getAssetMap().get(ASSET_NAME).longValue(),
           (999L * NUM) / TRX_NUM);
       Assert.assertEquals(
               toAccountAssetIssue.getAssetMap().get(ASSET_NAME).longValue(),
@@ -686,13 +714,16 @@ public class ParticipateAssetIssueActuatorTest {
       actuator.validate();
       actuator.execute(ret);
 
-      AccountAssetIssueCapsule ownerAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+      AccountAssetIssueCapsule ownerAccountAsset =
+              chainBaseManager.getAccountAssetIssueStore()
               .get(ByteArray.fromHexString(OWNER_ADDRESS));
-      AccountAssetIssueCapsule toAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+      AccountAssetIssueCapsule toAccountAssetIssue =
+              chainBaseManager.getAccountAssetIssueStore()
               .get(ByteArray.fromHexString(TO_ADDRESS));
 
       long id = chainBaseManager.getDynamicPropertiesStore().getTokenIdNum();
-      Assert.assertEquals(ownerAccountAssetIssue.getAssetMapV2().get(String.valueOf(id)).longValue(),
+      Assert.assertEquals(
+              ownerAccountAsset.getAssetMapV2().get(String.valueOf(id)).longValue(),
           (999L * NUM) / TRX_NUM);
       Assert.assertEquals(
               toAccountAssetIssue.getAssetMapV2().get(String.valueOf(id)).longValue(),
@@ -727,14 +758,15 @@ public class ParticipateAssetIssueActuatorTest {
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
       AccountCapsule toAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
-      AccountAssetIssueCapsule ownerAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+      AccountAssetIssueCapsule ownerAccountAsset = chainBaseManager.getAccountAssetIssueStore()
               .get(ByteArray.fromHexString(OWNER_ADDRESS));
       AccountAssetIssueCapsule toAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
               .get(ByteArray.fromHexString(TO_ADDRESS));
       Assert.assertEquals(owner.getBalance(), OWNER_BALANCE);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE);
-      Assert.assertTrue(isNullOrZero(ownerAccountAssetIssue.getAssetMap().get(ASSET_NAME)));
-      Assert.assertEquals(toAccountAssetIssue.getAssetMap().get(ASSET_NAME).longValue(), TOTAL_SUPPLY);
+      Assert.assertTrue(isNullOrZero(ownerAccountAsset.getAssetMap().get(ASSET_NAME)));
+      Assert.assertEquals(
+              toAccountAssetIssue.getAssetMap().get(ASSET_NAME).longValue(), TOTAL_SUPPLY);
     } catch (ContractExeException e) {
       Assert.assertFalse(e instanceof ContractExeException);
     }
@@ -764,16 +796,19 @@ public class ParticipateAssetIssueActuatorTest {
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
       AccountCapsule toAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
-      AccountAssetIssueCapsule ownerAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+      AccountAssetIssueCapsule ownerAccountAsset = chainBaseManager.getAccountAssetIssueStore()
               .get(ByteArray.fromHexString(OWNER_ADDRESS));
-      AccountAssetIssueCapsule toAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+      AccountAssetIssueCapsule toAccountAssetIssue =
+              chainBaseManager.getAccountAssetIssueStore()
               .get(ByteArray.fromHexString(TO_ADDRESS));
       Assert.assertEquals(owner.getBalance(), OWNER_BALANCE);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE);
       long id = chainBaseManager.getDynamicPropertiesStore().getTokenIdNum();
 
-      Assert.assertTrue(isNullOrZero(ownerAccountAssetIssue.getAssetMapV2().get(String.valueOf(id))));
-      Assert.assertEquals(toAccountAssetIssue.getAssetMapV2().get(String.valueOf(id)).longValue(),
+      Assert.assertTrue(
+              isNullOrZero(ownerAccountAsset.getAssetMapV2().get(String.valueOf(id))));
+      Assert.assertEquals(
+              toAccountAssetIssue.getAssetMapV2().get(String.valueOf(id)).longValue(),
           TOTAL_SUPPLY);
     } catch (ContractExeException e) {
       Assert.assertFalse(e instanceof ContractExeException);
@@ -803,15 +838,16 @@ public class ParticipateAssetIssueActuatorTest {
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
       AccountCapsule toAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
-      AccountAssetIssueCapsule ownerAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+      AccountAssetIssueCapsule ownerAccountAsset = chainBaseManager.getAccountAssetIssueStore()
               .get(ByteArray.fromHexString(OWNER_ADDRESS));
       AccountAssetIssueCapsule toAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
               .get(ByteArray.fromHexString(TO_ADDRESS));
 
       Assert.assertEquals(owner.getBalance(), OWNER_BALANCE);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE);
-      Assert.assertTrue(isNullOrZero(ownerAccountAssetIssue.getAssetMap().get(ASSET_NAME)));
-      Assert.assertEquals(toAccountAssetIssue.getAssetMap().get(ASSET_NAME).longValue(), TOTAL_SUPPLY);
+      Assert.assertTrue(isNullOrZero(ownerAccountAsset.getAssetMap().get(ASSET_NAME)));
+      Assert.assertEquals(
+              toAccountAssetIssue.getAssetMap().get(ASSET_NAME).longValue(), TOTAL_SUPPLY);
     } catch (ContractExeException e) {
       Assert.assertFalse(e instanceof ContractExeException);
     }
@@ -841,7 +877,7 @@ public class ParticipateAssetIssueActuatorTest {
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
       AccountCapsule toAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
-      AccountAssetIssueCapsule ownerAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+      AccountAssetIssueCapsule ownerAccountAsset = chainBaseManager.getAccountAssetIssueStore()
               .get(ByteArray.fromHexString(OWNER_ADDRESS));
       AccountAssetIssueCapsule toAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
               .get(ByteArray.fromHexString(TO_ADDRESS));
@@ -850,8 +886,10 @@ public class ParticipateAssetIssueActuatorTest {
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE);
       long id = chainBaseManager.getDynamicPropertiesStore().getTokenIdNum();
 
-      Assert.assertTrue(isNullOrZero(ownerAccountAssetIssue.getAssetMapV2().get(String.valueOf(id))));
-      Assert.assertEquals(toAccountAssetIssue.getAssetMapV2().get(String.valueOf(id)).longValue(),
+      Assert.assertTrue(
+              isNullOrZero(ownerAccountAsset.getAssetMapV2().get(String.valueOf(id))));
+      Assert.assertEquals(
+              toAccountAssetIssue.getAssetMapV2().get(String.valueOf(id)).longValue(),
           TOTAL_SUPPLY);
     } catch (ContractExeException e) {
       Assert.assertFalse(e instanceof ContractExeException);
@@ -884,15 +922,17 @@ public class ParticipateAssetIssueActuatorTest {
       AccountCapsule toAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
 
-      AccountAssetIssueCapsule ownerAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+      AccountAssetIssueCapsule ownerAccountAsset = chainBaseManager.getAccountAssetIssueStore()
               .get(ByteArray.fromHexString(OWNER_ADDRESS));
       AccountAssetIssueCapsule toAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
               .get(ByteArray.fromHexString(TO_ADDRESS));
 
       Assert.assertEquals(owner.getBalance(), OWNER_BALANCE);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE);
-      Assert.assertTrue(isNullOrZero(ownerAccountAssetIssue.getAssetMap().get(ASSET_NAME)));
-      Assert.assertEquals(toAccountAssetIssue.getAssetMap().get(ASSET_NAME).longValue(), TOTAL_SUPPLY);
+      Assert.assertTrue(
+              isNullOrZero(ownerAccountAsset.getAssetMap().get(ASSET_NAME)));
+      Assert.assertEquals(
+              toAccountAssetIssue.getAssetMap().get(ASSET_NAME).longValue(), TOTAL_SUPPLY);
     } catch (ContractExeException e) {
       Assert.assertFalse(e instanceof ContractExeException);
     }
@@ -924,16 +964,19 @@ public class ParticipateAssetIssueActuatorTest {
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
       AccountCapsule toAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
-      AccountAssetIssueCapsule ownerAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+      AccountAssetIssueCapsule ownerAccountAsset = chainBaseManager.getAccountAssetIssueStore()
               .get(ByteArray.fromHexString(OWNER_ADDRESS));
 
-      AccountAssetIssueCapsule toAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+      AccountAssetIssueCapsule toAccountAssetIssue =
+              chainBaseManager.getAccountAssetIssueStore()
               .get(ByteArray.fromHexString(TO_ADDRESS));
       Assert.assertEquals(owner.getBalance(), OWNER_BALANCE);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE);
       long id = chainBaseManager.getDynamicPropertiesStore().getTokenIdNum();
-      Assert.assertTrue(isNullOrZero(ownerAccountAssetIssue.getAssetMapV2().get(String.valueOf(id))));
-      Assert.assertEquals(toAccountAssetIssue.getAssetMapV2().get(String.valueOf(id)).longValue(),
+      Assert.assertTrue(
+              isNullOrZero(ownerAccountAsset.getAssetMapV2().get(String.valueOf(id))));
+      Assert.assertEquals(
+              toAccountAssetIssue.getAssetMapV2().get(String.valueOf(id)).longValue(),
           TOTAL_SUPPLY);
     } catch (ContractExeException e) {
       Assert.assertFalse(e instanceof ContractExeException);
@@ -968,15 +1011,18 @@ public class ParticipateAssetIssueActuatorTest {
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
       AccountCapsule toAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
-      AccountAssetIssueCapsule ownerAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+      AccountAssetIssueCapsule ownerAccountAsset =
+              chainBaseManager.getAccountAssetIssueStore()
               .get(ByteArray.fromHexString(OWNER_ADDRESS));
-      AccountAssetIssueCapsule toAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+      AccountAssetIssueCapsule toAccountAssetIssue =
+              chainBaseManager.getAccountAssetIssueStore()
               .get(ByteArray.fromHexString(TO_ADDRESS));
 
       Assert.assertEquals(owner.getBalance(), OWNER_BALANCE);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE);
-      Assert.assertTrue(isNullOrZero(ownerAccountAssetIssue.getAssetMap().get(ASSET_NAME)));
-      Assert.assertEquals(toAccountAssetIssue.getAssetMap().get(ASSET_NAME).longValue(), TOTAL_SUPPLY);
+      Assert.assertTrue(isNullOrZero(ownerAccountAsset.getAssetMap().get(ASSET_NAME)));
+      Assert.assertEquals(
+              toAccountAssetIssue.getAssetMap().get(ASSET_NAME).longValue(), TOTAL_SUPPLY);
     } catch (ContractExeException e) {
       Assert.assertFalse(e instanceof ContractExeException);
     }
@@ -1012,15 +1058,17 @@ public class ParticipateAssetIssueActuatorTest {
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
       AccountCapsule toAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
-      AccountAssetIssueCapsule ownerAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+      AccountAssetIssueCapsule ownerAccountAsset =
+              chainBaseManager.getAccountAssetIssueStore()
               .get(ByteArray.fromHexString(OWNER_ADDRESS));
-      AccountAssetIssueCapsule toAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+      AccountAssetIssueCapsule toAccountAssetIssue =
+              chainBaseManager.getAccountAssetIssueStore()
               .get(ByteArray.fromHexString(TO_ADDRESS));
 
       Assert.assertEquals(owner.getBalance(), OWNER_BALANCE);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE);
       long id = chainBaseManager.getDynamicPropertiesStore().getTokenIdNum();
-      Assert.assertTrue(isNullOrZero(ownerAccountAssetIssue.getAssetMapV2().get(String.valueOf(id))));
+      Assert.assertTrue(isNullOrZero(ownerAccountAsset.getAssetMapV2().get(String.valueOf(id))));
       Assert.assertEquals(toAccountAssetIssue.getAssetMapV2().get(String.valueOf(id)).longValue(),
           TOTAL_SUPPLY);
     } catch (ContractExeException e) {
@@ -1057,15 +1105,17 @@ public class ParticipateAssetIssueActuatorTest {
       AccountCapsule toAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
 
-      AccountAssetIssueCapsule ownerAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+      AccountAssetIssueCapsule ownerAccountAsset =
+              chainBaseManager.getAccountAssetIssueStore()
               .get(ByteArray.fromHexString(OWNER_ADDRESS));
       AccountAssetIssueCapsule toAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
               .get(ByteArray.fromHexString(TO_ADDRESS));
 
       Assert.assertEquals(owner.getBalance(), OWNER_BALANCE);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE);
-      Assert.assertTrue(isNullOrZero(ownerAccountAssetIssue.getAssetMap().get(ASSET_NAME)));
-      Assert.assertEquals(toAccountAssetIssue.getAssetMap().get(ASSET_NAME).longValue(), TOTAL_SUPPLY);
+      Assert.assertTrue(isNullOrZero(ownerAccountAsset.getAssetMap().get(ASSET_NAME)));
+      Assert.assertEquals(
+              toAccountAssetIssue.getAssetMap().get(ASSET_NAME).longValue(), TOTAL_SUPPLY);
     } catch (ContractExeException e) {
       Assert.assertFalse(e instanceof ContractExeException);
     }
@@ -1101,7 +1151,7 @@ public class ParticipateAssetIssueActuatorTest {
       AccountCapsule toAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
 
-      AccountAssetIssueCapsule ownerAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+      AccountAssetIssueCapsule ownerAccountAsset = chainBaseManager.getAccountAssetIssueStore()
               .get(ByteArray.fromHexString(OWNER_ADDRESS));
       AccountAssetIssueCapsule toAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
               .get(ByteArray.fromHexString(TO_ADDRESS));
@@ -1109,8 +1159,10 @@ public class ParticipateAssetIssueActuatorTest {
       Assert.assertEquals(owner.getBalance(), OWNER_BALANCE);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE);
       long id = chainBaseManager.getDynamicPropertiesStore().getTokenIdNum();
-      Assert.assertTrue(isNullOrZero(ownerAccountAssetIssue.getAssetMapV2().get(String.valueOf(id))));
-      Assert.assertEquals(toAccountAssetIssue.getAssetMapV2().get(String.valueOf(id)).longValue(),
+      Assert.assertTrue(
+              isNullOrZero(ownerAccountAsset.getAssetMapV2().get(String.valueOf(id))));
+      Assert.assertEquals(
+              toAccountAssetIssue.getAssetMapV2().get(String.valueOf(id)).longValue(),
           TOTAL_SUPPLY);
     } catch (ContractExeException e) {
       Assert.assertFalse(e instanceof ContractExeException);
@@ -1143,15 +1195,18 @@ public class ParticipateAssetIssueActuatorTest {
       AccountCapsule toAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
 
-      AccountAssetIssueCapsule ownerAccountAssetIssue =
-              chainBaseManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
+      AccountAssetIssueCapsule ownerAccountAsset =
+              chainBaseManager.getAccountAssetIssueStore()
+                      .get(ByteArray.fromHexString(OWNER_ADDRESS));
       AccountAssetIssueCapsule toAccountAssetIssue =
-              chainBaseManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(TO_ADDRESS));
+              chainBaseManager.getAccountAssetIssueStore()
+                      .get(ByteArray.fromHexString(TO_ADDRESS));
 
       Assert.assertEquals(owner.getBalance(), OWNER_BALANCE);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE);
-      Assert.assertTrue(isNullOrZero(ownerAccountAssetIssue.getAssetMap().get(ASSET_NAME)));
-      Assert.assertEquals(toAccountAssetIssue.getAssetMap().get(ASSET_NAME).longValue(), TOTAL_SUPPLY);
+      Assert.assertTrue(isNullOrZero(ownerAccountAsset.getAssetMap().get(ASSET_NAME)));
+      Assert.assertEquals(
+              toAccountAssetIssue.getAssetMap().get(ASSET_NAME).longValue(), TOTAL_SUPPLY);
     } catch (ContractExeException e) {
       Assert.assertFalse(e instanceof ContractExeException);
     }
@@ -1183,14 +1238,14 @@ public class ParticipateAssetIssueActuatorTest {
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
       AccountCapsule toAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
-      AccountAssetIssueCapsule ownerAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+      AccountAssetIssueCapsule ownerAccountAsset = chainBaseManager.getAccountAssetIssueStore()
               .get(ByteArray.fromHexString(OWNER_ADDRESS));
       AccountAssetIssueCapsule toAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
               .get(ByteArray.fromHexString(TO_ADDRESS));
       Assert.assertEquals(owner.getBalance(), OWNER_BALANCE);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE);
       long id = chainBaseManager.getDynamicPropertiesStore().getTokenIdNum();
-      Assert.assertTrue(isNullOrZero(ownerAccountAssetIssue.getAssetMapV2().get(String.valueOf(id))));
+      Assert.assertTrue(isNullOrZero(ownerAccountAsset.getAssetMapV2().get(String.valueOf(id))));
       Assert.assertEquals(toAccountAssetIssue.getAssetMapV2().get(String.valueOf(id)).longValue(),
           TOTAL_SUPPLY);
     } catch (ContractExeException e) {
@@ -1245,14 +1300,16 @@ public class ParticipateAssetIssueActuatorTest {
       AccountCapsule toAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
 
-      AccountAssetIssueCapsule ownerAccountAssetIssue =
-              chainBaseManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
+      AccountAssetIssueCapsule ownerAccountAsset =
+              chainBaseManager
+                      .getAccountAssetIssueStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
       AccountAssetIssueCapsule toAccountAssetIssue =
-              chainBaseManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(TO_ADDRESS));
+              chainBaseManager
+                      .getAccountAssetIssueStore().get(ByteArray.fromHexString(TO_ADDRESS));
 
       Assert.assertEquals(owner.getBalance(), OWNER_BALANCE - 1000);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE + 1000);
-      Assert.assertEquals(ownerAccountAssetIssue.getAssetMap().get(assetName).longValue(),
+      Assert.assertEquals(ownerAccountAsset.getAssetMap().get(assetName).longValue(),
           (1000L) / TRX_NUM * NUM);
       Assert.assertEquals(toAccountAssetIssue.getAssetMap().get(assetName).longValue(),
           TOTAL_SUPPLY - (1000L) / TRX_NUM * NUM);
@@ -1282,14 +1339,15 @@ public class ParticipateAssetIssueActuatorTest {
       AccountCapsule toAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
 
-      AccountAssetIssueCapsule ownerAccountAssetIssue =
-              chainBaseManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
+      AccountAssetIssueCapsule ownerAccountAsset =
+              chainBaseManager.getAccountAssetIssueStore()
+                      .get(ByteArray.fromHexString(OWNER_ADDRESS));
       AccountAssetIssueCapsule toAccountAssetIssue =
               chainBaseManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(TO_ADDRESS));
 
       Assert.assertEquals(owner.getBalance(), OWNER_BALANCE - 2000);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE + 2000);
-      Assert.assertEquals(ownerAccountAssetIssue.getAssetMap().get(assetName).longValue(),
+      Assert.assertEquals(ownerAccountAsset.getAssetMap().get(assetName).longValue(),
           (1000L) / TRX_NUM * NUM);
       Assert.assertEquals(toAccountAssetIssue.getAssetMap().get(assetName).longValue(),
           TOTAL_SUPPLY - (1000L) / TRX_NUM * NUM);
@@ -1330,15 +1388,16 @@ public class ParticipateAssetIssueActuatorTest {
       AccountCapsule toAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
 
-      AccountAssetIssueCapsule ownerAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+      AccountAssetIssueCapsule ownerAccountAsset = chainBaseManager.getAccountAssetIssueStore()
               .get(ByteArray.fromHexString(OWNER_ADDRESS));
       AccountAssetIssueCapsule toAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
               .get(ByteArray.fromHexString(TO_ADDRESS));
 
       Assert.assertEquals(owner.getBalance(), 100);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE);
-      Assert.assertTrue(isNullOrZero(ownerAccountAssetIssue.getAssetMap().get(ASSET_NAME)));
-      Assert.assertEquals(toAccountAssetIssue.getAssetMap().get(ASSET_NAME).longValue(), TOTAL_SUPPLY);
+      Assert.assertTrue(isNullOrZero(ownerAccountAsset.getAssetMap().get(ASSET_NAME)));
+      Assert.assertEquals(
+              toAccountAssetIssue.getAssetMap().get(ASSET_NAME).longValue(), TOTAL_SUPPLY);
     } catch (ContractExeException e) {
       Assert.assertFalse(e instanceof ContractExeException);
     }
@@ -1376,7 +1435,8 @@ public class ParticipateAssetIssueActuatorTest {
       Assert.assertTrue("No enough balance !".equals(e.getMessage()));
 
       owner = chainBaseManager.getAccountStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
-      ownerAssetIssue = chainBaseManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
+      ownerAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+              .get(ByteArray.fromHexString(OWNER_ADDRESS));
 
       AccountCapsule toAccount = chainBaseManager.getAccountStore()
           .get(ByteArray.fromHexString(TO_ADDRESS));
@@ -1430,14 +1490,14 @@ public class ParticipateAssetIssueActuatorTest {
       toAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
 
-      AccountAssetIssueCapsule ownerAccountAssetIssue =
+      AccountAssetIssueCapsule ownerAccountAsset =
               dbManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
       toAccountAssetIssue =
               dbManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(TO_ADDRESS));
 
       Assert.assertEquals(owner.getBalance(), OWNER_BALANCE);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE);
-      Assert.assertTrue(isNullOrZero(ownerAccountAssetIssue.getAssetMap().get(ASSET_NAME)));
+      Assert.assertTrue(isNullOrZero(ownerAccountAsset.getAssetMap().get(ASSET_NAME)));
       Assert.assertEquals(toAccountAssetIssue.getAssetMap().get(ASSET_NAME).longValue(), 10000);
     } catch (ContractExeException e) {
       Assert.assertFalse(e instanceof ContractExeException);
@@ -1459,12 +1519,15 @@ public class ParticipateAssetIssueActuatorTest {
         .get(ByteArray.fromHexString(TO_ADDRESS));
     long id = chainBaseManager.getDynamicPropertiesStore().getTokenIdNum();
 
-    AccountAssetIssueCapsule toAccountAssetIssue = dbManager.getAccountAssetIssueStore()
+    AccountAssetIssueCapsule toAccountAssetIssue =
+            dbManager.getAccountAssetIssueStore()
             .get(ByteArray.fromHexString(TO_ADDRESS));
-    toAccountAssetIssue.reduceAssetAmountV2(ByteString.copyFromUtf8(String.valueOf(id)).toByteArray(),
+    toAccountAssetIssue
+            .reduceAssetAmountV2(ByteString.copyFromUtf8(String.valueOf(id)).toByteArray(),
             TOTAL_SUPPLY - 10000, chainBaseManager.getDynamicPropertiesStore(),
             chainBaseManager.getAssetIssueStore());
-    chainBaseManager.getAccountAssetIssueStore().put(toAccountAssetIssue.getAddress().toByteArray(), toAccountAssetIssue);
+    chainBaseManager.getAccountAssetIssueStore()
+            .put(toAccountAssetIssue.getAddress().toByteArray(), toAccountAssetIssue);
 
     ParticipateAssetIssueActuator actuator = new ParticipateAssetIssueActuator();
     actuator.setChainBaseManager(chainBaseManager).setAny(getContract(1));
@@ -1483,14 +1546,16 @@ public class ParticipateAssetIssueActuatorTest {
       toAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
 
-      AccountAssetIssueCapsule ownerAccountAssetIssue =
-              chainBaseManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
+      AccountAssetIssueCapsule ownerAccountAsset =
+              chainBaseManager.getAccountAssetIssueStore()
+                      .get(ByteArray.fromHexString(OWNER_ADDRESS));
       toAccountAssetIssue =
-              chainBaseManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(TO_ADDRESS));
+              chainBaseManager.getAccountAssetIssueStore()
+                      .get(ByteArray.fromHexString(TO_ADDRESS));
       Assert.assertEquals(owner.getBalance(), OWNER_BALANCE);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE);
 
-      Assert.assertTrue(isNullOrZero(ownerAccountAssetIssue.getAssetMapV2().get(String.valueOf(id))));
+      Assert.assertTrue(isNullOrZero(ownerAccountAsset.getAssetMapV2().get(String.valueOf(id))));
       Assert.assertEquals(
               toAccountAssetIssue.getAssetMapV2().get(String.valueOf(id)).longValue(), 10000);
     } catch (ContractExeException e) {
@@ -1523,16 +1588,19 @@ public class ParticipateAssetIssueActuatorTest {
       AccountCapsule toAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
 
-      AccountAssetIssueCapsule ownerAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+      AccountAssetIssueCapsule ownerAccountAsset =
+              chainBaseManager.getAccountAssetIssueStore()
               .get(ByteArray.fromHexString(OWNER_ADDRESS));
 
-      AccountAssetIssueCapsule toAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+      AccountAssetIssueCapsule toAccountAssetIssue =
+              chainBaseManager.getAccountAssetIssueStore()
               .get(ByteArray.fromHexString(TO_ADDRESS));
 
       Assert.assertEquals(owner.getBalance(), OWNER_BALANCE);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE);
-      Assert.assertTrue(isNullOrZero(ownerAccountAssetIssue.getAssetMap().get(ASSET_NAME)));
-      Assert.assertEquals(toAccountAssetIssue.getAssetMap().get(ASSET_NAME).longValue(), TOTAL_SUPPLY);
+      Assert.assertTrue(isNullOrZero(ownerAccountAsset.getAssetMap().get(ASSET_NAME)));
+      Assert.assertEquals(
+              toAccountAssetIssue.getAssetMap().get(ASSET_NAME).longValue(), TOTAL_SUPPLY);
     } catch (ContractExeException e) {
       Assert.assertFalse(e instanceof ContractExeException);
     }
@@ -1565,7 +1633,7 @@ public class ParticipateAssetIssueActuatorTest {
       AccountCapsule toAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
 
-      AccountAssetIssueCapsule ownerAccountAssetIssue = dbManager.getAccountAssetIssueStore()
+      AccountAssetIssueCapsule ownerAccountAsset = dbManager.getAccountAssetIssueStore()
               .get(ByteArray.fromHexString(OWNER_ADDRESS));
       AccountAssetIssueCapsule toAccountAssetIssue = dbManager.getAccountAssetIssueStore()
               .get(ByteArray.fromHexString(TO_ADDRESS));
@@ -1573,7 +1641,7 @@ public class ParticipateAssetIssueActuatorTest {
       Assert.assertEquals(owner.getBalance(), OWNER_BALANCE);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE);
       long id = chainBaseManager.getDynamicPropertiesStore().getTokenIdNum();
-      Assert.assertTrue(isNullOrZero(ownerAccountAssetIssue.getAssetMapV2().get(String.valueOf(id))));
+      Assert.assertTrue(isNullOrZero(ownerAccountAsset.getAssetMapV2().get(String.valueOf(id))));
       Assert.assertEquals(toAccountAssetIssue.getAssetMapV2().get(String.valueOf(id)).longValue(),
           TOTAL_SUPPLY);
     } catch (ContractExeException e) {
@@ -1594,10 +1662,11 @@ public class ParticipateAssetIssueActuatorTest {
         .get(ByteArray.fromHexString(OWNER_ADDRESS));
     chainBaseManager.getAccountStore().put(owner.getAddress().toByteArray(), owner);
 
-    AccountAssetIssueCapsule ownerAccountAssetIssue = dbManager.getAccountAssetIssueStore()
+    AccountAssetIssueCapsule ownerAccountAsset = dbManager.getAccountAssetIssueStore()
             .get(ByteArray.fromHexString(OWNER_ADDRESS));
-    ownerAccountAssetIssue.addAsset(ASSET_NAME.getBytes(), Long.MAX_VALUE);
-    chainBaseManager.getAccountAssetIssueStore().put(ownerAccountAssetIssue.getAddress().toByteArray(), ownerAccountAssetIssue);
+    ownerAccountAsset.addAsset(ASSET_NAME.getBytes(), Long.MAX_VALUE);
+    chainBaseManager.getAccountAssetIssueStore()
+            .put(ownerAccountAsset.getAddress().toByteArray(), ownerAccountAsset);
 
     ParticipateAssetIssueActuator actuator = new ParticipateAssetIssueActuator();
     actuator.setChainBaseManager(chainBaseManager).setAny(getContract(1L));
@@ -1620,15 +1689,19 @@ public class ParticipateAssetIssueActuatorTest {
       AccountCapsule toAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
 
-      ownerAccountAssetIssue =
-              chainBaseManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
+      ownerAccountAsset =
+              chainBaseManager.getAccountAssetIssueStore()
+                      .get(ByteArray.fromHexString(OWNER_ADDRESS));
       AccountAssetIssueCapsule toAccountAssetIssue =
-              chainBaseManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(TO_ADDRESS));
+              chainBaseManager.getAccountAssetIssueStore()
+                      .get(ByteArray.fromHexString(TO_ADDRESS));
 
       Assert.assertEquals(owner.getBalance(), OWNER_BALANCE);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE);
-      Assert.assertEquals(ownerAccountAssetIssue.getAssetMap().get(ASSET_NAME).longValue(), Long.MAX_VALUE);
-      Assert.assertEquals(toAccountAssetIssue.getAssetMap().get(ASSET_NAME).longValue(), TOTAL_SUPPLY);
+      Assert.assertEquals(ownerAccountAsset.getAssetMap()
+              .get(ASSET_NAME).longValue(), Long.MAX_VALUE);
+      Assert.assertEquals(toAccountAssetIssue
+              .getAssetMap().get(ASSET_NAME).longValue(), TOTAL_SUPPLY);
     }
   }
 
@@ -1646,11 +1719,13 @@ public class ParticipateAssetIssueActuatorTest {
     AccountCapsule owner = chainBaseManager.getAccountStore()
         .get(ByteArray.fromHexString(OWNER_ADDRESS));
 
-    AccountAssetIssueCapsule ownerAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+    AccountAssetIssueCapsule ownerAccountAsset = chainBaseManager.getAccountAssetIssueStore()
             .get(ByteArray.fromHexString(OWNER_ADDRESS));
     long id = chainBaseManager.getDynamicPropertiesStore().getTokenIdNum();
-    ownerAccountAssetIssue.addAssetV2(ByteString.copyFromUtf8(String.valueOf(id)).toByteArray(), Long.MAX_VALUE);
-    chainBaseManager.getAccountAssetIssueStore().put(ownerAccountAssetIssue.getAddress().toByteArray(), ownerAccountAssetIssue);
+    ownerAccountAsset.addAssetV2(
+            ByteString.copyFromUtf8(String.valueOf(id)).toByteArray(), Long.MAX_VALUE);
+    chainBaseManager.getAccountAssetIssueStore()
+            .put(ownerAccountAsset.getAddress().toByteArray(), ownerAccountAsset);
 
     ParticipateAssetIssueActuator actuator = new ParticipateAssetIssueActuator();
     actuator.setChainBaseManager(chainBaseManager).setAny(getContract(1L));
@@ -1668,18 +1743,22 @@ public class ParticipateAssetIssueActuatorTest {
       Assert.assertTrue(e instanceof ContractExeException);
       Assert.assertTrue(("long overflow").equals(e.getMessage()));
 
-      ownerAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
+      ownerAccountAsset = chainBaseManager
+              .getAccountAssetIssueStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
       AccountCapsule toAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
       AccountAssetIssueCapsule toAccountAssetIssue =
-              chainBaseManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(TO_ADDRESS));
+              chainBaseManager
+                      .getAccountAssetIssueStore().get(ByteArray.fromHexString(TO_ADDRESS));
 
       Assert.assertEquals(owner.getBalance(), OWNER_BALANCE);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE);
 
-      Assert.assertEquals(ownerAccountAssetIssue.getAssetMapV2().get(String.valueOf(id)).longValue(),
+      Assert.assertEquals(ownerAccountAsset
+                      .getAssetMapV2().get(String.valueOf(id)).longValue(),
           Long.MAX_VALUE);
-      Assert.assertEquals(toAccountAssetIssue.getAssetMapV2().get(String.valueOf(id)).longValue(),
+      Assert.assertEquals(toAccountAssetIssue
+                      .getAssetMapV2().get(String.valueOf(id)).longValue(),
           TOTAL_SUPPLY);
     }
   }
@@ -1698,8 +1777,9 @@ public class ParticipateAssetIssueActuatorTest {
     owner.setBalance(100000000000000L);
     chainBaseManager.getAccountStore().put(owner.getAddress().toByteArray(), owner);
 
-    AccountAssetIssueCapsule ownerAccountAssetIssue =
-            chainBaseManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
+    AccountAssetIssueCapsule ownerAccountAsset =
+            chainBaseManager.getAccountAssetIssueStore()
+                    .get(ByteArray.fromHexString(OWNER_ADDRESS));
 
     ParticipateAssetIssueActuator actuator = new ParticipateAssetIssueActuator();
     actuator.setChainBaseManager(
@@ -1723,7 +1803,7 @@ public class ParticipateAssetIssueActuatorTest {
 
       owner =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
-      ownerAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+      ownerAccountAsset = chainBaseManager.getAccountAssetIssueStore()
               .get(ByteArray.fromHexString(OWNER_ADDRESS));
       AccountCapsule toAccount =
           chainBaseManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
@@ -1731,8 +1811,11 @@ public class ParticipateAssetIssueActuatorTest {
               .get(ByteArray.fromHexString(TO_ADDRESS));
       Assert.assertEquals(owner.getBalance(), 100000000000000L);
       Assert.assertEquals(toAccount.getBalance(), TO_BALANCE);
-      Assert.assertTrue(isNullOrZero(ownerAccountAssetIssue.getAssetMap().get(ASSET_NAME)));
-      Assert.assertEquals(toAccountAssetIssue.getAssetMap().get(ASSET_NAME).longValue(), TOTAL_SUPPLY);
+      Assert.assertTrue(
+              isNullOrZero(ownerAccountAsset.getAssetMap().get(ASSET_NAME)));
+      Assert.assertEquals(
+              toAccountAssetIssue.getAssetMap()
+                      .get(ASSET_NAME).longValue(), TOTAL_SUPPLY);
     } catch (ContractExeException e) {
       Assert.assertFalse(e instanceof ContractExeException);
     }
@@ -1754,7 +1837,7 @@ public class ParticipateAssetIssueActuatorTest {
     owner.setBalance(100000000000000L);
     chainBaseManager.getAccountStore().put(owner.getAddress().toByteArray(), owner);
 
-    AccountAssetIssueCapsule ownerAccountAssetIssue = chainBaseManager.getAccountAssetIssueStore()
+    AccountAssetIssueCapsule ownerAccountAsset = chainBaseManager.getAccountAssetIssueStore()
             .get(ByteArray.fromHexString(OWNER_ADDRESS));
 
     ParticipateAssetIssueActuator actuator = new ParticipateAssetIssueActuator();

--- a/framework/src/test/java/org/tron/core/actuator/ShieldedTransferActuatorTest.java
+++ b/framework/src/test/java/org/tron/core/actuator/ShieldedTransferActuatorTest.java
@@ -15,7 +15,14 @@ import org.tron.common.zksnark.IncrementalMerkleTreeContainer;
 import org.tron.common.zksnark.IncrementalMerkleVoucherContainer;
 import org.tron.core.Constant;
 import org.tron.core.Wallet;
-import org.tron.core.capsule.*;
+import org.tron.core.capsule.AccountAssetIssueCapsule;
+import org.tron.core.capsule.AccountCapsule;
+import org.tron.core.capsule.AssetIssueCapsule;
+import org.tron.core.capsule.BytesCapsule;
+import org.tron.core.capsule.IncrementalMerkleTreeCapsule;
+import org.tron.core.capsule.PedersenHashCapsule;
+import org.tron.core.capsule.TransactionCapsule;
+import org.tron.core.capsule.TransactionResultCapsule;
 import org.tron.core.config.DefaultConfig;
 import org.tron.core.config.args.Args;
 import org.tron.core.db.Manager;
@@ -145,7 +152,6 @@ public class ShieldedTransferActuatorTest {
             ByteString.copyFrom(ByteArray.fromHexString(PUBLIC_ADDRESS_ONE)),
             AccountType.Normal,
             OWNER_BALANCE);
-//    ownerCapsule.addAssetV2(ByteArray.fromString(String.valueOf(tokenId)), OWNER_BALANCE);
     dbManager.getAccountStore().put(ownerCapsule.getAddress().toByteArray(), ownerCapsule);
 
     AccountCapsule toAccountCapsule =
@@ -205,9 +211,11 @@ public class ShieldedTransferActuatorTest {
       return 0;
     }
   }
+
   private long getAssertBalance(AccountAssetIssueCapsule accountCapsule) {
     String token = String.valueOf(tokenId);
-    if (accountCapsule != null && accountCapsule.getAssetMapV2().containsKey(token)) {
+    if (accountCapsule != null && accountCapsule
+            .getAssetMapV2().containsKey(token)) {
       return accountCapsule.getAssetMapV2().get(token);
     } else {
       return 0;
@@ -240,7 +248,8 @@ public class ShieldedTransferActuatorTest {
         accountCapsule.addAssetAmountV2(token.getBytes(), (amount - currentBalance),
                 dbManager.getDynamicPropertiesStore(), dbManager.getAssetIssueStore());
       }
-      dbManager.getAccountAssetIssueStore().put(accountCapsule.getAddress().toByteArray(), accountCapsule);
+      dbManager.getAccountAssetIssueStore()
+              .put(accountCapsule.getAddress().toByteArray(), accountCapsule);
     }
   }
 
@@ -472,7 +481,8 @@ public class ShieldedTransferActuatorTest {
           dbManager.getAccountStore().get(ByteArray.fromHexString(PUBLIC_ADDRESS_ONE));
 
       AccountAssetIssueCapsule accountAssetIssueCapsule =
-              dbManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(PUBLIC_ADDRESS_ONE));
+              dbManager.getAccountAssetIssueStore()
+                      .get(ByteArray.fromHexString(PUBLIC_ADDRESS_ONE));
 
       long balance = accountCapsule.getBalance();
       long netUsage = accountCapsule.getNetUsage();
@@ -484,7 +494,8 @@ public class ShieldedTransferActuatorTest {
       accountCapsule =
           dbManager.getAccountStore().get(ByteArray.fromHexString(PUBLIC_ADDRESS_ONE));
       accountAssetIssueCapsule =
-              dbManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(PUBLIC_ADDRESS_ONE));
+              dbManager.getAccountAssetIssueStore()
+                      .get(ByteArray.fromHexString(PUBLIC_ADDRESS_ONE));
       Assert.assertEquals(assertBalance - AMOUNT, getAssertBalance(accountAssetIssueCapsule));
       Assert.assertEquals(balance, accountCapsule.getBalance());
       Assert.assertEquals(netUsage, accountCapsule.getNetUsage());

--- a/framework/src/test/java/org/tron/core/actuator/TransferAssetActuatorTest.java
+++ b/framework/src/test/java/org/tron/core/actuator/TransferAssetActuatorTest.java
@@ -131,7 +131,8 @@ public class TransferAssetActuatorTest {
             ByteString.copyFromUtf8("toAccount"),
             ByteString.copyFrom(ByteArray.fromHexString(TO_ADDRESS))
             );
-    dbManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.getAddress().toByteArray(), accountAssetIssueCapsule);
+    dbManager.getAccountAssetIssueStore()
+            .put(accountAssetIssueCapsule.getAddress().toByteArray(), accountAssetIssueCapsule);
   }
 
   private boolean isNullOrZero(Long value) {
@@ -146,7 +147,8 @@ public class TransferAssetActuatorTest {
         .get(ByteArray.fromHexString(OWNER_ADDRESS));
     ownerCapsule.addAsset(assetName.getBytes(), OWNER_ASSET_BALANCE);
 
-    AccountAssetIssueCapsule ownerAccountIssue = dbManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
+    AccountAssetIssueCapsule ownerAccountIssue =
+            dbManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
     ownerAccountIssue.addAsset(assetName.getBytes(), OWNER_ASSET_BALANCE);
 
     long id = dbManager.getDynamicPropertiesStore().getTokenIdNum() + 1;
@@ -169,7 +171,8 @@ public class TransferAssetActuatorTest {
     dbManager.getAccountStore().put(ownerCapsule.getAddress().toByteArray(), ownerCapsule);
     dbManager.getAssetIssueStore()
         .put(assetIssueCapsule.createDbKey(), assetIssueCapsule);
-    dbManager.getAccountAssetIssueStore().put(ownerAccountIssue.getAddress().toByteArray(), ownerAccountIssue);
+    dbManager.getAccountAssetIssueStore()
+            .put(ownerAccountIssue.getAddress().toByteArray(), ownerAccountIssue);
 
   }
 
@@ -276,8 +279,11 @@ public class TransferAssetActuatorTest {
             ByteString.copyFrom(ByteArray.fromHexString(OWNER_ADDRESS))
     );
     ownerAccountAssetIssueCapsule.addAsset(ASSET_NAME.getBytes(), OWNER_ASSET_BALANCE);
-    ownerAccountAssetIssueCapsule.addAssetV2(ByteArray.fromString(String.valueOf(id)), OWNER_ASSET_BALANCE);
-    dbManager.getAccountAssetIssueStore().put(ownerAccountAssetIssueCapsule.getAddress().toByteArray(), ownerAccountAssetIssueCapsule);
+    ownerAccountAssetIssueCapsule
+            .addAssetV2(ByteArray.fromString(String.valueOf(id)), OWNER_ASSET_BALANCE);
+    dbManager.getAccountAssetIssueStore()
+            .put(ownerAccountAssetIssueCapsule.getAddress()
+                    .toByteArray(), ownerAccountAssetIssueCapsule);
   }
 
   private void createAssertSameTokenNameActive() {
@@ -307,7 +313,6 @@ public class TransferAssetActuatorTest {
             ByteString.copyFromUtf8("owner"),
             AccountType.AssetIssue);
 
-//    ownerCapsule.addAssetV2(ByteArray.fromString(String.valueOf(id)), OWNER_ASSET_BALANCE);
     dbManager.getAccountStore().put(ownerCapsule.getAddress().toByteArray(), ownerCapsule);
 
     AccountAssetIssueCapsule ownerAccountAssetIssueCapsule =
@@ -316,8 +321,11 @@ public class TransferAssetActuatorTest {
                     ByteString.copyFrom(ByteArray.fromHexString(OWNER_ADDRESS))
                     );
 
-    ownerAccountAssetIssueCapsule.addAssetV2(ByteArray.fromString(String.valueOf(id)), OWNER_ASSET_BALANCE);
-    dbManager.getAccountAssetIssueStore().put(ownerAccountAssetIssueCapsule.getAddress().toByteArray(), ownerAccountAssetIssueCapsule);
+    ownerAccountAssetIssueCapsule
+            .addAssetV2(ByteArray.fromString(String.valueOf(id)), OWNER_ASSET_BALANCE);
+    dbManager.getAccountAssetIssueStore()
+            .put(ownerAccountAssetIssueCapsule.getAddress()
+                    .toByteArray(), ownerAccountAssetIssueCapsule);
 
   }
 
@@ -341,16 +349,20 @@ public class TransferAssetActuatorTest {
               dbManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(TO_ADDRESS));
 
       // check V1
-      Assert.assertEquals(ownerAccountAssetIssue.getInstance().getAssetMap().get(ASSET_NAME).longValue(),
+      Assert.assertEquals(
+              ownerAccountAssetIssue.getInstance().getAssetMap().get(ASSET_NAME).longValue(),
           OWNER_ASSET_BALANCE - 100);
-      Assert.assertEquals(toAccountAssetIssue.getInstance().getAssetMap().get(ASSET_NAME).longValue(), 100L);
+      Assert.assertEquals(toAccountAssetIssue.getInstance()
+              .getAssetMap().get(ASSET_NAME).longValue(), 100L);
       // check V2
       long tokenIdNum = dbManager.getDynamicPropertiesStore().getTokenIdNum();
       Assert.assertEquals(
-              ownerAccountAssetIssue.getInstance().getAssetV2Map().get(String.valueOf(tokenIdNum)).longValue(),
+              ownerAccountAssetIssue.getInstance()
+                      .getAssetV2Map().get(String.valueOf(tokenIdNum)).longValue(),
           OWNER_ASSET_BALANCE - 100);
       Assert.assertEquals(
-              toAccountAssetIssue.getInstance().getAssetV2Map().get(String.valueOf(tokenIdNum)).longValue(),
+              toAccountAssetIssue.getInstance()
+                      .getAssetV2Map().get(String.valueOf(tokenIdNum)).longValue(),
           100L);
 
     } catch (ContractValidateException e) {
@@ -417,15 +429,23 @@ public class TransferAssetActuatorTest {
               dbManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
       AccountAssetIssueCapsule toAccountAssetIssue =
               dbManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(TO_ADDRESS));
-      Assert.assertEquals(ownerAccountAssetIssue.getInstance().getAssetMap().get(ASSET_NAME).longValue(), 0L);
       Assert.assertEquals(
-              toAccountAssetIssue.getInstance().getAssetMap().get(ASSET_NAME).longValue(), OWNER_ASSET_BALANCE);
+              ownerAccountAssetIssue.getInstance().getAssetMap().get(ASSET_NAME).longValue(), 0L);
+      Assert.assertEquals(
+              toAccountAssetIssue
+                      .getInstance()
+                      .getAssetMap()
+                      .get(ASSET_NAME).longValue(), OWNER_ASSET_BALANCE);
       //check V2
       long tokenIdNum = dbManager.getDynamicPropertiesStore().getTokenIdNum();
       Assert.assertEquals(
-              ownerAccountAssetIssue.getInstance().getAssetV2Map().get(String.valueOf(tokenIdNum)).longValue(), 0L);
+              ownerAccountAssetIssue
+                      .getInstance()
+                      .getAssetV2Map()
+                      .get(String.valueOf(tokenIdNum)).longValue(), 0L);
       Assert.assertEquals(
-              toAccountAssetIssue.getInstance().getAssetV2Map().get(String.valueOf(tokenIdNum)).longValue(),
+              toAccountAssetIssue.getInstance()
+                      .getAssetV2Map().get(String.valueOf(tokenIdNum)).longValue(),
           OWNER_ASSET_BALANCE);
     } catch (ContractValidateException e) {
       Assert.assertFalse(e instanceof ContractValidateException);
@@ -451,27 +471,27 @@ public class TransferAssetActuatorTest {
       actuator.validate();
       actuator.execute(ret);
       Assert.assertEquals(ret.getInstance().getRet(), code.SUCESS);
-//      AccountCapsule owner =
-//          dbManager.getAccountStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
-//      AccountCapsule toAccount =
-//          dbManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
-        AccountAssetIssueCapsule ownerAccountAssetIssue =
-                dbManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
-        AccountAssetIssueCapsule toAccountAssetIssue =
-                dbManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(TO_ADDRESS));
+      AccountAssetIssueCapsule ownerAccountAssetIssue =
+              dbManager.getAccountAssetIssueStore()
+                      .get(ByteArray.fromHexString(OWNER_ADDRESS));
+      AccountAssetIssueCapsule toAccountAssetIssue =
+              dbManager.getAccountAssetIssueStore()
+                      .get(ByteArray.fromHexString(TO_ADDRESS));
 
-
-
-        //check V1
-      Assert.assertEquals(ownerAccountAssetIssue.getInstance().getAssetMap().get(ASSET_NAME).longValue(),
+      //check V1
+      Assert.assertEquals(
+              ownerAccountAssetIssue.getInstance()
+                      .getAssetMap().get(ASSET_NAME).longValue(),
           OWNER_ASSET_BALANCE);
       Assert.assertNull(toAccountAssetIssue.getInstance().getAssetMap().get(ASSET_NAME));
       //check V2
       long tokenIdNum = dbManager.getDynamicPropertiesStore().getTokenIdNum();
       Assert.assertEquals(
-              ownerAccountAssetIssue.getInstance().getAssetV2Map().get(String.valueOf(tokenIdNum)).longValue(), 0L);
+              ownerAccountAssetIssue.getInstance()
+                      .getAssetV2Map().get(String.valueOf(tokenIdNum)).longValue(), 0L);
       Assert.assertEquals(
-              toAccountAssetIssue.getInstance().getAssetV2Map().get(String.valueOf(tokenIdNum)).longValue(),
+              toAccountAssetIssue.getInstance()
+                      .getAssetV2Map().get(String.valueOf(tokenIdNum)).longValue(),
           OWNER_ASSET_BALANCE);
     } catch (ContractValidateException e) {
       Assert.assertFalse(e instanceof ContractValidateException);
@@ -522,11 +542,14 @@ public class TransferAssetActuatorTest {
   @Test
   public void SameTokenNameCloseOwnerNoAssetTest() {
     createAssertBeforSameTokenNameActive();
-    AccountCapsule owner = dbManager.getAccountStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
+    AccountCapsule owner = dbManager.getAccountStore()
+            .get(ByteArray.fromHexString(OWNER_ADDRESS));
     dbManager.getAccountStore().put(owner.createDbKey(), owner);
 
-    AccountAssetIssueCapsule ownerAccountAssetIssue = dbManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
-    ownerAccountAssetIssue.setInstance(ownerAccountAssetIssue.getInstance().toBuilder().clearAsset().build());
+    AccountAssetIssueCapsule ownerAccountAssetIssue =
+            dbManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
+    ownerAccountAssetIssue.setInstance(
+            ownerAccountAssetIssue.getInstance().toBuilder().clearAsset().build());
     dbManager.getAccountAssetIssueStore().put(owner.createDbKey(), ownerAccountAssetIssue);
 
     TransferAssetActuator actuator = new TransferAssetActuator();
@@ -556,11 +579,8 @@ public class TransferAssetActuatorTest {
   @Test
   public void SameTokenNameOpenOwnerNoAssetTest() {
     createAssertSameTokenNameActive();
-//    AccountCapsule owner = dbManager.getAccountStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
-//    owner.setInstance(owner.getInstance().toBuilder().clearAssetV2().build());
-//    dbManager.getAccountStore().put(owner.createDbKey(), owner);
-
-    AccountAssetIssueCapsule owner = dbManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
+    AccountAssetIssueCapsule owner =
+            dbManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
     owner.setInstance(owner.getInstance().toBuilder().clearAssetV2().build());
     dbManager.getAccountAssetIssueStore().put(owner.createDbKey(), owner);
 
@@ -696,21 +716,17 @@ public class TransferAssetActuatorTest {
       Assert.assertTrue(e instanceof ContractValidateException);
       Assert.assertTrue("Amount must be greater than 0.".equals(e.getMessage()));
       Assert.assertEquals(ret.getInstance().getRet(), code.SUCESS);
-//      AccountCapsule owner =
-//          dbManager.getAccountStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
-//      AccountCapsule toAccount =
-//          dbManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
-
       AccountAssetIssueCapsule ownerAccountAssetIssue =
               dbManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
       AccountAssetIssueCapsule toAccountAssetIssue =
               dbManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(TO_ADDRESS));
 
-
       long tokenIdNum = dbManager.getDynamicPropertiesStore().getTokenIdNum();
-      Assert.assertEquals(ownerAccountAssetIssue.getAssetMapV2().get(String.valueOf(tokenIdNum)).longValue(),
+      Assert.assertEquals(
+              ownerAccountAssetIssue.getAssetMapV2().get(String.valueOf(tokenIdNum)).longValue(),
           OWNER_ASSET_BALANCE);
-      Assert.assertTrue(isNullOrZero(toAccountAssetIssue.getAssetMapV2().get(String.valueOf(tokenIdNum))));
+      Assert.assertTrue(
+              isNullOrZero(toAccountAssetIssue.getAssetMapV2().get(String.valueOf(tokenIdNum))));
     } catch (ContractExeException e) {
       Assert.assertFalse(e instanceof ContractExeException);
     }
@@ -923,9 +939,12 @@ public class TransferAssetActuatorTest {
   @Test
   public void SameTokenNameCloseAddOverflowTest() {
     createAssertBeforSameTokenNameActive();
-    AccountAssetIssueCapsule toAccountAssetIssue = dbManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(TO_ADDRESS));
+    AccountAssetIssueCapsule toAccountAssetIssue =
+            dbManager.getAccountAssetIssueStore()
+                    .get(ByteArray.fromHexString(TO_ADDRESS));
     toAccountAssetIssue.addAsset(ASSET_NAME.getBytes(), Long.MAX_VALUE);
-    dbManager.getAccountAssetIssueStore().put(ByteArray.fromHexString(TO_ADDRESS), toAccountAssetIssue);
+    dbManager.getAccountAssetIssueStore()
+            .put(ByteArray.fromHexString(TO_ADDRESS), toAccountAssetIssue);
 
     TransferAssetActuator actuator = new TransferAssetActuator();
     actuator.setChainBaseManager(dbManager.getChainBaseManager()).setAny(getContract(1));
@@ -957,14 +976,19 @@ public class TransferAssetActuatorTest {
   public void SameTokenNameOpenAddOverflowTest() {
     createAssertSameTokenNameActive();
     // First, increase the to balance. Else can't complete this test case.
-    AccountCapsule toAccount = dbManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
+    AccountCapsule toAccount =
+            dbManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
     long tokenIdNum = dbManager.getDynamicPropertiesStore().getTokenIdNum();
-    toAccount.addAssetV2(ByteArray.fromString(String.valueOf(tokenIdNum)), Long.MAX_VALUE);
+    toAccount.addAssetV2(
+            ByteArray.fromString(String.valueOf(tokenIdNum)), Long.MAX_VALUE);
     dbManager.getAccountStore().put(ByteArray.fromHexString(TO_ADDRESS), toAccount);
 
-    AccountAssetIssueCapsule toAccountAssetIssue = dbManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(TO_ADDRESS));
-    toAccountAssetIssue.addAssetV2(ByteArray.fromString(String.valueOf(tokenIdNum)), Long.MAX_VALUE);
-    dbManager.getAccountAssetIssueStore().put(ByteArray.fromHexString(TO_ADDRESS), toAccountAssetIssue);
+    AccountAssetIssueCapsule toAccountAssetIssue =
+            dbManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(TO_ADDRESS));
+    toAccountAssetIssue.addAssetV2(
+            ByteArray.fromString(String.valueOf(tokenIdNum)), Long.MAX_VALUE);
+    dbManager.getAccountAssetIssueStore()
+            .put(ByteArray.fromHexString(TO_ADDRESS), toAccountAssetIssue);
 
     TransferAssetActuator actuator = new TransferAssetActuator();
     actuator.setChainBaseManager(dbManager.getChainBaseManager()).setAny(getContract(1));
@@ -980,10 +1004,13 @@ public class TransferAssetActuatorTest {
 
       AccountAssetIssueCapsule ownerAccountAssetIssue =
               dbManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
-      toAccountAssetIssue = dbManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(TO_ADDRESS));
-      Assert.assertEquals(ownerAccountAssetIssue.getAssetMapV2().get(String.valueOf(tokenIdNum)).longValue(),
+      toAccountAssetIssue =
+              dbManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(TO_ADDRESS));
+      Assert.assertEquals(
+              ownerAccountAssetIssue.getAssetMapV2().get(String.valueOf(tokenIdNum)).longValue(),
           OWNER_ASSET_BALANCE);
-      Assert.assertEquals(toAccountAssetIssue.getAssetMapV2().get(String.valueOf(tokenIdNum)).longValue(),
+      Assert.assertEquals(
+              toAccountAssetIssue.getAssetMapV2().get(String.valueOf(tokenIdNum)).longValue(),
           Long.MAX_VALUE);
     } catch (ContractExeException e) {
       Assert.assertFalse(e instanceof ContractExeException);
@@ -1040,11 +1067,6 @@ public class TransferAssetActuatorTest {
     } catch (ContractValidateException e) {
       Assert.assertTrue(e instanceof ContractValidateException);
       Assert.assertEquals("Cannot transfer asset to yourself.", e.getMessage());
-//      AccountCapsule owner = dbManager.getAccountStore()
-//          .get(ByteArray.fromHexString(OWNER_ADDRESS));
-//      AccountCapsule toAccount = dbManager.getAccountStore()
-//          .get(ByteArray.fromHexString(TO_ADDRESS));
-
       AccountAssetIssueCapsule owner = dbManager.getAccountAssetIssueStore()
               .get(ByteArray.fromHexString(OWNER_ADDRESS));
       AccountAssetIssueCapsule toAccount = dbManager.getAccountAssetIssueStore()
@@ -1299,8 +1321,10 @@ public class TransferAssetActuatorTest {
           OWNER_ASSET_BALANCE);
       Assert.assertTrue(isNullOrZero(toAccount.getAssetMapV2().get(String.valueOf(tokenIdNum))));
       AccountAssetIssueCapsule ownerAsset =
-              dbManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(ownerAsset_ADDRESS));
-      Assert.assertEquals(ownerAsset.getAssetMapV2().get(String.valueOf(tokenIdNum)).longValue(),
+              dbManager
+                      .getAccountAssetIssueStore().get(ByteArray.fromHexString(ownerAsset_ADDRESS));
+      Assert.assertEquals(
+              ownerAsset.getAssetMapV2().get(String.valueOf(tokenIdNum)).longValue(),
           OWNER_ASSET_Test_BALANCE);
     } catch (ContractExeException e) {
       Assert.assertFalse(e instanceof ContractExeException);
@@ -1391,18 +1415,16 @@ public class TransferAssetActuatorTest {
     try {
       actuator.validate();
       actuator.execute(ret);
-//      AccountCapsule owner =
-//          dbManager.getAccountStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
-//      AccountCapsule toAccount =
-//          dbManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
-
       AccountAssetIssueCapsule ownerAccountAssetIssue =
               dbManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
       AccountAssetIssueCapsule toAccountAssetIssue =
               dbManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(TO_ADDRESS));
-      Assert.assertEquals(ownerAccountAssetIssue.getInstance().getAssetMap().get(assetName).longValue(),
+      Assert.assertEquals(
+              ownerAccountAssetIssue.getInstance().getAssetMap().get(assetName).longValue(),
           OWNER_ASSET_BALANCE - 100);
-      Assert.assertEquals(toAccountAssetIssue.getInstance().getAssetMap().get(assetName).longValue(), 100L);
+      Assert.assertEquals(
+              toAccountAssetIssue.getInstance()
+                      .getAssetMap().get(assetName).longValue(), 100L);
     } catch (ContractValidateException e) {
       Assert.assertFalse(e instanceof ContractValidateException);
     } catch (ContractExeException e) {
@@ -1419,19 +1441,16 @@ public class TransferAssetActuatorTest {
     try {
       actuator.validate();
       actuator.execute(ret);
-//      AccountCapsule owner =
-//          dbManager.getAccountStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
-//      AccountCapsule toAccount =
-//          dbManager.getAccountStore().get(ByteArray.fromHexString(TO_ADDRESS));
-
       AccountAssetIssueCapsule ownerAccountAssetIssue =
               dbManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
       AccountAssetIssueCapsule toAccountAssetIssue =
               dbManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(TO_ADDRESS));
 
-      Assert.assertEquals(ownerAccountAssetIssue.getInstance().getAssetMap().get(assetName).longValue(),
+      Assert.assertEquals(
+              ownerAccountAssetIssue.getInstance().getAssetMap().get(assetName).longValue(),
           OWNER_ASSET_BALANCE - 100);
-      Assert.assertEquals(toAccountAssetIssue.getInstance().getAssetMap().get(assetName).longValue(), 100L);
+      Assert.assertEquals(
+              toAccountAssetIssue.getInstance().getAssetMap().get(assetName).longValue(), 100L);
     } catch (ContractValidateException e) {
       Assert.assertFalse(e instanceof ContractValidateException);
     } catch (ContractExeException e) {
@@ -1516,10 +1535,12 @@ public class TransferAssetActuatorTest {
       // check V2
       long tokenIdNum = dbManager.getDynamicPropertiesStore().getTokenIdNum();
       Assert.assertEquals(
-              ownerAssetIssue.getInstance().getAssetV2Map().get(String.valueOf(tokenIdNum)).longValue(),
+              ownerAssetIssue.getInstance()
+                      .getAssetV2Map().get(String.valueOf(tokenIdNum)).longValue(),
           OWNER_ASSET_BALANCE - 100);
       Assert.assertEquals(
-              toAccountAssetIssue.getInstance().getAssetV2Map().get(String.valueOf(tokenIdNum)).longValue(),
+              toAccountAssetIssue.getInstance()
+                      .getAssetV2Map().get(String.valueOf(tokenIdNum)).longValue(),
           100L);
     } catch (ContractValidateException e) {
       Assert.assertTrue(e.getMessage().contains("Cannot transfer"));

--- a/framework/src/test/java/org/tron/core/actuator/UnfreezeAssetActuatorTest.java
+++ b/framework/src/test/java/org/tron/core/actuator/UnfreezeAssetActuatorTest.java
@@ -26,8 +26,8 @@ import org.tron.core.exception.ContractExeException;
 import org.tron.core.exception.ContractValidateException;
 import org.tron.protos.Protocol.Account;
 import org.tron.protos.Protocol.Account.Frozen;
-import org.tron.protos.Protocol.AccountType;
 import org.tron.protos.Protocol.AccountAssetIssue;
+import org.tron.protos.Protocol.AccountType;
 import org.tron.protos.Protocol.Transaction.Result.code;
 import org.tron.protos.contract.AssetIssueContractOuterClass;
 import org.tron.protos.contract.AssetIssueContractOuterClass.AssetIssueContract;
@@ -115,12 +115,13 @@ public class UnfreezeAssetActuatorTest {
             initBalance);
     dbManager.getAccountStore().put(ownerCapsule.createDbKey(), ownerCapsule);
 
-    AccountAssetIssueCapsule ownerAccountAssetIssueCapsule = new AccountAssetIssueCapsule(
+    AccountAssetIssueCapsule ownerAssetIssue = new AccountAssetIssueCapsule(
             StringUtil.hexString2ByteString(OWNER_ADDRESS)
     );
-    ownerAccountAssetIssueCapsule.setAssetIssuedName(assetName.getBytes());
-    ownerAccountAssetIssueCapsule.setAssetIssuedID(assetIssueCapsule.createDbV2Key());
-    dbManager.getAccountAssetIssueStore().put(ownerAccountAssetIssueCapsule.createDbKey(), ownerAccountAssetIssueCapsule);
+    ownerAssetIssue.setAssetIssuedName(assetName.getBytes());
+    ownerAssetIssue.setAssetIssuedID(assetIssueCapsule.createDbV2Key());
+    dbManager.getAccountAssetIssueStore()
+            .put(ownerAssetIssue.createDbKey(), ownerAssetIssue);
   }
 
   private void createAssertSameTokenNameActive() {
@@ -131,7 +132,8 @@ public class UnfreezeAssetActuatorTest {
     builder.setName(ByteString.copyFromUtf8(assetName));
     builder.setId(String.valueOf(tokenId));
     AssetIssueCapsule assetIssueCapsule = new AssetIssueCapsule(builder.build());
-    dbManager.getAssetIssueV2Store().put(assetIssueCapsule.createDbV2Key(), assetIssueCapsule);
+    dbManager.getAssetIssueV2Store()
+            .put(assetIssueCapsule.createDbV2Key(), assetIssueCapsule);
 
     AccountCapsule ownerCapsule =
         new AccountCapsule(
@@ -141,14 +143,15 @@ public class UnfreezeAssetActuatorTest {
             initBalance);
     dbManager.getAccountStore().put(ownerCapsule.createDbKey(), ownerCapsule);
 
-    AccountAssetIssueCapsule ownerAccountAssetIssueCapsule = new AccountAssetIssueCapsule(
+    AccountAssetIssueCapsule ownerAssetIssue = new AccountAssetIssueCapsule(
             ByteString.copyFromUtf8("owner"),
             StringUtil.hexString2ByteString(OWNER_ADDRESS)
     );
 
-    ownerAccountAssetIssueCapsule.setAssetIssuedName(assetName.getBytes());
-    ownerAccountAssetIssueCapsule.setAssetIssuedID(assetIssueCapsule.createDbV2Key());
-    dbManager.getAccountAssetIssueStore().put(ownerAccountAssetIssueCapsule.createDbKey(), ownerAccountAssetIssueCapsule);
+    ownerAssetIssue.setAssetIssuedName(assetName.getBytes());
+    ownerAssetIssue.setAssetIssuedID(assetIssueCapsule.createDbV2Key());
+    dbManager.getAccountAssetIssueStore()
+            .put(ownerAssetIssue.createDbKey(), ownerAssetIssue);
   }
 
   /**
@@ -171,7 +174,8 @@ public class UnfreezeAssetActuatorTest {
         .setFrozenBalance(frozenBalance + 1)
         .setExpireTime(now + 600000)
         .build();
-    account = account.toBuilder().addFrozenSupply(newFrozen0).addFrozenSupply(newFrozen1).build();
+    account = account.toBuilder()
+            .addFrozenSupply(newFrozen0).addFrozenSupply(newFrozen1).build();
     AccountCapsule accountCapsule = new AccountCapsule(account);
     dbManager.getAccountStore().put(accountCapsule.createDbKey(), accountCapsule);
     UnfreezeAssetActuator actuator = new UnfreezeAssetActuator();
@@ -185,11 +189,16 @@ public class UnfreezeAssetActuatorTest {
       Assert.assertEquals(ret.getInstance().getRet(), code.SUCESS);
       AccountCapsule owner = dbManager.getAccountStore()
           .get(ByteArray.fromHexString(OWNER_ADDRESS));
-      AccountAssetIssueCapsule ownerAssetIssueCapsule = dbManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
+      AccountAssetIssueCapsule ownerAssetIssueCapsule =
+              dbManager.getAccountAssetIssueStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
       //V1
-      Assert.assertEquals(ownerAssetIssueCapsule.getAssetMap().get(assetName).longValue(), frozenBalance);
+      Assert.assertEquals(
+              ownerAssetIssueCapsule.getAssetMap()
+                      .get(assetName).longValue(), frozenBalance);
       //V2
-      Assert.assertEquals(ownerAssetIssueCapsule.getAssetMapV2().get(String.valueOf(tokenId)).longValue(),
+      Assert.assertEquals(
+              ownerAssetIssueCapsule.getAssetMapV2()
+                      .get(String.valueOf(tokenId)).longValue(),
           frozenBalance);
       Assert.assertEquals(owner.getFrozenSupplyCount(), 1);
     } catch (ContractValidateException e) {
@@ -238,7 +247,8 @@ public class UnfreezeAssetActuatorTest {
       //V1 assert not exist
       Assert.assertNull(ownerAccountAssetIssue.getAssetMap().get(assetName));
       //V2
-      Assert.assertEquals(ownerAccountAssetIssue.getAssetMapV2().get(String.valueOf(tokenId)).longValue(),
+      Assert.assertEquals(
+              ownerAccountAssetIssue.getAssetMapV2().get(String.valueOf(tokenId)).longValue(),
           frozenBalance);
       Assert.assertEquals(owner.getFrozenSupplyCount(), 1);
     } catch (ContractValidateException e) {
@@ -285,12 +295,12 @@ public class UnfreezeAssetActuatorTest {
       AccountCapsule owner = dbManager.getAccountStore()
           .get(ByteArray.fromHexString(OWNER_ADDRESS));
 
-      AccountAssetIssueCapsule ownerAccountAssetIssueCapsule = dbManager.getAccountAssetIssueStore()
+      AccountAssetIssueCapsule ownerAssetIssue = dbManager.getAccountAssetIssueStore()
               .get(ByteArray.fromHexString(OWNER_ADDRESS));
       //V1 assert not exist
-      Assert.assertNull(ownerAccountAssetIssueCapsule.getAssetMap().get(assetName));
+      Assert.assertNull(ownerAssetIssue.getAssetMap().get(assetName));
       //V2
-      Assert.assertEquals(ownerAccountAssetIssueCapsule.getAssetMapV2().get(String.valueOf(tokenId)).longValue(),
+      Assert.assertEquals(ownerAssetIssue.getAssetMapV2().get(String.valueOf(tokenId)).longValue(),
           frozenBalance);
       Assert.assertEquals(owner.getFrozenSupplyCount(), 1);
     } catch (ContractValidateException e) {
@@ -360,10 +370,13 @@ public class UnfreezeAssetActuatorTest {
 
     AccountAssetIssue accountAssetIssue = dbManager.getAccountAssetIssueStore()
             .get(ByteArray.fromHexString(OWNER_ADDRESS)).getInstance();
-    accountAssetIssue = accountAssetIssue.toBuilder().setAssetIssuedName(ByteString.EMPTY)
+    accountAssetIssue =
+            accountAssetIssue.toBuilder().setAssetIssuedName(ByteString.EMPTY)
             .build();
-    AccountAssetIssueCapsule accountAssetIssueCapsule = new AccountAssetIssueCapsule(accountAssetIssue);
-    dbManager.getAccountAssetIssueStore().put(accountAssetIssueCapsule.createDbKey(), accountAssetIssueCapsule);
+    AccountAssetIssueCapsule accountAssetIssueCapsule =
+            new AccountAssetIssueCapsule(accountAssetIssue);
+    dbManager.getAccountAssetIssueStore()
+            .put(accountAssetIssueCapsule.createDbKey(), accountAssetIssueCapsule);
 
     UnfreezeAssetActuator actuator = new UnfreezeAssetActuator();
     actuator.setChainBaseManager(dbManager.getChainBaseManager())

--- a/framework/src/test/java/org/tron/core/actuator/UpdateAssetActuatorTest.java
+++ b/framework/src/test/java/org/tron/core/actuator/UpdateAssetActuatorTest.java
@@ -102,7 +102,8 @@ public class UpdateAssetActuatorTest {
             );
 
     dbManager.getAccountStore().put(ByteArray.fromHexString(SECOND_ACCOUNT_ADDRESS), secondAccount);
-    dbManager.getAccountAssetIssueStore().put(ByteArray.fromHexString(SECOND_ACCOUNT_ADDRESS), secondAccountAssetIssue);
+    dbManager.getAccountAssetIssueStore()
+            .put(ByteArray.fromHexString(SECOND_ACCOUNT_ADDRESS), secondAccountAssetIssue);
 
     // address does not exist in accountStore
     dbManager.getAccountStore().delete(ByteArray.fromHexString(OWNER_ADDRESS_NOTEXIST));
@@ -194,7 +195,8 @@ public class UpdateAssetActuatorTest {
     accountAssetIssueCapsule.setAssetIssuedID(assetIssueCapsule.getId().getBytes());
     accountAssetIssueCapsule.addAssetV2(assetIssueCapsule.createDbV2Key(), TOTAL_SUPPLY);
     dbManager.getAccountStore().put(ByteArray.fromHexString(OWNER_ADDRESS), accountCapsule);
-    dbManager.getAccountAssetIssueStore().put(ByteArray.fromHexString(OWNER_ADDRESS), accountAssetIssueCapsule);
+    dbManager.getAccountAssetIssueStore()
+            .put(ByteArray.fromHexString(OWNER_ADDRESS), accountAssetIssueCapsule);
   }
 
   @Test

--- a/framework/src/test/java/org/tron/core/db/AccountAssetIssueStoreTest.java
+++ b/framework/src/test/java/org/tron/core/db/AccountAssetIssueStoreTest.java
@@ -1,6 +1,7 @@
 package org.tron.core.db;
 
 import com.google.protobuf.ByteString;
+import java.io.File;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -14,60 +15,59 @@ import org.tron.core.config.DefaultConfig;
 import org.tron.core.config.args.Args;
 import org.tron.core.store.AccountAssetIssueStore;
 
-
-import java.io.File;
-
 public class AccountAssetIssueStoreTest {
 
-    private static final byte[] data = TransactionStoreTest.randomBytes(32);
-    private static String dbPath = "output_AccountAssetIssueStore_test";
-    private static String dbDirectory = "db_AccountAssetIssueStore_test";
-    private static String indexDirectory = "index_AccountAssetIssueStore_test";
-    private static TronApplicationContext context;
-    private static AccountAssetIssueStore accountAssetIssueStore;
-    private static byte[] address = TransactionStoreTest.randomBytes(32);
-    private static byte[] accounAssetIssuetName = TransactionStoreTest.randomBytes(32);
+  private static final byte[] data = TransactionStoreTest.randomBytes(32);
+  private static String dbPath = "output_AccountAssetIssueStore_test";
+  private static String dbDirectory = "db_AccountAssetIssueStore_test";
+  private static String indexDirectory = "index_AccountAssetIssueStore_test";
+  private static TronApplicationContext context;
+  private static AccountAssetIssueStore accountAssetIssueStore;
+  private static byte[] address = TransactionStoreTest.randomBytes(32);
+  private static byte[] accounAssetIssuetName = TransactionStoreTest.randomBytes(32);
 
-    static {
-        Args.setParam(
-                new String[]{
-                        "--output-directory", dbPath,
-                        "--storage-db-directory", dbDirectory,
-                        "--storage-index-directory", indexDirectory
-                },
-                Constant.TEST_CONF
-        );
-        context = new TronApplicationContext(DefaultConfig.class);
-    }
+  static {
+    Args.setParam(
+        new String[]{
+            "--output-directory", dbPath,
+            "--storage-db-directory", dbDirectory,
+            "--storage-index-directory", indexDirectory
+        },
+          Constant.TEST_CONF
+    );
+    context = new TronApplicationContext(DefaultConfig.class);
+  }
 
-    @BeforeClass
-    public static void init() {
-        accountAssetIssueStore = context.getBean(AccountAssetIssueStore.class);
-        AccountAssetIssueCapsule accountCapsule = new AccountAssetIssueCapsule(
-                        ByteString.copyFrom(accounAssetIssuetName),
-                        ByteString.copyFrom(address)
-                );
-        accountAssetIssueStore.put(data, accountCapsule);
-    }
+  @BeforeClass
+  public static void init() {
+    accountAssetIssueStore = context.getBean(AccountAssetIssueStore.class);
+    AccountAssetIssueCapsule accountCapsule = new AccountAssetIssueCapsule(
+                    ByteString.copyFrom(accounAssetIssuetName),
+                    ByteString.copyFrom(address)
+            );
+    accountAssetIssueStore.put(data, accountCapsule);
+  }
 
-    @AfterClass
-    public static void destroy() {
-        Args.clearParam();
-        context.destroy();
-        FileUtil.deleteDir(new File(dbPath));
-    }
+  @AfterClass
+  public static void destroy() {
+    Args.clearParam();
+    context.destroy();
+    FileUtil.deleteDir(new File(dbPath));
+  }
 
-    @Test
-    public void get() {
-        //test get and has Method
-        Assert
-                .assertEquals(ByteArray.toHexString(address), ByteArray
-                        .toHexString(accountAssetIssueStore.get(data).getInstance().getAddress().toByteArray()))
-        ;
-        Assert
-                .assertEquals(ByteArray.toHexString(accounAssetIssuetName), ByteArray
-                        .toHexString(accountAssetIssueStore.get(data).getInstance().getAssetIssuedName().toByteArray()))
-        ;
-        Assert.assertTrue(accountAssetIssueStore.has(data));
-    }
+  @Test
+  public void get() {
+    //test get and has Method
+    Assert
+            .assertEquals(ByteArray.toHexString(address), ByteArray
+                    .toHexString(accountAssetIssueStore.get(data)
+                            .getInstance().getAddress().toByteArray()))
+    ;
+    Assert
+            .assertEquals(ByteArray.toHexString(accounAssetIssuetName), ByteArray
+                    .toHexString(accountAssetIssueStore.get(data)
+                            .getInstance().getAssetIssuedName().toByteArray()))
+    ;
+    Assert.assertTrue(accountAssetIssueStore.has(data));
+  }
 }

--- a/framework/src/test/java/org/tron/core/db/AccountAssetIssueStoreTest.java
+++ b/framework/src/test/java/org/tron/core/db/AccountAssetIssueStoreTest.java
@@ -1,0 +1,73 @@
+package org.tron.core.db;
+
+import com.google.protobuf.ByteString;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.tron.common.application.TronApplicationContext;
+import org.tron.common.utils.ByteArray;
+import org.tron.common.utils.FileUtil;
+import org.tron.core.Constant;
+import org.tron.core.capsule.AccountAssetIssueCapsule;
+import org.tron.core.config.DefaultConfig;
+import org.tron.core.config.args.Args;
+import org.tron.core.store.AccountAssetIssueStore;
+
+
+import java.io.File;
+
+public class AccountAssetIssueStoreTest {
+
+    private static final byte[] data = TransactionStoreTest.randomBytes(32);
+    private static String dbPath = "output_AccountAssetIssueStore_test";
+    private static String dbDirectory = "db_AccountAssetIssueStore_test";
+    private static String indexDirectory = "index_AccountAssetIssueStore_test";
+    private static TronApplicationContext context;
+    private static AccountAssetIssueStore accountAssetIssueStore;
+    private static byte[] address = TransactionStoreTest.randomBytes(32);
+    private static byte[] accounAssetIssuetName = TransactionStoreTest.randomBytes(32);
+
+    static {
+        Args.setParam(
+                new String[]{
+                        "--output-directory", dbPath,
+                        "--storage-db-directory", dbDirectory,
+                        "--storage-index-directory", indexDirectory
+                },
+                Constant.TEST_CONF
+        );
+        context = new TronApplicationContext(DefaultConfig.class);
+    }
+
+    @BeforeClass
+    public static void init() {
+        accountAssetIssueStore = context.getBean(AccountAssetIssueStore.class);
+        AccountAssetIssueCapsule accountCapsule = new AccountAssetIssueCapsule(
+                        ByteString.copyFrom(accounAssetIssuetName),
+                        ByteString.copyFrom(address)
+                );
+        accountAssetIssueStore.put(data, accountCapsule);
+    }
+
+    @AfterClass
+    public static void destroy() {
+        Args.clearParam();
+        context.destroy();
+        FileUtil.deleteDir(new File(dbPath));
+    }
+
+    @Test
+    public void get() {
+        //test get and has Method
+        Assert
+                .assertEquals(ByteArray.toHexString(address), ByteArray
+                        .toHexString(accountAssetIssueStore.get(data).getInstance().getAddress().toByteArray()))
+        ;
+        Assert
+                .assertEquals(ByteArray.toHexString(accounAssetIssuetName), ByteArray
+                        .toHexString(accountAssetIssueStore.get(data).getInstance().getAssetIssuedName().toByteArray()))
+        ;
+        Assert.assertTrue(accountAssetIssueStore.has(data));
+    }
+}

--- a/framework/src/test/java/org/tron/core/db/api/AssetUpdateHelperTest.java
+++ b/framework/src/test/java/org/tron/core/db/api/AssetUpdateHelperTest.java
@@ -29,133 +29,139 @@ import org.tron.protos.contract.AssetIssueContractOuterClass.AssetIssueContract;
 
 public class AssetUpdateHelperTest {
 
-    private static ChainBaseManager chainBaseManager;
-    private static TronApplicationContext context;
-    private static String dbPath = "output_AssetUpdateHelperTest_test";
-    private static Application AppT;
+  private static ChainBaseManager chainBaseManager;
+  private static TronApplicationContext context;
+  private static String dbPath = "output_AssetUpdateHelperTest_test";
+  private static Application AppT;
 
-    private static ByteString assetName = ByteString.copyFrom("assetIssueName".getBytes());
+  private static ByteString assetName = ByteString.copyFrom("assetIssueName".getBytes());
 
-    static {
-        Args.setParam(new String[]{"-d", dbPath, "-w"}, "config-test-index.conf");
-        Args.getInstance().setSolidityNode(true);
-        context = new TronApplicationContext(DefaultConfig.class);
-        AppT = ApplicationFactory.create(context);
+  static {
+    Args.setParam(new String[]{"-d", dbPath, "-w"}, "config-test-index.conf");
+    Args.getInstance().setSolidityNode(true);
+    context = new TronApplicationContext(DefaultConfig.class);
+    AppT = ApplicationFactory.create(context);
+  }
+
+  @BeforeClass
+  public static void init() {
+
+    chainBaseManager = context.getBean(ChainBaseManager.class);
+
+    AssetIssueContract contract =
+            AssetIssueContract.newBuilder().setName(assetName)
+                    .setNum(12581).setPrecision(5).build();
+    AssetIssueCapsule assetIssueCapsule = new AssetIssueCapsule(contract);
+    chainBaseManager.getAssetIssueStore()
+            .put(assetIssueCapsule.createDbKey(), assetIssueCapsule);
+
+    BlockCapsule blockCapsule = new BlockCapsule(1,
+            Sha256Hash.wrap(ByteString.copyFrom(
+                    ByteArray.fromHexString(
+                            "0000000000000002498b464ac0292229938a342238077182498b464ac0292222"))),
+            1234, ByteString.copyFrom("1234567".getBytes()));
+
+    blockCapsule.addTransaction(
+            new TransactionCapsule(contract, ContractType.AssetIssueContract));
+    chainBaseManager.getDynamicPropertiesStore().saveLatestBlockHeaderNumber(1L);
+    chainBaseManager.getBlockIndexStore().put(blockCapsule.getBlockId());
+    chainBaseManager.getBlockStore().put(blockCapsule.getBlockId().getBytes(), blockCapsule);
+
+    ExchangeCapsule exchangeCapsule =
+            new ExchangeCapsule(
+                    Exchange.newBuilder()
+                            .setExchangeId(1L)
+                            .setFirstTokenId(assetName)
+                            .setSecondTokenId(ByteString.copyFrom(TRX_SYMBOL_BYTES))
+                            .build());
+    chainBaseManager.getExchangeStore().put(exchangeCapsule.createDbKey(), exchangeCapsule);
+
+    AccountCapsule accountCapsule =
+            new AccountCapsule(
+                    Account.newBuilder()
+                            .setAssetIssuedName(assetName)
+                            .putAsset("assetIssueName", 100)
+                            .putFreeAssetNetUsage("assetIssueName", 20000)
+                            .putLatestAssetOperationTime("assetIssueName", 30000000)
+                            .setAddress(ByteString.copyFrom(ByteArray.fromHexString("121212abc")))
+                            .build());
+    chainBaseManager.getAccountStore().put(ByteArray.fromHexString("121212abc"),
+            accountCapsule);
+  }
+
+  @AfterClass
+  public static void removeDb() {
+    Args.clearParam();
+    context.destroy();
+    FileUtil.deleteDir(new File(dbPath));
+  }
+
+  @Test
+  public void test() {
+
+    if (chainBaseManager == null) {
+      init();
+    }
+    AssetUpdateHelper assetUpdateHelper = new AssetUpdateHelper(chainBaseManager);
+    assetUpdateHelper.init();
+    {
+      assetUpdateHelper.updateAsset();
+
+      String idNum = "1000001";
+
+      AssetIssueCapsule assetIssueCapsule =
+              chainBaseManager.getAssetIssueStore().get(assetName.toByteArray());
+      Assert.assertEquals(idNum, assetIssueCapsule.getId());
+      Assert.assertEquals(5L, assetIssueCapsule.getPrecision());
+
+      AssetIssueCapsule assetIssueCapsule2 =
+              chainBaseManager.getAssetIssueV2Store()
+                      .get(ByteArray.fromString(String.valueOf(idNum)));
+
+      Assert.assertEquals(idNum, assetIssueCapsule2.getId());
+      Assert.assertEquals(assetName, assetIssueCapsule2.getName());
+      Assert.assertEquals(0L, assetIssueCapsule2.getPrecision());
     }
 
-    @BeforeClass
-    public static void init() {
+    {
+      assetUpdateHelper.updateExchange();
 
-        chainBaseManager = context.getBean(ChainBaseManager.class);
-
-        AssetIssueContract contract =
-                AssetIssueContract.newBuilder().setName(assetName).setNum(12581).setPrecision(5).build();
-        AssetIssueCapsule assetIssueCapsule = new AssetIssueCapsule(contract);
-        chainBaseManager.getAssetIssueStore().put(assetIssueCapsule.createDbKey(), assetIssueCapsule);
-
-        BlockCapsule blockCapsule = new BlockCapsule(1,
-                Sha256Hash.wrap(ByteString.copyFrom(
-                        ByteArray.fromHexString(
-                                "0000000000000002498b464ac0292229938a342238077182498b464ac0292222"))),
-                1234, ByteString.copyFrom("1234567".getBytes()));
-
-        blockCapsule.addTransaction(new TransactionCapsule(contract, ContractType.AssetIssueContract));
-        chainBaseManager.getDynamicPropertiesStore().saveLatestBlockHeaderNumber(1L);
-        chainBaseManager.getBlockIndexStore().put(blockCapsule.getBlockId());
-        chainBaseManager.getBlockStore().put(blockCapsule.getBlockId().getBytes(), blockCapsule);
-
+      try {
         ExchangeCapsule exchangeCapsule =
-                new ExchangeCapsule(
-                        Exchange.newBuilder()
-                                .setExchangeId(1L)
-                                .setFirstTokenId(assetName)
-                                .setSecondTokenId(ByteString.copyFrom(TRX_SYMBOL_BYTES))
-                                .build());
-        chainBaseManager.getExchangeStore().put(exchangeCapsule.createDbKey(), exchangeCapsule);
-
-        AccountCapsule accountCapsule =
-                new AccountCapsule(
-                        Account.newBuilder()
-                                .setAssetIssuedName(assetName)
-                                .putAsset("assetIssueName", 100)
-                                .putFreeAssetNetUsage("assetIssueName", 20000)
-                                .putLatestAssetOperationTime("assetIssueName", 30000000)
-                                .setAddress(ByteString.copyFrom(ByteArray.fromHexString("121212abc")))
-                                .build());
-        chainBaseManager.getAccountStore().put(ByteArray.fromHexString("121212abc"),
-                accountCapsule);
+                chainBaseManager.getExchangeV2Store().get(ByteArray.fromLong(1L));
+        Assert.assertEquals("1000001", ByteArray.toStr(exchangeCapsule.getFirstTokenId()));
+        Assert.assertEquals("_", ByteArray.toStr(exchangeCapsule.getSecondTokenId()));
+      } catch (Exception ex) {
+        throw new RuntimeException("testUpdateExchange error");
+      }
     }
 
-    @AfterClass
-    public static void removeDb() {
-        Args.clearParam();
-        context.destroy();
-        FileUtil.deleteDir(new File(dbPath));
+    {
+      assetUpdateHelper.updateAccountAssetIssue();
+
+      AccountCapsule accountCapsule =
+              chainBaseManager.getAccountStore().get(ByteArray.fromHexString("121212abc"));
+
+      Assert.assertEquals(
+              ByteString.copyFrom(ByteArray.fromString("1000001")),
+              accountCapsule.getAssetIssuedID());
+
+      Assert.assertEquals(1, accountCapsule.getAssetMapV2().size());
+
+      Assert.assertEquals(100L, accountCapsule.getAssetMapV2().get("1000001").longValue());
+
+      Assert.assertEquals(1, accountCapsule.getAllFreeAssetNetUsageV2().size());
+
+      Assert.assertEquals(
+              20000L, accountCapsule.getAllFreeAssetNetUsageV2().get("1000001").longValue());
+
+      Assert.assertEquals(1, accountCapsule.getLatestAssetOperationTimeMapV2().size());
+
+      Assert.assertEquals(
+              30000000L,
+              accountCapsule.getLatestAssetOperationTimeMapV2().get("1000001").longValue());
     }
 
-    @Test
-    public void test() {
-
-        if (chainBaseManager == null) {
-            init();
-        }
-        AssetUpdateHelper assetUpdateHelper = new AssetUpdateHelper(chainBaseManager);
-        assetUpdateHelper.init();
-        {
-            assetUpdateHelper.updateAsset();
-
-            String idNum = "1000001";
-
-            AssetIssueCapsule assetIssueCapsule =
-                    chainBaseManager.getAssetIssueStore().get(assetName.toByteArray());
-            Assert.assertEquals(idNum, assetIssueCapsule.getId());
-            Assert.assertEquals(5L, assetIssueCapsule.getPrecision());
-
-            AssetIssueCapsule assetIssueCapsule2 =
-                    chainBaseManager.getAssetIssueV2Store().get(ByteArray.fromString(String.valueOf(idNum)));
-
-            Assert.assertEquals(idNum, assetIssueCapsule2.getId());
-            Assert.assertEquals(assetName, assetIssueCapsule2.getName());
-            Assert.assertEquals(0L, assetIssueCapsule2.getPrecision());
-        }
-
-        {
-            assetUpdateHelper.updateExchange();
-
-            try {
-                ExchangeCapsule exchangeCapsule =
-                        chainBaseManager.getExchangeV2Store().get(ByteArray.fromLong(1L));
-                Assert.assertEquals("1000001", ByteArray.toStr(exchangeCapsule.getFirstTokenId()));
-                Assert.assertEquals("_", ByteArray.toStr(exchangeCapsule.getSecondTokenId()));
-            } catch (Exception ex) {
-                throw new RuntimeException("testUpdateExchange error");
-            }
-        }
-
-        {
-            assetUpdateHelper.updateAccountAssetIssue();
-
-            AccountCapsule accountCapsule =
-                    chainBaseManager.getAccountStore().get(ByteArray.fromHexString("121212abc"));
-
-            Assert.assertEquals(
-                    ByteString.copyFrom(ByteArray.fromString("1000001")), accountCapsule.getAssetIssuedID());
-
-            Assert.assertEquals(1, accountCapsule.getAssetMapV2().size());
-
-            Assert.assertEquals(100L, accountCapsule.getAssetMapV2().get("1000001").longValue());
-
-            Assert.assertEquals(1, accountCapsule.getAllFreeAssetNetUsageV2().size());
-
-            Assert.assertEquals(
-                    20000L, accountCapsule.getAllFreeAssetNetUsageV2().get("1000001").longValue());
-
-            Assert.assertEquals(1, accountCapsule.getLatestAssetOperationTimeMapV2().size());
-
-            Assert.assertEquals(
-                    30000000L, accountCapsule.getLatestAssetOperationTimeMapV2().get("1000001").longValue());
-        }
-
-        removeDb();
-    }
+    removeDb();
+  }
 }

--- a/framework/src/test/java/org/tron/core/services/WitnessProductBlockServiceTest.java
+++ b/framework/src/test/java/org/tron/core/services/WitnessProductBlockServiceTest.java
@@ -85,8 +85,6 @@ public class WitnessProductBlockServiceTest {
     Assert.assertEquals(blockCapsule2.getNum(), block.getLatestBlockNum());
 
     Assert.assertEquals(block.getBlockCapsuleSet().contains(blockCapsule2), true);
-//    Assert.assertEquals(block.getBlockCapsuleSet().contains(blockCapsule1), true);
-
-
+    //    Assert.assertEquals(block.getBlockCapsuleSet().contains(blockCapsule1), true);
   }
 }

--- a/framework/src/test/java/org/tron/core/zksnark/ShieldedReceiveTest.java
+++ b/framework/src/test/java/org/tron/core/zksnark/ShieldedReceiveTest.java
@@ -41,6 +41,7 @@ import org.tron.core.ChainBaseManager;
 import org.tron.core.Wallet;
 import org.tron.core.actuator.Actuator;
 import org.tron.core.actuator.ActuatorCreator;
+import org.tron.core.capsule.AccountAssetIssueCapsule;
 import org.tron.core.capsule.AccountCapsule;
 import org.tron.core.capsule.AssetIssueCapsule;
 import org.tron.core.capsule.BlockCapsule;
@@ -51,7 +52,6 @@ import org.tron.core.capsule.ReceiveDescriptionCapsule;
 import org.tron.core.capsule.SpendDescriptionCapsule;
 import org.tron.core.capsule.TransactionCapsule;
 import org.tron.core.capsule.TransactionResultCapsule;
-import org.tron.core.capsule.AccountAssetIssueCapsule;
 import org.tron.core.capsule.WitnessCapsule;
 import org.tron.core.config.DefaultConfig;
 import org.tron.core.config.args.Args;
@@ -108,2489 +108,2490 @@ import org.tron.protos.contract.ShieldContract.SpendDescription;
 @Slf4j
 public class ShieldedReceiveTest extends BlockGenerate {
 
-    private static final String dbPath = "receive_description_test";
-    private static final String FROM_ADDRESS;
-    private static final String ADDRESS_ONE_PRIVATE_KEY;
-    private static final long OWNER_BALANCE = 100_000_000;
-    private static final long FROM_AMOUNT = 110_000_000;
-    private static final long tokenId = 1;
-    private static final String ASSET_NAME = "trx";
-    private static final int TRX_NUM = 10;
-    private static final int NUM = 1;
-    private static final long START_TIME = 1;
-    private static final long END_TIME = 2;
-    private static final int VOTE_SCORE = 2;
-    private static final String DESCRIPTION = "TRX";
-    private static final String URL = "https://tron.network";
-    private static Manager dbManager;
-    private static ChainBaseManager chainBaseManager;
-    private static ConsensusService consensusService;
-    private static TronApplicationContext context;
-    private static Wallet wallet;
-    private static TransactionUtil transactionUtil;
+  private static final String dbPath = "receive_description_test";
+  private static final String FROM_ADDRESS;
+  private static final String ADDRESS_ONE_PRIVATE_KEY;
+  private static final long OWNER_BALANCE = 100_000_000;
+  private static final long FROM_AMOUNT = 110_000_000;
+  private static final long tokenId = 1;
+  private static final String ASSET_NAME = "trx";
+  private static final int TRX_NUM = 10;
+  private static final int NUM = 1;
+  private static final long START_TIME = 1;
+  private static final long END_TIME = 2;
+  private static final int VOTE_SCORE = 2;
+  private static final String DESCRIPTION = "TRX";
+  private static final String URL = "https://tron.network";
+  private static Manager dbManager;
+  private static ChainBaseManager chainBaseManager;
+  private static ConsensusService consensusService;
+  private static TronApplicationContext context;
+  private static Wallet wallet;
+  private static TransactionUtil transactionUtil;
 
-    static {
-        Args.setParam(new String[]{"--output-directory", dbPath}, "config-localtest.conf");
-        context = new TronApplicationContext(DefaultConfig.class);
-        FROM_ADDRESS = Wallet.getAddressPreFixString() + "a7d8a35b260395c14aa456297662092ba3b76fc0";
-        ADDRESS_ONE_PRIVATE_KEY = "7f7f701e94d4f1dd60ee5205e7ea8ee31121427210417b608a6b2e96433549a7";
+  static {
+    Args.setParam(new String[]{"--output-directory", dbPath}, "config-localtest.conf");
+    context = new TronApplicationContext(DefaultConfig.class);
+    FROM_ADDRESS = Wallet.getAddressPreFixString() + "a7d8a35b260395c14aa456297662092ba3b76fc0";
+    ADDRESS_ONE_PRIVATE_KEY = "7f7f701e94d4f1dd60ee5205e7ea8ee31121427210417b608a6b2e96433549a7";
+  }
+
+  /**
+   * Init data.
+   */
+  @BeforeClass
+  public static void init() {
+    FileUtil.deleteDir(new File(dbPath));
+
+    wallet = context.getBean(Wallet.class);
+    transactionUtil = context.getBean(TransactionUtil.class);
+    dbManager = context.getBean(Manager.class);
+    chainBaseManager = context.getBean(ChainBaseManager.class);
+    setManager(dbManager);
+    consensusService = context.getBean(ConsensusService.class);
+    consensusService.start();
+    //give a big value for pool, avoid for
+    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(10_000_000_000L);
+    // Args.getInstance().setAllowShieldedTransaction(1);
+  }
+
+  /**
+   * Release resources.
+   */
+  @AfterClass
+  public static void destroy() {
+    Args.clearParam();
+    context.destroy();
+
+    if (FileUtil.deleteDir(new File(dbPath))) {
+      logger.info("Release resources successful.");
+    } else {
+      logger.info("Release resources failure.");
+    }
+  }
+
+  private static void librustzcashInitZksnarkParams() {
+    FullNodeHttpApiService.librustzcashInitZksnarkParams();
+  }
+
+  private static byte[] randomUint256() {
+    return org.tron.keystore.Wallet.generateRandomBytes(32);
+  }
+
+  private static byte[] randomUint640() {
+    return org.tron.keystore.Wallet.generateRandomBytes(80);
+  }
+
+  private static byte[] randomUint1536() {
+    return org.tron.keystore.Wallet.generateRandomBytes(192);
+  }
+
+  private static byte[] randomUint4640() {
+    return org.tron.keystore.Wallet.generateRandomBytes(580);
+  }
+
+  /**
+   * create temp Capsule test need.
+   */
+  @Before
+  public void createToken() {
+    Args.getInstance().setZenTokenId(String.valueOf(tokenId));
+    chainBaseManager.getDynamicPropertiesStore().saveAllowSameTokenName(1);
+    chainBaseManager.getDynamicPropertiesStore().saveTokenIdNum(tokenId);
+
+    AssetIssueContract assetIssueContract =
+        AssetIssueContract.newBuilder()
+            .setOwnerAddress(ByteString.copyFrom(ByteArray.fromHexString(FROM_ADDRESS)))
+            .setName(ByteString.copyFrom(ByteArray.fromString(ASSET_NAME)))
+            .setId(Long.toString(tokenId))
+            .setTotalSupply(OWNER_BALANCE)
+            .setTrxNum(TRX_NUM)
+            .setNum(NUM)
+            .setStartTime(START_TIME)
+            .setEndTime(END_TIME)
+            .setVoteScore(VOTE_SCORE)
+            .setDescription(ByteString.copyFrom(ByteArray.fromString(DESCRIPTION)))
+            .setUrl(ByteString.copyFrom(ByteArray.fromString(URL)))
+            .build();
+    AssetIssueCapsule assetIssueCapsule = new AssetIssueCapsule(assetIssueContract);
+    chainBaseManager
+        .getAssetIssueV2Store().put(assetIssueCapsule.createDbV2Key(), assetIssueCapsule);
+  }
+
+  /**
+   * create temp transparent address for  test need.
+   */
+  private void createCapsule() {
+    AccountCapsule ownerCapsule =
+        new AccountCapsule(
+            ByteString.copyFromUtf8("owner"),
+            ByteString.copyFrom(ByteArray.fromHexString(FROM_ADDRESS)),
+            AccountType.Normal,
+            OWNER_BALANCE);
+    ownerCapsule.addAssetV2(ByteArray.fromString(String.valueOf(tokenId)), OWNER_BALANCE);
+    chainBaseManager.getAccountStore().put(ownerCapsule.getAddress().toByteArray(), ownerCapsule);
+  }
+
+  private void createAccountAssetIssue() {
+    AccountAssetIssueCapsule ownerAssetIssueCapsule =
+            new AccountAssetIssueCapsule(
+                    ByteString.copyFromUtf8("owner"),
+                    ByteString.copyFrom(ByteArray.fromHexString(FROM_ADDRESS))
+            );
+    ownerAssetIssueCapsule
+            .addAssetV2(ByteArray.fromString(String.valueOf(tokenId)), OWNER_BALANCE);
+    chainBaseManager.getAccountAssetIssueStore()
+            .put(ownerAssetIssueCapsule.getAddress().toByteArray(), ownerAssetIssueCapsule);
+    AccountAssetIssueCapsule blackhole =
+            chainBaseManager.getAccountAssetIssueStore().getBlackhole();
+    AccountCapsule blackhole1 = chainBaseManager.getAccountStore().getBlackhole();
+    blackhole.getAssetIssuedName();
+    blackhole1.getBalance();
+  }
+
+  public IncrementalMerkleVoucherContainer createSimpleMerkleVoucherContainer(byte[] cm)
+      throws ZksnarkException {
+    IncrementalMerkleTreeContainer tree =
+        new IncrementalMerkleTreeContainer(new IncrementalMerkleTreeCapsule());
+    PedersenHashCapsule compressCapsule1 = new PedersenHashCapsule();
+    compressCapsule1.setContent(ByteString.copyFrom(cm));
+    PedersenHash a = compressCapsule1.getInstance();
+    tree.append(a);
+    IncrementalMerkleVoucherContainer voucher = tree.toVoucher();
+    return voucher;
+  }
+
+  private void updateTotalShieldedPoolValue(long valueBalance) {
+    long totalShieldedPoolValue =
+        chainBaseManager.getDynamicPropertiesStore().getTotalShieldedPoolValue();
+    totalShieldedPoolValue -= valueBalance;
+    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(totalShieldedPoolValue);
+  }
+
+  /*
+   * test of change ShieldedTransactionFee proposal
+   */
+  @Test
+  public void testSetShieldedTransactionFee() {
+    long fee = wallet.getShieldedTransactionFee();
+
+    chainBaseManager.getDynamicPropertiesStore().saveShieldedTransactionFee(2_000_000);
+    Assert.assertEquals(2_000_000, wallet.getShieldedTransactionFee());
+
+    chainBaseManager.getDynamicPropertiesStore().saveShieldedTransactionFee(fee);
+  }
+
+  /*
+   * test of creating shielded transaction before turn on the switch
+   */
+  @Test
+  public void testCreateBeforeAllowZksnark() throws ZksnarkException {
+    librustzcashInitZksnarkParams();
+    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(0);
+    createCapsule();
+    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+
+    //generate input
+    builder.setTransparentInput(ByteArray.fromHexString(FROM_ADDRESS), OWNER_BALANCE); //success
+    byte[] senderOvk = randomUint256();
+
+    //generate output
+    SpendingKey sk = SpendingKey.random();
+    FullViewingKey fullViewingKey12 = sk.fullViewingKey();
+    IncomingViewingKey ivk = fullViewingKey12.inViewingKey();
+    PaymentAddress paymentAddress = ivk.address(new DiversifierT()).get();
+    builder.addOutput(senderOvk, paymentAddress,
+        OWNER_BALANCE - wallet.getShieldedTransactionFee(), new byte[512]); //success
+
+    updateTotalShieldedPoolValue(builder.getValueBalance());
+    TransactionCapsule transactionCap = builder.build();
+
+    //online
+    try {
+      //validate
+      List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
+      actuator.get(0).validate();
+      Assert.assertFalse(true);
+    } catch (Exception e) {
+      Assert.assertTrue(e instanceof ContractValidateException);
+      Assert.assertEquals(
+          "Not support Shielded Transaction, need to be opened by the committee",
+          e.getMessage());
+    }
+  }
+
+  /*
+   * test of broadcasting shielded transaction before allow shielded transaction
+   */
+  @Test
+  public void testBroadcastBeforeAllowZksnark()
+      throws ZksnarkException, SignatureFormatException, SignatureException, PermissionException {
+    librustzcashInitZksnarkParams();
+    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(0);// or 1
+    createCapsule();
+    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+
+    //generate input
+    builder.setTransparentInput(ByteArray.fromHexString(FROM_ADDRESS), OWNER_BALANCE); //success
+    byte[] senderOvk = randomUint256();
+
+    //generate output
+    SpendingKey sk = SpendingKey.random();
+    FullViewingKey fullViewingKey12 = sk.fullViewingKey();
+    IncomingViewingKey ivk = fullViewingKey12.inViewingKey();
+    PaymentAddress paymentAddress = ivk.address(new DiversifierT()).get();
+    long fee = chainBaseManager.getDynamicPropertiesStore().getShieldedTransactionFee();
+    builder.addOutput(senderOvk, paymentAddress,
+        OWNER_BALANCE - fee, new byte[512]); //success
+
+    updateTotalShieldedPoolValue(builder.getValueBalance());
+    TransactionCapsule transactionCap = builder.build();
+
+    //Add public address sign
+    TransactionSign.Builder transactionSignBuild = TransactionSign.newBuilder();
+    transactionSignBuild.setTransaction(transactionCap.getInstance());
+    transactionSignBuild.setPrivateKey(ByteString.copyFrom(
+        ByteArray.fromHexString(ADDRESS_ONE_PRIVATE_KEY)));
+
+    transactionCap = transactionUtil.addSign(transactionSignBuild.build());
+
+    try {
+      dbManager.pushTransaction(transactionCap);
+      Assert.assertFalse(true);
+    } catch (Exception e) {
+      Assert.assertTrue(e instanceof ContractValidateException);
+      Assert.assertEquals(
+          "Not support Shielded Transaction, need to be opened by the committee",
+          e.getMessage());
+    }
+  }
+
+  /*
+   * generate spendproof, dataToBeSigned, outputproof example dynamicly according to the params file
+   */
+  public String[] generateSpendAndOutputParams() throws ZksnarkException, BadItemException {
+    librustzcashInitZksnarkParams();
+    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+    long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
+
+    //generate input
+    SpendingKey sk = SpendingKey.random();
+    ExpandedSpendingKey expsk = sk.expandedSpendingKey();
+    PaymentAddress address = sk.defaultAddress();
+
+    Note note = new Note(address, 100 * 1000000L);
+    IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
+    byte[] anchor = voucher.root().getContent().toByteArray();
+    chainBaseManager.getMerkleContainer()
+        .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
+    builder.addSpend(expsk, note, anchor, voucher);
+
+    // generate output
+    SpendingKey sk1 = SpendingKey.random();
+    FullViewingKey fullViewingKey1 = sk1.fullViewingKey();
+    IncomingViewingKey ivk1 = fullViewingKey1.inViewingKey();
+    PaymentAddress paymentAddress1 = ivk1.address(new DiversifierT()).get();
+    builder.addOutput(expsk.getOvk(), paymentAddress1,
+        100 * 1000000 - wallet.getShieldedTransactionFee(), new byte[512]);
+
+    // Create Sapling SpendDescriptions
+    for (SpendDescriptionInfo spend2 : builder.getSpends()) {
+      SpendDescriptionCapsule spendDescriptionCapsule = builder.generateSpendProof(spend2, ctx);
+      builder.getContractBuilder().addSpendDescription(spendDescriptionCapsule.getInstance());
     }
 
-    /**
-     * Init data.
-     */
-    @BeforeClass
-    public static void init() {
-        FileUtil.deleteDir(new File(dbPath));
-
-        wallet = context.getBean(Wallet.class);
-        transactionUtil = context.getBean(TransactionUtil.class);
-        dbManager = context.getBean(Manager.class);
-        chainBaseManager = context.getBean(ChainBaseManager.class);
-        setManager(dbManager);
-        consensusService = context.getBean(ConsensusService.class);
-        consensusService.start();
-        //give a big value for pool, avoid for
-        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(10_000_000_000L);
-        // Args.getInstance().setAllowShieldedTransaction(1);
+    // Create Sapling OutputDescriptions
+    for (ReceiveDescriptionInfo receive : builder.getReceives()) {
+      ReceiveDescriptionCapsule receiveDescriptionCapsule = builder
+          .generateOutputProof(receive, ctx);
+      builder.getContractBuilder().addReceiveDescription(receiveDescriptionCapsule.getInstance());
     }
 
-    /**
-     * Release resources.
-     */
-    @AfterClass
-    public static void destroy() {
-        Args.clearParam();
-        context.destroy();
+    // begin to generate dataToBeSigned
+    TransactionCapsule transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
+        builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
+    byte[] dataToBeSigned = TransactionCapsule
+        .getShieldTransactionHashIgnoreTypeException(transactionCapsule.getInstance());
+    TransactionCapsule transactionCap = generateTransactionCapsule(builder, ctx, dataToBeSigned,
+        transactionCapsule);
 
-        if (FileUtil.deleteDir(new File(dbPath))) {
-            logger.info("Release resources successful.");
+    // generate checkSpendParams
+    SpendDescription spendDescription = builder.getContractBuilder().getSpendDescription(0);
+    CheckSpendParams checkSpendParams = new CheckSpendParams(ctx,
+        spendDescription.getValueCommitment().toByteArray(),
+        spendDescription.getAnchor().toByteArray(),
+        spendDescription.getNullifier().toByteArray(),
+        spendDescription.getRk().toByteArray(),
+        spendDescription.getZkproof().toByteArray(),
+        spendDescription.getSpendAuthoritySignature().toByteArray(),
+        dataToBeSigned);
+
+    boolean ok1 = JLibrustzcash.librustzcashSaplingCheckSpend(checkSpendParams);
+    Assert.assertTrue(ok1);
+
+    byte[] checkSpendParamsData = new byte[385];
+    System.arraycopy(
+        checkSpendParams.getCv(), 0, checkSpendParamsData, 0, 32);
+    System.arraycopy(
+        checkSpendParams.getAnchor(), 0, checkSpendParamsData, 32, 32);
+    System.arraycopy(
+        checkSpendParams.getNullifier(), 0, checkSpendParamsData, 64, 32);
+    System.arraycopy(
+        checkSpendParams.getRk(), 0, checkSpendParamsData, 96, 32);
+    System.arraycopy(
+        checkSpendParams.getZkproof(), 0, checkSpendParamsData, 128, 192);
+    System.arraycopy(
+        checkSpendParams.getSpendAuthSig(), 0, checkSpendParamsData, 320, 64);
+
+    // generate CheckOutputParams
+    ReceiveDescription receiveDescription =
+        builder.getContractBuilder().getReceiveDescription(0);
+    CheckOutputParams checkOutputParams = new CheckOutputParams(ctx,
+        receiveDescription.getValueCommitment().toByteArray(),
+        receiveDescription.getNoteCommitment().toByteArray(),
+        receiveDescription.getEpk().toByteArray(),
+        receiveDescription.getZkproof().toByteArray()
+    );
+
+    boolean ok2 = JLibrustzcash.librustzcashSaplingCheckOutput(checkOutputParams);
+    Assert.assertTrue(ok2);
+
+    return new String[]{ByteArray.toHexString(checkSpendParamsData),
+        ByteArray.toHexString(dataToBeSigned),
+        ByteArray.toHexString(checkOutputParams.encode())};
+  }
+
+  private long benchmarkVerifySpend(String spend, String dataToBeSigned) throws ZksnarkException {
+    long startTime = System.currentTimeMillis();
+    long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
+
+    CheckSpendParams checkSpendParams = CheckSpendParams.decode(ctx,
+        ByteArray.fromHexString(spend),
+        ByteArray.fromHexString(dataToBeSigned));
+
+    boolean ok = JLibrustzcash.librustzcashSaplingCheckSpend(checkSpendParams);
+
+    JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
+    Assert.assertTrue(ok);
+
+    long endTime = System.currentTimeMillis();
+    long time = endTime - startTime;
+
+    System.out.println("--- time is: " + time + ", result is " + ok);
+    return time;
+  }
+
+  private long benchmarkVerifyOutput(String outputParams) throws ZksnarkException {
+    // expect true
+    long startTime = System.currentTimeMillis();
+    long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
+
+    CheckOutputParams checkOutputParams = CheckOutputParams.decode(ctx,
+        ByteArray.fromHexString(outputParams));
+
+    boolean ok = JLibrustzcash.librustzcashSaplingCheckOutput(checkOutputParams);
+
+    JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
+    Assert.assertTrue(ok);
+
+    long endTime = System.currentTimeMillis();
+    long time = endTime - startTime;
+
+    System.out.println("--- time is: " + time + ", result is " + ok);
+    return time;
+  }
+
+  @Test
+  public void calBenchmarkVerifySpend() throws ZksnarkException, BadItemException {
+    librustzcashInitZksnarkParams();
+    System.out.println("--- load ok ---");
+
+    int count = 10;
+    long minTime = 500;
+    long maxTime = 0;
+    double totalTime = 0.0;
+
+    String[] result = generateSpendAndOutputParams();
+    String spend = result[0];
+    String dataToBeSigned = result[1];
+
+    for (int i = 0; i < count; i++) {
+      long time = benchmarkVerifySpend(spend, dataToBeSigned);
+      if (time < minTime) {
+        minTime = time;
+      }
+      if (time > maxTime) {
+        maxTime = time;
+      }
+      totalTime += time;
+    }
+
+    System.out.println("---- result ----");
+    System.out.println("---- maxTime is: " + maxTime);
+    System.out.println("---- minTime is: " + minTime);
+    System.out.println("---- avgTime is: " + totalTime / count);
+
+  }
+
+  @Test
+  public void calBenchmarkVerifyOutput() throws ZksnarkException, BadItemException {
+    librustzcashInitZksnarkParams();
+    System.out.println("--- load ok ---");
+
+    int count = 2;
+    long minTime = 500;
+    long maxTime = 0;
+    double totalTime = 0.0;
+
+    String[] result = generateSpendAndOutputParams();
+    String outputParams = result[2];
+
+    for (int i = 0; i < count; i++) {
+      long time = benchmarkVerifyOutput(outputParams);
+      if (time < minTime) {
+        minTime = time;
+      }
+      if (time > maxTime) {
+        maxTime = time;
+      }
+      totalTime += time;
+    }
+
+    System.out.println("---- result ----");
+    System.out.println("---- maxTime is: " + maxTime);
+    System.out.println("---- minTime is: " + minTime);
+    System.out.println("---- avgTime is: " + totalTime / count);
+
+  }
+
+  private ZenTransactionBuilder generateBuilderWithoutColumnInDescription(
+      ZenTransactionBuilder builder, long ctx, TestReceiveMissingColumn column)
+      throws ZksnarkException, BadItemException {
+    //generate input
+    SpendingKey sk = SpendingKey.random();
+    ExpandedSpendingKey expsk = sk.expandedSpendingKey();
+    PaymentAddress address = sk.defaultAddress();
+
+    Note note = new Note(address, 100 * 1000000L);
+    IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
+    byte[] anchor = voucher.root().getContent().toByteArray();
+    chainBaseManager.getMerkleContainer()
+        .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
+    builder.addSpend(expsk, note, anchor, voucher);
+
+    // generate output
+    SpendingKey sk1 = SpendingKey.random();
+    FullViewingKey fullViewingKey1 = sk1.fullViewingKey();
+    IncomingViewingKey ivk1 = fullViewingKey1.inViewingKey();
+    PaymentAddress paymentAddress1 = ivk1.address(new DiversifierT()).get();
+    builder.addOutput(expsk.getOvk(), paymentAddress1,
+        100 * 1000000 - wallet.getShieldedTransactionFee(), new byte[512]);
+
+    // Create Sapling SpendDescriptions
+    for (SpendDescriptionInfo spend : builder.getSpends()) {
+      SpendDescriptionCapsule spendDescriptionCapsule = builder.generateSpendProof(spend, ctx);
+      builder.getContractBuilder().addSpendDescription(spendDescriptionCapsule.getInstance());
+    }
+
+    // Create Sapling OutputDescriptions
+    for (ReceiveDescriptionInfo receive : builder.getReceives()) {
+      ReceiveDescriptionCapsule receiveDescriptionCapsule = builder
+          .generateOutputProof(receive, ctx);
+      switch (column) {
+        case CV:
+          receiveDescriptionCapsule.setValueCommitment(ByteString.EMPTY);
+          break;
+        case CM:
+          receiveDescriptionCapsule.setNoteCommitment(ByteString.EMPTY);
+          break;
+        case EPK:
+          receiveDescriptionCapsule.setEpk(ByteString.EMPTY);
+          break;
+        case ZKPROOF:
+          receiveDescriptionCapsule.setZkproof(ByteString.EMPTY);
+          break;
+        case C_ENC:
+          receiveDescriptionCapsule.setCEnc(ByteString.EMPTY);
+          break;
+        case C_OUT:
+          receiveDescriptionCapsule.setCOut(ByteString.EMPTY);
+          break;
+        default:
+          break;
+      }
+      builder.getContractBuilder().addReceiveDescription(receiveDescriptionCapsule.getInstance());
+    }
+
+    return builder;
+  }
+
+  /*
+   * test of empty CV in receive description
+   */
+  @Test
+  public void testReceiveDescriptionWithEmptyCv()
+      throws BadItemException, RuntimeException, ZksnarkException {
+    librustzcashInitZksnarkParams();
+    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+    long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
+
+    builder = generateBuilderWithoutColumnInDescription(builder, ctx, TestReceiveMissingColumn.CV);
+
+    // Empty output script.
+    byte[] dataToBeSigned;//256
+    TransactionCapsule transactionCapsule;
+    try {
+      transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
+          builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
+      TransactionExtention transactionExtention = TransactionExtention.newBuilder()
+          .setTransaction(transactionCapsule.getInstance()).build();
+
+      dataToBeSigned = TransactionCapsule.hashShieldTransaction(transactionCapsule.getInstance(),
+          CommonParameter.getInstance().getZenTokenId());
+    } catch (Exception ex) {
+      JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
+      throw new RuntimeException("Could not construct signature hash: " + ex.getMessage());
+    }
+
+    TransactionCapsule transactionCap = generateTransactionCapsule(builder, ctx, dataToBeSigned,
+        transactionCapsule);
+
+    try {
+      //validate
+      List<Actuator> actuator = ActuatorCreator
+          .getINSTANCE().createActuator(transactionCap);
+      actuator.get(0).validate();
+      Assert.assertTrue(false);
+    } catch (Exception e) {
+      Assert.assertTrue(e instanceof ContractValidateException);
+      Assert.assertEquals("param is null", e.getMessage());
+    }
+    JLibrustzcash.librustzcashSaplingVerificationCtxFree(ctx);
+  }
+
+  /*
+   * test of empty cm in receive description
+   */
+  @Test
+  public void testReceiveDescriptionWithEmptyCm()
+      throws BadItemException, RuntimeException, ZksnarkException {
+    librustzcashInitZksnarkParams();
+    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+    long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
+
+    builder = generateBuilderWithoutColumnInDescription(builder, ctx, TestReceiveMissingColumn.CM);
+
+    // Empty output script.
+    byte[] dataToBeSigned;//256
+    TransactionCapsule transactionCapsule;
+    try {
+      transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
+          builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
+      dataToBeSigned = TransactionCapsule.hashShieldTransaction(transactionCapsule.getInstance(),
+          CommonParameter.getInstance().getZenTokenId());
+    } catch (Exception ex) {
+      JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
+      throw new RuntimeException("Could not construct signature hash: " + ex.getMessage());
+    }
+
+    TransactionCapsule transactionCap = generateTransactionCapsule(builder, ctx, dataToBeSigned,
+        transactionCapsule);
+
+    try {
+      //validate
+      List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
+      actuator.get(0).validate();
+
+      Assert.assertTrue(false);
+    } catch (Exception e) {
+      Assert.assertTrue(e instanceof ContractValidateException);
+      Assert.assertEquals("param is null", e.getMessage());
+    }
+    JLibrustzcash.librustzcashSaplingVerificationCtxFree(ctx);
+  }
+
+  /*
+   * test of empty epk in receive description
+   */
+  @Test
+  public void testReceiveDescriptionWithEmptyEpk()
+      throws BadItemException, RuntimeException, ZksnarkException {
+    librustzcashInitZksnarkParams();
+    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+    long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
+
+    builder = generateBuilderWithoutColumnInDescription(builder, ctx, TestReceiveMissingColumn.EPK);
+
+    // Empty output script.
+    byte[] dataToBeSigned;//256
+    TransactionCapsule transactionCapsule;
+    try {
+      transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
+          builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
+      dataToBeSigned = TransactionCapsule.hashShieldTransaction(transactionCapsule.getInstance(),
+          CommonParameter.getInstance().getZenTokenId());
+    } catch (Exception ex) {
+      JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
+      throw new RuntimeException("Could not construct signature hash: " + ex.getMessage());
+    }
+
+    TransactionCapsule transactionCap = generateTransactionCapsule(builder, ctx, dataToBeSigned,
+        transactionCapsule);
+
+    try {
+      //validate
+      List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
+      actuator.get(0).validate();
+      Assert.assertTrue(false);
+    } catch (Exception e) {
+      Assert.assertTrue(e instanceof ContractValidateException);
+      Assert.assertEquals("param is null", e.getMessage());
+    }
+    JLibrustzcash.librustzcashSaplingVerificationCtxFree(ctx);
+  }
+
+  /*
+   * test of empty zkproof in receive description
+   */
+  @Test
+  public void testReceiveDescriptionWithEmptyZkproof()
+      throws BadItemException, RuntimeException, ZksnarkException {
+    librustzcashInitZksnarkParams();
+    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+    long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
+
+    builder = generateBuilderWithoutColumnInDescription(builder, ctx,
+        TestReceiveMissingColumn.ZKPROOF);
+
+    // Empty output script.
+    byte[] dataToBeSigned;//256
+    TransactionCapsule transactionCapsule;
+    try {
+      transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
+          builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
+      dataToBeSigned = TransactionCapsule.hashShieldTransaction(transactionCapsule.getInstance(),
+          CommonParameter.getInstance().getZenTokenId());
+    } catch (Exception ex) {
+      JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
+      throw new RuntimeException("Could not construct signature hash: " + ex.getMessage());
+    }
+
+    TransactionCapsule transactionCap = generateTransactionCapsule(builder, ctx, dataToBeSigned,
+        transactionCapsule);
+
+    try {
+      //validate
+      List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
+      actuator.get(0).validate();
+      Assert.assertTrue(false);
+    } catch (Exception e) {
+      Assert.assertTrue(e instanceof ContractValidateException);
+      Assert.assertEquals("param is null", e.getMessage());
+    }
+    JLibrustzcash.librustzcashSaplingVerificationCtxFree(ctx);
+  }
+
+  /*
+   * test of empty c_enc in receive description
+   */
+  @Test
+  public void testReceiveDescriptionWithEmptyCenc()
+      throws BadItemException, RuntimeException, ZksnarkException {
+    librustzcashInitZksnarkParams();
+    dbManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+    dbManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+    long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
+
+    builder = generateBuilderWithoutColumnInDescription(builder, ctx,
+        TestReceiveMissingColumn.C_ENC);
+
+    // Empty output script.
+    byte[] dataToBeSigned;//256
+    TransactionCapsule transactionCapsule;
+    try {
+      transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
+          builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
+      dataToBeSigned = TransactionCapsule.hashShieldTransaction(transactionCapsule.getInstance(),
+          CommonParameter.getInstance().getZenTokenId());
+    } catch (Exception ex) {
+      JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
+      throw new RuntimeException("Could not construct signature hash: " + ex.getMessage());
+    }
+
+    TransactionCapsule transactionCap = generateTransactionCapsule(builder, ctx, dataToBeSigned,
+        transactionCapsule);
+
+    try {
+      //validate
+      List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
+      actuator.get(0).validate();
+      Assert.assertTrue(false);
+    } catch (Exception e) {
+      Assert.assertTrue(e instanceof ContractValidateException);
+      Assert.assertEquals("Cout or CEnc size error", e.getMessage());
+    }
+    JLibrustzcash.librustzcashSaplingVerificationCtxFree(ctx);
+  }
+
+  /*
+   * test of empty c_out in receive description
+   */
+  @Test
+  public void testReceiveDescriptionWithEmptyCout()
+      throws BadItemException, RuntimeException, ZksnarkException {
+    librustzcashInitZksnarkParams();
+    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+    long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
+
+    builder = generateBuilderWithoutColumnInDescription(builder, ctx,
+        TestReceiveMissingColumn.C_OUT);
+
+    // Empty output script.
+    byte[] dataToBeSigned;//256
+    TransactionCapsule transactionCapsule;
+    try {
+      transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
+          builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
+      dataToBeSigned = TransactionCapsule.hashShieldTransaction(transactionCapsule.getInstance(),
+          CommonParameter.getInstance().getZenTokenId());
+    } catch (Exception ex) {
+      JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
+      throw new RuntimeException("Could not construct signature hash: " + ex.getMessage());
+    }
+
+    TransactionCapsule transactionCap = generateTransactionCapsule(builder, ctx, dataToBeSigned,
+        transactionCapsule);
+
+    try {
+      //validate
+      List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
+      actuator.get(0).validate();
+      Assert.assertTrue(false);
+    } catch (Exception e) {
+      Assert.assertTrue(e instanceof ContractValidateException);
+      Assert.assertEquals("Cout or CEnc size error", e.getMessage());
+    }
+    JLibrustzcash.librustzcashSaplingVerificationCtxFree(ctx);
+  }
+
+  /*
+   * test some column in ReceiveDescription is wrong
+   */
+  private ReceiveDescriptionCapsule changeGenerateOutputProof(ReceiveDescriptionInfo output,
+      long ctx, TestColumn testColumn)
+      throws ZksnarkException {
+    byte[] cm = output.getNote().cm();
+    if (ByteArray.isEmpty(cm)) {
+      JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
+      throw new ZksnarkException("Output is invalid");
+    }
+
+    Optional<NotePlaintextEncryptionResult> res = output.getNote()
+        .encrypt(output.getNote().getPkD());
+    if (!res.isPresent()) {
+      JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
+      throw new ZksnarkException("Failed to encrypt note");
+    }
+
+    NotePlaintextEncryptionResult enc = res.get();
+    NoteEncryption encryptor = enc.getNoteEncryption();
+
+    byte[] cv = new byte[32];
+    byte[] zkProof = new byte[192];
+    if (!JLibrustzcash.librustzcashSaplingOutputProof(
+        new OutputProofParams(ctx,
+            encryptor.getEsk(),
+            output.getNote().getD().getData(),
+            output.getNote().getPkD(),
+            output.getNote().getRcm(),
+            output.getNote().getValue(),
+            cv,
+            zkProof))) {
+      JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
+      throw new ZksnarkException("Output proof failed");
+    }
+
+    ReceiveDescriptionCapsule receiveDescriptionCapsule = new ReceiveDescriptionCapsule();
+    receiveDescriptionCapsule.setValueCommitment(cv);
+    receiveDescriptionCapsule.setNoteCommitment(cm);
+    receiveDescriptionCapsule.setEpk(encryptor.getEpk());
+    receiveDescriptionCapsule.setCEnc(enc.getEncCiphertext());
+    receiveDescriptionCapsule.setZkproof(zkProof);
+
+    OutgoingPlaintext outPlaintext =
+        new OutgoingPlaintext(output.getNote().getPkD(), encryptor.getEsk());
+    receiveDescriptionCapsule.setCOut(outPlaintext
+        .encrypt(output.getOvk(), receiveDescriptionCapsule.getValueCommitment().toByteArray(),
+            receiveDescriptionCapsule.getCm().toByteArray(),
+            encryptor).getData());
+
+    Note newNote = output.getNote();
+    byte[] newCm;
+    switch (testColumn) {
+      case CV:
+        receiveDescriptionCapsule.setValueCommitment(randomUint256());
+        break;
+      case ZKPOOF:
+        receiveDescriptionCapsule.setZkproof(randomUint1536());
+        break;
+      case D_CM:
+        newNote.setD(DiversifierT.random());
+        newCm = newNote.cm();
+        if (newCm == null) {
+          receiveDescriptionCapsule.setNoteCommitment(ByteString.EMPTY);
         } else {
-            logger.info("Release resources failure.");
+          receiveDescriptionCapsule.setNoteCommitment(newCm);
         }
+        break;
+      case PKD_CM:
+        newNote.setPkD(randomUint256());
+        newCm = newNote.cm();
+        if (newCm == null) {
+          receiveDescriptionCapsule.setNoteCommitment(ByteString.EMPTY);
+        } else {
+          receiveDescriptionCapsule.setNoteCommitment(newCm);
+        }
+        break;
+      case VALUE_CM:
+        newNote.setValue(newNote.getValue() + 10000);
+        newCm = newNote.cm();
+        if (newCm == null) {
+          receiveDescriptionCapsule.setNoteCommitment(ByteString.EMPTY);
+        } else {
+          receiveDescriptionCapsule.setNoteCommitment(newCm);
+        }
+        break;
+      case R_CM:
+        newNote.setRcm(Note.generateR());
+        newCm = newNote.cm();
+        if (newCm == null) {
+          receiveDescriptionCapsule.setNoteCommitment(ByteString.EMPTY);
+        } else {
+          receiveDescriptionCapsule.setNoteCommitment(newCm);
+        }
+        break;
+
+      default:
+        break;
     }
 
-    private static void librustzcashInitZksnarkParams() {
-        FullNodeHttpApiService.librustzcashInitZksnarkParams();
+    return receiveDescriptionCapsule;
+  }
+
+  private TransactionCapsule changeBuildOutputProof(ZenTransactionBuilder builder, long ctx,
+      TestColumn testColumn)
+      throws ZksnarkException {
+    ShieldedTransferContract.Builder contractBuilder = builder.getContractBuilder();
+
+    // Create Sapling SpendDescriptions
+    for (SpendDescriptionInfo spend : builder.getSpends()) {
+      SpendDescriptionCapsule spendDescriptionCapsule = builder.generateSpendProof(spend, ctx);
+      contractBuilder.addSpendDescription(spendDescriptionCapsule.getInstance());
     }
 
-    private static byte[] randomUint256() {
-        return org.tron.keystore.Wallet.generateRandomBytes(32);
+    // Create Sapling OutputDescriptions
+    for (ReceiveDescriptionInfo receive : builder.getReceives()) {
+      //test case
+      ReceiveDescriptionCapsule receiveDescriptionCapsule = changeGenerateOutputProof(receive, ctx,
+          testColumn);
+      //end of test case
+      contractBuilder.addReceiveDescription(receiveDescriptionCapsule.getInstance());
     }
 
-    private static byte[] randomUint640() {
-        return org.tron.keystore.Wallet.generateRandomBytes(80);
+    // Empty output script.
+    byte[] dataToBeSigned;//256
+    TransactionCapsule transactionCapsule;
+    try {
+      transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
+          contractBuilder.build(), ContractType.ShieldedTransferContract);
+
+      dataToBeSigned = TransactionCapsule.hashShieldTransaction(transactionCapsule.getInstance(),
+          CommonParameter.getInstance().getZenTokenId());
+    } catch (Exception ex) {
+      JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
+      throw new ZksnarkException("Could not construct signature hash: " + ex.getMessage());
     }
 
-    private static byte[] randomUint1536() {
-        return org.tron.keystore.Wallet.generateRandomBytes(192);
+    // Create Sapling spendAuth and binding signatures
+    builder.createSpendAuth(dataToBeSigned);
+    byte[] bindingSig = new byte[64];
+    JLibrustzcash.librustzcashSaplingBindingSig(
+        new BindingSigParams(ctx,
+            builder.getValueBalance(),
+            dataToBeSigned,
+            bindingSig)
+    );
+    contractBuilder.setBindingSignature(ByteString.copyFrom(bindingSig));
+    JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
+
+    Transaction.raw.Builder rawBuilder = transactionCapsule.getInstance().toBuilder()
+        .getRawDataBuilder()
+        .clearContract()
+        .addContract(
+            Transaction.Contract.newBuilder().setType(ContractType.ShieldedTransferContract)
+                .setParameter(
+                    Any.pack(contractBuilder.build())).build());
+
+    Transaction transaction = transactionCapsule.getInstance().toBuilder().clearRawData()
+        .setRawData(rawBuilder).build();
+    return new TransactionCapsule(transaction);
+  }
+
+  private ZenTransactionBuilder generateBuilder(ZenTransactionBuilder builder, long ctx)
+      throws ZksnarkException, BadItemException {
+    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+
+    // generate input
+    SpendingKey sk = SpendingKey.random();
+    ExpandedSpendingKey expsk = sk.expandedSpendingKey();
+    PaymentAddress address = sk.defaultAddress();
+    Note note = new Note(address, 100 * 1000000L);
+    IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
+    byte[] anchor = voucher.root().getContent().toByteArray();
+    //put the voucher and anchor into db
+    chainBaseManager.getMerkleContainer()
+        .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
+    builder.addSpend(expsk, note, anchor, voucher);
+
+    // generate output
+    SpendingKey sk1 = SpendingKey.random();
+    FullViewingKey fullViewingKey1 = sk1.fullViewingKey();
+    IncomingViewingKey ivk1 = fullViewingKey1.inViewingKey();
+    PaymentAddress paymentAddress1 = ivk1.address(new DiversifierT()).get();
+    Note note2 = new Note(paymentAddress1, 100 * 1000000L - wallet.getShieldedTransactionFee());
+    builder
+        .addOutput(expsk.getOvk(), note2.getD(), note2.getPkD(), note2.getValue(), note2.getRcm(),
+            new byte[512]);
+
+    return builder;
+  }
+
+  /*
+   * test wrong value_commitment in ReceiveDescription
+   */
+  @Test
+  public void testReceiveDescriptionWithWrongCv()
+      throws BadItemException, RuntimeException, ZksnarkException {
+    librustzcashInitZksnarkParams();
+    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+    long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
+
+    builder = generateBuilder(builder, ctx);
+
+    TestColumn testColumn = TestColumn.CV;
+    TransactionCapsule transactionCap = changeBuildOutputProof(builder, ctx, testColumn);
+
+    updateTotalShieldedPoolValue(builder.getValueBalance());
+
+    try {
+      List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
+      actuator.get(0).validate();
+      Assert.assertFalse(true);
+    } catch (Exception e) {
+      Assert.assertTrue(e instanceof ContractValidateException);
+      Assert.assertEquals("librustzcashSaplingCheckOutput error", e.getMessage());
+    }
+  }
+
+  /*
+   * test wrong zkproof in ReceiveDescription
+   */
+  @Test
+  public void testReceiveDescriptionWithWrongZkproof()
+      throws BadItemException, RuntimeException, ZksnarkException {
+    librustzcashInitZksnarkParams();
+    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+    long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
+
+    builder = generateBuilder(builder, ctx);
+
+    TestColumn testColumn = TestColumn.ZKPOOF;
+    TransactionCapsule transactionCap = changeBuildOutputProof(builder, ctx, testColumn);
+
+    updateTotalShieldedPoolValue(builder.getValueBalance());
+
+    try {
+      List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
+      actuator.get(0).validate();
+      Assert.assertFalse(true);
+    } catch (Exception e) {
+      Assert.assertTrue(e instanceof ContractValidateException);
+      Assert.assertEquals("librustzcashSaplingCheckOutput error", e.getMessage());
+    }
+  }
+
+  /*
+   * test note_commitment in ReceiveDescription generated by wrong d
+   */
+  @Test
+  public void testReceiveDescriptionWithWrongD()
+      throws BadItemException, RuntimeException, ZksnarkException {
+    librustzcashInitZksnarkParams();
+    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+    long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
+
+    builder = generateBuilder(builder, ctx);
+
+    TestColumn testColumn = TestColumn.D_CM;
+    TransactionCapsule transactionCap = changeBuildOutputProof(builder, ctx, testColumn);
+
+    updateTotalShieldedPoolValue(builder.getValueBalance());
+
+    try {
+      List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
+      actuator.get(0).validate();
+      Assert.assertFalse(true);
+    } catch (Exception e) {
+      Assert.assertTrue(e instanceof ContractValidateException);
+      //if generate cm successful, checkout error; else param is null because of cm is null
+      Assert.assertTrue("librustzcashSaplingCheckOutput error".equalsIgnoreCase(e.getMessage())
+          || "param is null".equalsIgnoreCase(e.getMessage()));
+    }
+  }
+
+  /*
+   * test note_commitment in ReceiveDescription generated by wrong pkd
+   */
+  @Test
+  public void testReceiveDescriptionWithWrongPkd()
+      throws BadItemException, RuntimeException, ZksnarkException {
+    librustzcashInitZksnarkParams();
+    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+    long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
+
+    builder = generateBuilder(builder, ctx);
+
+    TestColumn testColumn = TestColumn.PKD_CM;
+    TransactionCapsule transactionCap = changeBuildOutputProof(builder, ctx, testColumn);
+
+    updateTotalShieldedPoolValue(builder.getValueBalance());
+
+    try {
+      List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
+      actuator.get(0).validate();
+      Assert.assertFalse(true);
+    } catch (Exception e) {
+      Assert.assertTrue(e instanceof ContractValidateException);
+      //if generate cm successful, checkout error; else param is null because of cm is null
+      Assert.assertTrue("librustzcashSaplingCheckOutput error".equalsIgnoreCase(e.getMessage())
+          || "param is null".equalsIgnoreCase(e.getMessage()));
+    }
+  }
+
+  /*
+   * test note_commitment in ReceiveDescription generated by wrong value
+   */
+  @Test
+  public void testReceiveDescriptionWithWrongValue()
+      throws BadItemException, RuntimeException, ZksnarkException {
+    librustzcashInitZksnarkParams();
+    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+    long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
+
+    builder = generateBuilder(builder, ctx);
+
+    TestColumn testColumn = TestColumn.VALUE_CM;
+    TransactionCapsule transactionCap = changeBuildOutputProof(builder, ctx, testColumn);
+
+    updateTotalShieldedPoolValue(builder.getValueBalance());
+
+    try {
+      List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
+      actuator.get(0).validate();
+      Assert.assertFalse(true);
+    } catch (Exception e) {
+      Assert.assertTrue(e instanceof ContractValidateException);
+      Assert.assertTrue(e.getMessage().equalsIgnoreCase("librustzcashSaplingCheckOutput error"));
+    }
+  }
+
+  /*
+   * test note_commitment in ReceiveDescription generated by wrong r
+   */
+  @Test
+  public void testReceiveDescriptionWithWrongRcm()
+      throws BadItemException, RuntimeException, ZksnarkException {
+    librustzcashInitZksnarkParams();
+    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+    long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
+
+    builder = generateBuilder(builder, ctx);
+
+    TestColumn testColumn = TestColumn.R_CM;
+    TransactionCapsule transactionCap = changeBuildOutputProof(builder, ctx, testColumn);
+
+    updateTotalShieldedPoolValue(builder.getValueBalance());
+
+    try {
+      List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
+      actuator.get(0).validate();
+      Assert.assertFalse(true);
+    } catch (Exception e) {
+      Assert.assertTrue(e instanceof ContractValidateException);
+      Assert.assertEquals("librustzcashSaplingCheckOutput error", e.getMessage());
+    }
+  }
+
+  /**
+   * use ask or nsk not belongs to sk.
+   */
+  @Test
+  public void testNotMatchAskAndNsk()
+      throws BadItemException, RuntimeException, ZksnarkException {
+    librustzcashInitZksnarkParams();
+    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+
+    // generate sk
+    SpendingKey sk = SpendingKey
+        .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
+    ExpandedSpendingKey expsk = sk.expandedSpendingKey();
+    PaymentAddress address = sk.defaultAddress();
+
+    //generate a note belongs to this sk
+    Note note = new Note(address, 100 * 1000000L);
+    IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
+    byte[] anchor = voucher.root().getContent().toByteArray();
+    //put the voucher and anchor into db
+    chainBaseManager.getMerkleContainer()
+        .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
+
+    //test case: give a random Ask or nsk
+    expsk.setAsk(randomUint256());
+    //expsk.setNsk(randomUint256());
+    //end of test case
+
+    builder.addSpend(expsk, note, anchor, voucher);
+
+    // generate output
+    SpendingKey sk1 = SpendingKey.random();
+    FullViewingKey fullViewingKey1 = sk1.fullViewingKey();
+    IncomingViewingKey ivk1 = fullViewingKey1.inViewingKey();
+    PaymentAddress paymentAddress1 = ivk1.address(new DiversifierT()).get();
+    builder.addOutput(expsk.getOvk(), paymentAddress1,
+        100 * 1000000L - wallet.getShieldedTransactionFee(), new byte[512]);
+
+    updateTotalShieldedPoolValue(builder.getValueBalance());
+    try {
+      TransactionCapsule transactionCap = builder.build();
+      Assert.assertFalse(true);
+
+    } catch (Exception e) {
+      Assert.assertTrue(e instanceof ZksnarkException);
+      Assert.assertEquals("Spend proof failed", e.getMessage());
+    }
+  }
+
+  /**
+   * use random ovk not related to sk.
+   */
+  @Test
+  public void testRandomOvk()
+      throws BadItemException, RuntimeException, ZksnarkException {
+    librustzcashInitZksnarkParams();
+    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+
+    // generate sk
+    SpendingKey sk = SpendingKey
+        .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
+    ExpandedSpendingKey expsk = sk.expandedSpendingKey();
+    PaymentAddress address = sk.defaultAddress();
+
+    //generate a note belongs to this sk
+    Note note = new Note(address, 100 * 1000000L);
+    IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
+    byte[] anchor = voucher.root().getContent().toByteArray();
+    //put the voucher and anchor into db
+    chainBaseManager.getMerkleContainer()
+        .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
+
+    //test case: give a random Ovk
+    expsk.setOvk(randomUint256());
+    //end of test case
+
+    builder.addSpend(expsk, note, anchor, voucher);
+
+    // generate output
+    SpendingKey sk1 = SpendingKey.random();
+    FullViewingKey fullViewingKey1 = sk1.fullViewingKey();
+    IncomingViewingKey ivk1 = fullViewingKey1.inViewingKey();
+    PaymentAddress paymentAddress1 = ivk1.address(new DiversifierT()).get();
+    builder.addOutput(expsk.getOvk(), paymentAddress1,
+        100 * 1000000L - wallet.getShieldedTransactionFee(), new byte[512]);
+
+    updateTotalShieldedPoolValue(builder.getValueBalance());
+    TransactionCapsule transactionCap = builder.build();
+    Assert.assertTrue(true);
+  }
+
+  /*
+   * test add two same cm into spend
+   */
+  //@Test not used
+  public void testSameInputCm()
+      throws BadItemException, RuntimeException, ZksnarkException {
+    librustzcashInitZksnarkParams();
+    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+
+    // generate input
+    SpendingKey sk = SpendingKey
+        .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
+    ExpandedSpendingKey expsk = sk.expandedSpendingKey();
+    PaymentAddress address = sk.defaultAddress();
+    Note note = new Note(address, 100 * 1000000L);
+    IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
+    byte[] anchor = voucher.root().getContent().toByteArray();
+    //put the voucher and anchor into db
+    chainBaseManager.getMerkleContainer()
+        .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
+
+    //add two same cm
+    builder.addSpend(expsk, note, anchor, voucher);
+    builder.addSpend(expsk, note, anchor, voucher);
+
+    // generate output
+    SpendingKey sk1 = SpendingKey.random();
+    FullViewingKey fullViewingKey1 = sk1.fullViewingKey();
+    IncomingViewingKey ivk1 = fullViewingKey1.inViewingKey();
+    PaymentAddress paymentAddress1 = ivk1.address(new DiversifierT()).get();
+    builder.addOutput(expsk.getOvk(), paymentAddress1,
+        200 * 1000000L - wallet.getShieldedTransactionFee(), new byte[512]);
+
+    updateTotalShieldedPoolValue(builder.getValueBalance());
+    TransactionCapsule transactionCap = builder.build();
+
+    try {
+      //validate
+      List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
+      actuator.get(0).validate();
+      Assert.assertFalse(true);
+    } catch (Exception e) {
+      Assert.assertTrue(e instanceof ContractValidateException);
+      Assert.assertEquals("duplicate sapling nullifiers in this transaction", e.getMessage());
+    }
+  }
+
+  /*
+   * test add two same cm into output
+   */
+  @Test
+  public void testSameOutputCm()
+      throws BadItemException, RuntimeException, ZksnarkException {
+    librustzcashInitZksnarkParams();
+    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+
+    // generate input
+    SpendingKey sk = SpendingKey
+        .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
+    ExpandedSpendingKey expsk = sk.expandedSpendingKey();
+    PaymentAddress address = sk.defaultAddress();
+    Note note = new Note(address, 100 * 1000000L);
+    IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
+    byte[] anchor = voucher.root().getContent().toByteArray();
+    //put the voucher and anchor into db
+    chainBaseManager.getMerkleContainer()
+        .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
+    builder.addSpend(expsk, note, anchor, voucher);
+
+    // generate output
+    SpendingKey sk1 = SpendingKey.random();
+    FullViewingKey fullViewingKey1 = sk1.fullViewingKey();
+    IncomingViewingKey ivk1 = fullViewingKey1.inViewingKey();
+    PaymentAddress paymentAddress1 = ivk1.address(new DiversifierT()).get();
+    Note note2 = new Note(address, (100 * 1000000L - wallet.getShieldedTransactionFee()) / 2);
+    //add two same output note
+    builder
+        .addOutput(expsk.getOvk(), note2.getD(), note2.getPkD(), note2.getValue(), note2.getRcm(),
+            new byte[512]);
+    builder
+        .addOutput(expsk.getOvk(), note2.getD(), note2.getPkD(), note2.getValue(), note2.getRcm(),
+            new byte[512]);//same output cm
+
+    updateTotalShieldedPoolValue(builder.getValueBalance());
+    TransactionCapsule transactionCap = builder.build();
+
+    try {
+      //validate
+      List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
+      actuator.get(0).validate();
+      Assert.assertFalse(true);
+    } catch (Exception e) {
+      Assert.assertTrue(e instanceof ContractValidateException);
+      Assert.assertEquals("duplicate cm in receive_description", e.getMessage());
+    }
+  }
+
+  /**
+   * test of transferring insufficient money from shield address to shield address.
+   */
+  @Test
+  public void testShieldInputInsufficient()
+      throws BadItemException, RuntimeException, ZksnarkException {
+    librustzcashInitZksnarkParams();
+    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+
+    // generate input
+    SpendingKey sk = SpendingKey
+        .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
+    ExpandedSpendingKey expsk = sk.expandedSpendingKey();
+    PaymentAddress address = sk.defaultAddress();
+    Note note = new Note(address, 100 * 1000000L);
+    IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
+    byte[] anchor = voucher.root().getContent().toByteArray();
+    chainBaseManager.getMerkleContainer()
+        .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
+
+    //set value that's bigger than own
+    note.setValue(note.getValue() + 10 * 1000000L); //test case of insufficient money
+
+    builder.addSpend(expsk, note, anchor, voucher);
+
+    // generate output
+    SpendingKey sk1 = SpendingKey.random();
+    FullViewingKey fullViewingKey1 = sk1.fullViewingKey();
+    IncomingViewingKey ivk1 = fullViewingKey1.inViewingKey();
+    PaymentAddress paymentAddress1 = ivk1.address(new DiversifierT()).get();
+    builder.addOutput(expsk.getOvk(), paymentAddress1,
+        100 * 1000000L - wallet.getShieldedTransactionFee(), new byte[512]);
+
+    updateTotalShieldedPoolValue(builder.getValueBalance());
+
+    try {
+      TransactionCapsule transactionCap = builder.build();
+      Assert.assertFalse(true);
+    } catch (Exception e) {
+      Assert.assertTrue(e instanceof ZksnarkException);
+      Assert.assertEquals("Spend proof failed", e.getMessage());
+    }
+  }
+
+  /**
+   * test of transferring insufficient money from transparent address to shield address.
+   */
+  @Test
+  public void testTransparentInputInsufficient() throws RuntimeException, ZksnarkException {
+    librustzcashInitZksnarkParams();
+    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+    long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
+    createCapsule();
+    createAccountAssetIssue();
+    //generate input
+    builder.setTransparentInput(ByteArray.fromHexString(FROM_ADDRESS), FROM_AMOUNT); // fail
+    //builder.setTransparentInput(ByteArray.fromHexString(FROM_ADDRESS), OWNER_BALANCE); //success
+    byte[] senderOvk = randomUint256();
+
+    //generate output
+    SpendingKey sk = SpendingKey.random();
+    FullViewingKey fullViewingKey12 = sk.fullViewingKey();
+    IncomingViewingKey ivk = fullViewingKey12.inViewingKey();
+    PaymentAddress paymentAddress = ivk.address(new DiversifierT()).get();
+    builder.addOutput(senderOvk, paymentAddress,
+        FROM_AMOUNT - wallet.getShieldedTransactionFee(), new byte[512]); // fail
+    //builder.addOutput(senderOvk, paymentAddress,
+    //        OWNER_BALANCE - wallet.getShieldedTransactionFee(), new byte[512]); //success
+
+    updateTotalShieldedPoolValue(builder.getValueBalance());
+    TransactionCapsule transactionCap = builder.build();
+
+    try {
+      //valdiate
+      List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
+      actuator.get(0).validate();
+      Assert.assertFalse(true);
+    } catch (Exception e) {
+      Assert.assertTrue(e instanceof ContractValidateException);
+      Assert.assertEquals("Validate ShieldedTransferContract error, balance is not sufficient",
+          e.getMessage());
+    }
+  }
+
+  /*
+  test if random DiversifierT is valid.
+ */
+  @Test
+  public void testDiversifierT() throws ZksnarkException {
+    //byte[] data = org.tron.keystore.Wallet.generateRandomBytes(Constant.ZC_DIVERSIFIER_SIZE);
+    byte[] data1 = ByteArray.fromHexString("93c9e5679850252b37a991");
+    byte[] data2 = ByteArray.fromHexString("c50124c6a9a2e1700fc0b5");
+    Assert.assertFalse(JLibrustzcash.librustzcashCheckDiversifier(data1));
+    Assert.assertTrue(JLibrustzcash.librustzcashCheckDiversifier(data2));
+  }
+
+  private byte[] hashWithMissingColumn(TransactionCapsule tx, TestSignMissingColumn column)
+      throws InvalidProtocolBufferException {
+    Any contractParameter = tx.getInstance().getRawData().getContract(0).getParameter();
+    ShieldedTransferContract shieldedTransferContract = contractParameter
+        .unpack(ShieldedTransferContract.class);
+    ShieldedTransferContract.Builder newContract = ShieldedTransferContract.newBuilder();
+
+    if (column != null) {
+      switch (column) {
+        case FROM_ADDRESS:
+          newContract.setFromAmount(shieldedTransferContract.getFromAmount());
+          newContract
+              .addAllReceiveDescription(shieldedTransferContract.getReceiveDescriptionList());
+          newContract.setToAmount(shieldedTransferContract.getToAmount());
+          newContract.setTransparentToAddress(shieldedTransferContract.getTransparentToAddress());
+          for (SpendDescription spendDescription : shieldedTransferContract
+              .getSpendDescriptionList()) {
+            newContract
+                .addSpendDescription(
+                    spendDescription.toBuilder().clearSpendAuthoritySignature().build());
+          }
+          break;
+        case FROM_AMOUNT:
+          //newContract.setFromAmount(shieldedTransferContract.getFromAmount());
+          newContract
+              .addAllReceiveDescription(shieldedTransferContract.getReceiveDescriptionList());
+          newContract.setToAmount(shieldedTransferContract.getToAmount());
+          newContract
+              .setTransparentFromAddress(shieldedTransferContract.getTransparentFromAddress());
+          newContract.setTransparentToAddress(shieldedTransferContract.getTransparentToAddress());
+          for (SpendDescription spendDescription : shieldedTransferContract
+              .getSpendDescriptionList()) {
+            newContract
+                .addSpendDescription(
+                    spendDescription.toBuilder().clearSpendAuthoritySignature().build());
+          }
+          break;
+        case SPEND_DESCRITPION:
+          newContract.setFromAmount(shieldedTransferContract.getFromAmount());
+          newContract
+              .addAllReceiveDescription(shieldedTransferContract.getReceiveDescriptionList());
+          newContract.setToAmount(shieldedTransferContract.getToAmount());
+          newContract
+              .setTransparentFromAddress(shieldedTransferContract.getTransparentFromAddress());
+          newContract.setTransparentToAddress(shieldedTransferContract.getTransparentToAddress());
+          break;
+        case RECEIVE_DESCRIPTION:
+          newContract.setFromAmount(shieldedTransferContract.getFromAmount());
+          newContract.setToAmount(shieldedTransferContract.getToAmount());
+          newContract
+              .setTransparentFromAddress(shieldedTransferContract.getTransparentFromAddress());
+          newContract.setTransparentToAddress(shieldedTransferContract.getTransparentToAddress());
+          for (SpendDescription spendDescription : shieldedTransferContract
+              .getSpendDescriptionList()) {
+            newContract
+                .addSpendDescription(
+                    spendDescription.toBuilder().clearSpendAuthoritySignature().build());
+          }
+          break;
+        case TO_ADDRESS:
+          newContract.setFromAmount(shieldedTransferContract.getFromAmount());
+          newContract
+              .addAllReceiveDescription(shieldedTransferContract.getReceiveDescriptionList());
+          newContract.setToAmount(shieldedTransferContract.getToAmount());
+          newContract
+              .setTransparentFromAddress(shieldedTransferContract.getTransparentFromAddress());
+          //newContract.setTransparentToAddress(shieldedTransferContract.getTransparentToAddress());
+          for (SpendDescription spendDescription : shieldedTransferContract
+              .getSpendDescriptionList()) {
+            newContract
+                .addSpendDescription(
+                    spendDescription.toBuilder().clearSpendAuthoritySignature().build());
+          }
+          break;
+        case TO_AMOUNT:
+          newContract.setFromAmount(shieldedTransferContract.getFromAmount());
+          newContract
+              .addAllReceiveDescription(shieldedTransferContract.getReceiveDescriptionList());
+          //newContract.setToAmount(shieldedTransferContract.getToAmount());
+          newContract
+              .setTransparentFromAddress(shieldedTransferContract.getTransparentFromAddress());
+          newContract.setTransparentToAddress(shieldedTransferContract.getTransparentToAddress());
+          for (SpendDescription spendDescription : shieldedTransferContract
+              .getSpendDescriptionList()) {
+            newContract
+                .addSpendDescription(
+                    spendDescription.toBuilder().clearSpendAuthoritySignature().build());
+          }
+          break;
+        default:
+          break;
+      }
+    }
+    Transaction.raw.Builder rawBuilder = tx.getInstance().toBuilder()
+        .getRawDataBuilder()
+        .clearContract()
+        .addContract(
+            Transaction.Contract.newBuilder().setType(ContractType.ShieldedTransferContract)
+                .setParameter(
+                    Any.pack(newContract.build())).build());
+
+    Transaction transaction = tx.getInstance().toBuilder().clearRawData()
+        .setRawData(rawBuilder).build();
+
+    byte[] mergedByte = Bytes.concat(
+        Sha256Hash.of(
+            CommonParameter
+                .getInstance().isECKeyCryptoEngine(),
+            CommonParameter.getInstance().getZenTokenId().getBytes()).getBytes(),
+        transaction.getRawData().toByteArray());
+    return Sha256Hash.of(CommonParameter
+        .getInstance().isECKeyCryptoEngine(), mergedByte).getBytes();
+  }
+
+  private ZenTransactionBuilder generateShield2ShieldBuilder(ZenTransactionBuilder builder,
+      long ctx)
+      throws ZksnarkException, BadItemException {
+    //generate input
+    SpendingKey sk = SpendingKey.random();
+    ExpandedSpendingKey expsk = sk.expandedSpendingKey();
+    PaymentAddress address = sk.defaultAddress();
+    Note note = new Note(address, 100 * 1000000L);
+    IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
+    byte[] anchor = voucher.root().getContent().toByteArray();
+    chainBaseManager.getMerkleContainer()
+        .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
+    builder.addSpend(expsk, note, anchor, voucher);
+
+    // generate output
+    SpendingKey sk1 = SpendingKey.random();
+    FullViewingKey fullViewingKey1 = sk1.fullViewingKey();
+    IncomingViewingKey ivk1 = fullViewingKey1.inViewingKey();
+    PaymentAddress paymentAddress1 = ivk1.address(new DiversifierT()).get();
+    builder.addOutput(expsk.getOvk(), paymentAddress1,
+        100 * 1000000L - wallet.getShieldedTransactionFee(), new byte[512]);
+
+    // Create Sapling SpendDescriptions
+    for (SpendDescriptionInfo spend : builder.getSpends()) {
+      SpendDescriptionCapsule spendDescriptionCapsule = builder.generateSpendProof(spend, ctx);
+      builder.getContractBuilder().addSpendDescription(spendDescriptionCapsule.getInstance());
     }
 
-    private static byte[] randomUint4640() {
-        return org.tron.keystore.Wallet.generateRandomBytes(580);
+    // Create Sapling OutputDescriptions
+    for (ReceiveDescriptionInfo receive : builder.getReceives()) {
+      ReceiveDescriptionCapsule receiveDescriptionCapsule = builder
+          .generateOutputProof(receive, ctx);
+      builder.getContractBuilder().addReceiveDescription(receiveDescriptionCapsule.getInstance());
     }
 
-    /**
-     * create temp Capsule test need.
-     */
-    @Before
-    public void createToken() {
-        Args.getInstance().setZenTokenId(String.valueOf(tokenId));
-        chainBaseManager.getDynamicPropertiesStore().saveAllowSameTokenName(1);
-        chainBaseManager.getDynamicPropertiesStore().saveTokenIdNum(tokenId);
+    return builder;
+  }
 
-        AssetIssueContract assetIssueContract =
-                AssetIssueContract.newBuilder()
-                        .setOwnerAddress(ByteString.copyFrom(ByteArray.fromHexString(FROM_ADDRESS)))
-                        .setName(ByteString.copyFrom(ByteArray.fromString(ASSET_NAME)))
-                        .setId(Long.toString(tokenId))
-                        .setTotalSupply(OWNER_BALANCE)
-                        .setTrxNum(TRX_NUM)
-                        .setNum(NUM)
-                        .setStartTime(START_TIME)
-                        .setEndTime(END_TIME)
-                        .setVoteScore(VOTE_SCORE)
-                        .setDescription(ByteString.copyFrom(ByteArray.fromString(DESCRIPTION)))
-                        .setUrl(ByteString.copyFrom(ByteArray.fromString(URL)))
-                        .build();
-        AssetIssueCapsule assetIssueCapsule = new AssetIssueCapsule(assetIssueContract);
-        chainBaseManager
-                .getAssetIssueV2Store().put(assetIssueCapsule.createDbV2Key(), assetIssueCapsule);
+  public TransactionCapsule generateTransactionCapsule(ZenTransactionBuilder builder,
+      long ctx, byte[] hashOfTransaction, TransactionCapsule transactionCapsule)
+      throws ZksnarkException {
+    // Create Sapling spendAuth
+    for (int i = 0; i < builder.getSpends().size(); i++) {
+      byte[] result = new byte[64];
+      JLibrustzcash.librustzcashSaplingSpendSig(
+          new SpendSigParams(builder.getSpends().get(i).getExpsk().getAsk(),
+              builder.getSpends().get(i).getAlpha(),
+              hashOfTransaction,
+              result));
+      builder.getContractBuilder().getSpendDescriptionBuilder(i)
+          .setSpendAuthoritySignature(ByteString.copyFrom(result));
     }
 
-    /**
-     * create temp transparent address for  test need.
-     */
-    private void createCapsule() {
-        AccountCapsule ownerCapsule =
-                new AccountCapsule(
-                        ByteString.copyFromUtf8("owner"),
-                        ByteString.copyFrom(ByteArray.fromHexString(FROM_ADDRESS)),
-                        AccountType.Normal,
-                        OWNER_BALANCE);
-        ownerCapsule.addAssetV2(ByteArray.fromString(String.valueOf(tokenId)), OWNER_BALANCE);
-        chainBaseManager.getAccountStore().put(ownerCapsule.getAddress().toByteArray(), ownerCapsule);
+    //create binding signatures
+    byte[] bindingSig = new byte[64];
+    JLibrustzcash.librustzcashSaplingBindingSig(
+        new BindingSigParams(ctx,
+            builder.getValueBalance(),
+            hashOfTransaction,
+            bindingSig)
+    );
+    builder.getContractBuilder().setBindingSignature(ByteString.copyFrom(bindingSig));
+
+    Transaction.raw.Builder rawBuilder = transactionCapsule.getInstance().toBuilder()
+        .getRawDataBuilder()
+        .clearContract()
+        .addContract(Transaction.Contract.newBuilder()
+            .setType(ContractType.ShieldedTransferContract)
+            .setParameter(Any.pack(builder.getContractBuilder().build()))
+            .build());
+
+    Transaction transaction = transactionCapsule.getInstance().toBuilder().clearRawData()
+        .setRawData(rawBuilder).build();
+    TransactionCapsule transactionCap = new TransactionCapsule(transaction);
+
+    updateTotalShieldedPoolValue(builder.getValueBalance());
+
+    return transactionCap;
+  }
+
+  /*
+   * test signature for shield to shield transaction with some column missing
+   */
+  @Test
+  public void testSignWithoutFromAddress()
+      throws BadItemException, ContractValidateException, RuntimeException,
+      ZksnarkException {
+    librustzcashInitZksnarkParams();
+    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+    long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
+
+    builder = generateShield2ShieldBuilder(builder, ctx);
+
+    // Empty output script.
+    byte[] hashOfTransaction;//256
+    TransactionCapsule transactionCapsule;
+    try {
+      transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
+          builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
+
+      //test case
+      hashOfTransaction = hashWithMissingColumn(transactionCapsule,
+          TestSignMissingColumn.FROM_ADDRESS);
+      //end of test case
+
+    } catch (Exception ex) {
+      JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
+      throw new RuntimeException("Could not construct signature hash: " + ex.getMessage());
     }
 
-    private void createAccountAssetIssue() {
-        AccountAssetIssueCapsule ownerAssetIssueCapsule =
-                new AccountAssetIssueCapsule(
-                        ByteString.copyFromUtf8("owner"),
-                        ByteString.copyFrom(ByteArray.fromHexString(FROM_ADDRESS))
-                );
-        ownerAssetIssueCapsule.addAssetV2(ByteArray.fromString(String.valueOf(tokenId)), OWNER_BALANCE);
-        chainBaseManager.getAccountAssetIssueStore().put(ownerAssetIssueCapsule.getAddress().toByteArray(), ownerAssetIssueCapsule);
-        AccountAssetIssueCapsule blackhole = chainBaseManager.getAccountAssetIssueStore().getBlackhole();
-        AccountCapsule blackhole1 = chainBaseManager.getAccountStore().getBlackhole();
-        blackhole.getAssetIssuedName();
-        blackhole1.getBalance();
+    TransactionCapsule transactionCap = generateTransactionCapsule(builder, ctx, hashOfTransaction,
+        transactionCapsule);
+
+    List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
+    actuator.get(0).validate(); //there is hash(transaction) in librustzcashSaplingFinalCheck
+    Assert.assertTrue(true);
+  }
+
+  /*
+   * test signature for shield to shield transaction with some column missing
+   */
+  @Test
+  public void testSignWithoutFromAmout()
+      throws BadItemException, ContractValidateException, RuntimeException,
+      ZksnarkException {
+    librustzcashInitZksnarkParams();
+    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+    long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
+
+    builder = generateShield2ShieldBuilder(builder, ctx);
+
+    // Empty output script.
+    byte[] hashOfTransaction;//256
+    TransactionCapsule transactionCapsule;
+    try {
+      transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
+          builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
+
+      //test case
+      hashOfTransaction = hashWithMissingColumn(transactionCapsule,
+          TestSignMissingColumn.FROM_AMOUNT);
+      //end of test case
+
+    } catch (Exception ex) {
+      JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
+      throw new RuntimeException("Could not construct signature hash: " + ex.getMessage());
     }
 
-    public IncrementalMerkleVoucherContainer createSimpleMerkleVoucherContainer(byte[] cm)
-            throws ZksnarkException {
-        IncrementalMerkleTreeContainer tree =
-                new IncrementalMerkleTreeContainer(new IncrementalMerkleTreeCapsule());
-        PedersenHashCapsule compressCapsule1 = new PedersenHashCapsule();
-        compressCapsule1.setContent(ByteString.copyFrom(cm));
-        PedersenHash a = compressCapsule1.getInstance();
-        tree.append(a);
-        IncrementalMerkleVoucherContainer voucher = tree.toVoucher();
-        return voucher;
+    TransactionCapsule transactionCap = generateTransactionCapsule(builder, ctx, hashOfTransaction,
+        transactionCapsule);
+
+    List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
+    actuator.get(0).validate(); //there is hash(transaction) in librustzcashSaplingFinalCheck
+    Assert.assertTrue(true);
+  }
+
+  /*
+   * test signature for shield to shield transaction with some column missing
+   */
+  @Test
+  public void testSignWithoutSpendDescription()
+      throws BadItemException, RuntimeException, ZksnarkException {
+    librustzcashInitZksnarkParams();
+    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+    long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
+
+    builder = generateShield2ShieldBuilder(builder, ctx);
+
+    // Empty output script.
+    byte[] hashOfTransaction;//256
+    TransactionCapsule transactionCapsule;
+    try {
+      transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
+          builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
+
+      //test case
+      hashOfTransaction = hashWithMissingColumn(transactionCapsule,
+          TestSignMissingColumn.SPEND_DESCRITPION);
+      //end of test case
+
+    } catch (Exception ex) {
+      JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
+      throw new RuntimeException("Could not construct signature hash: " + ex.getMessage());
     }
 
-    private void updateTotalShieldedPoolValue(long valueBalance) {
-        long totalShieldedPoolValue =
-                chainBaseManager.getDynamicPropertiesStore().getTotalShieldedPoolValue();
-        totalShieldedPoolValue -= valueBalance;
-        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(totalShieldedPoolValue);
+    TransactionCapsule transactionCap = generateTransactionCapsule(builder, ctx, hashOfTransaction,
+        transactionCapsule);
+
+    try {
+      //validate
+      List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
+      actuator.get(0).validate(); //there is hash(transaction) in librustzcashSaplingFinalCheck
+      Assert.assertFalse(true);
+    } catch (Exception e) {
+      Assert.assertTrue(e instanceof ContractValidateException);
+      Assert.assertEquals("librustzcashSaplingCheckSpend error", e.getMessage());
+    }
+    JLibrustzcash.librustzcashSaplingVerificationCtxFree(ctx);
+  }
+
+  /*
+   * test signature for shield to shield transaction with some column missing
+   */
+  @Test
+  public void testSignWithoutReceiveDescription()
+      throws BadItemException, RuntimeException, ZksnarkException {
+    librustzcashInitZksnarkParams();
+    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+    long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
+
+    builder = generateShield2ShieldBuilder(builder, ctx);
+
+    // Empty output script.
+    byte[] hashOfTransaction;//256
+    TransactionCapsule transactionCapsule;
+    try {
+      transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
+          builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
+
+      //test case
+      hashOfTransaction = hashWithMissingColumn(transactionCapsule,
+          TestSignMissingColumn.RECEIVE_DESCRIPTION);
+      //end of test case
+
+    } catch (Exception ex) {
+      JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
+      throw new RuntimeException("Could not construct signature hash: " + ex.getMessage());
     }
 
-    /*
-     * test of change ShieldedTransactionFee proposal
-     */
-    @Test
-    public void testSetShieldedTransactionFee() {
-        long fee = wallet.getShieldedTransactionFee();
+    TransactionCapsule transactionCap = generateTransactionCapsule(builder, ctx, hashOfTransaction,
+        transactionCapsule);
 
-        chainBaseManager.getDynamicPropertiesStore().saveShieldedTransactionFee(2_000_000);
-        Assert.assertEquals(2_000_000, wallet.getShieldedTransactionFee());
+    try {
+      //validate
+      List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
+      actuator.get(0).validate(); //there is hash(transaction) in librustzcashSaplingFinalCheck
+      Assert.assertFalse(true);
+    } catch (Exception e) {
+      Assert.assertTrue(e instanceof ContractValidateException);
+      Assert.assertEquals("librustzcashSaplingCheckSpend error", e.getMessage());
+    }
+    JLibrustzcash.librustzcashSaplingVerificationCtxFree(ctx);
+  }
 
-        chainBaseManager.getDynamicPropertiesStore().saveShieldedTransactionFee(fee);
+  /*
+   * test signature for shield to shield transaction with some column missing
+   */
+  @Test
+  public void testSignWithoutToAddress()
+      throws BadItemException, ContractValidateException, RuntimeException,
+      ZksnarkException {
+    librustzcashInitZksnarkParams();
+    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+    long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
+
+    builder = generateShield2ShieldBuilder(builder, ctx);
+
+    // Empty output script.
+    byte[] hashOfTransaction;//256
+    TransactionCapsule transactionCapsule;
+    try {
+      transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
+          builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
+
+      //test case
+      hashOfTransaction = hashWithMissingColumn(transactionCapsule,
+          TestSignMissingColumn.TO_ADDRESS);
+      //end of test case
+
+    } catch (Exception ex) {
+      JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
+      throw new RuntimeException("Could not construct signature hash: " + ex.getMessage());
     }
 
-    /*
-     * test of creating shielded transaction before turn on the switch
-     */
-    @Test
-    public void testCreateBeforeAllowZksnark() throws ZksnarkException {
-        librustzcashInitZksnarkParams();
-        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(0);
-        createCapsule();
-        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+    TransactionCapsule transactionCap = generateTransactionCapsule(builder, ctx, hashOfTransaction,
+        transactionCapsule);
 
-        //generate input
-        builder.setTransparentInput(ByteArray.fromHexString(FROM_ADDRESS), OWNER_BALANCE); //success
-        byte[] senderOvk = randomUint256();
+    List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
+    actuator.get(0).validate(); //there is hash(transaction) in librustzcashSaplingFinalCheck
+    Assert.assertTrue(true);
+  }
 
-        //generate output
-        SpendingKey sk = SpendingKey.random();
-        FullViewingKey fullViewingKey12 = sk.fullViewingKey();
-        IncomingViewingKey ivk = fullViewingKey12.inViewingKey();
-        PaymentAddress paymentAddress = ivk.address(new DiversifierT()).get();
-        builder.addOutput(senderOvk, paymentAddress,
-                OWNER_BALANCE - wallet.getShieldedTransactionFee(), new byte[512]); //success
+  /*
+   * test signature for shield to shield transaction with some column missing
+   */
+  @Test
+  public void testSignWithoutToAmount()
+      throws BadItemException, ContractValidateException, RuntimeException,
+      ZksnarkException {
+    librustzcashInitZksnarkParams();
+    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+    long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
 
-        updateTotalShieldedPoolValue(builder.getValueBalance());
-        TransactionCapsule transactionCap = builder.build();
+    builder = generateShield2ShieldBuilder(builder, ctx);
 
-        //online
-        try {
-            //validate
-            List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
-            actuator.get(0).validate();
-            Assert.assertFalse(true);
-        } catch (Exception e) {
-            Assert.assertTrue(e instanceof ContractValidateException);
-            Assert.assertEquals(
-                    "Not support Shielded Transaction, need to be opened by the committee",
-                    e.getMessage());
-        }
+    // Empty output script.
+    byte[] hashOfTransaction;//256
+    TransactionCapsule transactionCapsule;
+    try {
+      transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
+          builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
+
+      //test case
+      hashOfTransaction = hashWithMissingColumn(transactionCapsule,
+          TestSignMissingColumn.TO_AMOUNT);
+      //end of test case
+
+    } catch (Exception ex) {
+      JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
+      throw new RuntimeException("Could not construct signature hash: " + ex.getMessage());
     }
 
-    /*
-     * test of broadcasting shielded transaction before allow shielded transaction
-     */
-    @Test
-    public void testBroadcastBeforeAllowZksnark()
-            throws ZksnarkException, SignatureFormatException, SignatureException, PermissionException {
-        librustzcashInitZksnarkParams();
-        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(0);// or 1
-        createCapsule();
-        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+    TransactionCapsule transactionCap = generateTransactionCapsule(builder, ctx, hashOfTransaction,
+        transactionCapsule);
 
-        //generate input
-        builder.setTransparentInput(ByteArray.fromHexString(FROM_ADDRESS), OWNER_BALANCE); //success
-        byte[] senderOvk = randomUint256();
+    List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
+    actuator.get(0).validate(); //there is hash(transaction) in librustzcashSaplingFinalCheck
+    Assert.assertTrue(true);
+  }
 
-        //generate output
-        SpendingKey sk = SpendingKey.random();
-        FullViewingKey fullViewingKey12 = sk.fullViewingKey();
-        IncomingViewingKey ivk = fullViewingKey12.inViewingKey();
-        PaymentAddress paymentAddress = ivk.address(new DiversifierT()).get();
-        long fee = chainBaseManager.getDynamicPropertiesStore().getShieldedTransactionFee();
-        builder.addOutput(senderOvk, paymentAddress,
-                OWNER_BALANCE - fee, new byte[512]); //success
+  /*
+   * test spend authorize signature with some wrong column
+   */
+  @Test
+  public void testSpendSignatureWithWrongColumn()
+      throws BadItemException, RuntimeException, ZksnarkException {
+    librustzcashInitZksnarkParams();
+    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+    long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
 
-        updateTotalShieldedPoolValue(builder.getValueBalance());
-        TransactionCapsule transactionCap = builder.build();
+    // generate input
+    SpendingKey sk = SpendingKey
+        .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
+    ExpandedSpendingKey expsk = sk.expandedSpendingKey();
+    PaymentAddress address = sk.defaultAddress();
+    Note note = new Note(address, 100 * 1000000L);
+    IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
+    byte[] anchor = voucher.root().getContent().toByteArray();
+    chainBaseManager.getMerkleContainer()
+        .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
+    builder.addSpend(expsk, note, anchor, voucher);
 
-        //Add public address sign
-        TransactionSign.Builder transactionSignBuild = TransactionSign.newBuilder();
-        transactionSignBuild.setTransaction(transactionCap.getInstance());
-        transactionSignBuild.setPrivateKey(ByteString.copyFrom(
-                ByteArray.fromHexString(ADDRESS_ONE_PRIVATE_KEY)));
+    //shield transparent input
+    //createCapsule();
+    //builder.setTransparentInput(ByteArray.fromHexString(FROM_ADDRESS), OWNER_BALANCE);
 
-        transactionCap = transactionUtil.addSign(transactionSignBuild.build());
+    // generate output
+    SpendingKey sk1 = SpendingKey.random();
+    FullViewingKey fullViewingKey1 = sk1.fullViewingKey();
+    IncomingViewingKey ivk1 = fullViewingKey1.inViewingKey();
+    PaymentAddress paymentAddress1 = ivk1.address(new DiversifierT()).get();
+    builder.addOutput(expsk.getOvk(), paymentAddress1,
+        100 * 1000000L - wallet.getShieldedTransactionFee(), new byte[512]);
 
-        try {
-            dbManager.pushTransaction(transactionCap);
-            Assert.assertFalse(true);
-        } catch (Exception e) {
-            Assert.assertTrue(e instanceof ContractValidateException);
-            Assert.assertEquals(
-                    "Not support Shielded Transaction, need to be opened by the committee",
-                    e.getMessage());
-        }
+    // Create Sapling SpendDescriptions
+    for (SpendDescriptionInfo spend : builder.getSpends()) {
+      SpendDescriptionCapsule spendDescriptionCapsule = builder.generateSpendProof(spend, ctx);
+      builder.getContractBuilder().addSpendDescription(spendDescriptionCapsule.getInstance());
     }
 
-    /*
-     * generate spendproof, dataToBeSigned, outputproof example dynamicly according to the params file
-     */
-    public String[] generateSpendAndOutputParams() throws ZksnarkException, BadItemException {
-        librustzcashInitZksnarkParams();
-        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-        long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
-
-        //generate input
-        SpendingKey sk = SpendingKey.random();
-        ExpandedSpendingKey expsk = sk.expandedSpendingKey();
-        PaymentAddress address = sk.defaultAddress();
-
-        Note note = new Note(address, 100 * 1000000L);
-        IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
-        byte[] anchor = voucher.root().getContent().toByteArray();
-        chainBaseManager.getMerkleContainer()
-                .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
-        builder.addSpend(expsk, note, anchor, voucher);
-
-        // generate output
-        SpendingKey sk1 = SpendingKey.random();
-        FullViewingKey fullViewingKey1 = sk1.fullViewingKey();
-        IncomingViewingKey ivk1 = fullViewingKey1.inViewingKey();
-        PaymentAddress paymentAddress1 = ivk1.address(new DiversifierT()).get();
-        builder.addOutput(expsk.getOvk(), paymentAddress1,
-                100 * 1000000 - wallet.getShieldedTransactionFee(), new byte[512]);
-
-        // Create Sapling SpendDescriptions
-        for (SpendDescriptionInfo spend2 : builder.getSpends()) {
-            SpendDescriptionCapsule spendDescriptionCapsule = builder.generateSpendProof(spend2, ctx);
-            builder.getContractBuilder().addSpendDescription(spendDescriptionCapsule.getInstance());
-        }
-
-        // Create Sapling OutputDescriptions
-        for (ReceiveDescriptionInfo receive : builder.getReceives()) {
-            ReceiveDescriptionCapsule receiveDescriptionCapsule = builder
-                    .generateOutputProof(receive, ctx);
-            builder.getContractBuilder().addReceiveDescription(receiveDescriptionCapsule.getInstance());
-        }
-
-        // begin to generate dataToBeSigned
-        TransactionCapsule transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
-                builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
-        byte[] dataToBeSigned = TransactionCapsule
-                .getShieldTransactionHashIgnoreTypeException(transactionCapsule.getInstance());
-        TransactionCapsule transactionCap = generateTransactionCapsule(builder, ctx, dataToBeSigned,
-                transactionCapsule);
-
-        // generate checkSpendParams
-        SpendDescription spendDescription = builder.getContractBuilder().getSpendDescription(0);
-        CheckSpendParams checkSpendParams = new CheckSpendParams(ctx,
-                spendDescription.getValueCommitment().toByteArray(),
-                spendDescription.getAnchor().toByteArray(),
-                spendDescription.getNullifier().toByteArray(),
-                spendDescription.getRk().toByteArray(),
-                spendDescription.getZkproof().toByteArray(),
-                spendDescription.getSpendAuthoritySignature().toByteArray(),
-                dataToBeSigned);
-
-        boolean ok1 = JLibrustzcash.librustzcashSaplingCheckSpend(checkSpendParams);
-        Assert.assertTrue(ok1);
-
-        byte[] checkSpendParamsData = new byte[385];
-        System.arraycopy(
-                checkSpendParams.getCv(), 0, checkSpendParamsData, 0, 32);
-        System.arraycopy(
-                checkSpendParams.getAnchor(), 0, checkSpendParamsData, 32, 32);
-        System.arraycopy(
-                checkSpendParams.getNullifier(), 0, checkSpendParamsData, 64, 32);
-        System.arraycopy(
-                checkSpendParams.getRk(), 0, checkSpendParamsData, 96, 32);
-        System.arraycopy(
-                checkSpendParams.getZkproof(), 0, checkSpendParamsData, 128, 192);
-        System.arraycopy(
-                checkSpendParams.getSpendAuthSig(), 0, checkSpendParamsData, 320, 64);
-
-        // generate CheckOutputParams
-        ReceiveDescription receiveDescription =
-                builder.getContractBuilder().getReceiveDescription(0);
-        CheckOutputParams checkOutputParams = new CheckOutputParams(ctx,
-                receiveDescription.getValueCommitment().toByteArray(),
-                receiveDescription.getNoteCommitment().toByteArray(),
-                receiveDescription.getEpk().toByteArray(),
-                receiveDescription.getZkproof().toByteArray()
-        );
-
-        boolean ok2 = JLibrustzcash.librustzcashSaplingCheckOutput(checkOutputParams);
-        Assert.assertTrue(ok2);
-
-        return new String[]{ByteArray.toHexString(checkSpendParamsData),
-                ByteArray.toHexString(dataToBeSigned),
-                ByteArray.toHexString(checkOutputParams.encode())};
+    // Create Sapling OutputDescriptions
+    for (ReceiveDescriptionInfo receive : builder.getReceives()) {
+      ReceiveDescriptionCapsule receiveDescriptionCapsule = builder
+          .generateOutputProof(receive, ctx);
+      builder.getContractBuilder().addReceiveDescription(receiveDescriptionCapsule.getInstance());
     }
 
-    private long benchmarkVerifySpend(String spend, String dataToBeSigned) throws ZksnarkException {
-        long startTime = System.currentTimeMillis();
-        long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
+    // Empty output script.
+    byte[] hashOfTransaction;//256
+    TransactionCapsule transactionCapsule;
+    try {
+      transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
+          builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
 
-        CheckSpendParams checkSpendParams = CheckSpendParams.decode(ctx,
-                ByteArray.fromHexString(spend),
-                ByteArray.fromHexString(dataToBeSigned));
+      hashOfTransaction = TransactionCapsule
+          .hashShieldTransaction(transactionCapsule.getInstance(),
+              CommonParameter.getInstance().getZenTokenId());
 
-        boolean ok = JLibrustzcash.librustzcashSaplingCheckSpend(checkSpendParams);
-
-        JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
-        Assert.assertTrue(ok);
-
-        long endTime = System.currentTimeMillis();
-        long time = endTime - startTime;
-
-        System.out.println("--- time is: " + time + ", result is " + ok);
-        return time;
+    } catch (Exception ex) {
+      JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
+      throw new RuntimeException("Could not construct signature hash: " + ex.getMessage());
     }
 
-    private long benchmarkVerifyOutput(String outputParams) throws ZksnarkException {
-        // expect true
-        long startTime = System.currentTimeMillis();
-        long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
-
-        CheckOutputParams checkOutputParams = CheckOutputParams.decode(ctx,
-                ByteArray.fromHexString(outputParams));
-
-        boolean ok = JLibrustzcash.librustzcashSaplingCheckOutput(checkOutputParams);
-
-        JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
-        Assert.assertTrue(ok);
-
-        long endTime = System.currentTimeMillis();
-        long time = endTime - startTime;
-
-        System.out.println("--- time is: " + time + ", result is " + ok);
-        return time;
+    // Create Sapling spendAuth
+    for (int i = 0; i < builder.getSpends().size(); i++) {
+      byte[] result = new byte[64];
+      JLibrustzcash.librustzcashSaplingSpendSig(
+          new SpendSigParams(builder.getSpends().get(i).getExpsk().getAsk(),
+              Note.generateR(),
+              //replace builder.getSpends().get(i).alpha with random alpha, should fail
+              hashOfTransaction,
+              result));
+      builder.getContractBuilder().getSpendDescriptionBuilder(i)
+          .setSpendAuthoritySignature(ByteString.copyFrom(result));
     }
 
-    @Test
-    public void calBenchmarkVerifySpend() throws ZksnarkException, BadItemException {
-        librustzcashInitZksnarkParams();
-        System.out.println("--- load ok ---");
+    //create binding signatures
+    byte[] bindingSig = new byte[64];
+    JLibrustzcash.librustzcashSaplingBindingSig(
+        new BindingSigParams(ctx,
+            builder.getValueBalance(),
+            hashOfTransaction,
+            bindingSig)
+    );
+    builder.getContractBuilder().setBindingSignature(ByteString.copyFrom(bindingSig));
 
-        int count = 10;
-        long minTime = 500;
-        long maxTime = 0;
-        double totalTime = 0.0;
+    Transaction.raw.Builder rawBuilder = transactionCapsule.getInstance().toBuilder()
+        .getRawDataBuilder()
+        .clearContract()
+        .addContract(Transaction.Contract.newBuilder()
+            .setType(ContractType.ShieldedTransferContract)
+            .setParameter(Any.pack(builder.getContractBuilder().build()))
+            .build());
 
-        String[] result = generateSpendAndOutputParams();
-        String spend = result[0];
-        String dataToBeSigned = result[1];
+    Transaction transaction = transactionCapsule.getInstance().toBuilder().clearRawData()
+        .setRawData(rawBuilder).build();
+    TransactionCapsule transactionCap = new TransactionCapsule(transaction);
 
-        for (int i = 0; i < count; i++) {
-            long time = benchmarkVerifySpend(spend, dataToBeSigned);
-            if (time < minTime) {
-                minTime = time;
-            }
-            if (time > maxTime) {
-                maxTime = time;
-            }
-            totalTime += time;
-        }
+    updateTotalShieldedPoolValue(builder.getValueBalance());
 
-        System.out.println("---- result ----");
-        System.out.println("---- maxTime is: " + maxTime);
-        System.out.println("---- minTime is: " + minTime);
-        System.out.println("---- avgTime is: " + totalTime / count);
+    try {
+      //validate
+      List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
+      actuator.get(0)
+          .validate(); //there is getSpendAuthoritySignature in librustzcashSaplingCheckSpend
+      Assert.assertFalse(true);
+    } catch (Exception e) {
+      Assert.assertTrue(e instanceof ContractValidateException);
+      //signature for spend with some wrong column
+      //if transparent to shield, ok
+      //if shield to shield or shield to transparent, librustzcashSaplingFinalCheck error
+      Assert.assertTrue(e.getMessage().equalsIgnoreCase("librustzcashSaplingCheckSpend error"));
+    }
+    JLibrustzcash.librustzcashSaplingVerificationCtxFree(ctx);
+  }
 
+  /*
+   * test use isolate method to build the signature
+   */
+  @Test
+  public void testIsolateSignature()
+      throws ZksnarkException, BadItemException, ContractValidateException, ContractExeException {
+    librustzcashInitZksnarkParams();
+    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+    long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
+
+    // generate shield spend
+    SpendingKey sk = SpendingKey
+        .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
+    ExpandedSpendingKey expsk = sk.expandedSpendingKey();
+
+    //build transaction without spend signature and get transactionHash
+    TransactionHash transactionHash = new TransactionHash(new byte[32]);
+    TransactionCapsule transactionCapsule = buildShieldedTransactionWithoutSpendAuthSig(
+        sk.defaultAddress(),
+        sk.fullViewingKey().getAk(),
+        expsk.getNsk(),
+        expsk.getOvk(),
+        transactionHash,
+        builder,
+        ctx);
+    //filled with Sapling spendAuth in builder
+    List<SpendDescriptionInfo> spends = builder.getSpends();
+    for (int i = 0; i < spends.size(); i++) {
+      //replace with interface
+      SpendAuthSigParameters spendAuthSigParameters = SpendAuthSigParameters.newBuilder()
+          .setAsk(ByteString.copyFrom(expsk.getAsk())) //ask => ak
+          .setAlpha(ByteString.copyFrom(spends.get(i).getAlpha()))
+          .setTxHash(ByteString.copyFrom(transactionHash.getHash()))
+          .build();
+      BytesMessage spendAuthSig = wallet.createSpendAuthSig(spendAuthSigParameters);
+      builder.getContractBuilder().getSpendDescriptionBuilder(i)
+          .setSpendAuthoritySignature(spendAuthSig.getValue());
     }
 
-    @Test
-    public void calBenchmarkVerifyOutput() throws ZksnarkException, BadItemException {
-        librustzcashInitZksnarkParams();
-        System.out.println("--- load ok ---");
+    Transaction.raw.Builder rawBuilder = transactionCapsule.getInstance().toBuilder()
+        .getRawDataBuilder()
+        .clearContract()
+        .addContract(Transaction.Contract.newBuilder()
+            .setType(ContractType.ShieldedTransferContract)
+            .setParameter(Any.pack(builder.getContractBuilder().build()))
+            .build());
+    Transaction transaction = transactionCapsule.getInstance().toBuilder().clearRawData()
+        .setRawData(rawBuilder).build();
 
-        int count = 2;
-        long minTime = 500;
-        long maxTime = 0;
-        double totalTime = 0.0;
+    TransactionCapsule transactionCap = new TransactionCapsule(transaction);
+    //validate
+    List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
+    actuator.get(0).validate();
+    //execute
+    TransactionResultCapsule resultCapsule = new TransactionResultCapsule();
+    boolean executeResult = actuator.get(0).execute(resultCapsule);
+    Assert.assertTrue(executeResult);
+  }
 
-        String[] result = generateSpendAndOutputParams();
-        String outputParams = result[2];
+  /*
+   * build ShieldedTransaction Without SpendAuthSig
+   */
+  public TransactionCapsule buildShieldedTransactionWithoutSpendAuthSig(PaymentAddress address,
+      byte[] ak,
+      byte[] nsk, byte[] ovk, TransactionHash dataHashToBeSigned, ZenTransactionBuilder builder,
+      long ctx)
+      throws ZksnarkException, BadItemException, ContractValidateException {
+    // generate input
+    Note note = new Note(address, 100 * 1000000L);
+    note.setRcm(ByteArray.fromHexString(
+        "eb1aa5dd257b9da4e4064a853dec94651be38078e29fe441a9a8075016cfa701"));
+    IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
+    byte[] anchor = voucher.root().getContent().toByteArray();
+    chainBaseManager.getMerkleContainer()
+        .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
+    SpendDescriptionInfo skSpend = new SpendDescriptionInfo(ak,
+        nsk,
+        ovk,
+        note,
+        Note.generateR(),
+        anchor,
+        voucher
+    );
+    builder.addSpend(skSpend);
 
-        for (int i = 0; i < count; i++) {
-            long time = benchmarkVerifyOutput(outputParams);
-            if (time < minTime) {
-                minTime = time;
-            }
-            if (time > maxTime) {
-                maxTime = time;
-            }
-            totalTime += time;
-        }
+    // generate output
+    SpendingKey sk1 = SpendingKey.random();
+    FullViewingKey fullViewingKey1 = sk1.fullViewingKey();
+    IncomingViewingKey ivk1 = fullViewingKey1.inViewingKey();
+    PaymentAddress paymentAddress1 = ivk1.address(new DiversifierT()).get();
+    builder.addOutput(ovk, paymentAddress1,
+        100 * 1000000L - wallet.getShieldedTransactionFee(), new byte[512]);
 
-        System.out.println("---- result ----");
-        System.out.println("---- maxTime is: " + maxTime);
-        System.out.println("---- minTime is: " + minTime);
-        System.out.println("---- avgTime is: " + totalTime / count);
-
+    // Create Sapling SpendDescriptions
+    for (SpendDescriptionInfo spend : builder.getSpends()) {
+      SpendDescriptionCapsule spendDescriptionCapsule = builder.generateSpendProof(spend, ctx);
+      builder.getContractBuilder().addSpendDescription(spendDescriptionCapsule.getInstance());
     }
 
-    private ZenTransactionBuilder generateBuilderWithoutColumnInDescription(
-            ZenTransactionBuilder builder, long ctx, TestReceiveMissingColumn column)
-            throws ZksnarkException, BadItemException {
-        //generate input
-        SpendingKey sk = SpendingKey.random();
-        ExpandedSpendingKey expsk = sk.expandedSpendingKey();
-        PaymentAddress address = sk.defaultAddress();
-
-        Note note = new Note(address, 100 * 1000000L);
-        IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
-        byte[] anchor = voucher.root().getContent().toByteArray();
-        chainBaseManager.getMerkleContainer()
-                .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
-        builder.addSpend(expsk, note, anchor, voucher);
-
-        // generate output
-        SpendingKey sk1 = SpendingKey.random();
-        FullViewingKey fullViewingKey1 = sk1.fullViewingKey();
-        IncomingViewingKey ivk1 = fullViewingKey1.inViewingKey();
-        PaymentAddress paymentAddress1 = ivk1.address(new DiversifierT()).get();
-        builder.addOutput(expsk.getOvk(), paymentAddress1,
-                100 * 1000000 - wallet.getShieldedTransactionFee(), new byte[512]);
-
-        // Create Sapling SpendDescriptions
-        for (SpendDescriptionInfo spend : builder.getSpends()) {
-            SpendDescriptionCapsule spendDescriptionCapsule = builder.generateSpendProof(spend, ctx);
-            builder.getContractBuilder().addSpendDescription(spendDescriptionCapsule.getInstance());
-        }
-
-        // Create Sapling OutputDescriptions
-        for (ReceiveDescriptionInfo receive : builder.getReceives()) {
-            ReceiveDescriptionCapsule receiveDescriptionCapsule = builder
-                    .generateOutputProof(receive, ctx);
-            switch (column) {
-                case CV:
-                    receiveDescriptionCapsule.setValueCommitment(ByteString.EMPTY);
-                    break;
-                case CM:
-                    receiveDescriptionCapsule.setNoteCommitment(ByteString.EMPTY);
-                    break;
-                case EPK:
-                    receiveDescriptionCapsule.setEpk(ByteString.EMPTY);
-                    break;
-                case ZKPROOF:
-                    receiveDescriptionCapsule.setZkproof(ByteString.EMPTY);
-                    break;
-                case C_ENC:
-                    receiveDescriptionCapsule.setCEnc(ByteString.EMPTY);
-                    break;
-                case C_OUT:
-                    receiveDescriptionCapsule.setCOut(ByteString.EMPTY);
-                    break;
-                default:
-                    break;
-            }
-            builder.getContractBuilder().addReceiveDescription(receiveDescriptionCapsule.getInstance());
-        }
-
-        return builder;
+    // Create Sapling OutputDescriptions
+    for (ReceiveDescriptionInfo receive : builder.getReceives()) {
+      ReceiveDescriptionCapsule receiveDescriptionCapsule = builder
+          .generateOutputProof(receive, ctx);
+      builder.getContractBuilder().addReceiveDescription(receiveDescriptionCapsule.getInstance());
     }
 
-    /*
-     * test of empty CV in receive description
-     */
-    @Test
-    public void testReceiveDescriptionWithEmptyCv()
-            throws BadItemException, RuntimeException, ZksnarkException {
-        librustzcashInitZksnarkParams();
-        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-        long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
+    // Empty output script
+    TransactionCapsule transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
+        builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
+    //replace with interface
+    //System.out.println(JsonFormat.printToString(transactionCapsule.getInstance()));
+    BytesMessage transactionHash = wallet
+        .getShieldTransactionHash(transactionCapsule.getInstance());
 
-        builder = generateBuilderWithoutColumnInDescription(builder, ctx, TestReceiveMissingColumn.CV);
+    if (transactionHash == null) {
+      throw new ZksnarkException("cal transaction hash failed");
+    }
+    dataHashToBeSigned.setHash(transactionHash.getValue().toByteArray());
 
-        // Empty output script.
-        byte[] dataToBeSigned;//256
-        TransactionCapsule transactionCapsule;
-        try {
-            transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
-                    builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
-            TransactionExtention transactionExtention = TransactionExtention.newBuilder()
-                    .setTransaction(transactionCapsule.getInstance()).build();
+    // Create binding signatures
+    byte[] bindingSig = new byte[64];
+    JLibrustzcash.librustzcashSaplingBindingSig(
+        new BindingSigParams(ctx,
+            builder.getValueBalance(),
+            dataHashToBeSigned.getHash(),
+            bindingSig)
+    );
+    builder.getContractBuilder().setBindingSignature(ByteString.copyFrom(bindingSig));
+    return transactionCapsule;
+  }
 
-            dataToBeSigned = TransactionCapsule.hashShieldTransaction(transactionCapsule.getInstance(),
-                    CommonParameter.getInstance().getZenTokenId());
-        } catch (Exception ex) {
-            JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
-            throw new RuntimeException("Could not construct signature hash: " + ex.getMessage());
+  @Test
+  public void testMemoTooLong() throws ContractValidateException, TooBigTransactionException,
+      TooBigTransactionResultException, TaposException, TransactionExpirationException,
+      ReceiptCheckErrException, DupTransactionException, VMIllegalException,
+      ValidateSignatureException, BadItemException, ContractExeException,
+      AccountResourceInsufficientException, InvalidProtocolBufferException, ZksnarkException {
+    long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
+
+    librustzcashInitZksnarkParams();
+    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+
+    // generate spend proof
+    SpendingKey sk = SpendingKey
+        .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
+    ExpandedSpendingKey expsk = sk.expandedSpendingKey();
+    PaymentAddress address = sk.defaultAddress();
+    Note note = new Note(address, 100 * 1000000L);
+    IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
+    byte[] anchor = voucher.root().getContent().toByteArray();
+    chainBaseManager.getMerkleContainer()
+        .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
+    builder.addSpend(expsk, note, anchor, voucher);
+
+    // generate output proof
+    SpendingKey spendingKey = SpendingKey.random();
+    FullViewingKey fullViewingKey = spendingKey.fullViewingKey();
+    IncomingViewingKey incomingViewingKey = fullViewingKey.inViewingKey();
+    PaymentAddress paymentAddress = incomingViewingKey.address(new DiversifierT()).get();
+    byte[] memo = org.tron.keystore.Wallet.generateRandomBytes(1024);
+    builder.addOutput(expsk.getOvk(), paymentAddress,
+        100 * 1000000L - wallet.getShieldedTransactionFee(), memo);
+
+    TransactionCapsule transactionCap = builder.build();
+
+    boolean ok = dbManager.pushTransaction(transactionCap);
+    Assert.assertTrue(ok);
+
+    // add here
+    byte[] ivk = fullViewingKey.inViewingKey().getValue();
+    Protocol.Transaction t = transactionCap.getInstance();
+
+    for (org.tron.protos.Protocol.Transaction.Contract c : t.getRawData().getContractList()) {
+      if (c.getType() != ContractType.ShieldedTransferContract) {
+        continue;
+      }
+      ShieldedTransferContract stContract = c.getParameter()
+          .unpack(ShieldedTransferContract.class);
+      ReceiveDescription receiveDescription = stContract.getReceiveDescription(0);
+
+      Optional<Note> ret1 = Note.decrypt(
+          receiveDescription.getCEnc().toByteArray(),//ciphertext
+          ivk,
+          receiveDescription.getEpk().toByteArray(),//epk
+          receiveDescription.getNoteCommitment().toByteArray() //cm
+      );
+
+      if (ret1.isPresent()) {
+        Note noteText = ret1.get();
+        byte[] pkD = new byte[32];
+        if (!JLibrustzcash.librustzcashIvkToPkd(
+            new IvkToPkdParams(incomingViewingKey.getValue(),
+                noteText.getD().getData(), pkD))) {
+          JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
+          return;
         }
+        Assert.assertArrayEquals(paymentAddress.getPkD(), pkD);
+        Assert.assertEquals(100 * 1000000L - wallet.getShieldedTransactionFee(),
+            noteText.getValue());
 
-        TransactionCapsule transactionCap = generateTransactionCapsule(builder, ctx, dataToBeSigned,
-                transactionCapsule);
+        byte[] resultMemo = new byte[512];
+        System.arraycopy(memo, 0, resultMemo, 0, 512);
+        Assert.assertArrayEquals(resultMemo, noteText.getMemo());
+      } else {
+        Assert.assertFalse(true);
+      }
+    }
+    // end here
+    JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
+    Assert.assertTrue(ok);
+  }
 
-        try {
-            //validate
-            List<Actuator> actuator = ActuatorCreator
-                    .getINSTANCE().createActuator(transactionCap);
-            actuator.get(0).validate();
-            Assert.assertTrue(false);
-        } catch (Exception e) {
-            Assert.assertTrue(e instanceof ContractValidateException);
-            Assert.assertEquals("param is null", e.getMessage());
+  @Test
+  public void testMemoNotEnough() throws ContractValidateException, TooBigTransactionException,
+      TooBigTransactionResultException, TaposException, TransactionExpirationException,
+      ReceiptCheckErrException, DupTransactionException, VMIllegalException,
+      ValidateSignatureException, BadItemException, ContractExeException,
+      AccountResourceInsufficientException, InvalidProtocolBufferException, ZksnarkException {
+    long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
+
+    librustzcashInitZksnarkParams();
+    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
+    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+
+    // generate spend proof
+    SpendingKey sk = SpendingKey
+        .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
+    ExpandedSpendingKey expsk = sk.expandedSpendingKey();
+    PaymentAddress address = sk.defaultAddress();
+    Note note = new Note(address, 100 * 1000000L);
+    IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
+    byte[] anchor = voucher.root().getContent().toByteArray();
+    chainBaseManager.getMerkleContainer()
+        .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
+    builder.addSpend(expsk, note, anchor, voucher);
+
+    // generate output proof
+    SpendingKey spendingKey = SpendingKey.random();
+    FullViewingKey fullViewingKey = spendingKey.fullViewingKey();
+    IncomingViewingKey incomingViewingKey = fullViewingKey.inViewingKey();
+    PaymentAddress paymentAddress = incomingViewingKey.address(new DiversifierT()).get();
+    byte[] memo = org.tron.keystore.Wallet.generateRandomBytes(128);
+    builder.addOutput(expsk.getOvk(), paymentAddress,
+        100 * 1000000L - wallet.getShieldedTransactionFee(), memo);
+
+    TransactionCapsule transactionCap = builder.build();
+
+    boolean ok = dbManager.pushTransaction(transactionCap);
+    Assert.assertTrue(ok);
+
+    // add here
+    byte[] ivk = fullViewingKey.inViewingKey().getValue();
+    Protocol.Transaction t = transactionCap.getInstance();
+
+    for (org.tron.protos.Protocol.Transaction.Contract c : t.getRawData().getContractList()) {
+      if (c.getType() != ContractType.ShieldedTransferContract) {
+        continue;
+      }
+      ShieldedTransferContract stContract = c.getParameter()
+          .unpack(ShieldedTransferContract.class);
+      ReceiveDescription receiveDescription = stContract.getReceiveDescription(0);
+
+      Optional<Note> ret1 = Note.decrypt(
+          receiveDescription.getCEnc().toByteArray(),//ciphertext
+          ivk,
+          receiveDescription.getEpk().toByteArray(),//epk
+          receiveDescription.getNoteCommitment().toByteArray() //cm
+      );
+
+      if (ret1.isPresent()) {
+        Note noteText = ret1.get();
+        byte[] pkD = new byte[32];
+        if (!JLibrustzcash.librustzcashIvkToPkd(
+            new IvkToPkdParams(incomingViewingKey.getValue(),
+                noteText.getD().getData(), pkD))) {
+          JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
+          return;
         }
-        JLibrustzcash.librustzcashSaplingVerificationCtxFree(ctx);
+        Assert.assertArrayEquals(paymentAddress.getPkD(), pkD);
+        Assert.assertEquals(100 * 1000000L - wallet.getShieldedTransactionFee(),
+            noteText.getValue());
+
+        byte[] resultMemo = new byte[512];
+        System.arraycopy(memo, 0, resultMemo, 0, 128);
+        Assert.assertArrayEquals(resultMemo, noteText.getMemo());
+      } else {
+        Assert.assertFalse(true);
+      }
+    }
+    // end here
+    JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
+    Assert.assertTrue(ok);
+  }
+
+  /*
+  send coin to 2 different address generated by same sk, scan note by ivk; spend this note again
+   */
+  @Test
+  public void pushSameSkAndScanAndSpend() throws Exception {
+
+    byte[] privateKey = ByteArray
+        .fromHexString("f4df789d3210ac881cb900464dd30409453044d2777060a0c391cbdf4c6a4f57");
+    final ECKey ecKey = ECKey.fromPrivate(privateKey);
+    byte[] witnessAddress = ecKey.getAddress();
+    WitnessCapsule witnessCapsule = new WitnessCapsule(ByteString.copyFrom(witnessAddress));
+    chainBaseManager.addWitness(ByteString.copyFrom(witnessAddress));
+
+    //sometimes generate block failed, try several times.
+
+    Block block = getSignedBlock(witnessCapsule.getAddress(), 0, privateKey);
+    dbManager.pushBlock(new BlockCapsule(block));
+
+    //create transactions
+    librustzcashInitZksnarkParams();
+    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(1000 * 1000000L);
+    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+
+    // generate spend proof
+    SpendingKey sk = SpendingKey
+        .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
+    ExpandedSpendingKey expsk = sk.expandedSpendingKey();
+    byte[] senderOvk = expsk.getOvk();
+    PaymentAddress address = sk.defaultAddress();
+    Note note = new Note(address, 1000 * 1000000L);
+    IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
+    byte[] anchor = voucher.root().getContent().toByteArray();
+    chainBaseManager.getMerkleContainer()
+        .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
+    builder.addSpend(expsk, note, anchor, voucher);
+
+    // generate output proof
+    SpendingKey sk2 = SpendingKey.random();
+    FullViewingKey fullViewingKey = sk2.fullViewingKey();
+    IncomingViewingKey incomingViewingKey = fullViewingKey.inViewingKey();
+
+    byte[] memo = org.tron.keystore.Wallet.generateRandomBytes(512);
+
+    //send coin to 2 different address generated by same sk
+    DiversifierT d1 = DiversifierT.random();
+    PaymentAddress paymentAddress1 = incomingViewingKey.address(d1).get();
+    builder.addOutput(senderOvk, paymentAddress1,
+        (1000 * 1000000L - wallet.getShieldedTransactionFee()) / 2, memo);
+
+    DiversifierT d2 = DiversifierT.random();
+    PaymentAddress paymentAddress2 = incomingViewingKey.address(d2).get();
+    builder.addOutput(senderOvk, paymentAddress2,
+        (1000 * 1000000L - wallet.getShieldedTransactionFee()) / 2, memo);
+
+    TransactionCapsule transactionCap = builder.build();
+
+    byte[] trxId = transactionCap.getTransactionId().getBytes();
+    boolean ok = dbManager.pushTransaction(transactionCap);
+    Assert.assertTrue(ok);
+
+    Thread.sleep(500);
+    //package transaction to block
+    block = getSignedBlock(witnessCapsule.getAddress(), 0, privateKey);
+    dbManager.pushBlock(new BlockCapsule(block));
+
+    BlockCapsule blockCapsule3 = new BlockCapsule(wallet.getNowBlock());
+    Assert.assertEquals("blocknum != 2", 2, blockCapsule3.getNum());
+
+    // scan note by ivk
+    byte[] receiverIvk = incomingViewingKey.getValue();
+    DecryptNotes notes1 = wallet.scanNoteByIvk(0, 100, receiverIvk);
+    Assert.assertEquals(2, notes1.getNoteTxsCount());
+
+    // scan note by ovk
+    DecryptNotes notes2 = wallet.scanNoteByOvk(0, 100, senderOvk);
+    Assert.assertEquals(2, notes2.getNoteTxsCount());
+
+    // to spend received note above.
+    ZenTransactionBuilder builder2 = new ZenTransactionBuilder(wallet);
+
+    //query merkleinfo
+    OutputPointInfo.Builder request = OutputPointInfo.newBuilder();
+    for (int i = 0; i < notes1.getNoteTxsCount(); i++) {
+      OutputPoint.Builder outPointBuild = OutputPoint.newBuilder();
+      outPointBuild.setHash(ByteString.copyFrom(trxId));
+      outPointBuild.setIndex(i);
+      request.addOutPoints(outPointBuild.build());
+    }
+    IncrementalMerkleVoucherInfo merkleVoucherInfo = wallet
+        .getMerkleTreeVoucherInfo(request.build());
+
+    //build spend proof. allow only one note in spend
+    ExpandedSpendingKey expsk2 = sk2.expandedSpendingKey();
+    for (int i = 0; i < 1; i++) {
+      org.tron.api.GrpcAPI.Note grpcNote = notes1.getNoteTxs(i).getNote();
+      PaymentAddress paymentAddress = KeyIo.decodePaymentAddress(grpcNote.getPaymentAddress());
+      Note note2 = new Note(paymentAddress.getD(),
+          paymentAddress.getPkD(),
+          grpcNote.getValue(),
+          grpcNote.getRcm().toByteArray()
+      );
+
+      IncrementalMerkleVoucherContainer voucher2 =
+          new IncrementalMerkleVoucherContainer(
+              new IncrementalMerkleVoucherCapsule(merkleVoucherInfo.getVouchers(i)));
+      byte[] anchor2 = voucher2.root().getContent().toByteArray();
+      builder2.addSpend(expsk2, note2, anchor2, voucher2);
     }
 
-    /*
-     * test of empty cm in receive description
-     */
-    @Test
-    public void testReceiveDescriptionWithEmptyCm()
-            throws BadItemException, RuntimeException, ZksnarkException {
-        librustzcashInitZksnarkParams();
-        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-        long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
-
-        builder = generateBuilderWithoutColumnInDescription(builder, ctx, TestReceiveMissingColumn.CM);
-
-        // Empty output script.
-        byte[] dataToBeSigned;//256
-        TransactionCapsule transactionCapsule;
-        try {
-            transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
-                    builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
-            dataToBeSigned = TransactionCapsule.hashShieldTransaction(transactionCapsule.getInstance(),
-                    CommonParameter.getInstance().getZenTokenId());
-        } catch (Exception ex) {
-            JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
-            throw new RuntimeException("Could not construct signature hash: " + ex.getMessage());
-        }
-
-        TransactionCapsule transactionCap = generateTransactionCapsule(builder, ctx, dataToBeSigned,
-                transactionCapsule);
-
-        try {
-            //validate
-            List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
-            actuator.get(0).validate();
-
-            Assert.assertTrue(false);
-        } catch (Exception e) {
-            Assert.assertTrue(e instanceof ContractValidateException);
-            Assert.assertEquals("param is null", e.getMessage());
-        }
-        JLibrustzcash.librustzcashSaplingVerificationCtxFree(ctx);
-    }
-
-    /*
-     * test of empty epk in receive description
-     */
-    @Test
-    public void testReceiveDescriptionWithEmptyEpk()
-            throws BadItemException, RuntimeException, ZksnarkException {
-        librustzcashInitZksnarkParams();
-        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-        long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
-
-        builder = generateBuilderWithoutColumnInDescription(builder, ctx, TestReceiveMissingColumn.EPK);
-
-        // Empty output script.
-        byte[] dataToBeSigned;//256
-        TransactionCapsule transactionCapsule;
-        try {
-            transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
-                    builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
-            dataToBeSigned = TransactionCapsule.hashShieldTransaction(transactionCapsule.getInstance(),
-                    CommonParameter.getInstance().getZenTokenId());
-        } catch (Exception ex) {
-            JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
-            throw new RuntimeException("Could not construct signature hash: " + ex.getMessage());
-        }
-
-        TransactionCapsule transactionCap = generateTransactionCapsule(builder, ctx, dataToBeSigned,
-                transactionCapsule);
-
-        try {
-            //validate
-            List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
-            actuator.get(0).validate();
-            Assert.assertTrue(false);
-        } catch (Exception e) {
-            Assert.assertTrue(e instanceof ContractValidateException);
-            Assert.assertEquals("param is null", e.getMessage());
-        }
-        JLibrustzcash.librustzcashSaplingVerificationCtxFree(ctx);
-    }
-
-    /*
-     * test of empty zkproof in receive description
-     */
-    @Test
-    public void testReceiveDescriptionWithEmptyZkproof()
-            throws BadItemException, RuntimeException, ZksnarkException {
-        librustzcashInitZksnarkParams();
-        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-        long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
-
-        builder = generateBuilderWithoutColumnInDescription(builder, ctx,
-                TestReceiveMissingColumn.ZKPROOF);
-
-        // Empty output script.
-        byte[] dataToBeSigned;//256
-        TransactionCapsule transactionCapsule;
-        try {
-            transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
-                    builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
-            dataToBeSigned = TransactionCapsule.hashShieldTransaction(transactionCapsule.getInstance(),
-                    CommonParameter.getInstance().getZenTokenId());
-        } catch (Exception ex) {
-            JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
-            throw new RuntimeException("Could not construct signature hash: " + ex.getMessage());
-        }
-
-        TransactionCapsule transactionCap = generateTransactionCapsule(builder, ctx, dataToBeSigned,
-                transactionCapsule);
-
-        try {
-            //validate
-            List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
-            actuator.get(0).validate();
-            Assert.assertTrue(false);
-        } catch (Exception e) {
-            Assert.assertTrue(e instanceof ContractValidateException);
-            Assert.assertEquals("param is null", e.getMessage());
-        }
-        JLibrustzcash.librustzcashSaplingVerificationCtxFree(ctx);
-    }
-
-    /*
-     * test of empty c_enc in receive description
-     */
-    @Test
-    public void testReceiveDescriptionWithEmptyCenc()
-            throws BadItemException, RuntimeException, ZksnarkException {
-        librustzcashInitZksnarkParams();
-        dbManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-        dbManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-        long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
-
-        builder = generateBuilderWithoutColumnInDescription(builder, ctx,
-                TestReceiveMissingColumn.C_ENC);
-
-        // Empty output script.
-        byte[] dataToBeSigned;//256
-        TransactionCapsule transactionCapsule;
-        try {
-            transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
-                    builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
-            dataToBeSigned = TransactionCapsule.hashShieldTransaction(transactionCapsule.getInstance(),
-                    CommonParameter.getInstance().getZenTokenId());
-        } catch (Exception ex) {
-            JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
-            throw new RuntimeException("Could not construct signature hash: " + ex.getMessage());
-        }
-
-        TransactionCapsule transactionCap = generateTransactionCapsule(builder, ctx, dataToBeSigned,
-                transactionCapsule);
-
-        try {
-            //validate
-            List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
-            actuator.get(0).validate();
-            Assert.assertTrue(false);
-        } catch (Exception e) {
-            Assert.assertTrue(e instanceof ContractValidateException);
-            Assert.assertEquals("Cout or CEnc size error", e.getMessage());
-        }
-        JLibrustzcash.librustzcashSaplingVerificationCtxFree(ctx);
-    }
-
-    /*
-     * test of empty c_out in receive description
-     */
-    @Test
-    public void testReceiveDescriptionWithEmptyCout()
-            throws BadItemException, RuntimeException, ZksnarkException {
-        librustzcashInitZksnarkParams();
-        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-        long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
-
-        builder = generateBuilderWithoutColumnInDescription(builder, ctx,
-                TestReceiveMissingColumn.C_OUT);
-
-        // Empty output script.
-        byte[] dataToBeSigned;//256
-        TransactionCapsule transactionCapsule;
-        try {
-            transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
-                    builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
-            dataToBeSigned = TransactionCapsule.hashShieldTransaction(transactionCapsule.getInstance(),
-                    CommonParameter.getInstance().getZenTokenId());
-        } catch (Exception ex) {
-            JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
-            throw new RuntimeException("Could not construct signature hash: " + ex.getMessage());
-        }
-
-        TransactionCapsule transactionCap = generateTransactionCapsule(builder, ctx, dataToBeSigned,
-                transactionCapsule);
-
-        try {
-            //validate
-            List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
-            actuator.get(0).validate();
-            Assert.assertTrue(false);
-        } catch (Exception e) {
-            Assert.assertTrue(e instanceof ContractValidateException);
-            Assert.assertEquals("Cout or CEnc size error", e.getMessage());
-        }
-        JLibrustzcash.librustzcashSaplingVerificationCtxFree(ctx);
-    }
-
-    /*
-     * test some column in ReceiveDescription is wrong
-     */
-    private ReceiveDescriptionCapsule changeGenerateOutputProof(ReceiveDescriptionInfo output,
-                                                                long ctx, TestColumn testColumn)
-            throws ZksnarkException {
-        byte[] cm = output.getNote().cm();
-        if (ByteArray.isEmpty(cm)) {
-            JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
-            throw new ZksnarkException("Output is invalid");
-        }
-
-        Optional<NotePlaintextEncryptionResult> res = output.getNote()
-                .encrypt(output.getNote().getPkD());
-        if (!res.isPresent()) {
-            JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
-            throw new ZksnarkException("Failed to encrypt note");
-        }
-
-        NotePlaintextEncryptionResult enc = res.get();
-        NoteEncryption encryptor = enc.getNoteEncryption();
-
-        byte[] cv = new byte[32];
-        byte[] zkProof = new byte[192];
-        if (!JLibrustzcash.librustzcashSaplingOutputProof(
-                new OutputProofParams(ctx,
-                        encryptor.getEsk(),
-                        output.getNote().getD().getData(),
-                        output.getNote().getPkD(),
-                        output.getNote().getRcm(),
-                        output.getNote().getValue(),
-                        cv,
-                        zkProof))) {
-            JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
-            throw new ZksnarkException("Output proof failed");
-        }
-
-        ReceiveDescriptionCapsule receiveDescriptionCapsule = new ReceiveDescriptionCapsule();
-        receiveDescriptionCapsule.setValueCommitment(cv);
-        receiveDescriptionCapsule.setNoteCommitment(cm);
-        receiveDescriptionCapsule.setEpk(encryptor.getEpk());
-        receiveDescriptionCapsule.setCEnc(enc.getEncCiphertext());
-        receiveDescriptionCapsule.setZkproof(zkProof);
-
-        OutgoingPlaintext outPlaintext =
-                new OutgoingPlaintext(output.getNote().getPkD(), encryptor.getEsk());
-        receiveDescriptionCapsule.setCOut(outPlaintext
-                .encrypt(output.getOvk(), receiveDescriptionCapsule.getValueCommitment().toByteArray(),
-                        receiveDescriptionCapsule.getCm().toByteArray(),
-                        encryptor).getData());
-
-        Note newNote = output.getNote();
-        byte[] newCm;
-        switch (testColumn) {
-            case CV:
-                receiveDescriptionCapsule.setValueCommitment(randomUint256());
-                break;
-            case ZKPOOF:
-                receiveDescriptionCapsule.setZkproof(randomUint1536());
-                break;
-            case D_CM:
-                newNote.setD(DiversifierT.random());
-                newCm = newNote.cm();
-                if (newCm == null) {
-                    receiveDescriptionCapsule.setNoteCommitment(ByteString.EMPTY);
-                } else {
-                    receiveDescriptionCapsule.setNoteCommitment(newCm);
-                }
-                break;
-            case PKD_CM:
-                newNote.setPkD(randomUint256());
-                newCm = newNote.cm();
-                if (newCm == null) {
-                    receiveDescriptionCapsule.setNoteCommitment(ByteString.EMPTY);
-                } else {
-                    receiveDescriptionCapsule.setNoteCommitment(newCm);
-                }
-                break;
-            case VALUE_CM:
-                newNote.setValue(newNote.getValue() + 10000);
-                newCm = newNote.cm();
-                if (newCm == null) {
-                    receiveDescriptionCapsule.setNoteCommitment(ByteString.EMPTY);
-                } else {
-                    receiveDescriptionCapsule.setNoteCommitment(newCm);
-                }
-                break;
-            case R_CM:
-                newNote.setRcm(Note.generateR());
-                newCm = newNote.cm();
-                if (newCm == null) {
-                    receiveDescriptionCapsule.setNoteCommitment(ByteString.EMPTY);
-                } else {
-                    receiveDescriptionCapsule.setNoteCommitment(newCm);
-                }
-                break;
-
-            default:
-                break;
-        }
-
-        return receiveDescriptionCapsule;
-    }
-
-    private TransactionCapsule changeBuildOutputProof(ZenTransactionBuilder builder, long ctx,
-                                                      TestColumn testColumn)
-            throws ZksnarkException {
-        ShieldedTransferContract.Builder contractBuilder = builder.getContractBuilder();
-
-        // Create Sapling SpendDescriptions
-        for (SpendDescriptionInfo spend : builder.getSpends()) {
-            SpendDescriptionCapsule spendDescriptionCapsule = builder.generateSpendProof(spend, ctx);
-            contractBuilder.addSpendDescription(spendDescriptionCapsule.getInstance());
-        }
-
-        // Create Sapling OutputDescriptions
-        for (ReceiveDescriptionInfo receive : builder.getReceives()) {
-            //test case
-            ReceiveDescriptionCapsule receiveDescriptionCapsule = changeGenerateOutputProof(receive, ctx,
-                    testColumn);
-            //end of test case
-            contractBuilder.addReceiveDescription(receiveDescriptionCapsule.getInstance());
-        }
-
-        // Empty output script.
-        byte[] dataToBeSigned;//256
-        TransactionCapsule transactionCapsule;
-        try {
-            transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
-                    contractBuilder.build(), ContractType.ShieldedTransferContract);
-
-            dataToBeSigned = TransactionCapsule.hashShieldTransaction(transactionCapsule.getInstance(),
-                    CommonParameter.getInstance().getZenTokenId());
-        } catch (Exception ex) {
-            JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
-            throw new ZksnarkException("Could not construct signature hash: " + ex.getMessage());
-        }
-
-        // Create Sapling spendAuth and binding signatures
-        builder.createSpendAuth(dataToBeSigned);
-        byte[] bindingSig = new byte[64];
-        JLibrustzcash.librustzcashSaplingBindingSig(
-                new BindingSigParams(ctx,
-                        builder.getValueBalance(),
-                        dataToBeSigned,
-                        bindingSig)
-        );
-        contractBuilder.setBindingSignature(ByteString.copyFrom(bindingSig));
-        JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
-
-        Transaction.raw.Builder rawBuilder = transactionCapsule.getInstance().toBuilder()
-                .getRawDataBuilder()
-                .clearContract()
-                .addContract(
-                        Transaction.Contract.newBuilder().setType(ContractType.ShieldedTransferContract)
-                                .setParameter(
-                                        Any.pack(contractBuilder.build())).build());
-
-        Transaction transaction = transactionCapsule.getInstance().toBuilder().clearRawData()
-                .setRawData(rawBuilder).build();
-        return new TransactionCapsule(transaction);
-    }
-
-    private ZenTransactionBuilder generateBuilder(ZenTransactionBuilder builder, long ctx)
-            throws ZksnarkException, BadItemException {
-        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-
-        // generate input
-        SpendingKey sk = SpendingKey.random();
-        ExpandedSpendingKey expsk = sk.expandedSpendingKey();
-        PaymentAddress address = sk.defaultAddress();
-        Note note = new Note(address, 100 * 1000000L);
-        IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
-        byte[] anchor = voucher.root().getContent().toByteArray();
-        //put the voucher and anchor into db
-        chainBaseManager.getMerkleContainer()
-                .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
-        builder.addSpend(expsk, note, anchor, voucher);
-
-        // generate output
-        SpendingKey sk1 = SpendingKey.random();
-        FullViewingKey fullViewingKey1 = sk1.fullViewingKey();
-        IncomingViewingKey ivk1 = fullViewingKey1.inViewingKey();
-        PaymentAddress paymentAddress1 = ivk1.address(new DiversifierT()).get();
-        Note note2 = new Note(paymentAddress1, 100 * 1000000L - wallet.getShieldedTransactionFee());
-        builder
-                .addOutput(expsk.getOvk(), note2.getD(), note2.getPkD(), note2.getValue(), note2.getRcm(),
-                        new byte[512]);
-
-        return builder;
-    }
-
-    /*
-     * test wrong value_commitment in ReceiveDescription
-     */
-    @Test
-    public void testReceiveDescriptionWithWrongCv()
-            throws BadItemException, RuntimeException, ZksnarkException {
-        librustzcashInitZksnarkParams();
-        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-        long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
-
-        builder = generateBuilder(builder, ctx);
-
-        TestColumn testColumn = TestColumn.CV;
-        TransactionCapsule transactionCap = changeBuildOutputProof(builder, ctx, testColumn);
-
-        updateTotalShieldedPoolValue(builder.getValueBalance());
-
-        try {
-            List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
-            actuator.get(0).validate();
-            Assert.assertFalse(true);
-        } catch (Exception e) {
-            Assert.assertTrue(e instanceof ContractValidateException);
-            Assert.assertEquals("librustzcashSaplingCheckOutput error", e.getMessage());
-        }
-    }
-
-    /*
-     * test wrong zkproof in ReceiveDescription
-     */
-    @Test
-    public void testReceiveDescriptionWithWrongZkproof()
-            throws BadItemException, RuntimeException, ZksnarkException {
-        librustzcashInitZksnarkParams();
-        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-        long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
-
-        builder = generateBuilder(builder, ctx);
-
-        TestColumn testColumn = TestColumn.ZKPOOF;
-        TransactionCapsule transactionCap = changeBuildOutputProof(builder, ctx, testColumn);
-
-        updateTotalShieldedPoolValue(builder.getValueBalance());
-
-        try {
-            List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
-            actuator.get(0).validate();
-            Assert.assertFalse(true);
-        } catch (Exception e) {
-            Assert.assertTrue(e instanceof ContractValidateException);
-            Assert.assertEquals("librustzcashSaplingCheckOutput error", e.getMessage());
-        }
-    }
-
-    /*
-     * test note_commitment in ReceiveDescription generated by wrong d
-     */
-    @Test
-    public void testReceiveDescriptionWithWrongD()
-            throws BadItemException, RuntimeException, ZksnarkException {
-        librustzcashInitZksnarkParams();
-        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-        long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
-
-        builder = generateBuilder(builder, ctx);
-
-        TestColumn testColumn = TestColumn.D_CM;
-        TransactionCapsule transactionCap = changeBuildOutputProof(builder, ctx, testColumn);
-
-        updateTotalShieldedPoolValue(builder.getValueBalance());
-
-        try {
-            List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
-            actuator.get(0).validate();
-            Assert.assertFalse(true);
-        } catch (Exception e) {
-            Assert.assertTrue(e instanceof ContractValidateException);
-            //if generate cm successful, checkout error; else param is null because of cm is null
-            Assert.assertTrue("librustzcashSaplingCheckOutput error".equalsIgnoreCase(e.getMessage())
-                    || "param is null".equalsIgnoreCase(e.getMessage()));
-        }
-    }
-
-    /*
-     * test note_commitment in ReceiveDescription generated by wrong pkd
-     */
-    @Test
-    public void testReceiveDescriptionWithWrongPkd()
-            throws BadItemException, RuntimeException, ZksnarkException {
-        librustzcashInitZksnarkParams();
-        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-        long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
-
-        builder = generateBuilder(builder, ctx);
-
-        TestColumn testColumn = TestColumn.PKD_CM;
-        TransactionCapsule transactionCap = changeBuildOutputProof(builder, ctx, testColumn);
-
-        updateTotalShieldedPoolValue(builder.getValueBalance());
-
-        try {
-            List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
-            actuator.get(0).validate();
-            Assert.assertFalse(true);
-        } catch (Exception e) {
-            Assert.assertTrue(e instanceof ContractValidateException);
-            //if generate cm successful, checkout error; else param is null because of cm is null
-            Assert.assertTrue("librustzcashSaplingCheckOutput error".equalsIgnoreCase(e.getMessage())
-                    || "param is null".equalsIgnoreCase(e.getMessage()));
-        }
-    }
-
-    /*
-     * test note_commitment in ReceiveDescription generated by wrong value
-     */
-    @Test
-    public void testReceiveDescriptionWithWrongValue()
-            throws BadItemException, RuntimeException, ZksnarkException {
-        librustzcashInitZksnarkParams();
-        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-        long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
-
-        builder = generateBuilder(builder, ctx);
-
-        TestColumn testColumn = TestColumn.VALUE_CM;
-        TransactionCapsule transactionCap = changeBuildOutputProof(builder, ctx, testColumn);
-
-        updateTotalShieldedPoolValue(builder.getValueBalance());
-
-        try {
-            List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
-            actuator.get(0).validate();
-            Assert.assertFalse(true);
-        } catch (Exception e) {
-            Assert.assertTrue(e instanceof ContractValidateException);
-            Assert.assertTrue(e.getMessage().equalsIgnoreCase("librustzcashSaplingCheckOutput error"));
-        }
-    }
-
-    /*
-     * test note_commitment in ReceiveDescription generated by wrong r
-     */
-    @Test
-    public void testReceiveDescriptionWithWrongRcm()
-            throws BadItemException, RuntimeException, ZksnarkException {
-        librustzcashInitZksnarkParams();
-        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-        long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
-
-        builder = generateBuilder(builder, ctx);
-
-        TestColumn testColumn = TestColumn.R_CM;
-        TransactionCapsule transactionCap = changeBuildOutputProof(builder, ctx, testColumn);
-
-        updateTotalShieldedPoolValue(builder.getValueBalance());
-
-        try {
-            List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
-            actuator.get(0).validate();
-            Assert.assertFalse(true);
-        } catch (Exception e) {
-            Assert.assertTrue(e instanceof ContractValidateException);
-            Assert.assertEquals("librustzcashSaplingCheckOutput error", e.getMessage());
-        }
-    }
-
-    /**
-     * use ask or nsk not belongs to sk.
-     */
-    @Test
-    public void testNotMatchAskAndNsk()
-            throws BadItemException, RuntimeException, ZksnarkException {
-        librustzcashInitZksnarkParams();
-        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-
-        // generate sk
-        SpendingKey sk = SpendingKey
-                .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
-        ExpandedSpendingKey expsk = sk.expandedSpendingKey();
-        PaymentAddress address = sk.defaultAddress();
-
-        //generate a note belongs to this sk
-        Note note = new Note(address, 100 * 1000000L);
-        IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
-        byte[] anchor = voucher.root().getContent().toByteArray();
-        //put the voucher and anchor into db
-        chainBaseManager.getMerkleContainer()
-                .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
-
-        //test case: give a random Ask or nsk
-        expsk.setAsk(randomUint256());
-        //expsk.setNsk(randomUint256());
-        //end of test case
-
-        builder.addSpend(expsk, note, anchor, voucher);
-
-        // generate output
-        SpendingKey sk1 = SpendingKey.random();
-        FullViewingKey fullViewingKey1 = sk1.fullViewingKey();
-        IncomingViewingKey ivk1 = fullViewingKey1.inViewingKey();
-        PaymentAddress paymentAddress1 = ivk1.address(new DiversifierT()).get();
-        builder.addOutput(expsk.getOvk(), paymentAddress1,
-                100 * 1000000L - wallet.getShieldedTransactionFee(), new byte[512]);
-
-        updateTotalShieldedPoolValue(builder.getValueBalance());
-        try {
-            TransactionCapsule transactionCap = builder.build();
-            Assert.assertFalse(true);
-
-        } catch (Exception e) {
-            Assert.assertTrue(e instanceof ZksnarkException);
-            Assert.assertEquals("Spend proof failed", e.getMessage());
-        }
-    }
-
-    /**
-     * use random ovk not related to sk.
-     */
-    @Test
-    public void testRandomOvk()
-            throws BadItemException, RuntimeException, ZksnarkException {
-        librustzcashInitZksnarkParams();
-        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-
-        // generate sk
-        SpendingKey sk = SpendingKey
-                .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
-        ExpandedSpendingKey expsk = sk.expandedSpendingKey();
-        PaymentAddress address = sk.defaultAddress();
-
-        //generate a note belongs to this sk
-        Note note = new Note(address, 100 * 1000000L);
-        IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
-        byte[] anchor = voucher.root().getContent().toByteArray();
-        //put the voucher and anchor into db
-        chainBaseManager.getMerkleContainer()
-                .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
-
-        //test case: give a random Ovk
-        expsk.setOvk(randomUint256());
-        //end of test case
-
-        builder.addSpend(expsk, note, anchor, voucher);
-
-        // generate output
-        SpendingKey sk1 = SpendingKey.random();
-        FullViewingKey fullViewingKey1 = sk1.fullViewingKey();
-        IncomingViewingKey ivk1 = fullViewingKey1.inViewingKey();
-        PaymentAddress paymentAddress1 = ivk1.address(new DiversifierT()).get();
-        builder.addOutput(expsk.getOvk(), paymentAddress1,
-                100 * 1000000L - wallet.getShieldedTransactionFee(), new byte[512]);
-
-        updateTotalShieldedPoolValue(builder.getValueBalance());
-        TransactionCapsule transactionCap = builder.build();
-        Assert.assertTrue(true);
-    }
-
-    /*
-     * test add two same cm into spend
-     */
-    //@Test not used
-    public void testSameInputCm()
-            throws BadItemException, RuntimeException, ZksnarkException {
-        librustzcashInitZksnarkParams();
-        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-
-        // generate input
-        SpendingKey sk = SpendingKey
-                .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
-        ExpandedSpendingKey expsk = sk.expandedSpendingKey();
-        PaymentAddress address = sk.defaultAddress();
-        Note note = new Note(address, 100 * 1000000L);
-        IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
-        byte[] anchor = voucher.root().getContent().toByteArray();
-        //put the voucher and anchor into db
-        chainBaseManager.getMerkleContainer()
-                .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
-
-        //add two same cm
-        builder.addSpend(expsk, note, anchor, voucher);
-        builder.addSpend(expsk, note, anchor, voucher);
-
-        // generate output
-        SpendingKey sk1 = SpendingKey.random();
-        FullViewingKey fullViewingKey1 = sk1.fullViewingKey();
-        IncomingViewingKey ivk1 = fullViewingKey1.inViewingKey();
-        PaymentAddress paymentAddress1 = ivk1.address(new DiversifierT()).get();
-        builder.addOutput(expsk.getOvk(), paymentAddress1,
-                200 * 1000000L - wallet.getShieldedTransactionFee(), new byte[512]);
-
-        updateTotalShieldedPoolValue(builder.getValueBalance());
-        TransactionCapsule transactionCap = builder.build();
-
-        try {
-            //validate
-            List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
-            actuator.get(0).validate();
-            Assert.assertFalse(true);
-        } catch (Exception e) {
-            Assert.assertTrue(e instanceof ContractValidateException);
-            Assert.assertEquals("duplicate sapling nullifiers in this transaction", e.getMessage());
-        }
-    }
-
-    /*
-     * test add two same cm into output
-     */
-    @Test
-    public void testSameOutputCm()
-            throws BadItemException, RuntimeException, ZksnarkException {
-        librustzcashInitZksnarkParams();
-        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-
-        // generate input
-        SpendingKey sk = SpendingKey
-                .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
-        ExpandedSpendingKey expsk = sk.expandedSpendingKey();
-        PaymentAddress address = sk.defaultAddress();
-        Note note = new Note(address, 100 * 1000000L);
-        IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
-        byte[] anchor = voucher.root().getContent().toByteArray();
-        //put the voucher and anchor into db
-        chainBaseManager.getMerkleContainer()
-                .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
-        builder.addSpend(expsk, note, anchor, voucher);
-
-        // generate output
-        SpendingKey sk1 = SpendingKey.random();
-        FullViewingKey fullViewingKey1 = sk1.fullViewingKey();
-        IncomingViewingKey ivk1 = fullViewingKey1.inViewingKey();
-        PaymentAddress paymentAddress1 = ivk1.address(new DiversifierT()).get();
-        Note note2 = new Note(address, (100 * 1000000L - wallet.getShieldedTransactionFee()) / 2);
-        //add two same output note
-        builder
-                .addOutput(expsk.getOvk(), note2.getD(), note2.getPkD(), note2.getValue(), note2.getRcm(),
-                        new byte[512]);
-        builder
-                .addOutput(expsk.getOvk(), note2.getD(), note2.getPkD(), note2.getValue(), note2.getRcm(),
-                        new byte[512]);//same output cm
-
-        updateTotalShieldedPoolValue(builder.getValueBalance());
-        TransactionCapsule transactionCap = builder.build();
-
-        try {
-            //validate
-            List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
-            actuator.get(0).validate();
-            Assert.assertFalse(true);
-        } catch (Exception e) {
-            Assert.assertTrue(e instanceof ContractValidateException);
-            Assert.assertEquals("duplicate cm in receive_description", e.getMessage());
-        }
-    }
-
-    /**
-     * test of transferring insufficient money from shield address to shield address.
-     */
-    @Test
-    public void testShieldInputInsufficient()
-            throws BadItemException, RuntimeException, ZksnarkException {
-        librustzcashInitZksnarkParams();
-        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-
-        // generate input
-        SpendingKey sk = SpendingKey
-                .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
-        ExpandedSpendingKey expsk = sk.expandedSpendingKey();
-        PaymentAddress address = sk.defaultAddress();
-        Note note = new Note(address, 100 * 1000000L);
-        IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
-        byte[] anchor = voucher.root().getContent().toByteArray();
-        chainBaseManager.getMerkleContainer()
-                .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
-
-        //set value that's bigger than own
-        note.setValue(note.getValue() + 10 * 1000000L); //test case of insufficient money
-
-        builder.addSpend(expsk, note, anchor, voucher);
-
-        // generate output
-        SpendingKey sk1 = SpendingKey.random();
-        FullViewingKey fullViewingKey1 = sk1.fullViewingKey();
-        IncomingViewingKey ivk1 = fullViewingKey1.inViewingKey();
-        PaymentAddress paymentAddress1 = ivk1.address(new DiversifierT()).get();
-        builder.addOutput(expsk.getOvk(), paymentAddress1,
-                100 * 1000000L - wallet.getShieldedTransactionFee(), new byte[512]);
-
-        updateTotalShieldedPoolValue(builder.getValueBalance());
-
-        try {
-            TransactionCapsule transactionCap = builder.build();
-            Assert.assertFalse(true);
-        } catch (Exception e) {
-            Assert.assertTrue(e instanceof ZksnarkException);
-            Assert.assertEquals("Spend proof failed", e.getMessage());
-        }
-    }
-
-    /**
-     * test of transferring insufficient money from transparent address to shield address.
-     */
-    @Test
-    public void testTransparentInputInsufficient() throws RuntimeException, ZksnarkException {
-        librustzcashInitZksnarkParams();
-        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-        long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
-        createCapsule();
-        createAccountAssetIssue();
-        //generate input
-        builder.setTransparentInput(ByteArray.fromHexString(FROM_ADDRESS), FROM_AMOUNT); // fail
-        //builder.setTransparentInput(ByteArray.fromHexString(FROM_ADDRESS), OWNER_BALANCE); //success
-        byte[] senderOvk = randomUint256();
-
-        //generate output
-        SpendingKey sk = SpendingKey.random();
-        FullViewingKey fullViewingKey12 = sk.fullViewingKey();
-        IncomingViewingKey ivk = fullViewingKey12.inViewingKey();
-        PaymentAddress paymentAddress = ivk.address(new DiversifierT()).get();
-        builder.addOutput(senderOvk, paymentAddress,
-                FROM_AMOUNT - wallet.getShieldedTransactionFee(), new byte[512]); // fail
-        //builder.addOutput(senderOvk, paymentAddress,
-        //        OWNER_BALANCE - wallet.getShieldedTransactionFee(), new byte[512]); //success
-
-        updateTotalShieldedPoolValue(builder.getValueBalance());
-        TransactionCapsule transactionCap = builder.build();
-
-        try {
-            //valdiate
-            List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
-            actuator.get(0).validate();
-            Assert.assertFalse(true);
-        } catch (Exception e) {
-            Assert.assertTrue(e instanceof ContractValidateException);
-            Assert.assertEquals("Validate ShieldedTransferContract error, balance is not sufficient",
-                    e.getMessage());
-        }
-    }
-
-    /*
-    test if random DiversifierT is valid.
-  */
-    @Test
-    public void testDiversifierT() throws ZksnarkException {
-        //byte[] data = org.tron.keystore.Wallet.generateRandomBytes(Constant.ZC_DIVERSIFIER_SIZE);
-        byte[] data1 = ByteArray.fromHexString("93c9e5679850252b37a991");
-        byte[] data2 = ByteArray.fromHexString("c50124c6a9a2e1700fc0b5");
-        Assert.assertFalse(JLibrustzcash.librustzcashCheckDiversifier(data1));
-        Assert.assertTrue(JLibrustzcash.librustzcashCheckDiversifier(data2));
-    }
-
-    private byte[] hashWithMissingColumn(TransactionCapsule tx, TestSignMissingColumn column)
-            throws InvalidProtocolBufferException {
-        Any contractParameter = tx.getInstance().getRawData().getContract(0).getParameter();
-        ShieldedTransferContract shieldedTransferContract = contractParameter
-                .unpack(ShieldedTransferContract.class);
-        ShieldedTransferContract.Builder newContract = ShieldedTransferContract.newBuilder();
-
-        if (column != null) {
-            switch (column) {
-                case FROM_ADDRESS:
-                    newContract.setFromAmount(shieldedTransferContract.getFromAmount());
-                    newContract
-                            .addAllReceiveDescription(shieldedTransferContract.getReceiveDescriptionList());
-                    newContract.setToAmount(shieldedTransferContract.getToAmount());
-                    newContract.setTransparentToAddress(shieldedTransferContract.getTransparentToAddress());
-                    for (SpendDescription spendDescription : shieldedTransferContract
-                            .getSpendDescriptionList()) {
-                        newContract
-                                .addSpendDescription(
-                                        spendDescription.toBuilder().clearSpendAuthoritySignature().build());
-                    }
-                    break;
-                case FROM_AMOUNT:
-                    //newContract.setFromAmount(shieldedTransferContract.getFromAmount());
-                    newContract
-                            .addAllReceiveDescription(shieldedTransferContract.getReceiveDescriptionList());
-                    newContract.setToAmount(shieldedTransferContract.getToAmount());
-                    newContract
-                            .setTransparentFromAddress(shieldedTransferContract.getTransparentFromAddress());
-                    newContract.setTransparentToAddress(shieldedTransferContract.getTransparentToAddress());
-                    for (SpendDescription spendDescription : shieldedTransferContract
-                            .getSpendDescriptionList()) {
-                        newContract
-                                .addSpendDescription(
-                                        spendDescription.toBuilder().clearSpendAuthoritySignature().build());
-                    }
-                    break;
-                case SPEND_DESCRITPION:
-                    newContract.setFromAmount(shieldedTransferContract.getFromAmount());
-                    newContract
-                            .addAllReceiveDescription(shieldedTransferContract.getReceiveDescriptionList());
-                    newContract.setToAmount(shieldedTransferContract.getToAmount());
-                    newContract
-                            .setTransparentFromAddress(shieldedTransferContract.getTransparentFromAddress());
-                    newContract.setTransparentToAddress(shieldedTransferContract.getTransparentToAddress());
-                    break;
-                case RECEIVE_DESCRIPTION:
-                    newContract.setFromAmount(shieldedTransferContract.getFromAmount());
-                    newContract.setToAmount(shieldedTransferContract.getToAmount());
-                    newContract
-                            .setTransparentFromAddress(shieldedTransferContract.getTransparentFromAddress());
-                    newContract.setTransparentToAddress(shieldedTransferContract.getTransparentToAddress());
-                    for (SpendDescription spendDescription : shieldedTransferContract
-                            .getSpendDescriptionList()) {
-                        newContract
-                                .addSpendDescription(
-                                        spendDescription.toBuilder().clearSpendAuthoritySignature().build());
-                    }
-                    break;
-                case TO_ADDRESS:
-                    newContract.setFromAmount(shieldedTransferContract.getFromAmount());
-                    newContract
-                            .addAllReceiveDescription(shieldedTransferContract.getReceiveDescriptionList());
-                    newContract.setToAmount(shieldedTransferContract.getToAmount());
-                    newContract
-                            .setTransparentFromAddress(shieldedTransferContract.getTransparentFromAddress());
-                    //newContract.setTransparentToAddress(shieldedTransferContract.getTransparentToAddress());
-                    for (SpendDescription spendDescription : shieldedTransferContract
-                            .getSpendDescriptionList()) {
-                        newContract
-                                .addSpendDescription(
-                                        spendDescription.toBuilder().clearSpendAuthoritySignature().build());
-                    }
-                    break;
-                case TO_AMOUNT:
-                    newContract.setFromAmount(shieldedTransferContract.getFromAmount());
-                    newContract
-                            .addAllReceiveDescription(shieldedTransferContract.getReceiveDescriptionList());
-                    //newContract.setToAmount(shieldedTransferContract.getToAmount());
-                    newContract
-                            .setTransparentFromAddress(shieldedTransferContract.getTransparentFromAddress());
-                    newContract.setTransparentToAddress(shieldedTransferContract.getTransparentToAddress());
-                    for (SpendDescription spendDescription : shieldedTransferContract
-                            .getSpendDescriptionList()) {
-                        newContract
-                                .addSpendDescription(
-                                        spendDescription.toBuilder().clearSpendAuthoritySignature().build());
-                    }
-                    break;
-                default:
-                    break;
-            }
-        }
-        Transaction.raw.Builder rawBuilder = tx.getInstance().toBuilder()
-                .getRawDataBuilder()
-                .clearContract()
-                .addContract(
-                        Transaction.Contract.newBuilder().setType(ContractType.ShieldedTransferContract)
-                                .setParameter(
-                                        Any.pack(newContract.build())).build());
-
-        Transaction transaction = tx.getInstance().toBuilder().clearRawData()
-                .setRawData(rawBuilder).build();
-
-        byte[] mergedByte = Bytes.concat(
-                Sha256Hash.of(
-                        CommonParameter
-                                .getInstance().isECKeyCryptoEngine(),
-                        CommonParameter.getInstance().getZenTokenId().getBytes()).getBytes(),
-                transaction.getRawData().toByteArray());
-        return Sha256Hash.of(CommonParameter
-                .getInstance().isECKeyCryptoEngine(), mergedByte).getBytes();
-    }
-
-    private ZenTransactionBuilder generateShield2ShieldBuilder(ZenTransactionBuilder builder,
-                                                               long ctx)
-            throws ZksnarkException, BadItemException {
-        //generate input
-        SpendingKey sk = SpendingKey.random();
-        ExpandedSpendingKey expsk = sk.expandedSpendingKey();
-        PaymentAddress address = sk.defaultAddress();
-        Note note = new Note(address, 100 * 1000000L);
-        IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
-        byte[] anchor = voucher.root().getContent().toByteArray();
-        chainBaseManager.getMerkleContainer()
-                .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
-        builder.addSpend(expsk, note, anchor, voucher);
-
-        // generate output
-        SpendingKey sk1 = SpendingKey.random();
-        FullViewingKey fullViewingKey1 = sk1.fullViewingKey();
-        IncomingViewingKey ivk1 = fullViewingKey1.inViewingKey();
-        PaymentAddress paymentAddress1 = ivk1.address(new DiversifierT()).get();
-        builder.addOutput(expsk.getOvk(), paymentAddress1,
-                100 * 1000000L - wallet.getShieldedTransactionFee(), new byte[512]);
-
-        // Create Sapling SpendDescriptions
-        for (SpendDescriptionInfo spend : builder.getSpends()) {
-            SpendDescriptionCapsule spendDescriptionCapsule = builder.generateSpendProof(spend, ctx);
-            builder.getContractBuilder().addSpendDescription(spendDescriptionCapsule.getInstance());
-        }
-
-        // Create Sapling OutputDescriptions
-        for (ReceiveDescriptionInfo receive : builder.getReceives()) {
-            ReceiveDescriptionCapsule receiveDescriptionCapsule = builder
-                    .generateOutputProof(receive, ctx);
-            builder.getContractBuilder().addReceiveDescription(receiveDescriptionCapsule.getInstance());
-        }
-
-        return builder;
-    }
-
-    public TransactionCapsule generateTransactionCapsule(ZenTransactionBuilder builder,
-                                                         long ctx, byte[] hashOfTransaction, TransactionCapsule transactionCapsule)
-            throws ZksnarkException {
-        // Create Sapling spendAuth
-        for (int i = 0; i < builder.getSpends().size(); i++) {
-            byte[] result = new byte[64];
-            JLibrustzcash.librustzcashSaplingSpendSig(
-                    new SpendSigParams(builder.getSpends().get(i).getExpsk().getAsk(),
-                            builder.getSpends().get(i).getAlpha(),
-                            hashOfTransaction,
-                            result));
-            builder.getContractBuilder().getSpendDescriptionBuilder(i)
-                    .setSpendAuthoritySignature(ByteString.copyFrom(result));
-        }
-
-        //create binding signatures
-        byte[] bindingSig = new byte[64];
-        JLibrustzcash.librustzcashSaplingBindingSig(
-                new BindingSigParams(ctx,
-                        builder.getValueBalance(),
-                        hashOfTransaction,
-                        bindingSig)
-        );
-        builder.getContractBuilder().setBindingSignature(ByteString.copyFrom(bindingSig));
-
-        Transaction.raw.Builder rawBuilder = transactionCapsule.getInstance().toBuilder()
-                .getRawDataBuilder()
-                .clearContract()
-                .addContract(Transaction.Contract.newBuilder()
-                        .setType(ContractType.ShieldedTransferContract)
-                        .setParameter(Any.pack(builder.getContractBuilder().build()))
-                        .build());
-
-        Transaction transaction = transactionCapsule.getInstance().toBuilder().clearRawData()
-                .setRawData(rawBuilder).build();
-        TransactionCapsule transactionCap = new TransactionCapsule(transaction);
-
-        updateTotalShieldedPoolValue(builder.getValueBalance());
-
-        return transactionCap;
-    }
-
-    /*
-     * test signature for shield to shield transaction with some column missing
-     */
-    @Test
-    public void testSignWithoutFromAddress()
-            throws BadItemException, ContractValidateException, RuntimeException,
-            ZksnarkException {
-        librustzcashInitZksnarkParams();
-        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-        long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
-
-        builder = generateShield2ShieldBuilder(builder, ctx);
-
-        // Empty output script.
-        byte[] hashOfTransaction;//256
-        TransactionCapsule transactionCapsule;
-        try {
-            transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
-                    builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
-
-            //test case
-            hashOfTransaction = hashWithMissingColumn(transactionCapsule,
-                    TestSignMissingColumn.FROM_ADDRESS);
-            //end of test case
-
-        } catch (Exception ex) {
-            JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
-            throw new RuntimeException("Could not construct signature hash: " + ex.getMessage());
-        }
-
-        TransactionCapsule transactionCap = generateTransactionCapsule(builder, ctx, hashOfTransaction,
-                transactionCapsule);
-
-        List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
-        actuator.get(0).validate(); //there is hash(transaction) in librustzcashSaplingFinalCheck
-        Assert.assertTrue(true);
-    }
-
-    /*
-     * test signature for shield to shield transaction with some column missing
-     */
-    @Test
-    public void testSignWithoutFromAmout()
-            throws BadItemException, ContractValidateException, RuntimeException,
-            ZksnarkException {
-        librustzcashInitZksnarkParams();
-        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-        long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
-
-        builder = generateShield2ShieldBuilder(builder, ctx);
-
-        // Empty output script.
-        byte[] hashOfTransaction;//256
-        TransactionCapsule transactionCapsule;
-        try {
-            transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
-                    builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
-
-            //test case
-            hashOfTransaction = hashWithMissingColumn(transactionCapsule,
-                    TestSignMissingColumn.FROM_AMOUNT);
-            //end of test case
-
-        } catch (Exception ex) {
-            JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
-            throw new RuntimeException("Could not construct signature hash: " + ex.getMessage());
-        }
-
-        TransactionCapsule transactionCap = generateTransactionCapsule(builder, ctx, hashOfTransaction,
-                transactionCapsule);
-
-        List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
-        actuator.get(0).validate(); //there is hash(transaction) in librustzcashSaplingFinalCheck
-        Assert.assertTrue(true);
-    }
-
-    /*
-     * test signature for shield to shield transaction with some column missing
-     */
-    @Test
-    public void testSignWithoutSpendDescription()
-            throws BadItemException, RuntimeException, ZksnarkException {
-        librustzcashInitZksnarkParams();
-        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-        long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
-
-        builder = generateShield2ShieldBuilder(builder, ctx);
-
-        // Empty output script.
-        byte[] hashOfTransaction;//256
-        TransactionCapsule transactionCapsule;
-        try {
-            transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
-                    builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
-
-            //test case
-            hashOfTransaction = hashWithMissingColumn(transactionCapsule,
-                    TestSignMissingColumn.SPEND_DESCRITPION);
-            //end of test case
-
-        } catch (Exception ex) {
-            JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
-            throw new RuntimeException("Could not construct signature hash: " + ex.getMessage());
-        }
-
-        TransactionCapsule transactionCap = generateTransactionCapsule(builder, ctx, hashOfTransaction,
-                transactionCapsule);
-
-        try {
-            //validate
-            List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
-            actuator.get(0).validate(); //there is hash(transaction) in librustzcashSaplingFinalCheck
-            Assert.assertFalse(true);
-        } catch (Exception e) {
-            Assert.assertTrue(e instanceof ContractValidateException);
-            Assert.assertEquals("librustzcashSaplingCheckSpend error", e.getMessage());
-        }
-        JLibrustzcash.librustzcashSaplingVerificationCtxFree(ctx);
-    }
-
-    /*
-     * test signature for shield to shield transaction with some column missing
-     */
-    @Test
-    public void testSignWithoutReceiveDescription()
-            throws BadItemException, RuntimeException, ZksnarkException {
-        librustzcashInitZksnarkParams();
-        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-        long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
-
-        builder = generateShield2ShieldBuilder(builder, ctx);
-
-        // Empty output script.
-        byte[] hashOfTransaction;//256
-        TransactionCapsule transactionCapsule;
-        try {
-            transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
-                    builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
-
-            //test case
-            hashOfTransaction = hashWithMissingColumn(transactionCapsule,
-                    TestSignMissingColumn.RECEIVE_DESCRIPTION);
-            //end of test case
-
-        } catch (Exception ex) {
-            JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
-            throw new RuntimeException("Could not construct signature hash: " + ex.getMessage());
-        }
-
-        TransactionCapsule transactionCap = generateTransactionCapsule(builder, ctx, hashOfTransaction,
-                transactionCapsule);
-
-        try {
-            //validate
-            List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
-            actuator.get(0).validate(); //there is hash(transaction) in librustzcashSaplingFinalCheck
-            Assert.assertFalse(true);
-        } catch (Exception e) {
-            Assert.assertTrue(e instanceof ContractValidateException);
-            Assert.assertEquals("librustzcashSaplingCheckSpend error", e.getMessage());
-        }
-        JLibrustzcash.librustzcashSaplingVerificationCtxFree(ctx);
-    }
-
-    /*
-     * test signature for shield to shield transaction with some column missing
-     */
-    @Test
-    public void testSignWithoutToAddress()
-            throws BadItemException, ContractValidateException, RuntimeException,
-            ZksnarkException {
-        librustzcashInitZksnarkParams();
-        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-        long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
-
-        builder = generateShield2ShieldBuilder(builder, ctx);
-
-        // Empty output script.
-        byte[] hashOfTransaction;//256
-        TransactionCapsule transactionCapsule;
-        try {
-            transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
-                    builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
-
-            //test case
-            hashOfTransaction = hashWithMissingColumn(transactionCapsule,
-                    TestSignMissingColumn.TO_ADDRESS);
-            //end of test case
-
-        } catch (Exception ex) {
-            JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
-            throw new RuntimeException("Could not construct signature hash: " + ex.getMessage());
-        }
-
-        TransactionCapsule transactionCap = generateTransactionCapsule(builder, ctx, hashOfTransaction,
-                transactionCapsule);
-
-        List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
-        actuator.get(0).validate(); //there is hash(transaction) in librustzcashSaplingFinalCheck
-        Assert.assertTrue(true);
-    }
-
-    /*
-     * test signature for shield to shield transaction with some column missing
-     */
-    @Test
-    public void testSignWithoutToAmount()
-            throws BadItemException, ContractValidateException, RuntimeException,
-            ZksnarkException {
-        librustzcashInitZksnarkParams();
-        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-        long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
-
-        builder = generateShield2ShieldBuilder(builder, ctx);
-
-        // Empty output script.
-        byte[] hashOfTransaction;//256
-        TransactionCapsule transactionCapsule;
-        try {
-            transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
-                    builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
-
-            //test case
-            hashOfTransaction = hashWithMissingColumn(transactionCapsule,
-                    TestSignMissingColumn.TO_AMOUNT);
-            //end of test case
-
-        } catch (Exception ex) {
-            JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
-            throw new RuntimeException("Could not construct signature hash: " + ex.getMessage());
-        }
-
-        TransactionCapsule transactionCap = generateTransactionCapsule(builder, ctx, hashOfTransaction,
-                transactionCapsule);
-
-        List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
-        actuator.get(0).validate(); //there is hash(transaction) in librustzcashSaplingFinalCheck
-        Assert.assertTrue(true);
-    }
-
-    /*
-     * test spend authorize signature with some wrong column
-     */
-    @Test
-    public void testSpendSignatureWithWrongColumn()
-            throws BadItemException, RuntimeException, ZksnarkException {
-        librustzcashInitZksnarkParams();
-        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-        long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
-
-        // generate input
-        SpendingKey sk = SpendingKey
-                .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
-        ExpandedSpendingKey expsk = sk.expandedSpendingKey();
-        PaymentAddress address = sk.defaultAddress();
-        Note note = new Note(address, 100 * 1000000L);
-        IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
-        byte[] anchor = voucher.root().getContent().toByteArray();
-        chainBaseManager.getMerkleContainer()
-                .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
-        builder.addSpend(expsk, note, anchor, voucher);
-
-        //shield transparent input
-        //createCapsule();
-        //builder.setTransparentInput(ByteArray.fromHexString(FROM_ADDRESS), OWNER_BALANCE);
-
-        // generate output
-        SpendingKey sk1 = SpendingKey.random();
-        FullViewingKey fullViewingKey1 = sk1.fullViewingKey();
-        IncomingViewingKey ivk1 = fullViewingKey1.inViewingKey();
-        PaymentAddress paymentAddress1 = ivk1.address(new DiversifierT()).get();
-        builder.addOutput(expsk.getOvk(), paymentAddress1,
-                100 * 1000000L - wallet.getShieldedTransactionFee(), new byte[512]);
-
-        // Create Sapling SpendDescriptions
-        for (SpendDescriptionInfo spend : builder.getSpends()) {
-            SpendDescriptionCapsule spendDescriptionCapsule = builder.generateSpendProof(spend, ctx);
-            builder.getContractBuilder().addSpendDescription(spendDescriptionCapsule.getInstance());
-        }
-
-        // Create Sapling OutputDescriptions
-        for (ReceiveDescriptionInfo receive : builder.getReceives()) {
-            ReceiveDescriptionCapsule receiveDescriptionCapsule = builder
-                    .generateOutputProof(receive, ctx);
-            builder.getContractBuilder().addReceiveDescription(receiveDescriptionCapsule.getInstance());
-        }
-
-        // Empty output script.
-        byte[] hashOfTransaction;//256
-        TransactionCapsule transactionCapsule;
-        try {
-            transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
-                    builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
-
-            hashOfTransaction = TransactionCapsule
-                    .hashShieldTransaction(transactionCapsule.getInstance(),
-                            CommonParameter.getInstance().getZenTokenId());
-
-        } catch (Exception ex) {
-            JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
-            throw new RuntimeException("Could not construct signature hash: " + ex.getMessage());
-        }
-
-        // Create Sapling spendAuth
-        for (int i = 0; i < builder.getSpends().size(); i++) {
-            byte[] result = new byte[64];
-            JLibrustzcash.librustzcashSaplingSpendSig(
-                    new SpendSigParams(builder.getSpends().get(i).getExpsk().getAsk(),
-                            Note.generateR(),
-                            //replace builder.getSpends().get(i).alpha with random alpha, should fail
-                            hashOfTransaction,
-                            result));
-            builder.getContractBuilder().getSpendDescriptionBuilder(i)
-                    .setSpendAuthoritySignature(ByteString.copyFrom(result));
-        }
-
-        //create binding signatures
-        byte[] bindingSig = new byte[64];
-        JLibrustzcash.librustzcashSaplingBindingSig(
-                new BindingSigParams(ctx,
-                        builder.getValueBalance(),
-                        hashOfTransaction,
-                        bindingSig)
-        );
-        builder.getContractBuilder().setBindingSignature(ByteString.copyFrom(bindingSig));
-
-        Transaction.raw.Builder rawBuilder = transactionCapsule.getInstance().toBuilder()
-                .getRawDataBuilder()
-                .clearContract()
-                .addContract(Transaction.Contract.newBuilder()
-                        .setType(ContractType.ShieldedTransferContract)
-                        .setParameter(Any.pack(builder.getContractBuilder().build()))
-                        .build());
-
-        Transaction transaction = transactionCapsule.getInstance().toBuilder().clearRawData()
-                .setRawData(rawBuilder).build();
-        TransactionCapsule transactionCap = new TransactionCapsule(transaction);
-
-        updateTotalShieldedPoolValue(builder.getValueBalance());
-
-        try {
-            //validate
-            List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
-            actuator.get(0)
-                    .validate(); //there is getSpendAuthoritySignature in librustzcashSaplingCheckSpend
-            Assert.assertFalse(true);
-        } catch (Exception e) {
-            Assert.assertTrue(e instanceof ContractValidateException);
-            //signature for spend with some wrong column
-            //if transparent to shield, ok
-            //if shield to shield or shield to transparent, librustzcashSaplingFinalCheck error
-            Assert.assertTrue(e.getMessage().equalsIgnoreCase("librustzcashSaplingCheckSpend error"));
-        }
-        JLibrustzcash.librustzcashSaplingVerificationCtxFree(ctx);
-    }
-
-    /*
-     * test use isolate method to build the signature
-     */
-    @Test
-    public void testIsolateSignature()
-            throws ZksnarkException, BadItemException, ContractValidateException, ContractExeException {
-        librustzcashInitZksnarkParams();
-        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-        long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
-
-        // generate shield spend
-        SpendingKey sk = SpendingKey
-                .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
-        ExpandedSpendingKey expsk = sk.expandedSpendingKey();
-
-        //build transaction without spend signature and get transactionHash
-        TransactionHash transactionHash = new TransactionHash(new byte[32]);
-        TransactionCapsule transactionCapsule = buildShieldedTransactionWithoutSpendAuthSig(
-                sk.defaultAddress(),
-                sk.fullViewingKey().getAk(),
-                expsk.getNsk(),
-                expsk.getOvk(),
-                transactionHash,
-                builder,
-                ctx);
-        //filled with Sapling spendAuth in builder
-        List<SpendDescriptionInfo> spends = builder.getSpends();
-        for (int i = 0; i < spends.size(); i++) {
-            //replace with interface
-            SpendAuthSigParameters spendAuthSigParameters = SpendAuthSigParameters.newBuilder()
-                    .setAsk(ByteString.copyFrom(expsk.getAsk())) //ask => ak
-                    .setAlpha(ByteString.copyFrom(spends.get(i).getAlpha()))
-                    .setTxHash(ByteString.copyFrom(transactionHash.getHash()))
-                    .build();
-            BytesMessage spendAuthSig = wallet.createSpendAuthSig(spendAuthSigParameters);
-            builder.getContractBuilder().getSpendDescriptionBuilder(i)
-                    .setSpendAuthoritySignature(spendAuthSig.getValue());
-        }
-
-        Transaction.raw.Builder rawBuilder = transactionCapsule.getInstance().toBuilder()
-                .getRawDataBuilder()
-                .clearContract()
-                .addContract(Transaction.Contract.newBuilder()
-                        .setType(ContractType.ShieldedTransferContract)
-                        .setParameter(Any.pack(builder.getContractBuilder().build()))
-                        .build());
-        Transaction transaction = transactionCapsule.getInstance().toBuilder().clearRawData()
-                .setRawData(rawBuilder).build();
-
-        TransactionCapsule transactionCap = new TransactionCapsule(transaction);
-        //validate
-        List<Actuator> actuator = ActuatorCreator.getINSTANCE().createActuator(transactionCap);
-        actuator.get(0).validate();
-        //execute
-        TransactionResultCapsule resultCapsule = new TransactionResultCapsule();
-        boolean executeResult = actuator.get(0).execute(resultCapsule);
-        Assert.assertTrue(executeResult);
-    }
-
-    /*
-     * build ShieldedTransaction Without SpendAuthSig
-     */
-    public TransactionCapsule buildShieldedTransactionWithoutSpendAuthSig(PaymentAddress address,
-                                                                          byte[] ak,
-                                                                          byte[] nsk, byte[] ovk, TransactionHash dataHashToBeSigned, ZenTransactionBuilder builder,
-                                                                          long ctx)
-            throws ZksnarkException, BadItemException, ContractValidateException {
-        // generate input
-        Note note = new Note(address, 100 * 1000000L);
-        note.setRcm(ByteArray.fromHexString(
-                "eb1aa5dd257b9da4e4064a853dec94651be38078e29fe441a9a8075016cfa701"));
-        IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
-        byte[] anchor = voucher.root().getContent().toByteArray();
-        chainBaseManager.getMerkleContainer()
-                .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
-        SpendDescriptionInfo skSpend = new SpendDescriptionInfo(ak,
-                nsk,
-                ovk,
-                note,
-                Note.generateR(),
-                anchor,
-                voucher
-        );
-        builder.addSpend(skSpend);
-
-        // generate output
-        SpendingKey sk1 = SpendingKey.random();
-        FullViewingKey fullViewingKey1 = sk1.fullViewingKey();
-        IncomingViewingKey ivk1 = fullViewingKey1.inViewingKey();
-        PaymentAddress paymentAddress1 = ivk1.address(new DiversifierT()).get();
-        builder.addOutput(ovk, paymentAddress1,
-                100 * 1000000L - wallet.getShieldedTransactionFee(), new byte[512]);
-
-        // Create Sapling SpendDescriptions
-        for (SpendDescriptionInfo spend : builder.getSpends()) {
-            SpendDescriptionCapsule spendDescriptionCapsule = builder.generateSpendProof(spend, ctx);
-            builder.getContractBuilder().addSpendDescription(spendDescriptionCapsule.getInstance());
-        }
-
-        // Create Sapling OutputDescriptions
-        for (ReceiveDescriptionInfo receive : builder.getReceives()) {
-            ReceiveDescriptionCapsule receiveDescriptionCapsule = builder
-                    .generateOutputProof(receive, ctx);
-            builder.getContractBuilder().addReceiveDescription(receiveDescriptionCapsule.getInstance());
-        }
-
-        // Empty output script
-        TransactionCapsule transactionCapsule = wallet.createTransactionCapsuleWithoutValidate(
-                builder.getContractBuilder().build(), ContractType.ShieldedTransferContract);
-        //replace with interface
-        //System.out.println(JsonFormat.printToString(transactionCapsule.getInstance()));
-        BytesMessage transactionHash = wallet
-                .getShieldTransactionHash(transactionCapsule.getInstance());
-
-        if (transactionHash == null) {
-            throw new ZksnarkException("cal transaction hash failed");
-        }
-        dataHashToBeSigned.setHash(transactionHash.getValue().toByteArray());
-
-        // Create binding signatures
-        byte[] bindingSig = new byte[64];
-        JLibrustzcash.librustzcashSaplingBindingSig(
-                new BindingSigParams(ctx,
-                        builder.getValueBalance(),
-                        dataHashToBeSigned.getHash(),
-                        bindingSig)
-        );
-        builder.getContractBuilder().setBindingSignature(ByteString.copyFrom(bindingSig));
-        return transactionCapsule;
-    }
-
-    @Test
-    public void testMemoTooLong() throws ContractValidateException, TooBigTransactionException,
-            TooBigTransactionResultException, TaposException, TransactionExpirationException,
-            ReceiptCheckErrException, DupTransactionException, VMIllegalException,
-            ValidateSignatureException, BadItemException, ContractExeException,
-            AccountResourceInsufficientException, InvalidProtocolBufferException, ZksnarkException {
-        long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
-
-        librustzcashInitZksnarkParams();
-        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-
-        // generate spend proof
-        SpendingKey sk = SpendingKey
-                .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
-        ExpandedSpendingKey expsk = sk.expandedSpendingKey();
-        PaymentAddress address = sk.defaultAddress();
-        Note note = new Note(address, 100 * 1000000L);
-        IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
-        byte[] anchor = voucher.root().getContent().toByteArray();
-        chainBaseManager.getMerkleContainer()
-                .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
-        builder.addSpend(expsk, note, anchor, voucher);
-
-        // generate output proof
-        SpendingKey spendingKey = SpendingKey.random();
-        FullViewingKey fullViewingKey = spendingKey.fullViewingKey();
-        IncomingViewingKey incomingViewingKey = fullViewingKey.inViewingKey();
-        PaymentAddress paymentAddress = incomingViewingKey.address(new DiversifierT()).get();
-        byte[] memo = org.tron.keystore.Wallet.generateRandomBytes(1024);
-        builder.addOutput(expsk.getOvk(), paymentAddress,
-                100 * 1000000L - wallet.getShieldedTransactionFee(), memo);
-
-        TransactionCapsule transactionCap = builder.build();
-
-        boolean ok = dbManager.pushTransaction(transactionCap);
-        Assert.assertTrue(ok);
-
-        // add here
-        byte[] ivk = fullViewingKey.inViewingKey().getValue();
-        Protocol.Transaction t = transactionCap.getInstance();
-
-        for (org.tron.protos.Protocol.Transaction.Contract c : t.getRawData().getContractList()) {
-            if (c.getType() != ContractType.ShieldedTransferContract) {
-                continue;
-            }
-            ShieldedTransferContract stContract = c.getParameter()
-                    .unpack(ShieldedTransferContract.class);
-            ReceiveDescription receiveDescription = stContract.getReceiveDescription(0);
-
-            Optional<Note> ret1 = Note.decrypt(
-                    receiveDescription.getCEnc().toByteArray(),//ciphertext
-                    ivk,
-                    receiveDescription.getEpk().toByteArray(),//epk
-                    receiveDescription.getNoteCommitment().toByteArray() //cm
-            );
-
-            if (ret1.isPresent()) {
-                Note noteText = ret1.get();
-                byte[] pkD = new byte[32];
-                if (!JLibrustzcash.librustzcashIvkToPkd(
-                        new IvkToPkdParams(incomingViewingKey.getValue(),
-                                noteText.getD().getData(), pkD))) {
-                    JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
-                    return;
-                }
-                Assert.assertArrayEquals(paymentAddress.getPkD(), pkD);
-                Assert.assertEquals(100 * 1000000L - wallet.getShieldedTransactionFee(),
-                        noteText.getValue());
-
-                byte[] resultMemo = new byte[512];
-                System.arraycopy(memo, 0, resultMemo, 0, 512);
-                Assert.assertArrayEquals(resultMemo, noteText.getMemo());
-            } else {
-                Assert.assertFalse(true);
-            }
-        }
-        // end here
-        JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
-        Assert.assertTrue(ok);
-    }
-
-    @Test
-    public void testMemoNotEnough() throws ContractValidateException, TooBigTransactionException,
-            TooBigTransactionResultException, TaposException, TransactionExpirationException,
-            ReceiptCheckErrException, DupTransactionException, VMIllegalException,
-            ValidateSignatureException, BadItemException, ContractExeException,
-            AccountResourceInsufficientException, InvalidProtocolBufferException, ZksnarkException {
-        long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
-
-        librustzcashInitZksnarkParams();
-        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(100 * 1000000L);
-        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-
-        // generate spend proof
-        SpendingKey sk = SpendingKey
-                .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
-        ExpandedSpendingKey expsk = sk.expandedSpendingKey();
-        PaymentAddress address = sk.defaultAddress();
-        Note note = new Note(address, 100 * 1000000L);
-        IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
-        byte[] anchor = voucher.root().getContent().toByteArray();
-        chainBaseManager.getMerkleContainer()
-                .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
-        builder.addSpend(expsk, note, anchor, voucher);
-
-        // generate output proof
-        SpendingKey spendingKey = SpendingKey.random();
-        FullViewingKey fullViewingKey = spendingKey.fullViewingKey();
-        IncomingViewingKey incomingViewingKey = fullViewingKey.inViewingKey();
-        PaymentAddress paymentAddress = incomingViewingKey.address(new DiversifierT()).get();
-        byte[] memo = org.tron.keystore.Wallet.generateRandomBytes(128);
-        builder.addOutput(expsk.getOvk(), paymentAddress,
-                100 * 1000000L - wallet.getShieldedTransactionFee(), memo);
-
-        TransactionCapsule transactionCap = builder.build();
-
-        boolean ok = dbManager.pushTransaction(transactionCap);
-        Assert.assertTrue(ok);
-
-        // add here
-        byte[] ivk = fullViewingKey.inViewingKey().getValue();
-        Protocol.Transaction t = transactionCap.getInstance();
-
-        for (org.tron.protos.Protocol.Transaction.Contract c : t.getRawData().getContractList()) {
-            if (c.getType() != ContractType.ShieldedTransferContract) {
-                continue;
-            }
-            ShieldedTransferContract stContract = c.getParameter()
-                    .unpack(ShieldedTransferContract.class);
-            ReceiveDescription receiveDescription = stContract.getReceiveDescription(0);
-
-            Optional<Note> ret1 = Note.decrypt(
-                    receiveDescription.getCEnc().toByteArray(),//ciphertext
-                    ivk,
-                    receiveDescription.getEpk().toByteArray(),//epk
-                    receiveDescription.getNoteCommitment().toByteArray() //cm
-            );
-
-            if (ret1.isPresent()) {
-                Note noteText = ret1.get();
-                byte[] pkD = new byte[32];
-                if (!JLibrustzcash.librustzcashIvkToPkd(
-                        new IvkToPkdParams(incomingViewingKey.getValue(),
-                                noteText.getD().getData(), pkD))) {
-                    JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
-                    return;
-                }
-                Assert.assertArrayEquals(paymentAddress.getPkD(), pkD);
-                Assert.assertEquals(100 * 1000000L - wallet.getShieldedTransactionFee(),
-                        noteText.getValue());
-
-                byte[] resultMemo = new byte[512];
-                System.arraycopy(memo, 0, resultMemo, 0, 128);
-                Assert.assertArrayEquals(resultMemo, noteText.getMemo());
-            } else {
-                Assert.assertFalse(true);
-            }
-        }
-        // end here
-        JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
-        Assert.assertTrue(ok);
-    }
-
-    /*
-    send coin to 2 different address generated by same sk, scan note by ivk; spend this note again
-     */
-    @Test
-    public void pushSameSkAndScanAndSpend() throws Exception {
-
-        byte[] privateKey = ByteArray
-                .fromHexString("f4df789d3210ac881cb900464dd30409453044d2777060a0c391cbdf4c6a4f57");
-        final ECKey ecKey = ECKey.fromPrivate(privateKey);
-        byte[] witnessAddress = ecKey.getAddress();
-        WitnessCapsule witnessCapsule = new WitnessCapsule(ByteString.copyFrom(witnessAddress));
-        chainBaseManager.addWitness(ByteString.copyFrom(witnessAddress));
-
-        createAccountAssetIssue();
-        //sometimes generate block failed, try several times.
-
-        Block block = getSignedBlock(witnessCapsule.getAddress(), 0, privateKey);
-        dbManager.pushBlock(new BlockCapsule(block));
-
-        //create transactions
-        librustzcashInitZksnarkParams();
-        chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-        chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(1000 * 1000000L);
-        ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
-
-        // generate spend proof
-        SpendingKey sk = SpendingKey
-                .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
-        ExpandedSpendingKey expsk = sk.expandedSpendingKey();
-        byte[] senderOvk = expsk.getOvk();
-        PaymentAddress address = sk.defaultAddress();
-        Note note = new Note(address, 1000 * 1000000L);
-        IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
-        byte[] anchor = voucher.root().getContent().toByteArray();
-        chainBaseManager.getMerkleContainer()
-                .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
-        builder.addSpend(expsk, note, anchor, voucher);
-
-        // generate output proof
-        SpendingKey sk2 = SpendingKey.random();
-        FullViewingKey fullViewingKey = sk2.fullViewingKey();
-        IncomingViewingKey incomingViewingKey = fullViewingKey.inViewingKey();
-
-        byte[] memo = org.tron.keystore.Wallet.generateRandomBytes(512);
-
-        //send coin to 2 different address generated by same sk
-        DiversifierT d1 = DiversifierT.random();
-        PaymentAddress paymentAddress1 = incomingViewingKey.address(d1).get();
-        builder.addOutput(senderOvk, paymentAddress1,
-                (1000 * 1000000L - wallet.getShieldedTransactionFee()) / 2, memo);
-
-        DiversifierT d2 = DiversifierT.random();
-        PaymentAddress paymentAddress2 = incomingViewingKey.address(d2).get();
-        builder.addOutput(senderOvk, paymentAddress2,
-                (1000 * 1000000L - wallet.getShieldedTransactionFee()) / 2, memo);
-
-        TransactionCapsule transactionCap = builder.build();
-
-        byte[] trxId = transactionCap.getTransactionId().getBytes();
-//        chainBaseManager.getAccountAssetIssueStore().getBlackhole().getAssetMapV2();
-        boolean ok = dbManager.pushTransaction(transactionCap);
-        Assert.assertTrue(ok);
-
-        Thread.sleep(500);
-        //package transaction to block
-        block = getSignedBlock(witnessCapsule.getAddress(), 0, privateKey);
-        dbManager.pushBlock(new BlockCapsule(block));
-
-        BlockCapsule blockCapsule3 = new BlockCapsule(wallet.getNowBlock());
-        Assert.assertEquals("blocknum != 2", 2, blockCapsule3.getNum());
-
-        // scan note by ivk
-        byte[] receiverIvk = incomingViewingKey.getValue();
-        DecryptNotes notes1 = wallet.scanNoteByIvk(0, 100, receiverIvk);
-        Assert.assertEquals(2, notes1.getNoteTxsCount());
-
-        // scan note by ovk
-        DecryptNotes notes2 = wallet.scanNoteByOvk(0, 100, senderOvk);
-        Assert.assertEquals(2, notes2.getNoteTxsCount());
-
-        // to spend received note above.
-        ZenTransactionBuilder builder2 = new ZenTransactionBuilder(wallet);
-
-        //query merkleinfo
-        OutputPointInfo.Builder request = OutputPointInfo.newBuilder();
-        for (int i = 0; i < notes1.getNoteTxsCount(); i++) {
-            OutputPoint.Builder outPointBuild = OutputPoint.newBuilder();
-            outPointBuild.setHash(ByteString.copyFrom(trxId));
-            outPointBuild.setIndex(i);
-            request.addOutPoints(outPointBuild.build());
-        }
-        IncrementalMerkleVoucherInfo merkleVoucherInfo = wallet
-                .getMerkleTreeVoucherInfo(request.build());
-
-        //build spend proof. allow only one note in spend
-        ExpandedSpendingKey expsk2 = sk2.expandedSpendingKey();
-        for (int i = 0; i < 1; i++) {
-            org.tron.api.GrpcAPI.Note grpcNote = notes1.getNoteTxs(i).getNote();
-            PaymentAddress paymentAddress = KeyIo.decodePaymentAddress(grpcNote.getPaymentAddress());
-            Note note2 = new Note(paymentAddress.getD(),
-                    paymentAddress.getPkD(),
-                    grpcNote.getValue(),
-                    grpcNote.getRcm().toByteArray()
-            );
-
-            IncrementalMerkleVoucherContainer voucher2 =
-                    new IncrementalMerkleVoucherContainer(
-                            new IncrementalMerkleVoucherCapsule(merkleVoucherInfo.getVouchers(i)));
-            byte[] anchor2 = voucher2.root().getContent().toByteArray();
-            builder2.addSpend(expsk2, note2, anchor2, voucher2);
-        }
-
-        //build output proof
-        SpendingKey sk3 = SpendingKey.random();
-        FullViewingKey fvk3 = sk3.fullViewingKey();
-        IncomingViewingKey ivk3 = fvk3.inViewingKey();
-
-        DiversifierT d3 = DiversifierT.random();
-        PaymentAddress paymentAddress3 = incomingViewingKey.address(d3).get();
-        byte[] memo3 = org.tron.keystore.Wallet.generateRandomBytes(512);
-        builder2.addOutput(expsk2.getOvk(), paymentAddress3,
-                (1000 * 1000000L - wallet.getShieldedTransactionFee()) / 2 - wallet
-                        .getShieldedTransactionFee(), memo3);
-
-        TransactionCapsule transactionCap2 = builder2.build();
-        boolean ok2 = dbManager.pushTransaction(transactionCap2);
-        Assert.assertTrue(ok2);
-    }
-
-    @Test
-    public void decodePaymentAddressIgnoreCase() {
-        String addressLower =
-                "ztron1975m0wyg8f30cgf2l5fgndhzqzkzgkgnxge8cwx2wr7m3q7chsuwewh2e6u24yykum0hq8ue99u";
-        String addressUpper = addressLower.toUpperCase();
-
-        PaymentAddress paymentAddress1 = KeyIo.decodePaymentAddress(addressLower);
-        PaymentAddress paymentAddress2 = KeyIo.decodePaymentAddress(addressUpper);
-
-        Assert.assertEquals(ByteArray.toHexString(paymentAddress1.getD().getData()),
-                ByteArray.toHexString(paymentAddress2.getD().getData()));
-        Assert.assertEquals(ByteArray.toHexString(paymentAddress1.getPkD()),
-                ByteArray.toHexString(paymentAddress2.getPkD()));
-
-    }
-
-    @Test
-    public void testCreateReceiveNoteRandom() throws ZksnarkException, BadItemException {
-        ReceiveNote receiveNote1 = wallet.createReceiveNoteRandom(0);
-        Assert.assertEquals(0, receiveNote1.getNote().getValue());
-
-        ReceiveNote receiveNote2 = wallet.createReceiveNoteRandom(0);
-        Assert.assertNotEquals(receiveNote1.getNote().getPaymentAddress(),
-                receiveNote2.getNote().getPaymentAddress());
-    }
-
-    public enum TestColumn {
-        CV,
-        ZKPOOF,
-        D_CM,
-        PKD_CM,
-        VALUE_CM,
-        R_CM
-    }
-
-    public enum TestSignMissingColumn {
-        FROM_ADDRESS, FROM_AMOUNT, SPEND_DESCRITPION,
-        RECEIVE_DESCRIPTION, TO_ADDRESS, TO_AMOUNT
-    }
-
-    public enum TestReceiveMissingColumn {
-        CV, CM, EPK, C_ENC, C_OUT, ZKPROOF
-    }
-
-    @AllArgsConstructor
-    class TransactionHash {
-
-        @Setter
-        @Getter
-        byte[] hash;
-    }
+    //build output proof
+    SpendingKey sk3 = SpendingKey.random();
+    FullViewingKey fvk3 = sk3.fullViewingKey();
+    IncomingViewingKey ivk3 = fvk3.inViewingKey();
+
+    DiversifierT d3 = DiversifierT.random();
+    PaymentAddress paymentAddress3 = incomingViewingKey.address(d3).get();
+    byte[] memo3 = org.tron.keystore.Wallet.generateRandomBytes(512);
+    builder2.addOutput(expsk2.getOvk(), paymentAddress3,
+        (1000 * 1000000L - wallet.getShieldedTransactionFee()) / 2 - wallet
+            .getShieldedTransactionFee(), memo3);
+
+    TransactionCapsule transactionCap2 = builder2.build();
+    boolean ok2 = dbManager.pushTransaction(transactionCap2);
+    Assert.assertTrue(ok2);
+  }
+
+  @Test
+  public void decodePaymentAddressIgnoreCase() {
+    String addressLower =
+        "ztron1975m0wyg8f30cgf2l5fgndhzqzkzgkgnxge8cwx2wr7m3q7chsuwewh2e6u24yykum0hq8ue99u";
+    String addressUpper = addressLower.toUpperCase();
+
+    PaymentAddress paymentAddress1 = KeyIo.decodePaymentAddress(addressLower);
+    PaymentAddress paymentAddress2 = KeyIo.decodePaymentAddress(addressUpper);
+
+    Assert.assertEquals(ByteArray.toHexString(paymentAddress1.getD().getData()),
+        ByteArray.toHexString(paymentAddress2.getD().getData()));
+    Assert.assertEquals(ByteArray.toHexString(paymentAddress1.getPkD()),
+        ByteArray.toHexString(paymentAddress2.getPkD()));
+
+  }
+
+  @Test
+  public void testCreateReceiveNoteRandom() throws ZksnarkException, BadItemException {
+    ReceiveNote receiveNote1 = wallet.createReceiveNoteRandom(0);
+    Assert.assertEquals(0, receiveNote1.getNote().getValue());
+
+    ReceiveNote receiveNote2 = wallet.createReceiveNoteRandom(0);
+    Assert.assertNotEquals(receiveNote1.getNote().getPaymentAddress(),
+        receiveNote2.getNote().getPaymentAddress());
+  }
+
+  public enum TestColumn {
+    CV,
+    ZKPOOF,
+    D_CM,
+    PKD_CM,
+    VALUE_CM,
+    R_CM
+  }
+
+  public enum TestSignMissingColumn {
+    FROM_ADDRESS, FROM_AMOUNT, SPEND_DESCRITPION,
+    RECEIVE_DESCRIPTION, TO_ADDRESS, TO_AMOUNT
+  }
+
+  public enum TestReceiveMissingColumn {
+    CV, CM, EPK, C_ENC, C_OUT, ZKPROOF
+  }
+
+  @AllArgsConstructor
+  class TransactionHash {
+
+    @Setter
+    @Getter
+    byte[] hash;
+  }
 
 }


### PR DESCRIPTION
### 1. What did you do?
Optimize your Account account. Create a new store of account assets.

Compare with [release_4.1.2](https://github.com/tronprotocol/java-tron/releases/tag/GreatVoyage-v4.1.2) and  [optimized version](https://github.com/tronprotocol/java-tron/tree/feature/account_asset_optimization) 



The serialization speed is optimized on the original side according to the Account account volume, and as much as possible, other than the necessary fields of the account, such as address, balance, accountName and other related fields are kept, other business fields that can be taken out separately are extracted.

This time, the Asset asset-related storage is optimized, stripped from the Account and moved to the new Asset-related storage.


### 2. What did you expect to see?
Account transfer speed further optimized
**1. Serialization speed**
Account reduces Asset-related fields during serialization, and after serialization fields are performed, a performance comparison of 1 million serializations is performed:

**Results of comparing the results of 4 tests**
|    version   |  improvements  |
| ---- | ---- |
|   1      |  14.77%  |
|    2    |  37.31%  |
|    3    |  28.69%  |
|    4     |  23.15%  |

**2.Transaction processing speed**
Account deserialization 1 million times compared, the optimized version will be slightly faster in deserialization about 16%

**Results of comparing the results of 4 tests**
|    version |  improvements  |
| ---- | ---- |
|    1    |  28.75% |
|    2    |  39.35% |
|    3   |  37.92%  |
|    4   |  30.04%  |


**3.Transaction processing speed**
There is a significant increase in average speed when comparing both transaction and block processing speeds


|    version  |  txs/ms   |  block/ms    |  
| ---- | ---- | ---- |
|    optimized   |  23.26%| 33.91% |





### 3. What did you see instead?
Account transfer speeds have improved, as have transaction and block packing speeds
Based on the above comparison, it can be determined that the version that extracts the fields will be faster in the serialization operation.

