### PR TITLE
fix(freezeV2): fix freezeV2

### DIFF
--- a/actuator/src/main/java/org/tron/core/actuator/UnDelegateResourceActuator.java
+++ b/actuator/src/main/java/org/tron/core/actuator/UnDelegateResourceActuator.java
@@ -92,6 +92,7 @@ public class UnDelegateResourceActuator extends AbstractActuator {
 
           long newNetUsage = receiverCapsule.getNetUsage() - transferUsage;
           receiverCapsule.setNetUsage(newNetUsage);
+          receiverCapsule.setLatestConsumeTime(chainBaseManager.getHeadSlot());
           break;
         case ENERGY:
           EnergyProcessor energyProcessor = new EnergyProcessor(dynamicStore, accountStore);
@@ -114,6 +115,7 @@ public class UnDelegateResourceActuator extends AbstractActuator {
 
           long newEnergyUsage = receiverCapsule.getEnergyUsage() - transferUsage;
           receiverCapsule.setEnergyUsage(newEnergyUsage);
+          receiverCapsule.setLatestConsumeTimeForEnergy(chainBaseManager.getHeadSlot());
           break;
         default:
           //this should never happen

--- a/chainbase/src/main/java/org/tron/core/db/BandwidthProcessor.java
+++ b/chainbase/src/main/java/org/tron/core/db/BandwidthProcessor.java
@@ -47,11 +47,9 @@ public class BandwidthProcessor extends ResourceProcessor {
     long latestConsumeTime = accountCapsule.getLatestConsumeTime();
     accountCapsule.setNetUsage(increase(accountCapsule, BANDWIDTH,
             oldNetUsage, 0, latestConsumeTime, now));
-    accountCapsule.setLatestConsumeTime(now);
     long oldFreeNetUsage = accountCapsule.getFreeNetUsage();
     long latestConsumeFreeTime = accountCapsule.getLatestConsumeFreeTime();
     accountCapsule.setFreeNetUsage(increase(oldFreeNetUsage, 0, latestConsumeFreeTime, now));
-    accountCapsule.setLatestConsumeFreeTime(now);
 
     if (chainBaseManager.getDynamicPropertiesStore().getAllowSameTokenName() == 0) {
       Map<String, Long> assetMap = accountCapsule.getAssetMap();
@@ -60,7 +58,6 @@ public class BandwidthProcessor extends ResourceProcessor {
         long latestAssetOperationTime = accountCapsule.getLatestAssetOperationTime(assetName);
         accountCapsule.putFreeAssetNetUsage(assetName,
             increase(oldFreeAssetNetUsage, 0, latestAssetOperationTime, now));
-        accountCapsule.putLatestAssetOperationTimeMap(assetName, now);
       });
     }
     Map<String, Long> assetMapV2 = accountCapsule.getAssetMapV2();
@@ -76,7 +73,6 @@ public class BandwidthProcessor extends ResourceProcessor {
       long latestAssetOperationTime = accountCapsule.getLatestAssetOperationTimeV2(assetName);
       accountCapsule.putFreeAssetNetUsageV2(assetName,
           increase(oldFreeAssetNetUsage, 0, latestAssetOperationTime, now));
-      accountCapsule.putLatestAssetOperationTimeMapV2(assetName, now);
     });
   }
 

--- a/chainbase/src/main/java/org/tron/core/db/EnergyProcessor.java
+++ b/chainbase/src/main/java/org/tron/core/db/EnergyProcessor.java
@@ -45,7 +45,6 @@ public class EnergyProcessor extends ResourceProcessor {
 
     accountCapsule.setEnergyUsage(increase(accountCapsule, ENERGY,
             oldEnergyUsage, 0, latestConsumeTime, now));
-    accountCapsule.setLatestConsumeTimeForEnergy(now);
   }
 
   public void updateTotalEnergyAverageUsage() {


### PR DESCRIPTION
**What does this PR do?**
restore to previous configuration

- When the updateUsage method is called, only the usage is updated, not the latest consume time.

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

