### PR TITLE
feat(net): turn off log printing of transaction message

### DIFF
--- a/framework/src/main/java/org/tron/core/net/P2pEventHandlerImpl.java
+++ b/framework/src/main/java/org/tron/core/net/P2pEventHandlerImpl.java
@@ -136,8 +136,10 @@ public class P2pEventHandlerImpl extends P2pEventHandler {
       msg = TronMessageFactory.create(data);
       type = msg.getType();
       peer.getPeerStatistics().messageStatistics.addTcpInMessage(msg);
-      logger.info("Receive message from  peer: {}, {}",
-              peer.getInetSocketAddress(), msg);
+      if (PeerConnection.needToLog(msg)) {
+        logger.info("Receive message from  peer: {}, {}",
+          peer.getInetSocketAddress(), msg);
+      }
       switch (type) {
         case P2P_PING:
         case P2P_PONG:

--- a/framework/src/main/java/org/tron/core/net/peer/PeerConnection.java
+++ b/framework/src/main/java/org/tron/core/net/peer/PeerConnection.java
@@ -264,7 +264,7 @@ public class PeerConnection {
             reason.name().toLowerCase(Locale.ROOT));
   }
 
-  private boolean needToLog(Message msg) {
+  public static boolean needToLog(Message msg) {
     if (msg instanceof PingMessage
             || msg instanceof PongMessage
             || msg instanceof TransactionsMessage


### PR DESCRIPTION
**What does this PR do?**
Turn off log printing of transaction message

**Why are these changes required?**
There are too many transaction-related logs, there is no need to print them out, taking up disk space

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

