### PR TITLE
feat(db): optimize bloom filter for transaction cache

### DIFF
--- a/chainbase/src/main/java/org/tron/core/db/TronStoreWithRevoking.java
+++ b/chainbase/src/main/java/org/tron/core/db/TronStoreWithRevoking.java
@@ -51,7 +51,8 @@ public abstract class TronStoreWithRevoking<T extends ProtoCapsule> implements I
   @Autowired
   private DbStatService dbStatService;
 
-  private DB<byte[], byte[]> db;
+  @Getter
+  private final DB<byte[], byte[]> db;
 
   protected TronStoreWithRevoking(String dbName) {
     String dbEngine = CommonParameter.getInstance().getStorage().getDbEngine();

--- a/chainbase/src/main/java/org/tron/core/db2/common/TxCacheDB.java
+++ b/chainbase/src/main/java/org/tron/core/db2/common/TxCacheDB.java
@@ -86,7 +86,6 @@ public class TxCacheDB implements DB<byte[], byte[]>, Flusher {
     this.bloomFilters[1] = BloomFilter.create(Funnels.byteArrayFunnel(),
         MAX_BLOCK_SIZE * TRANSACTION_COUNT);
 
-    init();
   }
 
   /**
@@ -110,7 +109,7 @@ public class TxCacheDB implements DB<byte[], byte[]>, Flusher {
         System.currentTimeMillis() - start);
   }
 
-  private void init() {
+  public void init() {
     long size = recentTransactionStore.size();
     if (size != MAX_BLOCK_SIZE) {
       // 0. load from persistentStore

--- a/chainbase/src/main/java/org/tron/core/db2/core/SnapshotManager.java
+++ b/chainbase/src/main/java/org/tron/core/db2/core/SnapshotManager.java
@@ -509,6 +509,7 @@ public class SnapshotManager implements RevokingDatabase {
       }
     }
     recover(checkTmpStore);
+    logger.info("checkpoint v1 recover success");
     unChecked = false;
   }
 

--- a/framework/src/main/java/org/tron/core/db/Manager.java
+++ b/framework/src/main/java/org/tron/core/db/Manager.java
@@ -450,6 +450,7 @@ public class Manager {
     trieService.setChainBaseManager(chainBaseManager);
     revokingStore.disable();
     revokingStore.check();
+    transactionCache.initCache();
     this.setProposalController(ProposalController.createInstance(this));
     this.setMerkleContainer(
         merkleContainer.createInstance(chainBaseManager.getMerkleTreeStore(),

--- a/framework/src/main/java/org/tron/core/db/TransactionCache.java
+++ b/framework/src/main/java/org/tron/core/db/TransactionCache.java
@@ -14,4 +14,8 @@ public class TransactionCache extends TronStoreWithRevoking<BytesCapsule> {
                           RecentTransactionStore recentTransactionStore) {
     super(new TxCacheDB(dbName, recentTransactionStore));
   }
+
+  public void initCache() {
+    ((TxCacheDB) getDb()).init();
+  }
 }


### PR DESCRIPTION
**What does this PR do?**
    make bloom filter initialization after checkpoint recovery
**Why are these changes required?**
    optimize bloom filter initialization for transaction cache
**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

