### PR TITLE
fix(db): Revert sending timeout of zmq

### DIFF
--- a/framework/src/main/java/org/tron/common/logsfilter/nativequeue/NativeMessageQueue.java
+++ b/framework/src/main/java/org/tron/common/logsfilter/nativequeue/NativeMessageQueue.java
@@ -11,7 +11,6 @@ public class NativeMessageQueue {
 
   private static final int DEFAULT_BIND_PORT = 5555;
   private static final int DEFAULT_QUEUE_LENGTH = 1000;
-  private static final int ZMQ_SEND_TIME_OUT = 1_000;
   private static NativeMessageQueue instance;
   private ZContext context = null;
   private ZMQ.Socket publisher = null;
@@ -34,7 +33,7 @@ public class NativeMessageQueue {
     if (Objects.isNull(publisher)) {
       return false;
     }
-    publisher.setSendTimeOut(ZMQ_SEND_TIME_OUT);
+
     if (bindPort == 0 || bindPort < 0) {
       bindPort = DEFAULT_BIND_PORT;
     }


### PR DESCRIPTION
**What does this PR do?**
Revert sending timeout of zmq.

**Why are these changes required?**
Sending timeout of zmq can not solve the problem that SR fails to produce block and fails to write data at the same time, we need a perfect solution later. 

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

