### PR TITLE
feat(trie): fix `getStorageAt` logic for `create2` contracts

### DIFF
--- a/framework/src/main/java/org/tron/core/Wallet.java
+++ b/framework/src/main/java/org/tron/core/Wallet.java
@@ -4498,6 +4498,7 @@ public class Wallet {
     }
     Storage storage = new Storage(address, worldStateQueryInstance);
     storage.setContractVersion(contractCapsule.getInstance().getVersion());
+    storage.generateAddrHash(contractCapsule.getTrxHash());
     DataWord value = storage.getValue(new DataWord(ByteArray.fromHexString(storageIdx)));
     return value == null ? new byte[32] : value.getData();
   }

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/TronJsonRpcImpl.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/TronJsonRpcImpl.java
@@ -593,6 +593,7 @@ public class TronJsonRpcImpl implements TronJsonRpc {
       StorageRowStore store = manager.getStorageRowStore();
       Storage storage = new Storage(addressByte, store);
       storage.setContractVersion(smartContract.getVersion());
+      storage.generateAddrHash(smartContract.getTrxHash().toByteArray());
 
       DataWord value = storage.getValue(new DataWord(ByteArray.fromHexString(storageIdx)));
       return ByteArray.toJsonHex(value == null ? new byte[32] : value.getData());

--- a/framework/src/test/java/org/tron/common/runtime/VmStateTestUtil.java
+++ b/framework/src/test/java/org/tron/common/runtime/VmStateTestUtil.java
@@ -37,12 +37,13 @@ public class VmStateTestUtil {
 
   public static BlockCapsule mockBlock(ChainBaseManager chainBaseManager,
                                        WorldStateCallBack worldStateCallBack) {
-    chainBaseManager.getDynamicPropertiesStore().saveLatestBlockHeaderNumber(1000);
+    long mockNumber = 1000;
+    chainBaseManager.getDynamicPropertiesStore().saveLatestBlockHeaderNumber(mockNumber);
     TrieImpl2 trie = flushTrie(worldStateCallBack);
     BlockCapsule blockCap = new BlockCapsule(Protocol.Block.newBuilder().build());
     Protocol.BlockHeader.raw blockHeaderRaw =
         blockCap.getInstance().getBlockHeader().getRawData().toBuilder()
-            .setNumber(100)
+            .setNumber(mockNumber)
             .setTimestamp(System.currentTimeMillis())
             .setWitnessAddress(ByteString.copyFrom(ByteArray.fromHexString(OWNER_ADDRESS)))
             .build();
@@ -53,6 +54,8 @@ public class VmStateTestUtil {
     blockCap = new BlockCapsule(
         blockCap.getInstance().toBuilder().setBlockHeader(blockHeader).build());
     blockCap.generatedByMyself = true;
+    chainBaseManager.getBlockStore().put(blockCap.getBlockId().getBytes(), blockCap);
+    chainBaseManager.getBlockIndexStore().put(blockCap.getBlockId());
     return blockCap;
   }
 

--- a/framework/src/test/java/org/tron/common/runtime/vm/Create2Test.java
+++ b/framework/src/test/java/org/tron/common/runtime/vm/Create2Test.java
@@ -11,11 +11,16 @@ import org.junit.Test;
 import org.testng.Assert;
 import org.tron.common.runtime.TVMTestResult;
 import org.tron.common.runtime.TvmTestUtils;
+import org.tron.common.utils.ByteArray;
 import org.tron.common.utils.WalletUtil;
+import org.tron.core.Wallet;
 import org.tron.core.exception.ContractExeException;
 import org.tron.core.exception.ContractValidateException;
+import org.tron.core.exception.JsonRpcInvalidParamsException;
 import org.tron.core.exception.ReceiptCheckErrException;
 import org.tron.core.exception.VMIllegalException;
+import org.tron.core.services.NodeInfoService;
+import org.tron.core.services.jsonrpc.TronJsonRpcImpl;
 import org.tron.protos.Protocol.Transaction;
 import stest.tron.wallet.common.client.utils.AbiUtil;
 import stest.tron.wallet.common.client.utils.DataWord;
@@ -171,13 +176,30 @@ public class Create2Test extends VMTestBase {
 
     // trigger deployed contract
     String methodToTrigger = "plusOne()";
-    for (int i = 1; i < 3; i++) {
+    long loop = 2;
+    for (int i = 1; i <= loop; i++) {
       hexInput = AbiUtil.parseMethod(methodToTrigger, Collections.emptyList());
       result = TvmTestUtils
           .triggerContractAndReturnTvmTestResult(Hex.decode(OWNER_ADDRESS),
               actualContract, Hex.decode(hexInput), 0, fee, manager, null);
       Assert.assertNull(result.getRuntime().getRuntimeError());
       Assert.assertEquals(result.getRuntime().getResult().getHReturn(), new DataWord(i).getData());
+    }
+    testJsonRpc(actualContract, loop);
+  }
+
+  private void testJsonRpc(byte[] actualContract, long loop) {
+    TronJsonRpcImpl tronJsonRpc;
+    NodeInfoService nodeInfoService;
+    nodeInfoService = context.getBean(NodeInfoService.class);
+    Wallet wallet = context.getBean(Wallet.class);
+    tronJsonRpc = new TronJsonRpcImpl(nodeInfoService, wallet, manager);
+    try {
+      String res =
+          tronJsonRpc.getStorageAt(ByteArray.toHexString(actualContract), "0", "latest");
+      Assert.assertEquals(loop, ByteArray.jsonHexToLong(res));
+    } catch (JsonRpcInvalidParamsException e) {
+      Assert.fail();
     }
   }
 

--- a/framework/src/test/java/org/tron/common/runtime/vm/Create2Test.java
+++ b/framework/src/test/java/org/tron/common/runtime/vm/Create2Test.java
@@ -5,15 +5,18 @@ import static org.tron.core.db.TransactionTrace.convertToTronAddress;
 
 import java.util.Arrays;
 import java.util.Collections;
+
 import lombok.extern.slf4j.Slf4j;
 import org.bouncycastle.util.encoders.Hex;
 import org.junit.Test;
 import org.testng.Assert;
 import org.tron.common.runtime.TVMTestResult;
 import org.tron.common.runtime.TvmTestUtils;
+import org.tron.common.runtime.VmStateTestUtil;
 import org.tron.common.utils.ByteArray;
 import org.tron.common.utils.WalletUtil;
 import org.tron.core.Wallet;
+import org.tron.core.capsule.BlockCapsule;
 import org.tron.core.exception.ContractExeException;
 import org.tron.core.exception.ContractValidateException;
 import org.tron.core.exception.JsonRpcInvalidParamsException;
@@ -21,6 +24,7 @@ import org.tron.core.exception.ReceiptCheckErrException;
 import org.tron.core.exception.VMIllegalException;
 import org.tron.core.services.NodeInfoService;
 import org.tron.core.services.jsonrpc.TronJsonRpcImpl;
+import org.tron.core.state.WorldStateCallBack;
 import org.tron.protos.Protocol.Transaction;
 import stest.tron.wallet.common.client.utils.AbiUtil;
 import stest.tron.wallet.common.client.utils.DataWord;
@@ -102,10 +106,15 @@ public class Create2Test extends VMTestBase {
 
   */
 
+  private WorldStateCallBack worldStateCallBack;
+
   @Test
   public void testCreate2()
       throws ContractExeException, ReceiptCheckErrException,
       VMIllegalException, ContractValidateException {
+    worldStateCallBack = context.getBean(WorldStateCallBack.class);
+    worldStateCallBack.setExecute(true);
+
     manager.getDynamicPropertiesStore().saveAllowTvmTransferTrc10(1);
     manager.getDynamicPropertiesStore().saveAllowTvmConstantinople(1);
     manager.getDynamicPropertiesStore().saveAllowTvmIstanbul(0);
@@ -197,6 +206,18 @@ public class Create2Test extends VMTestBase {
     try {
       String res =
           tronJsonRpc.getStorageAt(ByteArray.toHexString(actualContract), "0", "latest");
+      Assert.assertEquals(loop, ByteArray.jsonHexToLong(res));
+    } catch (JsonRpcInvalidParamsException e) {
+      Assert.fail();
+    }
+
+    // test for archive node
+    BlockCapsule blockCapsule =
+        VmStateTestUtil.mockBlock(manager.getChainBaseManager(), worldStateCallBack);
+    try {
+      String res =
+          tronJsonRpc.getStorageAt(ByteArray.toHexString(actualContract), "0",
+              "0x" + Long.toHexString(blockCapsule.getNum()));
       Assert.assertEquals(loop, ByteArray.jsonHexToLong(res));
     } catch (JsonRpcInvalidParamsException e) {
       Assert.fail();


### PR DESCRIPTION
**What does this PR do?**

Fix `getStorageAt` logic when querying contracts created by `create2`.

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

