### PR TITLE
feat(db): add timeout sending of zmq

### DIFF
--- a/framework/src/main/java/org/tron/common/logsfilter/nativequeue/NativeMessageQueue.java
+++ b/framework/src/main/java/org/tron/common/logsfilter/nativequeue/NativeMessageQueue.java
@@ -30,12 +30,11 @@ public class NativeMessageQueue {
   public boolean start(int bindPort, int sendQueueLength) {
     context = new ZContext();
     publisher = context.createSocket(SocketType.PUB);
-    publisher.setSendTimeOut(ZMQ_SEND_TIME_OUT);
 
     if (Objects.isNull(publisher)) {
       return false;
     }
-
+    publisher.setSendTimeOut(ZMQ_SEND_TIME_OUT);
     if (bindPort == 0 || bindPort < 0) {
       bindPort = DEFAULT_BIND_PORT;
     }

--- a/framework/src/main/java/org/tron/common/logsfilter/nativequeue/NativeMessageQueue.java
+++ b/framework/src/main/java/org/tron/common/logsfilter/nativequeue/NativeMessageQueue.java
@@ -11,6 +11,7 @@ public class NativeMessageQueue {
 
   private static final int DEFAULT_BIND_PORT = 5555;
   private static final int DEFAULT_QUEUE_LENGTH = 1000;
+  private static final int ZMQ_SEND_TIME_OUT = 1_000;
   private static NativeMessageQueue instance;
   private ZContext context = null;
   private ZMQ.Socket publisher = null;
@@ -29,7 +30,7 @@ public class NativeMessageQueue {
   public boolean start(int bindPort, int sendQueueLength) {
     context = new ZContext();
     publisher = context.createSocket(SocketType.PUB);
-    publisher.setSendTimeOut(1000);
+    publisher.setSendTimeOut(ZMQ_SEND_TIME_OUT);
 
     if (Objects.isNull(publisher)) {
       return false;

--- a/framework/src/main/java/org/tron/common/logsfilter/nativequeue/NativeMessageQueue.java
+++ b/framework/src/main/java/org/tron/common/logsfilter/nativequeue/NativeMessageQueue.java
@@ -29,6 +29,7 @@ public class NativeMessageQueue {
   public boolean start(int bindPort, int sendQueueLength) {
     context = new ZContext();
     publisher = context.createSocket(SocketType.PUB);
+    publisher.setSendTimeOut(1000);
 
     if (Objects.isNull(publisher)) {
       return false;

--- a/framework/src/main/java/org/tron/core/net/P2pEventHandlerImpl.java
+++ b/framework/src/main/java/org/tron/core/net/P2pEventHandlerImpl.java
@@ -222,10 +222,10 @@ public class P2pEventHandlerImpl extends P2pEventHandler {
           break;
       }
       if (type.equals(P2pException.TypeEnum.BAD_MESSAGE)) {
-        logger.error("Message from {} process failed, {} \n type: {}",
+        logger.error("Message from {} process failed, {} \n type: ({})",
             peer.getInetSocketAddress(), msg, type, ex);
       } else {
-        logger.warn("Message from {} process failed, {} \n type: {}, detail: {}",
+        logger.warn("Message from {} process failed, {} \n type: ({}), detail: {}",
             peer.getInetSocketAddress(), msg, type, ex.getMessage());
       }
     } else {


### PR DESCRIPTION
**What does this PR do?**
Add timeout sending of zmq.

**Why are these changes required?**
If the thead of writing zmq takes too long, then postSolidityTrigger is dead, node couldn't not pushBlock.

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

