### PR TITLE
feat(db): optimize trans cache

### DIFF
--- a/framework/src/main/java/org/tron/core/db/Manager.java
+++ b/framework/src/main/java/org/tron/core/db/Manager.java
@@ -1919,6 +1919,7 @@ public class Manager {
 
   public void closeAllStore() {
     logger.info("******** Begin to close db. ********");
+
     chainBaseManager.closeAllStore();
     validateSignService.shutdown();
     logger.info("******** End to close db. ********");


### PR DESCRIPTION
**What does this PR do?**
1. Write bloom filters of trans cache to the disk when the node is stopped(by kill -15).
2. Restore bloom filters of trans cache when the node start.

**Why are these changes required?**
make the node start faster




