### PR TITLE
fix(db): fix exceptional for auto-stop

### DIFF
--- a/framework/src/main/java/org/tron/core/db/Manager.java
+++ b/framework/src/main/java/org/tron/core/db/Manager.java
@@ -541,6 +541,13 @@ public class Manager {
     long exitHeight = CommonParameter.getInstance().getShutdownBlockHeight();
     long exitCount = CommonParameter.getInstance().getShutdownBlockCount();
 
+    if (exitHeight > 0 && exitHeight < headNum) {
+      logger.info("ShutDownBlockHeight {} is less than headNum {}, reset it to -1.",
+          exitHeight, headNum);
+      CommonParameter.getInstance().setShutdownBlockHeight(-1);
+      exitHeight = -1;
+    }
+
     if (exitCount > 0 && (exitHeight < 0 || exitHeight > headNum + exitCount)) {
       CommonParameter.getInstance().setShutdownBlockHeight(headNum + exitCount);
     }


### PR DESCRIPTION
  
**What does this PR do?**
 
 Fix the scenario to trigger auto-stop when blockHeight and blockCount are set, and blockHeight < head. 

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

