### PR TITLE
fix(net):if num is bigger than head num, get blockid from khaosdb

### DIFF
--- a/framework/src/main/java/org/tron/core/net/service/sync/SyncService.java
+++ b/framework/src/main/java/org/tron/core/net/service/sync/SyncService.java
@@ -210,7 +210,9 @@ public class SyncService {
 
   private BlockId getBlockIdByNum(long num) throws P2pException {
     BlockId head = tronNetDelegate.getHeadBlockId();
-    if (num == head.getNum()) {
+    if (num > head.getNum()) {
+      return tronNetDelegate.getKhaosDbHeadBlockId();
+    } else if (num == head.getNum()) {
       return head;
     }
     return tronNetDelegate.getBlockIdByNum(num);


### PR DESCRIPTION
**What does this PR do?**
- if num is bigger than head num, get blockid from khaosdb when generate syncblockchain

**Why are these changes required?**
- if num is bigger than dynamic store's head, getting block from index store will fail

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

