### PR TITLE
fix(net): change process exception

### DIFF
--- a/framework/src/main/java/org/tron/common/overlay/server/Channel.java
+++ b/framework/src/main/java/org/tron/common/overlay/server/Channel.java
@@ -1,5 +1,6 @@
 package org.tron.common.overlay.server;
 
+import com.google.common.base.Throwables;
 import com.google.protobuf.ByteString;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPipeline;
@@ -148,8 +149,11 @@ public class Channel {
 
   public void processException(Throwable throwable) {
     Throwable baseThrowable = throwable;
-    while (baseThrowable.getCause() != null) {
-      baseThrowable = baseThrowable.getCause();
+    try {
+      baseThrowable = Throwables.getRootCause(baseThrowable);
+    } catch (IllegalArgumentException e) {
+      baseThrowable = e.getCause();
+      logger.warn("Loop in causal chain detected");
     }
     SocketAddress address = ctx.channel().remoteAddress();
     if (throwable instanceof ReadTimeoutException


### PR DESCRIPTION

**What does this PR do?**
avoid infinite loop when exception cause has loop
**Why are these changes required?**
when process exception with loop cause, function will stuck in an infinite loop
**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

