### PR TITLE
fix(api): optimize API call compatibility

### DIFF
--- a/framework/src/main/java/org/tron/core/services/http/Util.java
+++ b/framework/src/main/java/org/tron/core/services/http/Util.java
@@ -613,6 +613,9 @@ public class Util {
   }
 
   public static String getJsonString(String str) {
+    if (isValidJson(str)) {
+      return str;
+    }
     if (StringUtils.isEmpty(str)) {
       return EMPTY;
     }
@@ -631,4 +634,12 @@ public class Util {
     return json.toString();
   }
 
+  public static boolean isValidJson(String json) {
+    try {
+      JSON.parse(json);
+      return true;
+    } catch (Exception e) {
+      return false;
+    }
+  }
 }


### PR DESCRIPTION
**What does this PR do?**
When calling the HTTP interface through curl, if the contentType is not specified, its default value is "application/x-www form urlencoded". for example:
`curl - X POST ' http://localhost:8090/wallet/getblockbynum '-- data' {"num": 0} '
`
In this case, JSON format data should not be passed in. However, to ensure compatibility with historical interface calls, calling through JSON format is now supported in this case.

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

