### PR TITLE
Optimize block synchronization logic

### DIFF
--- a/framework/src/main/java/org/tron/common/overlay/server/Channel.java
+++ b/framework/src/main/java/org/tron/common/overlay/server/Channel.java
@@ -61,6 +61,7 @@ public class Channel {
   private InetSocketAddress inetSocketAddress;
   private Node node;
   private long startTime;
+  @Getter
   private TronState tronState = TronState.INIT;
   private boolean isActive;
   @Getter

--- a/framework/src/main/java/org/tron/core/net/messagehandler/ChainInventoryMsgHandler.java
+++ b/framework/src/main/java/org/tron/core/net/messagehandler/ChainInventoryMsgHandler.java
@@ -11,6 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.tron.common.overlay.server.Channel;
 import org.tron.core.capsule.BlockCapsule.BlockId;
 import org.tron.core.config.Parameter.ChainConstant;
 import org.tron.core.config.Parameter.NetConstants;
@@ -46,6 +47,7 @@ public class ChainInventoryMsgHandler implements TronMsgHandler {
     Deque<BlockId> blockIdWeGet = new LinkedList<>(chainInventoryMessage.getBlockIds());
 
     if (blockIdWeGet.size() == 1 && tronNetDelegate.containBlock(blockIdWeGet.peek())) {
+      peer.setTronState(Channel.TronState.SYNC_COMPLETED);
       peer.setNeedSyncFromPeer(false);
       return;
     }

--- a/framework/src/main/java/org/tron/core/net/service/SyncService.java
+++ b/framework/src/main/java/org/tron/core/net/service/SyncService.java
@@ -92,6 +92,10 @@ public class SyncService {
   }
 
   public void startSync(PeerConnection peer) {
+    if (peer.getTronState().equals(TronState.SYNCING)) {
+      logger.warn("Start sync failed, peer {} is in sync.", peer.getNode().getHost());
+      return;
+    }
     peer.setTronState(TronState.SYNCING);
     peer.setNeedSyncFromPeer(true);
     peer.getSyncBlockToFetch().clear();


### PR DESCRIPTION
**What does this PR do?**
Optimize block synchronization logic, the peer that is being synchronized may be disconnected if the synchronization is triggered again.
Refer to issue： https://github.com/tronprotocol/tips/issues/438

**Why are these changes required?**
To increase the stability of the network, it is necessary to eliminate these abnormal disconnections.

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

