### PR TITLE
feat(http): optimize parameter parsing

### DIFF
--- a/framework/src/main/java/org/tron/core/services/http/Util.java
+++ b/framework/src/main/java/org/tron/core/services/http/Util.java
@@ -524,7 +524,6 @@ public class Util {
 
   private static String checkGetParam(HttpServletRequest request, String key) throws Exception {
     String method = request.getMethod();
-    String value = null;
 
     if (HttpMethod.GET.toString().toUpperCase().equalsIgnoreCase(method)) {
       return request.getParameter(key);
@@ -534,8 +533,10 @@ public class Util {
       if (StringUtils.isBlank(contentType)) {
         return null;
       }
-      if (contentType.contains(MimeTypes.Type.APPLICATION_JSON.asString())) {
-        value = getRequestValue(request);
+      if (contentType.contains(MimeTypes.Type.FORM_ENCODED.asString())) {
+        return request.getParameter(key);
+      } else {
+        String value = getRequestValue(request);
         if (StringUtils.isBlank(value)) {
           return null;
         }
@@ -544,13 +545,10 @@ public class Util {
         if (jsonObject != null) {
           return jsonObject.getString(key);
         }
-      } else if (contentType.contains(MimeTypes.Type.FORM_ENCODED.asString())) {
-        return request.getParameter(key);
-      } else {
         return null;
       }
     }
-    return value;
+    return null;
   }
 
   public static String getRequestValue(HttpServletRequest request) throws IOException {

--- a/framework/src/main/java/org/tron/core/services/http/Util.java
+++ b/framework/src/main/java/org/tron/core/services/http/Util.java
@@ -534,9 +534,7 @@ public class Util {
       if (StringUtils.isBlank(contentType)) {
         return null;
       }
-      if (contentType.contains(MimeTypes.Type.APPLICATION_JSON.asString())
-              || contentType.contains(MimeTypes.Type.APPLICATION_JSON_UTF_8.asString())
-              || contentType.contains(MimeTypes.Type.APPLICATION_JSON_8859_1.asString())) {
+      if (contentType.contains(MimeTypes.Type.APPLICATION_JSON.asString())) {
         value = getRequestValue(request);
         if (StringUtils.isBlank(value)) {
           return null;

--- a/framework/src/main/java/org/tron/core/services/http/Util.java
+++ b/framework/src/main/java/org/tron/core/services/http/Util.java
@@ -30,6 +30,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.bouncycastle.util.encoders.Hex;
 import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.http.MimeTypes;
 import org.eclipse.jetty.util.MultiMap;
 import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.UrlEncoded;
@@ -78,8 +79,6 @@ public class Util {
   public static final String FUNCTION_SELECTOR = "function_selector";
   public static final String FUNCTION_PARAMETER = "parameter";
   public static final String CALL_DATA = "data";
-  public static final String APPLICATION_FORM_URLENCODED = "application/x-www-form-urlencoded";
-  public static final String APPLICATION_JSON = "application/json";
 
   public static String printTransactionFee(String transactionFee) {
     JSONObject jsonObject = new JSONObject();
@@ -535,7 +534,9 @@ public class Util {
       if (StringUtils.isBlank(contentType)) {
         return null;
       }
-      if (APPLICATION_JSON.toLowerCase().contains(contentType)) {
+      if (contentType.contains(MimeTypes.Type.APPLICATION_JSON.asString())
+              || contentType.contains(MimeTypes.Type.APPLICATION_JSON_UTF_8.asString())
+              || contentType.contains(MimeTypes.Type.APPLICATION_JSON_8859_1.asString())) {
         value = getRequestValue(request);
         if (StringUtils.isBlank(value)) {
           return null;
@@ -545,7 +546,7 @@ public class Util {
         if (jsonObject != null) {
           return jsonObject.getString(key);
         }
-      } else if (APPLICATION_FORM_URLENCODED.toLowerCase().contains(contentType)) {
+      } else if (contentType.contains(MimeTypes.Type.FORM_ENCODED.asString())) {
         return request.getParameter(key);
       } else {
         return null;

--- a/framework/src/test/java/org/tron/core/services/http/GetBrokerageServletTest.java
+++ b/framework/src/test/java/org/tron/core/services/http/GetBrokerageServletTest.java
@@ -53,6 +53,25 @@ public class GetBrokerageServletTest extends BaseTest {
     }
   }
 
+
+  @Test
+  public void getBrokerageByJsonUTF8Test() {
+    int expect = 20;
+    String jsonParam = "{\"address\": \"27VZHn9PFZwNh7o2EporxmLkpe157iWZVkh\"}";
+    MockHttpServletRequest request = createRequest("application/json; charset=utf-8");
+    request.setContent(jsonParam.getBytes());
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    getBrokerageServlet.doPost(request, response);
+    try {
+      String contentAsString = response.getContentAsString();
+      JSONObject result = JSONObject.parseObject(contentAsString);
+      int brokerage = (int)result.get("brokerage");
+      Assert.assertEquals(expect, brokerage);
+    } catch (UnsupportedEncodingException e) {
+      Assert.fail(e.getMessage());
+    }
+  }
+
   @Test
   public void getBrokerageValueTest() {
     int expect = 20;

--- a/framework/src/test/java/org/tron/core/services/http/GetRewardServletTest.java
+++ b/framework/src/test/java/org/tron/core/services/http/GetRewardServletTest.java
@@ -63,18 +63,6 @@ public class GetRewardServletTest extends BaseTest {
     delegationStore.setWitnessVote(0, sr, 100000000);
   }
 
-  @After
-  public void destroy1() {
-    Args.clearParam();
-    if (StringUtils.isNotEmpty(dbPath)) {
-      if (FileUtil.deleteDir(new File(dbPath))) {
-        logger.info("Release resources successful.");
-      } else {
-        logger.info("Release resources failure.");
-      }
-    }
-  }
-
   @Test
   public void getRewardValueByJsonTest() {
     int expect = 138181;

--- a/framework/src/test/java/org/tron/core/services/http/GetRewardServletTest.java
+++ b/framework/src/test/java/org/tron/core/services/http/GetRewardServletTest.java
@@ -8,9 +8,11 @@ import java.io.File;
 import java.io.UnsupportedEncodingException;
 import javax.annotation.Resource;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -22,6 +24,7 @@ import org.tron.core.db.Manager;
 import org.tron.core.service.MortgageService;
 import org.tron.core.store.DelegationStore;
 
+@Slf4j
 public class GetRewardServletTest extends BaseTest {
 
   @Resource
@@ -53,6 +56,7 @@ public class GetRewardServletTest extends BaseTest {
     return request;
   }
 
+  @Before
   public void init() {
     manager.getDynamicPropertiesStore().saveChangeDelegation(1);
     byte[] sr = decodeFromBase58Check("27VZHn9PFZwNh7o2EporxmLkpe157iWZVkh");
@@ -60,9 +64,20 @@ public class GetRewardServletTest extends BaseTest {
     delegationStore.setWitnessVote(0, sr, 100000000);
   }
 
+  @After
+  public void destroy1() {
+    Args.clearParam();
+    if (StringUtils.isNotEmpty(dbPath)) {
+      if (FileUtil.deleteDir(new File(dbPath))) {
+        logger.info("Release resources successful.");
+      } else {
+        logger.info("Release resources failure.");
+      }
+    }
+  }
+
   @Test
   public void getRewardValueByJsonTest() {
-    init();
     int expect = 138181;
     String jsonParam = "{\"address\": \"27VZHn9PFZwNh7o2EporxmLkpe157iWZVkh\"}";
     MockHttpServletRequest request = createRequest("application/json");
@@ -80,8 +95,25 @@ public class GetRewardServletTest extends BaseTest {
   }
 
   @Test
+  public void getRewardByJsonUTF8Test() {
+    int expect = 138181;
+    String jsonParam = "{\"address\": \"27VZHn9PFZwNh7o2EporxmLkpe157iWZVkh\"}";
+    MockHttpServletRequest request = createRequest("application/json; charset=utf-8");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    request.setContent(jsonParam.getBytes());
+    try {
+      getRewardServlet.doPost(request, response);
+      String contentAsString = response.getContentAsString();
+      JSONObject result = JSONObject.parseObject(contentAsString);
+      int reward = (int)result.get("reward");
+      Assert.assertEquals(expect, reward);
+    } catch (UnsupportedEncodingException e) {
+      Assert.fail(e.getMessage());
+    }
+  }
+
+  @Test
   public void getRewardValueTest() {
-    init();
     int expect = 138181;
     MockHttpServletRequest request = createRequest("application/x-www-form-urlencoded");
     MockHttpServletResponse response = new MockHttpServletResponse();


### PR DESCRIPTION
**What does this PR do?**
optimize incorrect content-type comparisons.

**Why are these changes required?**
When a client requests an interface, if it is an application/json request, it may be written in a variety of ways, including:
1. `application/json`
2. `application/json;charset=iso-8859-1`
3. `application/json;charset=utf-8`

When determining the content-type of a request,  the interface needs to be compatible with the variable writing ways of the requests.

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

