### PR TITLE
feat(test): bump junit from 4.12 to 4.13.2

### DIFF
--- a/actuator/build.gradle
+++ b/actuator/build.gradle
@@ -3,7 +3,7 @@ description = "actuator – a series of transactions for blockchain."
 // Dependency versions
 // ---------------------------------------
 
-def junitVersion = "4.12"
+def junitVersion = "4.13.2"
 def mockitoVersion = "2.1.0"
 def testNgVersion = "6.11"
 def slf4jVersion = "1.7.25"

--- a/chainbase/build.gradle
+++ b/chainbase/build.gradle
@@ -3,7 +3,7 @@ description = "chainbase – a decentralized database for blockchain."
 // Dependency versions
 // ---------------------------------------
 
-def junitVersion = "4.12"
+def junitVersion = "4.13.2"
 def mockitoVersion = "2.1.0"
 def testNgVersion = "6.11"
 def jacocoVersion = "0.8.0"

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -35,7 +35,7 @@ repositories {
 }
 
 dependencies {
-    testCompile group: 'junit', name: 'junit', version: '4.12'
+    testCompile group: 'junit', name: 'junit', version: '4.13.2'
     compile group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: '1.69'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.4.1'
     compile "com.cedarsoftware:java-util:1.8.0"

--- a/consensus/build.gradle
+++ b/consensus/build.gradle
@@ -2,7 +2,7 @@ description = "consensus – a distributed consensus arithmetic for blockchain."
 
 // Dependency versions
 // ---------------------------------------
-def junitVersion = "4.12"
+def junitVersion = "4.13.2"
 def mockitoVersion = "2.1.0"
 def testNgVersion = "6.11"
 def slf4jVersion = "1.7.25"

--- a/crypto/build.gradle
+++ b/crypto/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    testCompile group: 'junit', name: 'junit', version: '4.12'
+    testCompile group: 'junit', name: 'junit', version: '4.13.2'
     compile group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: '1.69'
     compile project(":common")
 }

--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     //local libraries
     compile fileTree(dir: 'libs', include: '*.jar')
     // end local libraries
-    testCompile group: 'junit', name: 'junit', version: '4.12'
+    testCompile group: 'junit', name: 'junit', version: '4.13.2'
     testCompile group: 'org.mockito', name: 'mockito-core', version: '2.13.0'
     testCompile group: 'org.hamcrest', name: 'hamcrest-junit', version: '1.0.0.1'
 
@@ -54,7 +54,7 @@ dependencies {
 
     compile group: 'com.beust', name: 'jcommander', version: '1.72'
 
-    compile group: 'junit', name: 'junit', version: '4.12'
+    compile group: 'junit', name: 'junit', version: '4.13.2'
 
     compile group: 'net.jcip', name: 'jcip-annotations', version: '1.0'
 

--- a/plugins/build.gradle
+++ b/plugins/build.gradle
@@ -26,7 +26,7 @@ configurations.getByName('checkstyleConfig') {
 dependencies {
     //local libraries
     compile fileTree(dir: 'libs', include: '*.jar')
-    testCompile group: 'junit', name: 'junit', version: '4.12'
+    testCompile group: 'junit', name: 'junit', version: '4.13.2'
     testCompile group: 'org.mockito', name: 'mockito-core', version: '2.13.0'
     testCompile group: 'org.hamcrest', name: 'hamcrest-junit', version: '1.0.0.1'
     testCompile group: 'org.testng', name: 'testng', version: '6.14.3'


### PR DESCRIPTION
**What does this PR do?**
     bump junit from 4.12 to 4.13.2

**Why are these changes required?**
   TemporaryFolder on unix-like systems does not limit access to created files, detail in [CVE - CVE-2020-15250](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15250).

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

