### PR TITLE
fix(gradle): clean up the sub-project build directory

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,3 +82,11 @@ task copyToParent(type: Copy) {
 
 build.finalizedBy(copyToParent)
 
+gradle.buildFinished {
+    if (project.hasProperty('cleanSubBuild')) {
+        subprojects {
+            buildDir.deleteDir()
+        }
+    }
+}
+


### PR DESCRIPTION
**What does this PR do?**
Add gradle compilation option to clear the sub-project build directory
**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

