### PR TITLE
fix: set contractAddress if transaction was a contract creation in transactionReceipt

### DIFF
--- a/framework/src/main/java/org/tron/core/services/jsonrpc/TransactionReceipt.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/TransactionReceipt.java
@@ -15,6 +15,7 @@ import org.tron.core.capsule.TransactionCapsule;
 import org.tron.protos.Protocol;
 import org.tron.protos.Protocol.ResourceReceipt;
 import org.tron.protos.Protocol.Transaction.Contract;
+import org.tron.protos.Protocol.Transaction.Contract.ContractType;
 import org.tron.protos.Protocol.TransactionInfo;
 
 @JsonPropertyOrder(alphabetic = true)
@@ -92,18 +93,21 @@ public class TransactionReceipt {
     transactionHash = ByteArray.toJsonHex(txInfo.getId().toByteArray());
     effectiveGasPrice = ByteArray.toJsonHex(wallet.getEnergyFee(blockCapsule.getTimeStamp()));
 
+    from = null;
+    to = null;
+    contractAddress = null;
+
     if (transaction != null && !transaction.getRawData().getContractList().isEmpty()) {
       Contract contract = transaction.getRawData().getContract(0);
       byte[] fromByte = TransactionCapsule.getOwner(contract);
       byte[] toByte = getToAddress(transaction);
       from = ByteArray.toJsonHexAddress(fromByte);
       to = ByteArray.toJsonHexAddress(toByte);
-    } else {
-      from = null;
-      to = null;
-    }
 
-    contractAddress = ByteArray.toJsonHexAddress(txInfo.getContractAddress().toByteArray());
+      if (contract.getType() == ContractType.CreateSmartContract) {
+        contractAddress = ByteArray.toJsonHexAddress(txInfo.getContractAddress().toByteArray());
+      }
+    }
 
     // logs
     List<TransactionLog> logList = new ArrayList<>();

--- a/framework/src/test/java/org/tron/common/overlay/discover/node/NodeHandlerTest.java
+++ b/framework/src/test/java/org/tron/common/overlay/discover/node/NodeHandlerTest.java
@@ -3,14 +3,13 @@ package org.tron.common.overlay.discover.node;
 import java.io.File;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
-import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.tron.common.application.Application;
-import org.tron.common.application.ApplicationFactory;
 import org.tron.common.application.TronApplicationContext;
 import org.tron.common.parameter.CommonParameter;
 import org.tron.common.utils.FileUtil;
