### PR TITLE
feat(master): upgrade build.gradle dependencies

### DIFF
--- a/protocol/build.gradle
+++ b/protocol/build.gradle
@@ -12,6 +12,10 @@ dependencies {
     compile group: 'io.grpc', name: 'grpc-stub', version: '1.14.0'
     // end google grpc
 
+    // JDK11 required dependencies
+    compile group: 'javax.annotation', name: 'javax.annotation-api', version: '1.3.2'
+    compile group: 'javax.jws', name: 'javax.jws-api', version: '1.1'
+
     compile group: 'com.google.api.grpc', name: 'googleapis-common-protos', version: '0.0.3'
 }
 


### PR DESCRIPTION
**What does this PR do?**
1. add javax.annotation-api
2. add javax.jws-api

**Why are these changes required?**

JDK11 removes javax.annotation-api and javax.jws-api, you need to add these two dependencies manually to upgrade JDK11

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

