### PR TITLE
feat(log): remove unused appender in AsyncAppender

### DIFF
--- a/framework/src/main/resources/logback.xml
+++ b/framework/src/main/resources/logback.xml
@@ -60,7 +60,6 @@
     <queueSize>100</queueSize>
     <includeCallerData>true</includeCallerData>
     <appender-ref ref="FILE"/>
-    <appender-ref ref="DB"/>
   </appender>
 
   <root level="INFO">


### PR DESCRIPTION
 

**What does this PR do?**
    An unused appender is removed from the configuration.
**Why are these changes required?**
    One and only one appender can be attached to AsyncAppender, previous PR: #5010.

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

