### PR TITLE
fix(db): skip expired checkpoints for recovery

### DIFF
--- a/chainbase/src/main/java/org/tron/core/db2/core/SnapshotManager.java
+++ b/chainbase/src/main/java/org/tron/core/db2/core/SnapshotManager.java
@@ -471,9 +471,10 @@ public class SnapshotManager implements RevokingDatabase {
     if (cpList.size() < 3) {
       return;
     }
+    long latestTimestamp = Long.parseLong(cpList.get(cpList.size()-1));
     for (String cp: cpList.subList(0, cpList.size()-3)) {
       long timestamp = Long.parseLong(cp);
-      if (System.currentTimeMillis() - timestamp < ONE_MINUTE_MILLS*2) {
+      if (latestTimestamp - timestamp <= ONE_MINUTE_MILLS*2) {
         break;
       }
       String checkpointPath = Paths.get(StorageUtils.getOutputDirectoryByDbName(CHECKPOINT_V2_DIR),
@@ -522,7 +523,12 @@ public class SnapshotManager implements RevokingDatabase {
       return;
     }
 
+    long latestTimestamp = Long.parseLong(cpList.get(cpList.size()-1));
     for (String cp: cpList) {
+      long timestamp = Long.parseLong(cp);
+      if (latestTimestamp - timestamp > ONE_MINUTE_MILLS*2) {
+        continue;
+      }
       TronDatabase<byte[]> checkPointV2Store = getCheckpointDB(cp);
       recover(checkPointV2Store);
       checkPointV2Store.close();


### PR DESCRIPTION
**What does this PR do?**

The logic of checkpoint v2 prune is just deleting the directory if the checkpoint is expired, but the deletion is not an atomic operation and the expired checkpoints may be corrupted when `kill -9` or machine shutdown, so we should skip the expired checkpoints when recovering.

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

