### PR TITLE
remove the Participation Rate judge

### DIFF
--- a/consensus/src/main/java/org/tron/consensus/dpos/StateManager.java
+++ b/consensus/src/main/java/org/tron/consensus/dpos/StateManager.java
@@ -51,13 +51,13 @@ public class StateManager {
       return State.DUP_WITNESS;
     }
 
-    int participation = consensusDelegate.calculateFilledSlotsCount();
-    int minParticipationRate = dposService.getMinParticipationRate();
-    if (participation < minParticipationRate) {
-      logger
-          .warn("Participation:{} <  minParticipationRate:{}", participation, minParticipationRate);
-      return State.LOW_PARTICIPATION;
-    }
+//    int participation = consensusDelegate.calculateFilledSlotsCount();
+//    int minParticipationRate = dposService.getMinParticipationRate();
+//    if (participation < minParticipationRate) {
+//      logger
+//          .warn("Participation:{} <  minParticipationRate:{}", participation, minParticipationRate);
+//      return State.LOW_PARTICIPATION;
+//    }
 
     return State.OK;
   }


### PR DESCRIPTION
In the main net, the config value of minParticipationRate is 15.
How about the consensus can continued working in this case:
There are Symmetric network partitioning separating the net into two part, one part are num of 5, the other part are num of 22 for a period of time。And after 4 round（1 round per num of 27 block produce）consensus, the accumulative total amount of un filled slots count must be more than 20 for each node, which mean each node will change state into LOW_PARTICIPATION。
before a node producing bock, it will judge it state is OK ，which will cause it can't produce a block any more for each node?
So i think it can remove the Participation Rate judge when getState()

