### PR TITLE
feat(LiteFullNodeTool): mark LiteFullNodeTool as deprecated

### DIFF
--- a/framework/src/main/java/org/tron/tool/litefullnode/LiteFullNodeTool.java
+++ b/framework/src/main/java/org/tron/tool/litefullnode/LiteFullNodeTool.java
@@ -528,8 +528,6 @@ public class LiteFullNodeTool {
   }
 
   private void run(Args argv) {
-    logger.info("LiteFullNodeTool is deprecated and it will be removed in the next major release,"
-            + " use Toolkit.jar db lite instead, parameters are fully compatible.");
     if (StringUtils.isBlank(argv.fnDataPath) || StringUtils.isBlank(argv.datasetPath)) {
       throw new ParameterException("fnDataPath or datasetPath can't be null");
     }
@@ -559,6 +557,8 @@ public class LiteFullNodeTool {
    * main.
    */
   public static void main(String[] args) {
+    logger.info("LiteFullNodeTool is deprecated and it will be removed in the next major release,"
+            + " use Toolkit.jar db lite instead, parameters are fully compatible.");
     Args argv = new Args();
     CommonParameter.getInstance().setValidContractProtoThreadNum(1);
     LiteFullNodeTool tool = new LiteFullNodeTool();

--- a/framework/src/main/java/org/tron/tool/litefullnode/LiteFullNodeTool.java
+++ b/framework/src/main/java/org/tron/tool/litefullnode/LiteFullNodeTool.java
@@ -39,6 +39,7 @@ import org.tron.tool.litefullnode.db.DBInterface;
 import org.tron.tool.litefullnode.iterator.DBIterator;
 
 @Slf4j(topic = "tool")
+@Deprecated
 public class LiteFullNodeTool {
 
   private static final long START_TIME = System.currentTimeMillis() / 1000;
@@ -527,6 +528,8 @@ public class LiteFullNodeTool {
   }
 
   private void run(Args argv) {
+    logger.info("LiteFullNodeTool is an obsolete tool and is not recommended"
+            + " to be used any more, please use the tool DbLite.");
     if (StringUtils.isBlank(argv.fnDataPath) || StringUtils.isBlank(argv.datasetPath)) {
       throw new ParameterException("fnDataPath or datasetPath can't be null");
     }

--- a/framework/src/main/java/org/tron/tool/litefullnode/LiteFullNodeTool.java
+++ b/framework/src/main/java/org/tron/tool/litefullnode/LiteFullNodeTool.java
@@ -528,8 +528,8 @@ public class LiteFullNodeTool {
   }
 
   private void run(Args argv) {
-    logger.info("LiteFullNodeTool is an obsolete tool and is not recommended"
-            + " to be used any more, please use the tool DbLite.");
+    logger.info("LiteFullNodeTool is deprecated and it will be removed in the next major release,"
+            + " use Toolkit.jar db lite instead, parameters are fully compatible.");
     if (StringUtils.isBlank(argv.fnDataPath) || StringUtils.isBlank(argv.datasetPath)) {
       throw new ParameterException("fnDataPath or datasetPath can't be null");
     }

--- a/framework/src/test/java/org/tron/program/LiteFullNodeToolTest.java
+++ b/framework/src/test/java/org/tron/program/LiteFullNodeToolTest.java
@@ -24,6 +24,7 @@ import org.tron.core.services.interfaceOnSolidity.RpcApiServiceOnSolidity;
 import org.tron.tool.litefullnode.LiteFullNodeTool;
 
 @Slf4j
+@Deprecated
 public class LiteFullNodeToolTest {
 
   private TronApplicationContext context;


### PR DESCRIPTION
**What does this PR do?**
1. mark `LiteFullNodeTool` status as obsolete
2. mark `LiteFullNodeToolTest` as obsolete.

**Why are these changes required?**
to improve test case execution efficiency and shorten test case execution time.

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

