### PR TITLE
fix(freezeV2): upgrade freezeV2

### DIFF
--- a/actuator/src/main/java/org/tron/core/actuator/UnDelegateResourceActuator.java
+++ b/actuator/src/main/java/org/tron/core/actuator/UnDelegateResourceActuator.java
@@ -81,7 +81,7 @@ public class UnDelegateResourceActuator extends AbstractActuator {
             receiverCapsule.setAcquiredDelegatedFrozenBalanceForBandwidth(0);
           } else {
             // calculate usage
-            long unDelegateMaxUsage = (long) (unDelegateBalance / TRX_PRECISION
+            long unDelegateMaxUsage = (long) ((double) unDelegateBalance / TRX_PRECISION
                 * ((double) (dynamicStore.getTotalNetLimit()) / dynamicStore.getTotalNetWeight()));
             transferUsage = (long) (receiverCapsule.getNetUsage()
                 * ((double) (unDelegateBalance) / receiverCapsule.getAllFrozenBalanceForBandwidth()));
@@ -103,7 +103,7 @@ public class UnDelegateResourceActuator extends AbstractActuator {
             receiverCapsule.setAcquiredDelegatedFrozenBalanceForEnergy(0);
           } else {
             // calculate usage
-            long unDelegateMaxUsage = (long) (unDelegateBalance / TRX_PRECISION
+            long unDelegateMaxUsage = (long) ((double) unDelegateBalance / TRX_PRECISION
                 * ((double) (dynamicStore.getTotalEnergyCurrentLimit()) / dynamicStore.getTotalEnergyWeight()));
             transferUsage = (long) (receiverCapsule.getEnergyUsage()
                 * ((double) (unDelegateBalance) / receiverCapsule.getAllFrozenBalanceForEnergy()));
@@ -224,7 +224,7 @@ public class UnDelegateResourceActuator extends AbstractActuator {
     }
 
     if (!dynamicStore.supportUnfreezeDelay()) {
-      throw new ContractValidateException("Not support Delegate resource transaction,"
+      throw new ContractValidateException("Not support unDelegate resource transaction,"
           + " need to be opened by the committee");
     }
 

--- a/actuator/src/main/java/org/tron/core/actuator/UnfreezeBalanceV2Actuator.java
+++ b/actuator/src/main/java/org/tron/core/actuator/UnfreezeBalanceV2Actuator.java
@@ -65,7 +65,7 @@ public class UnfreezeBalanceV2Actuator extends AbstractActuator {
     mortgageService.withdrawReward(ownerAddress);
 
     AccountCapsule accountCapsule = accountStore.get(ownerAddress);
-    this.unfreezeExpire(accountCapsule, now);
+    long unfreezeAmount = this.unfreezeExpire(accountCapsule, now);
     long unfreezeBalance = unfreezeBalanceV2Contract.getUnfreezeBalance();
 
     if (dynamicStore.supportAllowNewResourceModel()
@@ -91,6 +91,7 @@ public class UnfreezeBalanceV2Actuator extends AbstractActuator {
     accountStore.put(ownerAddress, accountCapsule);
 
     ret.setUnfreezeAmount(unfreezeBalance);
+    ret.setWithdrawExpireAmount(unfreezeAmount);
     ret.setStatus(fee, code.SUCESS);
     return true;
   }
@@ -250,7 +251,7 @@ public class UnfreezeBalanceV2Actuator extends AbstractActuator {
     }
   }
 
-  public void unfreezeExpire(AccountCapsule accountCapsule, long now) {
+  public long unfreezeExpire(AccountCapsule accountCapsule, long now) {
     long unfreezeBalance = 0L;
 
     List<Protocol.Account.UnFreezeV2> unFrozenV2List = Lists.newArrayList();
@@ -271,6 +272,7 @@ public class UnfreezeBalanceV2Actuator extends AbstractActuator {
             .clearUnfrozenV2()
             .addAllUnfrozenV2(unFrozenV2List).build()
     );
+    return unfreezeBalance;
   }
 
   public void updateTotalResourceWeight(final UnfreezeBalanceV2Contract unfreezeBalanceV2Contract,

--- a/actuator/src/main/java/org/tron/core/actuator/WithdrawExpireUnfreezeActuator.java
+++ b/actuator/src/main/java/org/tron/core/actuator/WithdrawExpireUnfreezeActuator.java
@@ -60,6 +60,7 @@ public class WithdrawExpireUnfreezeActuator extends AbstractActuator {
     accountCapsule.clearUnfrozenV2();
     newUnFreezeList.forEach(accountCapsule::addUnfrozenV2);
     accountStore.put(accountCapsule.createDbKey(), accountCapsule);
+    ret.setWithdrawExpireAmount(totalWithdrawUnfreeze);
     ret.setStatus(fee, code.SUCESS);
     return true;
   }

--- a/chainbase/src/main/java/org/tron/core/capsule/TransactionResultCapsule.java
+++ b/chainbase/src/main/java/org/tron/core/capsule/TransactionResultCapsule.java
@@ -80,6 +80,15 @@ public class TransactionResultCapsule implements ProtoCapsule<Result> {
     this.transactionResult = this.transactionResult.toBuilder().setWithdrawAmount(amount).build();
   }
 
+  public long getWithdrawExpireAmount() {
+    return transactionResult.getWithdrawExpireAmount();
+  }
+
+  public void setWithdrawExpireAmount(long amount) {
+    this.transactionResult = this.transactionResult.toBuilder()
+            .setWithdrawExpireAmount(amount).build();
+  }
+
   public long getExchangeReceivedAmount() {
     return transactionResult.getExchangeReceivedAmount();
   }

--- a/chainbase/src/main/java/org/tron/core/capsule/utils/TransactionUtil.java
+++ b/chainbase/src/main/java/org/tron/core/capsule/utils/TransactionUtil.java
@@ -90,15 +90,16 @@ public class TransactionUtil {
     }
 
     ByteString contractResult = ByteString.copyFrom(programResult.getHReturn());
-    ByteString ContractAddress = ByteString.copyFrom(programResult.getContractAddress());
+    ByteString contractAddress = ByteString.copyFrom(programResult.getContractAddress());
 
     builder.setFee(fee);
     builder.addContractResult(contractResult);
-    builder.setContractAddress(ContractAddress);
+    builder.setContractAddress(contractAddress);
     builder.setUnfreezeAmount(programResult.getRet().getUnfreezeAmount());
     builder.setAssetIssueID(programResult.getRet().getAssetIssueID());
     builder.setExchangeId(programResult.getRet().getExchangeId());
     builder.setWithdrawAmount(programResult.getRet().getWithdrawAmount());
+    builder.setWithdrawExpireAmount(programResult.getRet().getWithdrawExpireAmount());
     builder.setExchangeReceivedAmount(programResult.getRet().getExchangeReceivedAmount());
     builder.setExchangeInjectAnotherAmount(programResult.getRet().getExchangeInjectAnotherAmount());
     builder.setExchangeWithdrawAnotherAmount(

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/JsonRpcApiUtil.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/JsonRpcApiUtil.java
@@ -198,6 +198,8 @@ public class JsonRpcApiUtil {
       switch (contract.getType()) {
         case UnfreezeBalanceContract:
         case WithdrawBalanceContract:
+        case WithdrawExpireUnfreezeContract:
+        case UnfreezeBalanceV2Contract:
           TransactionInfo transactionInfo = wallet
               .getTransactionInfoById(ByteString.copyFrom(ByteArray.fromHexString(hash)));
           amount = getAmountFromTransactionInfo(hash, contract.getType(), transactionInfo);
@@ -272,6 +274,8 @@ public class JsonRpcApiUtil {
           break;
         case UnfreezeBalanceContract:
         case WithdrawBalanceContract:
+        case WithdrawExpireUnfreezeContract:
+        case UnfreezeBalanceV2Contract:
           amount = getAmountFromTransactionInfo(hash, contract.getType(), transactionInfo);
           break;
         case UnfreezeAssetContract:
@@ -296,6 +300,7 @@ public class JsonRpcApiUtil {
 
         switch (contractType) {
           case UnfreezeBalanceContract:
+          case UnfreezeBalanceV2Contract:
             amount = transactionInfo.getUnfreezeAmount();
             break;
           case WithdrawBalanceContract:
@@ -309,6 +314,9 @@ public class JsonRpcApiUtil {
             break;
           case ExchangeTransactionContract:
             amount = transactionInfo.getExchangeReceivedAmount();
+            break;
+          case WithdrawExpireUnfreezeContract:
+            amount = transactionInfo.getWithdrawExpireAmount();
             break;
           default:
             break;

--- a/framework/src/test/java/org/tron/core/BandwidthProcessorTest.java
+++ b/framework/src/test/java/org/tron/core/BandwidthProcessorTest.java
@@ -147,6 +147,8 @@ public class BandwidthProcessorTest {
             AccountType.AssetIssue,
             chainBaseManager.getDynamicPropertiesStore().getAssetIssueFee());
 
+    assetCapsule2.addAcquiredDelegatedFrozenBalanceForBandwidth(999999L);
+
     chainBaseManager.getAccountStore().reset();
     chainBaseManager.getAccountAssetStore().reset();
     chainBaseManager.getAccountStore().put(ownerCapsule.getAddress().toByteArray(), ownerCapsule);
@@ -857,5 +859,18 @@ public class BandwidthProcessorTest {
       chainBaseManager.getAccountStore().delete(ByteArray.fromHexString(OWNER_ADDRESS));
       chainBaseManager.getAccountStore().delete(ByteArray.fromHexString(TO_ADDRESS));
     }
+  }
+
+  @Test
+  public void testCalculateGlobalNetLimit() {
+    chainBaseManager.getDynamicPropertiesStore().saveTotalNetWeight(6310L);
+    BandwidthProcessor processor = new BandwidthProcessor(chainBaseManager);
+    AccountCapsule accountCapsule = chainBaseManager.getAccountStore()
+            .get(ByteArray.fromHexString(ASSET_ADDRESS_V2));
+    long netLimit = processor.calculateGlobalNetLimit(accountCapsule);
+    Assert.assertEquals(0, netLimit);
+    long netLimitV2 = processor
+            .calculateGlobalNetLimitV2(accountCapsule.getAllFrozenBalanceForBandwidth());
+    Assert.assertTrue(netLimitV2 > 0);
   }
 }

--- a/framework/src/test/java/org/tron/core/actuator/WithdrawExpireUnfreezeActuatorTest.java
+++ b/framework/src/test/java/org/tron/core/actuator/WithdrawExpireUnfreezeActuatorTest.java
@@ -132,7 +132,7 @@ public class WithdrawExpireUnfreezeActuatorTest {
       Assert.assertEquals(1, unfrozenV2List.size());
       Assert.assertEquals(Long.MAX_VALUE, unfrozenV2List.get(0).getUnfreezeExpireTime());
       Assert.assertEquals(initBalance + 32_000_000L, owner.getBalance());
-      Assert.assertEquals(0, owner.getAllowance());
+      Assert.assertEquals(32_000_000L, ret.getWithdrawExpireAmount());
     } catch (ContractValidateException e) {
       Assert.assertFalse(e instanceof ContractValidateException);
     } catch (ContractExeException e) {

--- a/protocol/src/main/protos/core/Tron.proto
+++ b/protocol/src/main/protos/core/Tron.proto
@@ -414,6 +414,7 @@ message Transaction {
 
     bytes orderId = 25;
     repeated MarketOrderDetail orderDetails = 26;
+    int64 withdraw_expire_amount = 27;
   }
 
   message raw {
@@ -473,6 +474,7 @@ message TransactionInfo {
   repeated MarketOrderDetail orderDetails = 26;
   int64 packingFee = 27;
 
+  int64 withdraw_Expire_amount = 28;
 }
 
 message TransactionRet {


### PR DESCRIPTION
**What does this PR do?**
upgrade freezeV2 
- Update latestConsumeTime when use updateUsage
- Fix undelegate calculation result when parameter is below 1 TRX
- Add withdrawExpireAmount for the return of GetTransactionInfoByID interface

discussion:https://github.com/tronprotocol/tips/issues/467

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

