### PR TITLE
fix(test\db): fix wrong output path

### DIFF
--- a/framework/src/test/java/org/tron/core/db/AccountAssetStoreTest.java
+++ b/framework/src/test/java/org/tron/core/db/AccountAssetStoreTest.java
@@ -44,10 +44,9 @@ public class AccountAssetStoreTest extends BaseTest {
   private AccountStore accountStore;
 
   static {
-    dbPath = "db_AccountAssetStore_test";
     Args.setParam(
             new String[]{
-                "--output-directory", dbPath,
+                "--output-directory", dbPath(),
             },
             Constant.TEST_CONF
     );

--- a/framework/src/test/java/org/tron/core/db/AssetIssueStoreTest.java
+++ b/framework/src/test/java/org/tron/core/db/AssetIssueStoreTest.java
@@ -26,10 +26,9 @@ public class AssetIssueStoreTest extends BaseTest {
   private AssetIssueStore assetIssueStore;
 
   static {
-    dbPath = "db_AssetIssueStoreTest_test";
     Args.setParam(
             new String[]{
-                "--output-directory", dbPath,
+                "--output-directory", dbPath(),
             },
             Constant.TEST_CONF
     );

--- a/framework/src/test/java/org/tron/core/db/AssetIssueV2StoreTest.java
+++ b/framework/src/test/java/org/tron/core/db/AssetIssueV2StoreTest.java
@@ -16,10 +16,9 @@ import org.tron.protos.contract.AssetIssueContractOuterClass;
 public class AssetIssueV2StoreTest extends BaseTest {
 
   static {
-    dbPath = "db_AssetIssueV2StoreTest_test";
     Args.setParam(
           new String[]{
-              "--output-directory", dbPath,
+              "--output-directory", dbPath(),
           },
           Constant.TEST_CONF
     );

--- a/framework/src/test/java/org/tron/core/db/ContractStoreTest.java
+++ b/framework/src/test/java/org/tron/core/db/ContractStoreTest.java
@@ -22,10 +22,9 @@ public class ContractStoreTest extends BaseTest {
   private static String OWNER_ADDRESS;
 
   static {
-    dbPath = "db_ContractStoreTest_test";
     Args.setParam(
             new String[]{
-                "--output-directory", dbPath,
+                "--output-directory", dbPath(),
             },
             Constant.TEST_CONF
     );

--- a/framework/src/test/java/org/tron/core/db/DelegatedResourceStoreTest.java
+++ b/framework/src/test/java/org/tron/core/db/DelegatedResourceStoreTest.java
@@ -23,10 +23,9 @@ public class DelegatedResourceStoreTest extends BaseTest {
   private DelegatedResourceStore delegatedResourceStore;
 
   static {
-    dbPath = "db_DelegatedResourceStore_test";
     Args.setParam(
             new String[]{
-                "--output-directory", dbPath,
+                "--output-directory", dbPath(),
             },
             Constant.TEST_CONF
     );

--- a/framework/src/test/java/org/tron/core/db/DelegationStoreTest.java
+++ b/framework/src/test/java/org/tron/core/db/DelegationStoreTest.java
@@ -23,10 +23,9 @@ public class DelegationStoreTest extends BaseTest {
   private DelegationStore delegationStore;
 
   static {
-    dbPath = "db_DelegationStore_test";
     Args.setParam(
             new String[]{
-                "--output-directory", dbPath,
+                "--output-directory", dbPath(),
             },
             Constant.TEST_CONF
     );

--- a/framework/src/test/java/org/tron/core/db/WitnessScheduleStoreTest.java
+++ b/framework/src/test/java/org/tron/core/db/WitnessScheduleStoreTest.java
@@ -31,8 +31,7 @@ public class WitnessScheduleStoreTest extends BaseTest {
 
 
   static {
-    dbPath = "output-WitnessScheduleStore-test";
-    Args.setParam(new String[]{"-d", dbPath}, Constant.TEST_CONF);
+    Args.setParam(new String[]{"-d", dbPath()}, Constant.TEST_CONF);
   }
 
   @Before


### PR DESCRIPTION
**What does this PR do?**
fix test case database output path
<img width="721" alt="image" src="https://github.com/tronprotocol/java-tron/assets/82020050/1ad4ef8f-d87a-44b0-bf24-67bba26c66dd">

Detail in : https://buildkite.com/tronprotocol/build-on-debian-9-dot-8/builds/5156#018aa841-449d-4660-9754-50887765153f

**Why are these changes required?**
Specifying the temporary file path with `TemporaryFolder` ensures that the database files generated temporarily will be deleted regardless of whether the test case execution is successful or not.

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

