### PR TITLE
feat: use Thread.currentThread().getContextClassLoader

### DIFF
--- a/framework/src/main/java/org/tron/core/services/jsonrpc/JsonRpcServlet.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/JsonRpcServlet.java
@@ -33,9 +33,10 @@ public class JsonRpcServlet extends RateLimiterServlet {
   public void init(ServletConfig config) throws ServletException {
     super.init(config);
 
+    ClassLoader cl = Thread.currentThread().getContextClassLoader();
     TronJsonRpcImpl jsonRpcImpl = new TronJsonRpcImpl(nodeInfoService, wallet, manager);
     Object compositeService = ProxyUtil.createCompositeServiceProxy(
-        this.getClass().getClassLoader(),
+        cl,
         new Object[] {jsonRpcImpl},
         new Class[] {TronJsonRpc.class},
         true);


### PR DESCRIPTION
**What does this PR do?**
feat: use Thread.currentThread().getContextClassLoader() instead of this.getClass().getClassLoader()


**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

