### PR TITLE
fix(db): reserve putting byte[0] in db recovery

### DIFF
--- a/chainbase/src/main/java/org/tron/core/db2/core/SnapshotManager.java
+++ b/chainbase/src/main/java/org/tron/core/db2/core/SnapshotManager.java
@@ -530,7 +530,12 @@ public class SnapshotManager implements RevokingDatabase {
       if (realValue != null) {
         dbMap.get(db).getHead().put(realKey, realValue);
       } else {
-        dbMap.get(db).getHead().remove(realKey);
+        byte op = value[0];
+        if (Value.Operator.DELETE.getValue() == op) {
+          dbMap.get(db).getHead().remove(realKey);
+        } else {
+          dbMap.get(db).getHead().put(realKey, new byte[0]);
+        }
       }
     }
 


### PR DESCRIPTION
**What does this PR do?**

The operation of putting byte[0] should be reserved instead of being deleted.

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

