### PR TITLE
change wallet interface

### DIFF
--- a/framework/src/main/java/org/tron/core/Wallet.java
+++ b/framework/src/main/java/org/tron/core/Wallet.java
@@ -171,6 +171,7 @@ import org.tron.core.exception.ZksnarkException;
 import org.tron.core.net.TronNetDelegate;
 import org.tron.core.net.TronNetService;
 import org.tron.core.net.message.TransactionMessage;
+import org.tron.core.services.http.Util;
 import org.tron.core.store.AccountAssetIssueStore;
 import org.tron.core.store.AccountIdIndexStore;
 import org.tron.core.store.AccountStore;
@@ -346,7 +347,10 @@ public class Wallet {
     accountCapsule.setLatestConsumeTimeForEnergy(genesisTimeStamp
         + BLOCK_PRODUCED_INTERVAL * accountCapsule.getLatestConsumeTimeForEnergy());
 
-    return accountCapsule.getInstance();
+    Account instance = accountCapsule.getInstance();
+    AccountAssetIssue accountAssetIssue = getAccountAssetIssueById(instance);
+
+    return Util.convertAccount(instance, accountAssetIssue);
   }
 
   public Account getAccountById(Account account) {
@@ -376,7 +380,9 @@ public class Wallet {
     accountCapsule.setLatestConsumeTimeForEnergy(genesisTimeStamp
         + BLOCK_PRODUCED_INTERVAL * accountCapsule.getLatestConsumeTimeForEnergy());
 
-    return accountCapsule.getInstance();
+    Account instance = accountCapsule.getInstance();
+    AccountAssetIssue accountAssetIssue = getAccountAssetIssueById(instance);
+    return Util.convertAccount(instance, accountAssetIssue);
   }
 
   public AccountAssetIssue getAccountAssetIssueById(Account account) {

--- a/framework/src/main/java/org/tron/core/services/http/GetAccountByIdServlet.java
+++ b/framework/src/main/java/org/tron/core/services/http/GetAccountByIdServlet.java
@@ -9,7 +9,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.tron.core.Wallet;
 import org.tron.protos.Protocol.Account;
-import org.tron.protos.Protocol.AccountAssetIssue;
 
 
 @Component
@@ -47,7 +46,6 @@ public class GetAccountByIdServlet extends RateLimiterServlet {
   private void fillResponse(Account account, boolean visible, HttpServletResponse response)
       throws IOException {
     Account reply = wallet.getAccountById(account);
-    AccountAssetIssue accountAssetIssue = wallet.getAccountAssetIssueById(account);
-    Util.printAccount(reply, accountAssetIssue, response, visible);
+    Util.printAccount(reply, response, visible);
   }
 }

--- a/framework/src/main/java/org/tron/core/services/http/GetAccountServlet.java
+++ b/framework/src/main/java/org/tron/core/services/http/GetAccountServlet.java
@@ -8,7 +8,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.tron.core.Wallet;
 import org.tron.protos.Protocol.Account;
-import org.tron.protos.Protocol.AccountAssetIssue;
 
 
 @Component
@@ -46,11 +45,6 @@ public class GetAccountServlet extends RateLimiterServlet {
   private void fillResponse(boolean visible, Account account, HttpServletResponse response)
       throws Exception {
     Account reply = wallet.getAccount(account);
-    AccountAssetIssue accountAssetIssue = wallet.getAccountAssetIssueById(account);
-    if (null != accountAssetIssue) {
-      Util.printAccount(reply, accountAssetIssue, response, visible);
-    } else {
-      Util.printAccount(reply, response, visible);
-    }
+    Util.printAccount(reply, response, visible);
   }
 }


### PR DESCRIPTION
### 1. What did you do?
Optimize your Account account. Create a new store of account assets.

Compare with [release_4.1.2](https://github.com/tronprotocol/java-tron/releases/tag/GreatVoyage-v4.1.2) and  [optimized version](https://github.com/tronprotocol/java-tron/tree/feature/account_asset_optimization) 



The serialization speed is optimized on the original side according to the Account account volume, and as much as possible, other than the necessary fields of the account, such as address, balance, accountName and other related fields are kept, other business fields that can be taken out separately are extracted.

This time, the Asset asset-related storage is optimized, stripped from the Account and moved to the new Asset-related storage.


### 2. What did you expect to see?
Account transfer speed further optimized
**1. Serialization speed**
Account reduces Asset-related fields during serialization, and after serialization fields are performed, a performance comparison of 1 million serializations is performed:

**Results of comparing the results of 4 tests**
|    version   |  improvements  |
| ---- | ---- |
|   1      |  14.77%  |
|    2    |  37.31%  |
|    3    |  28.69%  |
|    4     |  23.15%  |

**2.Transaction processing speed**
Account deserialization 1 million times compared, the optimized version will be slightly faster in deserialization about 16%

**Results of comparing the results of 4 tests**
|    version |  improvements  |
| ---- | ---- |
|    1    |  28.75% |
|    2    |  39.35% |
|    3   |  37.92%  |
|    4   |  30.04%  |


**3.Transaction processing speed**
There is a significant increase in average speed when comparing both transaction and block processing speeds


|    version  |  txs/ms   |  block/ms    |  
| ---- | ---- | ---- |
|    optimized   |  23.26%| 33.91% |





### 3. What did you see instead?
Account transfer speeds have improved, as have transaction and block packing speeds
Based on the above comparison, it can be determined that the version that extracts the fields will be faster in the serialization operation.

