### PR TITLE
fix: make delete operation atomic when cleaning tmp db

### DIFF
--- a/chainbase/src/main/java/org/tron/core/db2/core/SnapshotManager.java
+++ b/chainbase/src/main/java/org/tron/core/db2/core/SnapshotManager.java
@@ -429,7 +429,17 @@ public class SnapshotManager implements RevokingDatabase {
   }
 
   private void deleteCheckpoint() {
-    checkTmpStore.reset();
+    try {
+      Map<byte[], byte[]> hmap = new HashMap<>();
+      for (Map.Entry<byte[], byte[]> e : checkTmpStore.getDbSource()) {
+        hmap.put(e.getKey(), null);
+      }
+      if (hmap.size() != 0) {
+        checkTmpStore.getDbSource().updateByBatch(hmap);
+      }
+    } catch (Exception e) {
+      throw new TronDBException(e);
+    }
   }
 
   private void pruneCheckpoint() {


### PR DESCRIPTION
**What does this PR do?**

Make delete operation atomic when cleaning `tmp` db.

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

