### PR TITLE
Bump protobuf-java from 3.4.0 to 3.19.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,12 @@ subprojects {
         preserveFileTimestamps = false
         reproducibleFileOrder = true
     }
+
+    configurations.all {
+        resolutionStrategy {
+            force group: 'com.google.guava', name: 'guava', version: '30.1-jre'
+        }
+    }
 }
 
 task copyToParent(type: Copy) {

--- a/chainbase/src/main/java/org/tron/common/overlay/message/Message.java
+++ b/chainbase/src/main/java/org/tron/common/overlay/message/Message.java
@@ -21,15 +21,15 @@ import org.tron.core.store.DynamicPropertiesStore;
 public abstract class Message {
 
   protected static final Logger logger = LoggerFactory.getLogger("Message");
+  // https://developers.google.com/protocol-buffers/docs/proto3#unknowns
+  // https://github.com/protocolbuffers/protobuf/issues/272
   private static final Field field = ReflectionUtils
-      .findField(CodedInputStream.class, "explicitDiscardUnknownFields");
+      .findField(CodedInputStream.class, "shouldDiscardUnknownFields");
   @Setter
   private static DynamicPropertiesStore dynamicPropertiesStore;
 
   static {
-    if (field != null) {
-      ReflectionUtils.makeAccessible(field);
-    }
+    ReflectionUtils.makeAccessible(field);
   }
 
   protected byte[] data;

--- a/chainbase/src/main/java/org/tron/common/overlay/message/Message.java
+++ b/chainbase/src/main/java/org/tron/common/overlay/message/Message.java
@@ -27,7 +27,9 @@ public abstract class Message {
   private static DynamicPropertiesStore dynamicPropertiesStore;
 
   static {
-    ReflectionUtils.makeAccessible(field);
+    if (field != null) {
+      ReflectionUtils.makeAccessible(field);
+    }
   }
 
   protected byte[] data;

--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -152,6 +152,7 @@ test {
         exclude 'org/tron/core/ShieldedTRC20BuilderTest.class'
         exclude 'org/tron/common/runtime/vm/WithdrawRewardTest.class'
     }
+    maxHeapSize = "1024m"
 }
 
 task stest(type: Test) {

--- a/protocol/build.gradle
+++ b/protocol/build.gradle
@@ -1,15 +1,19 @@
 apply plugin: 'com.google.protobuf'
 
+def protobufVersion = "3.16.1"
+
+def grpcVersion = "1.14.0"
+
 dependencies {
-    compile group: 'com.google.protobuf', name: 'protobuf-java', version: '3.4.0'
-    compile group: 'com.google.protobuf', name: 'protobuf-java-util', version: '3.4.0'
+    compile group: 'com.google.protobuf', name: 'protobuf-java', version: protobufVersion
+    compile group: 'com.google.protobuf', name: 'protobuf-java-util', version: protobufVersion
     compile group: 'net.jcip', name: 'jcip-annotations', version: '1.0'
 
 //    checkstyleConfig "com.puppycrawl.tools:checkstyle:${versions.checkstyle}"
     // google grpc
-    compile group: 'io.grpc', name: 'grpc-netty', version: '1.14.0'
-    compile group: 'io.grpc', name: 'grpc-protobuf', version: '1.14.0'
-    compile group: 'io.grpc', name: 'grpc-stub', version: '1.14.0'
+    compile group: 'io.grpc', name: 'grpc-netty', version: grpcVersion
+    compile group: 'io.grpc', name: 'grpc-protobuf', version: grpcVersion
+    compile group: 'io.grpc', name: 'grpc-stub', version: grpcVersion
     // end google grpc
 
     compile group: 'com.google.api.grpc', name: 'googleapis-common-protos', version: '0.0.3'

--- a/protocol/build.gradle
+++ b/protocol/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.google.protobuf'
 
-def protobufVersion = "3.16.1"
+def protobufVersion = "3.19.2"
 
 def grpcVersion = "1.14.0"
 


### PR DESCRIPTION
**What does this PR do?**
Bumps [protobuf-java](https://github.com/protocolbuffers/protobuf) from 3.4.0 to 3.19.2
**Why are these changes required?**
upgrade for security.
**This PR has been tested by:**

- Unit Tests
- Manual Testing

**Follow up**

**Extra details**