### PR TITLE
Add jvm & os info to version command

### DIFF
--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id "org.sonarqube" version "2.6"
+    id "com.gorylenko.gradle-git-properties" version "2.4.1"
 }
 
 apply plugin: 'application'

--- a/framework/src/main/java/org/tron/core/config/args/Args.java
+++ b/framework/src/main/java/org/tron/core/config/args/Args.java
@@ -14,6 +14,7 @@ import io.grpc.netty.NettyServerBuilder;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.InetAddress;
 import java.net.Socket;
@@ -26,6 +27,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Properties;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
@@ -211,14 +213,32 @@ public class Args extends CommonParameter {
   }
 
   /**
+   * print Version.
+   */
+  private static void printVersion() {
+    Properties properties = new Properties();
+    try {
+      InputStream in = Thread.currentThread()
+          .getContextClassLoader().getResourceAsStream("git.properties");
+      properties.load(in);
+    } catch (IOException e) {
+      logger.error(e.getMessage());
+    }
+    JCommander.getConsole().println("OS : " + System.getProperty("os.name"));
+    JCommander.getConsole().println("JVM : " + System.getProperty("java.vendor") + " "
+        + System.getProperty("java.version") + " " + System.getProperty("os.arch"));
+    JCommander.getConsole().println("Git : " + properties.getProperty("git.commit.id"));
+    JCommander.getConsole().println("Version : " + Version.getVersion());
+    JCommander.getConsole().println("Code : " + Version.VERSION_CODE);
+  }
+
+  /**
    * set parameters.
    */
   public static void setParam(final String[] args, final String confFileName) {
     JCommander.newBuilder().addObject(PARAMETER).build().parse(args);
     if (PARAMETER.version) {
-      JCommander.getConsole()
-          .println(Version.getVersion()
-              + "\n" + Version.VERSION_NAME + "\n" + Version.VERSION_CODE);
+      printVersion();
       exit(0);
     }
 


### PR DESCRIPTION
**What does this PR do?**

Add jvm & os info to version command

**Why are these changes required?**

The current version information does not include the environment info and cannot effectively filter the problems caused by the environment.

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

