### PR TITLE
fix(db): fix concurrent error

### DIFF
--- a/chainbase/src/main/java/org/tron/core/db/TronDatabase.java
+++ b/chainbase/src/main/java/org/tron/core/db/TronDatabase.java
@@ -59,7 +59,7 @@ public abstract class TronDatabase<T> implements ITronChainBase<T> {
   }
 
   @PostConstruct
-  private void init() {
+  protected void init() {
     dbStatService.register(dbSource);
   }
 

--- a/chainbase/src/main/java/org/tron/core/store/CheckPointV2Store.java
+++ b/chainbase/src/main/java/org/tron/core/store/CheckPointV2Store.java
@@ -45,4 +45,9 @@ public class CheckPointV2Store extends TronDatabase<byte[]> {
   public Spliterator spliterator() {
     return null;
   }
+
+  @Override
+  protected void init() {
+  }
+
 }


### PR DESCRIPTION
**What does this PR do?**

 1. add write lock for resetDb
2. add read lock for getStats
3. disable db metric for checkpointV2 db

**Why are these changes required?**

  1.  `resetDb`  and `getStats` is not locked properly 
  2.   See https://github.com/tronprotocol/java-tron/pull/4614, `tmp` database and `checkpointV2` databases maybe close when involve getStats due to concurrent.


**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

