### PR TITLE
optimize granularity of blockLock

### DIFF
--- a/framework/src/main/java/org/tron/common/overlay/server/ChannelManager.java
+++ b/framework/src/main/java/org/tron/common/overlay/server/ChannelManager.java
@@ -34,7 +34,7 @@ import org.tron.protos.Protocol.ReasonCode;
 @Component
 public class ChannelManager {
 
-  private final Map<ByteArrayWrapper, Channel> activePeers = new ConcurrentHashMap<>();
+  private final Map<ByteArrayWrapper, Channel> activeChannels = new ConcurrentHashMap<>();
   @Autowired
   private PeerServer peerServer;
   @Autowired
@@ -121,7 +121,7 @@ public class ChannelManager {
 
   public void notifyDisconnect(Channel channel) {
     syncPool.onDisconnect(channel);
-    activePeers.values().remove(channel);
+    activeChannels.values().remove(channel);
     if (channel != null) {
       if (channel.getNodeStatistics() != null) {
         channel.getNodeStatistics().notifyDisconnect();
@@ -146,7 +146,7 @@ public class ChannelManager {
         return false;
       }
 
-      if (!peer.isActive() && activePeers.size() >= maxActivePeers) {
+      if (!peer.isActive() && activeChannels.size() >= maxActivePeers) {
         peer.disconnect(TOO_MANY_PEERS);
         return false;
       }
@@ -157,7 +157,7 @@ public class ChannelManager {
       }
     }
 
-    Channel channel = activePeers.get(peer.getNodeIdWrapper());
+    Channel channel = activeChannels.get(peer.getNodeIdWrapper());
     if (channel != null) {
       if (channel.getStartTime() > peer.getStartTime()) {
         logger.info("Disconnect connection established later, {}", channel.getNode());
@@ -167,14 +167,14 @@ public class ChannelManager {
         return false;
       }
     }
-    activePeers.put(peer.getNodeIdWrapper(), peer);
-    logger.info("Add active peer {}, total active peers: {}", peer, activePeers.size());
+    activeChannels.put(peer.getNodeIdWrapper(), peer);
+    logger.info("Add active peer {}, total active peers: {}", peer, activeChannels.size());
     return true;
   }
 
   public int getConnectionNum(InetAddress inetAddress) {
     int cnt = 0;
-    for (Channel channel : activePeers.values()) {
+    for (Channel channel : activeChannels.values()) {
       if (channel.getInetAddress().equals(inetAddress)) {
         cnt++;
       }
@@ -183,7 +183,7 @@ public class ChannelManager {
   }
 
   public Collection<Channel> getActivePeers() {
-    return activePeers.values();
+    return activeChannels.values();
   }
 
   public Cache<InetAddress, ReasonCode> getRecentlyDisconnected() {

--- a/framework/src/main/java/org/tron/common/overlay/server/MessageQueue.java
+++ b/framework/src/main/java/org/tron/common/overlay/server/MessageQueue.java
@@ -69,11 +69,6 @@ public class MessageQueue {
             continue;
           }
           Message msg = msgQueue.take();
-          if (channel.isDisconnect()) {
-            logger.warn("Failed to send to {} as channel has closed, {}",
-                ctx.channel().remoteAddress(), msg);
-            return;
-          }
           ctx.writeAndFlush(msg.getSendData()).addListener((ChannelFutureListener) future -> {
             if (!future.isSuccess() && !channel.isDisconnect()) {
               logger.warn("Failed to send to {}, {}", ctx.channel().remoteAddress(), msg);
@@ -97,11 +92,6 @@ public class MessageQueue {
   }
 
   public void fastSend(Message msg) {
-    if (channel.isDisconnect()) {
-      logger.warn("Fast send to {} failed as channel has closed, {} ",
-          ctx.channel().remoteAddress(), msg);
-      return;
-    }
     logger.info("Fast send to {}, {} ", ctx.channel().remoteAddress(), msg);
     ctx.writeAndFlush(msg.getSendData()).addListener((ChannelFutureListener) future -> {
       if (!future.isSuccess() && !channel.isDisconnect()) {

--- a/framework/src/main/java/org/tron/common/overlay/server/MessageQueue.java
+++ b/framework/src/main/java/org/tron/common/overlay/server/MessageQueue.java
@@ -69,6 +69,11 @@ public class MessageQueue {
             continue;
           }
           Message msg = msgQueue.take();
+          if (channel.isDisconnect()) {
+            logger.warn("Failed to send to {} as channel has closed, {}",
+                ctx.channel().remoteAddress(), msg);
+            return;
+          }
           ctx.writeAndFlush(msg.getSendData()).addListener((ChannelFutureListener) future -> {
             if (!future.isSuccess() && !channel.isDisconnect()) {
               logger.warn("Failed to send to {}, {}", ctx.channel().remoteAddress(), msg);
@@ -92,6 +97,11 @@ public class MessageQueue {
   }
 
   public void fastSend(Message msg) {
+    if (channel.isDisconnect()) {
+      logger.warn("Fast send to {} failed as channel has closed, {} ",
+          ctx.channel().remoteAddress(), msg);
+      return;
+    }
     logger.info("Fast send to {}, {} ", ctx.channel().remoteAddress(), msg);
     ctx.writeAndFlush(msg.getSendData()).addListener((ChannelFutureListener) future -> {
       if (!future.isSuccess() && !channel.isDisconnect()) {

--- a/framework/src/main/java/org/tron/core/net/service/SyncService.java
+++ b/framework/src/main/java/org/tron/core/net/service/SyncService.java
@@ -234,8 +234,8 @@ public class SyncService {
 
       isProcessed[0] = false;
 
-      synchronized (tronNetDelegate.getBlockLock()) {
-        blockWaitToProcess.forEach((msg, peerConnection) -> {
+      blockWaitToProcess.forEach((msg, peerConnection) -> {
+        synchronized (tronNetDelegate.getBlockLock()) {
           if (peerConnection.isDisconnect()) {
             blockWaitToProcess.remove(msg);
             invalid(msg.getBlockId());
@@ -254,8 +254,8 @@ public class SyncService {
             isProcessed[0] = true;
             processSyncBlock(msg.getBlockCapsule());
           }
-        });
-      }
+        }
+      });
     }
   }
 


### PR DESCRIPTION
**What does this PR do?**
We introduce a solution to reduce the log error "Peer xxx not sync for a long time" when fullnode syncs with peer.

**Why are these changes required?**
ChannelManager.activePeers and SyncPool.activePeers is confusing, wo change ChannelManager.activePeers to ChannelManager.activeChannels.

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**
https://github.com/tronprotocol/tips/issues/427

