### PR TITLE
feat(db): remove auto-repair for corrupted leveldb

### DIFF
--- a/chainbase/src/main/java/org/tron/common/storage/leveldb/LevelDbDataSourceImpl.java
+++ b/chainbase/src/main/java/org/tron/common/storage/leveldb/LevelDbDataSourceImpl.java
@@ -142,22 +142,11 @@ public class LevelDbDataSourceImpl extends DbStat implements DbSourceInter<byte[
     if (!Files.isSymbolicLink(dbPath.getParent())) {
       Files.createDirectories(dbPath.getParent());
     }
-    try {
-      database = factory.open(dbPath.toFile(), dbOptions);
-      if (!this.getDBName().startsWith("checkpoint")) {
-        logger.info("DB {} open success with writeBufferSize {} M, cacheSize {} M, maxOpenFiles {}.",
-            this.getDBName(), dbOptions.writeBufferSize() / 1024 / 1024,
-            dbOptions.cacheSize() / 1024 / 1024, dbOptions.maxOpenFiles());
-      }
-    } catch (IOException e) {
-      if (e.getMessage().contains("Corruption:")) {
-        logger.warn("DB {} corruption detected, try to repair it.", this.getDBName(), e);
-        factory.repair(dbPath.toFile(), dbOptions);
-        logger.warn("DB {} corruption detected, repair done.", this.getDBName());
-        database = factory.open(dbPath.toFile(), dbOptions);
-      } else {
-        throw e;
-      }
+    database = factory.open(dbPath.toFile(), dbOptions);
+    if (!this.getDBName().startsWith("checkpoint")) {
+      logger.info("DB {} open success with writeBufferSize {} M, cacheSize {} M, maxOpenFiles {}.",
+          this.getDBName(), dbOptions.writeBufferSize() / 1024 / 1024,
+          dbOptions.cacheSize() / 1024 / 1024, dbOptions.maxOpenFiles());
     }
   }
 


### PR DESCRIPTION
**What does this PR do?**
    Remove auto-repair for leveldb when db is corrupted.

**Why are these changes required?**
    The repair function could not guarantee a full recovery of the data, this could lead to misjudging of the database integrity. 

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

