### PR TITLE
dependency: upgrade for security.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,8 +44,8 @@ subprojects {
         testAnnotationProcessor 'org.projectlombok:lombok:1.18.12'
         compile group: 'com.google.guava', name: 'guava', version: '24.1-jre'
         compile "com.google.code.findbugs:jsr305:3.0.0"
-        compile group: 'org.springframework', name: 'spring-context', version: '4.2.4.RELEASE'
-        compile group: 'org.springframework', name: 'spring-tx', version: '4.2.4.RELEASE'
+        compile group: 'org.springframework', name: 'spring-context', version: '5.3.18'
+        compile group: 'org.springframework', name: 'spring-tx', version: '5.3.18'
         compile "org.apache.commons:commons-lang3:3.4"
         compile group: 'org.apache.commons', name: 'commons-math', version: '2.2'
         compile "org.apache.commons:commons-collections4:4.0"


### PR DESCRIPTION
1. spring-framework: 4.2.4.RELEASE -> 5.3.18, [CVE-2022-22965]

**What does this PR do?**

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

