### PR TITLE
made nix shell for old java/gradle

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,15 @@
+{}:
+let
+  pkgs = import (fetchTarball https://github.com/NixOS/nixpkgs/archive/619d52a37ef190017a71b26469ec434f1861c20e.tar.gz)
+    { };
+in
+pkgs.mkShell {
+  buildInputs = [
+    pkgs.jdk8
+    pkgs.gradle_4
+    pkgs.grpcurl
+  ];
+  shellHook = ''
+    export NIX_ENV=dev
+  '';
+}


### PR DESCRIPTION
**What does this PR do?**

allows anybody build tron

**Why are these changes required?**

it is hard to get old gradle/java other way

**This PR has been tested by:**
- Unit Tests
- Manual Testing +

**Follow up**

more nix for running tron

**Extra details**

nix is standard on reproducible deterministic software