### PR TITLE
upgrade logback version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ subprojects {
         compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
         compile group: 'org.slf4j', name: 'jcl-over-slf4j', version: '1.7.25'
         compile "org.slf4j:jcl-over-slf4j:1.7.25"
-        compile group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
+        compile group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.9'
         compileOnly 'org.projectlombok:lombok:1.18.12'
         annotationProcessor 'org.projectlombok:lombok:1.18.12'
         testCompileOnly 'org.projectlombok:lombok:1.18.12'


### PR DESCRIPTION
**What does this PR do?**
1.upgrade logback version to 1.2.9
**Why are these changes required?**
1.fix possible security issues with the logging framework.
**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

