### PR TITLE
fix(net): solve the problem that K-bucket nodes cannot be deleted

### DIFF
--- a/framework/src/main/java/org/tron/common/overlay/discover/table/NodeEntry.java
+++ b/framework/src/main/java/org/tron/common/overlay/discover/table/NodeEntry.java
@@ -31,14 +31,6 @@ public class NodeEntry {
   private int distance;
   private long modified;
 
-  public NodeEntry(Node n) {
-    this.node = n;
-    this.ownerId = n.getId();
-    entryId = n.getHost();
-    distance = distance(ownerId, n.getId());
-    touch();
-  }
-
   public NodeEntry(byte[] ownerId, Node n) {
     this.node = n;
     this.ownerId = ownerId;
@@ -115,6 +107,6 @@ public class NodeEntry {
 
   @Override
   public int hashCode() {
-    return this.node.hashCode();
+    return this.entryId.hashCode();
   }
 }

--- a/framework/src/test/java/org/tron/common/overlay/discover/table/NodeEntryTest.java
+++ b/framework/src/test/java/org/tron/common/overlay/discover/table/NodeEntryTest.java
@@ -9,20 +9,16 @@ public class NodeEntryTest {
   @Test
   public void test() throws InterruptedException {
     Node node1 = Node.instanceOf("127.0.0.1:10001");
-    NodeEntry nodeEntry = new NodeEntry(node1);
-    int distance = nodeEntry.getDistance();
-    Assert.assertEquals(-256, distance);
+    NodeEntry nodeEntry = new NodeEntry(Node.getNodeId(), node1);
 
     long lastModified = nodeEntry.getModified();
-    //System.out.println(lastModified);
     Thread.sleep(1);
     nodeEntry.touch();
     long nowModified = nodeEntry.getModified();
-    //System.out.println(nowModified);
     Assert.assertNotEquals(lastModified, nowModified);
 
     Node node2 = Node.instanceOf("127.0.0.1:10002");
-    NodeEntry nodeEntry2 = new NodeEntry(node2);
+    NodeEntry nodeEntry2 = new NodeEntry(Node.getNodeId(), node2);
     boolean isDif = nodeEntry.equals(nodeEntry2);
     Assert.assertTrue(isDif);
   }

--- a/framework/src/test/java/org/tron/common/overlay/discover/table/NodeTableTest.java
+++ b/framework/src/test/java/org/tron/common/overlay/discover/table/NodeTableTest.java
@@ -133,6 +133,9 @@ public class NodeTableTest {
     Assert.assertTrue(nodeTable.contains(node));
     nodeTable.dropNode(node);
     Assert.assertTrue(!nodeTable.contains(node));
+    nodeTable.addNode(node);
+    nodeTable.dropNode(new Node(ids.get(1), ips[0], 10000, 10000));
+    Assert.assertTrue(!nodeTable.contains(node));
   }
 
   @Test

--- a/framework/src/test/java/org/tron/common/overlay/discover/table/TimeComparatorTest.java
+++ b/framework/src/test/java/org/tron/common/overlay/discover/table/TimeComparatorTest.java
@@ -9,10 +9,10 @@ public class TimeComparatorTest {
   @Test
   public void test() throws InterruptedException {
     Node node1 = Node.instanceOf("127.0.0.1:10001");
-    NodeEntry ne1 = new NodeEntry(node1);
+    NodeEntry ne1 = new NodeEntry(Node.getNodeId(), node1);
     Thread.sleep(1);
     Node node2 = Node.instanceOf("127.0.0.1:10002");
-    NodeEntry ne2 = new NodeEntry(node2);
+    NodeEntry ne2 = new NodeEntry(Node.getNodeId(), node2);
     TimeComparator tc = new TimeComparator();
     int result = tc.compare(ne1, ne2);
     Assert.assertEquals(1, result);


### PR DESCRIPTION
**What does this PR do?**
solve the problem that K-bucket nodes cannot be deleted when it’s node id changes

**Why are these changes required?**
This problem will affect the efficiency of node discovery

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

