### PR TITLE
optimize SR’s production order when multi masters exist

### DIFF
--- a/consensus/src/main/java/org/tron/consensus/dpos/StateManager.java
+++ b/consensus/src/main/java/org/tron/consensus/dpos/StateManager.java
@@ -90,12 +90,14 @@ public class StateManager {
       return;
     }
 
-    if (dupBlockCount.get() == 0) {
-      dupBlockCount.set(new Random().nextInt(10));
-    } else {
-      dupBlockCount.set(10);
+    //multi master occurs. If currentBlockId is bigger, we continue to produce block at next cycle.
+    if (null != currentBlockId
+        && currentBlockId.toString().compareTo(blockCapsule.getBlockId().toString()) > 0) {
+      return;
     }
 
+    //currentBlockId is smaller, we may pause one cycle
+    dupBlockCount.set(1);
     dupBlockTime.set(System.currentTimeMillis());
 
     logger.warn("Dup block produced: {}", blockCapsule);

--- a/consensus/src/main/java/org/tron/consensus/dpos/StateManager.java
+++ b/consensus/src/main/java/org/tron/consensus/dpos/StateManager.java
@@ -90,13 +90,11 @@ public class StateManager {
       return;
     }
 
-    //multi master occurs. If currentBlockId is bigger, we continue to produce block at next cycle.
     if (null != currentBlockId
         && currentBlockId.toString().compareTo(blockCapsule.getBlockId().toString()) > 0) {
       return;
     }
 
-    //currentBlockId is smaller, we may pause one cycle
     dupBlockCount.set(1);
     dupBlockTime.set(System.currentTimeMillis());
 

--- a/framework/src/test/java/org/tron/common/overlay/discover/table/NodeEntryTest.java
+++ b/framework/src/test/java/org/tron/common/overlay/discover/table/NodeEntryTest.java
@@ -3,6 +3,7 @@ package org.tron.common.overlay.discover.table;
 import org.junit.Assert;
 import org.junit.Test;
 import org.tron.common.overlay.discover.node.Node;
+import org.tron.common.utils.ByteArray;
 
 public class NodeEntryTest {
 
@@ -21,6 +22,48 @@ public class NodeEntryTest {
     NodeEntry nodeEntry2 = new NodeEntry(Node.getNodeId(), node2);
     boolean isDif = nodeEntry.equals(nodeEntry2);
     Assert.assertTrue(isDif);
+  }
+
+  @Test
+  public void testDistance() {
+    byte[] randomId = Node.getNodeId();
+    String hexRandomIdStr = ByteArray.toHexString(randomId);
+    Assert.assertEquals(128, hexRandomIdStr.length());
+
+    byte[] nodeId1 = ByteArray.fromHexString(
+        "0000000000000000000000000000000000000000000000000000000000000000"
+            + "0000000000000000000000000000000000000000000000000000000000000000");
+    byte[] nodeId2 = ByteArray.fromHexString(
+        "a000000000000000000000000000000000000000000000000000000000000000"
+            + "0000000000000000000000000000000000000000000000000000000000000000");
+    Assert.assertEquals(256, NodeEntry.distance(nodeId1, nodeId2));
+
+    byte[] nodeId3 = ByteArray.fromHexString(
+        "0000000000000000000000000000000000000000000000000000000000000001"
+            + "0000000000000000000000000000000000000000000000000000000000000000");
+    Assert.assertEquals(1, NodeEntry.distance(nodeId1, nodeId3));
+
+    byte[] nodeId4 = ByteArray.fromHexString(
+        "0000000000000000000000000000000000000000000000000000000000000000"
+            + "8000000000000000000000000000000000000000000000000000000000000000");
+    Assert.assertEquals(0, NodeEntry.distance(nodeId1, nodeId4)); // => 0
+
+    byte[] nodeId5 = ByteArray.fromHexString(
+        "0000000000000000000000000000000000000000000000000000000000000000"
+            + "4000000000000000000000000000000000000000000000000000000000000000");
+    Assert.assertEquals(-1, NodeEntry.distance(nodeId1, nodeId5)); // => 0
+
+    byte[] nodeId6 = ByteArray.fromHexString(
+        "0000000000000000000000000000000000000000000000000000000000000000"
+            + "2000000000000000000000000000000000000000000000000000000000000000");
+    Assert.assertEquals(-2, NodeEntry.distance(nodeId1, nodeId6)); // => 0
+
+    byte[] nodeId7 = ByteArray.fromHexString(
+        "0000000000000000000000000000000000000000000000000000000000000000"
+            + "0000000000000000000000000000000000000000000000000000000000000001");
+    Assert.assertEquals(-255, NodeEntry.distance(nodeId1, nodeId7)); // => 0
+
+    Assert.assertEquals(-256, NodeEntry.distance(nodeId1, nodeId1)); // => 0
   }
 
 }


### PR DESCRIPTION
**What does this PR do?**
1. when multi master occurs, the master with bigger blockId is elected to produce block
2. add testcase  NodeEntryTest.testDistance

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

