### PR TITLE
fix(net): update fetch block timeout to 500ms

### DIFF
--- a/framework/src/main/java/org/tron/core/config/args/Args.java
+++ b/framework/src/main/java/org/tron/core/config/args/Args.java
@@ -570,7 +570,7 @@ public class Args extends CommonParameter {
             : 2000;
 
     if (!config.hasPath(Constant.NODE_FETCH_BLOCK_TIMEOUT)) {
-      PARAMETER.fetchBlockTimeout = 200;
+      PARAMETER.fetchBlockTimeout = 500;
     } else if (config.getInt(Constant.NODE_FETCH_BLOCK_TIMEOUT) > 1000) {
       PARAMETER.fetchBlockTimeout = 1000;
     } else if (config.getInt(Constant.NODE_FETCH_BLOCK_TIMEOUT) < 100) {


### PR DESCRIPTION
**What does this PR do?**
update fetch block timeout to 500ms

**Why are these changes required?**
Increase the possibility of nodes fetching blocks in abnormal network scenarios. 

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

