### PR TITLE
chore(gitignore):ignore the .cache folder generated by test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ Wallet
 /vm_trace/
 
 /framework/propPath
+.cache


### PR DESCRIPTION
the .cache folder is generated by https://github.com/tronprotocol/java-tron/pull/5394/files#diff-132a9ebbd696b083bea6988abca54f688183b39eb07e601356e30e6fc594306fR110