@@ -24,41 +23,40 @@ import org.tron.core.db.Manager;
 public class NodeHandlerTest {
 
   private static final Logger logger = LoggerFactory.getLogger("Test");
-  private Manager dbManager;
-  private TronApplicationContext context;
+  private static Manager dbManager;
+  private static TronApplicationContext context;
   private Application appTest;
   private CommonParameter argsTest;
-  private Node currNode;
-  private Node oldNode;
-  private Node replaceNode;
-  private NodeHandler currHandler;
-  private NodeHandler oldHandler;
-  private NodeHandler replaceHandler;
-  private NodeManager nodeManager;
+  private static Node currNode;
+  private static Node oldNode;
+  private static Node replaceNode;
+  private static NodeHandler currHandler;
+  private static NodeHandler oldHandler;
+  private static NodeHandler replaceHandler;
+  private static NodeManager nodeManager;
+  private static String dbPath = "NodeHandlerTest";
+
+  static {
+    Args.setParam(new String[]{"-d", dbPath}, Constant.TEST_CONF);
+    context = new TronApplicationContext(DefaultConfig.class);
+  }
 
   /**
    * init the application.
    */
-  @Before
-  public void init() {
-    argsTest = Args.getInstance();
-    Args.setParam(new String[]{"--output-directory", "output-directory", "--debug"},
-        Constant.TEST_CONF);
-    context = new TronApplicationContext(DefaultConfig.class);
-    appTest = ApplicationFactory.create(context);
-    appTest.initServices(argsTest);
-    appTest.startServices();
-    appTest.startup();
+  @BeforeClass
+  public static void init() {
+    initNodes();
   }
 
   /**
    * destroy the context.
    */
-  @After
-  public void destroy() {
+  @AfterClass
+  public static void destroy() {
     Args.clearParam();
     context.destroy();
-    if (FileUtil.deleteDir(new File("output-directory"))) {
+    if (FileUtil.deleteDir(new File(dbPath))) {
       logger.info("Release resources successful.");
     } else {
       logger.info("Release resources failure.");
@@ -68,8 +66,7 @@ public class NodeHandlerTest {
   /**
    * init nodes.
    */
-  @Before
-  public void initNodes() {
+  public static void initNodes() {
     dbManager = context.getBean(Manager.class);
     nodeManager = new NodeManager(context.getBean(ChainBaseManager.class));
     String currNodeId = "74c11ffad1d59d7b1a56691a0b84a53f0791c92361357364f1d2537"

--- a/framework/src/test/java/org/tron/common/overlay/discover/node/NodeManagerTest.java
+++ b/framework/src/test/java/org/tron/common/overlay/discover/node/NodeManagerTest.java
@@ -55,7 +55,7 @@ public class NodeManagerTest {
     try {
       initManager();
     } catch (Exception e) {
-
+      logger.error("init failed {}", e.getMessage());
     }
   }
 

--- a/framework/src/test/java/org/tron/common/overlay/discover/node/NodeManagerTest.java
+++ b/framework/src/test/java/org/tron/common/overlay/discover/node/NodeManagerTest.java
@@ -6,17 +6,13 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.tron.common.application.Application;
-import org.tron.common.application.ApplicationFactory;
 import org.tron.common.application.TronApplicationContext;
 import org.tron.common.parameter.CommonParameter;
 import org.tron.common.utils.FileUtil;
@@ -35,23 +31,32 @@ public class NodeManagerTest {
   private static TronApplicationContext context;
   private static CommonParameter argsTest;
   private static Application appTest;
-  private Class nodeManagerClazz;
+  private static Class nodeManagerClazz;
   private static String dbPath = "NodeManagerTest";
 
+  static {
+    Args.setParam(new String[]{"-d", dbPath}, Constant.TEST_CONF);
+    context = new TronApplicationContext(DefaultConfig.class);
+  }
 
   /**
    * start the application.
    */
   @BeforeClass
   public static void init() {
-    argsTest = Args.getInstance();
-    Args.setParam(new String[]{"--output-directory", dbPath},
-        Constant.TEST_CONF);
-    context = new TronApplicationContext(DefaultConfig.class);
-    appTest = ApplicationFactory.create(context);
-    appTest.initServices(argsTest);
-    appTest.startServices();
-    appTest.startup();
+    // argsTest = Args.getInstance();
+    // Args.setParam(new String[]{"--output-directory", dbPath},
+    //     Constant.TEST_CONF);
+    // context = new TronApplicationContext(DefaultConfig.class);
+    // appTest = ApplicationFactory.create(context);
+    // appTest.initServices(argsTest);
+    // appTest.startServices();
+    // appTest.startup();
+    try {
+      initManager();
+    } catch (Exception e) {
+
+    }
   }
 
   /**
@@ -71,8 +76,8 @@ public class NodeManagerTest {
   /**
    * init the managers.
    */
-  @Before
-  public void initManager() throws Exception {
+  // @Before
+  public static void initManager() throws Exception {
     nodeManagerClazz = NodeManager.class;
     Constructor<NodeManager> handlerConstructor
         = nodeManagerClazz.getConstructor(ChainBaseManager.class);


### PR DESCRIPTION
**What does this PR do?**
fix: set contractAddress if transaction was a contract creation in transactionReceipt


**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

