### PR TITLE
add logback shutdown hock

### DIFF
--- a/framework/src/main/java/org/tron/common/application/ApplicationImpl.java
+++ b/framework/src/main/java/org/tron/common/application/ApplicationImpl.java
@@ -11,6 +11,7 @@ import org.tron.core.consensus.ConsensusService;
 import org.tron.core.db.Manager;
 import org.tron.core.metrics.MetricsUtil;
 import org.tron.core.net.TronNetService;
+import org.tron.program.FullNode;
 
 @Slf4j(topic = "app")
 @Component
@@ -73,6 +74,7 @@ public class ApplicationImpl implements Application {
     dbManager.stopRePushTriggerThread();
     EventPluginLoader.getInstance().stopPlugin();
     logger.info("******** end to shutdown ********");
+    FullNode.shutDownSign = true;
   }
 
   @Override

--- a/framework/src/main/java/org/tron/core/config/TronLogShutdownHook.java
+++ b/framework/src/main/java/org/tron/core/config/TronLogShutdownHook.java
@@ -1,0 +1,42 @@
+package org.tron.core.config;
+
+import ch.qos.logback.core.hook.ShutdownHookBase;
+import ch.qos.logback.core.util.Duration;
+import org.tron.program.FullNode;
+
+/**
+ * @author kiven
+ * tron log shutdown hock
+ */
+public class TronLogShutdownHook extends ShutdownHookBase {
+
+  /**
+   * The default shutdown delay check unit.
+   */
+  private static final Duration CHECK_SHUTDOWN_DELAY = Duration.buildByMilliseconds(100);
+
+  /**
+   * The check times before shutdown.  default is 50
+   */
+  private Integer check_times = 50;
+
+  public TronLogShutdownHook() {
+  }
+
+  @Override
+  public void run() {
+    try {
+      for (int i = 0; i < check_times; i++) {
+        if (FullNode.shutDownSign) {
+          break;
+        }
+        addInfo("Sleeping for " + CHECK_SHUTDOWN_DELAY);
+        Thread.sleep(CHECK_SHUTDOWN_DELAY.getMilliseconds());
+      }
+    } catch (InterruptedException e) {
+      addInfo("TronLogShutdownHook run error :" + e.getMessage());
+    }
+    super.stop();
+  }
+
+}

--- a/framework/src/main/java/org/tron/program/FullNode.java
+++ b/framework/src/main/java/org/tron/program/FullNode.java
@@ -25,6 +25,8 @@ public class FullNode {
   
   public static final int dbVersion = 2;
 
+  public static volatile boolean shutDownSign = false;
+
   public static void load(String path) {
     try {
       File file = new File(path);

--- a/framework/src/main/resources/logback.xml
+++ b/framework/src/main/resources/logback.xml
@@ -3,7 +3,7 @@
 <configuration>
 
   <!-- Be sure to flush latest logs on exit -->
-  <shutdownHook class="ch.qos.logback.core.hook.DelayingShutdownHook"/>
+  <shutdownHook class="org.tron.core.config.TronLogShutdownHook"/>
 
   <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>


### PR DESCRIPTION
**What does this PR do?**
add logback shutdown hock

**Why are these changes required?**
when tron server shutdown , the service logs lost sometimes , so we fix it with a logback shutdown hock

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

