### PR TITLE
Optimize the heap usage by making the Jackson ObjectMapper a static m…

### DIFF
--- a/common/src/main/java/org/tron/common/utils/JsonUtil.java
+++ b/common/src/main/java/org/tron/common/utils/JsonUtil.java
@@ -4,12 +4,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.util.StringUtils;
 
 public class JsonUtil {
+  private static final ObjectMapper objectMapper = new ObjectMapper();
 
   public static final <T> T json2Obj(String jsonString, Class<T> clazz) {
     if (!StringUtils.isEmpty(jsonString) && clazz != null) {
       try {
-        ObjectMapper om = new ObjectMapper();
-        return om.readValue(jsonString, clazz);
+        return objectMapper.readValue(jsonString, clazz);
       } catch (Exception var3) {
         throw new RuntimeException(var3);
       }
@@ -22,9 +22,8 @@ public class JsonUtil {
     if (obj == null) {
       return null;
     } else {
-      ObjectMapper om = new ObjectMapper();
       try {
-        return om.writeValueAsString(obj);
+        return objectMapper.writeValueAsString(obj);
       } catch (Exception var3) {
         throw new RuntimeException(var3);
       }


### PR DESCRIPTION
…ember

**What does this PR do?**
This makes the instance of ObjectMapper static member of org.tron.common.utils.JsonUtil and reuse the object rather than instantiating one whenever the class's static method is called.

**Why are these changes required?**
org.tron.common.utils.JsonUtil has two static methods that transform the string JSON representation to a Java object vice versa.
The two methods instantiate the ObjectMapper object whenever they are called.
The problem is that this instantiation operation is expensive and the best practice is to reuse the ObjectMapper object in the multiple operations.

As the doc explains, this object is thread-safe as long as the configuration is not changed.

Please refer to the javadoc for the detailed explanation: https://fasterxml.github.io/jackson-databind/javadoc/2.9/com/fasterxml/jackson/databind/ObjectMapper.html

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

