### PR TITLE
restore jsonrpc api consistency to display only TRX as value

### DIFF
--- a/framework/src/main/java/org/tron/core/services/jsonrpc/JsonRpcApiUtil.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/JsonRpcApiUtil.java
@@ -242,17 +242,6 @@ public class JsonRpcApiUtil {
         case TransferContract:
           amount = contractParameter.unpack(TransferContract.class).getAmount();
           break;
-        case TransferAssetContract:
-          amount = contractParameter.unpack(TransferAssetContract.class).getAmount();
-          break;
-        case VoteWitnessContract:
-          List<Vote> votesList = contractParameter.unpack(VoteWitnessContract.class).getVotesList();
-          long voteNumber = 0L;
-          for (Vote vote : votesList) {
-            voteNumber += vote.getVoteCount();
-          }
-          amount = voteNumber;
-          break;
         case WitnessCreateContract:
           amount = 9999_000_000L;
           break;
@@ -261,21 +250,18 @@ public class JsonRpcApiUtil {
           amount = 1024_000_000L;
           break;
         case ParticipateAssetIssueContract:
-          break;
+        case UnfreezeAssetContract:
+        case VoteWitnessContract:
+        case TransferAssetContract:
+        case ExchangeWithdrawContract:
+        case ExchangeInjectContract:
+        case ExchangeTransactionContract:
+              break;
         case FreezeBalanceContract:
           amount = contractParameter.unpack(FreezeBalanceContract.class).getFrozenBalance();
           break;
         case TriggerSmartContract:
           amount = contractParameter.unpack(TriggerSmartContract.class).getCallValue();
-          break;
-        case ExchangeInjectContract:
-          amount = contractParameter.unpack(ExchangeInjectContract.class).getQuant();
-          break;
-        case ExchangeWithdrawContract:
-          amount = contractParameter.unpack(ExchangeWithdrawContract.class).getQuant();
-          break;
-        case ExchangeTransactionContract:
-          amount = contractParameter.unpack(ExchangeTransactionContract.class).getQuant();
           break;
         case AccountPermissionUpdateContract:
           amount = 100_000_000L;
@@ -295,10 +281,6 @@ public class JsonRpcApiUtil {
         case UnfreezeBalanceV2Contract:
         case CancelAllUnfreezeV2Contract:
           amount = getAmountFromTransactionInfo(hash, contract.getType(), transactionInfo);
-          break;
-        case UnfreezeAssetContract:
-          amount = getUnfreezeAssetAmount(contractParameter.unpack(UnfreezeAssetContract.class)
-              .getOwnerAddress().toByteArray(), wallet);
           break;
         default:
       }
@@ -354,33 +336,6 @@ public class JsonRpcApiUtil {
     }
     return amount;
   }
-
-  public static long getUnfreezeAssetAmount(byte[] addressBytes, Wallet wallet) {
-    long amount = 0L;
-    try {
-      if (addressBytes == null) {
-        return amount;
-      }
-
-      AssetIssueList assetIssueList = wallet
-          .getAssetIssueByAccount(ByteString.copyFrom(addressBytes));
-      if (assetIssueList != null) {
-        if (assetIssueList.getAssetIssueCount() != 1) {
-          return amount;
-        } else {
-          AssetIssueContract assetIssue = assetIssueList.getAssetIssue(0);
-          for (FrozenSupply frozenSupply : assetIssue.getFrozenSupplyList()) {
-            amount += frozenSupply.getFrozenAmount();
-          }
-        }
-      }
-    } catch (Exception e) {
-      logger.warn("Exception happens when get token10 frozenAmount. Exception = [{}]",
-          Throwables.getStackTraceAsString(e));
-    }
-    return amount;
-  }
-
   /**
    * convert 40 or 42 hex string of address to byte array, compatible with "41"(T) ahead,
    * padding 0 ahead if length is odd.


### PR DESCRIPTION
**What does this PR do?**
This PR restores consistency in JSON-RPC API. Previously `value` field in `JSON-RPC` response displayed various currencies(TRC-10 or TRX) and this is incorrect.  

**Why are these changes required?**
As we can't distinguish the transaction type in `JSON-RPC` response it's weird to return various currencies amount in `value` field or vote amount.
For instance, for transaction types `UnfreezeAssetContract`,`TransferAssetContract` `value` field indicates token amount, for `VoteWitnessContract` it indicates vote count, for `Exchange*Contract` it indicates unknown currency at all as the currency depends on exchange.

**This PR has been tested by:**
- Manual Testing

**Follow up**
#### System information

java-tron version: `GreatVoyage-v4.7.2`
OS & Version: Linux

#### Expected behaviour
In order to keep consistent API, `value` field in JSON-RPC response should indicate TRX(TRON) amount, neither asset amount nor vote count.

#### Actual behaviour
`value` field indicates not only TRX(TRON) value but TRC-10 token value as well.

Check for example transaction `64e594ccb2cb47b23ade85adbcb3404a501d2627291b09a0ed49364049c5abfa`:

<details><summary>eth_getTransactionByHash response</summary>

```json
{
    "jsonrpc": "2.0",
    "id": 1,
    "result": {
        "blockHash": "0x0000000003197e6a40297fe291280f9c7ad3cc970564b93f96ced133d305a55e",
        "blockNumber": "0x3197e6a",
        "from": "0x4da5ddaaea7f1138c030ac8d97017d5020dd6536",
        "gas": "0x0",
        "gasPrice": "0x1a4",
        "hash": "0x64e594ccb2cb47b23ade85adbcb3404a501d2627291b09a0ed49364049c5abfa",
        "input": "0x",
        "nonce": "0x0000000000000000",
        "r": "0x49a16c9c202a9ab7b2b71e172e440d475733169a90514dc9fb6c89be576a57ad",
        "s": "0x150276b20b7aa21f96afbde95d4f31b30a10b0839bb8f7af85c99e274de248d3",
        "to": "0x49d216cb7b1cc41f166be76241301781f87e039a",
        "transactionIndex": "0x5",
        "type": "0x0",
        "v": "0x1c",
        "value": "0x87a238"
    }
}
```
</details>

#### Steps to reproduce the behaviour
```bash
curl --location 'http://node/jsonrpc' \
--header 'Content-Type: application/json' \
--data '{
    "id": 1,
    "jsonrpc": "2.0",
    "method": "eth_getTransactionByHash",
    "params": [
        "0x64e594ccb2cb47b23ade85adbcb3404a501d2627291b09a0ed49364049c5abfa"
    ]
}
```

**Extra details**
With this PR jsonrpc response is consistent and returns correct value of tron for the transacion above (`0x64e594ccb2cb47b23ade85adbcb3404a501d2627291b09a0ed49364049c5abfa`):

```json
{
    "jsonrpc": "2.0",
    "id": 7704110,
    "result": {
        "blockHash": "0x0000000003197e6a40297fe291280f9c7ad3cc970564b93f96ced133d305a55e",
        "blockNumber": "0x3197e6a",
        "from": "0x4da5ddaaea7f1138c030ac8d97017d5020dd6536",
        "gas": "0x0",
        "gasPrice": "0x1a4",
        "hash": "0x64e594ccb2cb47b23ade85adbcb3404a501d2627291b09a0ed49364049c5abfa",
        "input": "0x",
        "nonce": "0x0000000000000000",
        "r": "0x49a16c9c202a9ab7b2b71e172e440d475733169a90514dc9fb6c89be576a57ad",
        "s": "0x150276b20b7aa21f96afbde95d4f31b30a10b0839bb8f7af85c99e274de248d3",
        "to": "0x49d216cb7b1cc41f166be76241301781f87e039a",
        "transactionIndex": "0x5",
        "type": "0x0",
        "v": "0x1c",
        "value": "0x0"
    }
}
```
