### PR TITLE
remove gradle build warnings

### DIFF
--- a/actuator/build.gradle
+++ b/actuator/build.gradle
@@ -72,11 +72,11 @@ jacocoTestReport {
         xml.enabled = true
         html.enabled = true
     }
-    executionData = files('../framework/build/jacoco/jacocoTest.exec')
+    executionData.from = '../framework/build/jacoco/jacocoTest.exec'
     afterEvaluate {
-        classDirectories = files(classDirectories.files.collect {
+        classDirectories.from = classDirectories.files.collect {
             fileTree(dir: it,)
-        })
+        }
     }
 }
 

--- a/chainbase/build.gradle
+++ b/chainbase/build.gradle
@@ -102,11 +102,11 @@ jacocoTestReport {
         xml.enabled = true
         html.enabled = true
     }
-    executionData = files('../framework/build/jacoco/jacocoTest.exec')
+    executionData.from = '../framework/build/jacoco/jacocoTest.exec'
     afterEvaluate {
-        classDirectories = files(classDirectories.files.collect {
+        classDirectories.from = classDirectories.files.collect {
             fileTree(dir: it,)
-        })
+        }
     }
 }
 

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -53,10 +53,10 @@ jacocoTestReport {
         xml.enabled = true
         html.enabled = true
     }
-    executionData = files('../framework/build/jacoco/jacocoTest.exec')
+    executionData.from = '../framework/build/jacoco/jacocoTest.exec'
     afterEvaluate {
-        classDirectories = files(classDirectories.files.collect {
+        classDirectories.from = classDirectories.files.collect {
             fileTree(dir: it,)
-        })
+        }
     }
 }

--- a/consensus/build.gradle
+++ b/consensus/build.gradle
@@ -67,11 +67,11 @@ jacocoTestReport {
         xml.enabled = true
         html.enabled = true
     }
-    executionData = files('../framework/build/jacoco/jacocoTest.exec')
+    executionData.from = '../framework/build/jacoco/jacocoTest.exec'
     afterEvaluate {
-        classDirectories = files(classDirectories.files.collect {
+        classDirectories.from = classDirectories.files.collect {
             fileTree(dir: it,)
-        })
+        }
     }
 }
 

--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -135,7 +135,6 @@ test {
         exceptionFormat = 'full'
     }
     jacoco {
-        append = true
         destinationFile = file("$buildDir/jacoco/jacocoTest.exec")
         classDumpDir = file("$buildDir/jacoco/classpathdumps")
     }
@@ -165,7 +164,6 @@ task stest(type: Test) {
     }
 
     jacoco {
-        append = false
         destinationFile = file("$buildDir/jacoco/jacocoTest.exec")
         classDumpDir = file("$buildDir/jacoco/classpathdumps")
     }
@@ -186,7 +184,7 @@ jacocoTestReport {
         csv.enabled false
         html.destination file("${buildDir}/jacocoHtml")
     }
-    executionData = files('build/jacoco/jacocoTest.exec')
+    executionData.from = 'build/jacoco/jacocoTest.exec'
 }
 
 def binaryRelease(taskName, jarName, mainClass) {


### PR DESCRIPTION
**What does this PR do?**
remove the deprecation warnings when running build:
```
./gradlew --warning-mode all build
```
**Why are these changes required?**
Existing warnings
> The JacocoReportBase.setExecutionData(FileCollection) method has been deprecated. This is scheduled to be removed in > Gradle 6.0. Use getExecutionData().from(...)
>         at build_cpogxklcinlvoaolps6y8op2j$_run_closure15.doCall(/root/java-tron/framework/build.gradle:187)
>      (Run with --stacktrace to get the full stack trace of this deprecation warning.)
and
> The append property has been deprecated. This is scheduled to be removed in Gradle 6.0. Append should always be true.
>        at build_cpogxklcinlvoaolps6y8op2j$_run_closure12$_closure24.doCall(/root/java-tron/framework/build.gradle:138)
>        (Run with --stacktrace to get the full stack trace of this deprecation warning.)

**This PR has been tested by:**
- Unit Tests

**Follow up**

**Extra details**
![image](https://user-images.githubusercontent.com/1764434/117948285-e64f5080-b308-11eb-9a55-5e0690a3093a.png)

**Testing**
Local Deploy a Full Node on TestNet - running ok.
![image](https://user-images.githubusercontent.com/1764434/118845566-cbaa4800-b8c3-11eb-9203-1e221730b70e.png)
