### PR TITLE
close initCacheTrx

### DIFF
--- a/framework/src/main/java/org/tron/core/db/Manager.java
+++ b/framework/src/main/java/org/tron/core/db/Manager.java
@@ -412,7 +412,7 @@ public class Manager {
     //for test only
     chainBaseManager.getDynamicPropertiesStore().updateDynamicStoreByConfig();
 
-    initCacheTxs();
+    // initCacheTxs();
     revokingStore.enable();
     validateSignService = Executors
         .newFixedThreadPool(Args.getInstance().getValidateSignThreadNum());


### PR DESCRIPTION
**What does this PR do?**
  close initCacheTrx in manager init
**Why are these changes required?**
    exit db trans-cache,no need init again
**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

