### PR TITLE
test(db): fix org.iq80.leveldb.DBException: Closed

### DIFF
--- a/framework/src/test/java/org/tron/common/BaseTest.java
+++ b/framework/src/test/java/org/tron/common/BaseTest.java
@@ -2,6 +2,7 @@ package org.tron.common;
 
 import com.google.protobuf.ByteString;
 import java.io.IOException;
+import javax.annotation.PostConstruct;
 import javax.annotation.Resource;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.AfterClass;
@@ -12,6 +13,7 @@ import org.junit.runner.RunWith;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.tron.common.application.Application;
 import org.tron.common.crypto.ECKey;
 import org.tron.common.parameter.CommonParameter;
 import org.tron.common.utils.Sha256Hash;
@@ -37,6 +39,16 @@ public abstract class BaseTest {
   @Resource
   protected ChainBaseManager chainBaseManager;
 
+  @Resource
+  protected Application appT;
+
+  private static Application appT1;
+
+
+  @PostConstruct
+  private void prepare() {
+    appT1 = appT;
+  }
 
   public static String dbPath() {
     try {
@@ -49,6 +61,7 @@ public abstract class BaseTest {
 
   @AfterClass
   public static void destroy() {
+    appT1.shutdown();
     Args.clearParam();
   }
 

--- a/framework/src/test/java/org/tron/core/db/NullifierStoreTest.java
+++ b/framework/src/test/java/org/tron/core/db/NullifierStoreTest.java
@@ -7,7 +7,6 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.tron.common.BaseTest;
-import org.tron.common.application.Application;
 import org.tron.core.Constant;
 import org.tron.core.Wallet;
 import org.tron.core.capsule.BytesCapsule;
@@ -20,8 +19,6 @@ public class NullifierStoreTest extends BaseTest {
   private static final byte[] NULLIFIER_TWO = randomBytes(32);
   private static final byte[] TRX_TWO = randomBytes(32);
   private static final byte[] TRX_TWO_NEW = randomBytes(32);
-  @Resource
-  public Application AppT;
   @Resource
   private NullifierStore nullifierStore;
   private static BytesCapsule nullifier1;

--- a/framework/src/test/java/org/tron/core/db/TxCacheDBTest.java
+++ b/framework/src/test/java/org/tron/core/db/TxCacheDBTest.java
@@ -1,11 +1,9 @@
 package org.tron.core.db;
 
-import javax.annotation.Resource;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.tron.common.BaseTest;
-import org.tron.common.application.Application;
 import org.tron.common.utils.ByteArray;
 import org.tron.core.Constant;
 import org.tron.core.capsule.BytesCapsule;
@@ -13,8 +11,6 @@ import org.tron.core.config.args.Args;
 import org.tron.keystore.Wallet;
 
 public class TxCacheDBTest extends BaseTest {
-  @Resource
-  private Application appT;
 
   /**
    * Init data.

--- a/framework/src/test/java/org/tron/core/services/filter/HttpApiAccessFilterTest.java
+++ b/framework/src/test/java/org/tron/core/services/filter/HttpApiAccessFilterTest.java
@@ -17,7 +17,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.tron.common.BaseTest;
-import org.tron.common.application.Application;
 import org.tron.common.parameter.CommonParameter;
 import org.tron.core.Constant;
 import org.tron.core.config.args.Args;
@@ -27,8 +26,6 @@ import org.tron.core.services.interfaceOnSolidity.http.solidity.HttpApiOnSolidit
 
 public class HttpApiAccessFilterTest extends BaseTest {
 
-  @Resource
-  private Application appTest;
   @Resource
   private FullNodeHttpApiService httpApiService;
   @Resource
@@ -49,10 +46,10 @@ public class HttpApiAccessFilterTest extends BaseTest {
    */
   @Before
   public void init() {
-    appTest.addService(httpApiService);
-    appTest.addService(httpApiOnSolidityService);
-    appTest.addService(httpApiOnPBFTService);
-    appTest.startup();
+    appT.addService(httpApiService);
+    appT.addService(httpApiOnSolidityService);
+    appT.addService(httpApiOnPBFTService);
+    appT.startup();
   }
 
   @Test

--- a/framework/src/test/java/org/tron/core/services/filter/LiteFnQueryHttpFilterTest.java
+++ b/framework/src/test/java/org/tron/core/services/filter/LiteFnQueryHttpFilterTest.java
@@ -19,7 +19,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.tron.common.BaseTest;
-import org.tron.common.application.Application;
 import org.tron.core.Constant;
 import org.tron.core.config.args.Args;
 import org.tron.core.services.http.FullNodeHttpApiService;
@@ -31,8 +30,6 @@ public class LiteFnQueryHttpFilterTest extends BaseTest {
 
   private final String ip = "127.0.0.1";
   private int fullHttpPort;
-  @Resource
-  private Application appTest;
   @Resource
   private FullNodeHttpApiService httpApiService;
   @Resource
@@ -51,10 +48,10 @@ public class LiteFnQueryHttpFilterTest extends BaseTest {
    */
   @Before
   public void init() {
-    appTest.addService(httpApiService);
-    appTest.addService(httpApiOnSolidityService);
-    appTest.addService(httpApiOnPBFTService);
-    appTest.startup();
+    appT.addService(httpApiService);
+    appT.addService(httpApiOnSolidityService);
+    appT.addService(httpApiOnPBFTService);
+    appT.startup();
   }
 
   @Test

--- a/framework/src/test/java/org/tron/core/services/http/TriggerSmartContractServletTest.java
+++ b/framework/src/test/java/org/tron/core/services/http/TriggerSmartContractServletTest.java
@@ -11,7 +11,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.tron.common.BaseTest;
-import org.tron.common.application.Application;
 import org.tron.common.utils.ByteArray;
 import org.tron.common.utils.client.Configuration;
 import org.tron.common.utils.client.utils.HttpMethed;
@@ -35,8 +34,6 @@ public class TriggerSmartContractServletTest extends BaseTest {
 
   @Resource
   private FullNodeHttpApiService httpApiService;
-  @Resource
-  private Application appT;
 
   @BeforeClass
   public static void init() throws Exception {

--- a/framework/src/test/java/org/tron/program/SupplementTest.java
+++ b/framework/src/test/java/org/tron/program/SupplementTest.java
@@ -9,15 +9,10 @@ import java.io.IOException;
 import java.math.BigInteger;
 import javax.annotation.Resource;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.tron.common.BaseTest;
 import org.tron.common.config.DbBackupConfig;
 import org.tron.common.entity.PeerInfo;
 import org.tron.common.utils.CompactEncoder;
@@ -26,19 +21,13 @@ import org.tron.common.utils.Value;
 import org.tron.core.Constant;
 import org.tron.core.capsule.StorageRowCapsule;
 import org.tron.core.capsule.utils.RLP;
-import org.tron.core.config.DefaultConfig;
 import org.tron.core.config.args.Args;
 import org.tron.core.services.http.HttpSelfFormatFieldName;
 import org.tron.core.store.StorageRowStore;
 import org.tron.keystore.WalletUtils;
 
-@RunWith(SpringJUnit4ClassRunner.class)
-@DirtiesContext
-@ContextConfiguration(classes = {DefaultConfig.class})
-public class SupplementTest {
+public class SupplementTest extends BaseTest {
 
-  @ClassRule
-  public static final TemporaryFolder temporaryFolder = new TemporaryFolder();
   private static String dbPath;
 
   @Resource
@@ -49,7 +38,7 @@ public class SupplementTest {
 
   @BeforeClass
   public static void init() throws IOException {
-    dbPath = temporaryFolder.newFolder().toString();
+    dbPath = dbPath();
     Args.setParam(new String[]{"--output-directory", dbPath, "--debug"}, Constant.TEST_CONF);
   }
 


### PR DESCRIPTION
# Error Log
```
16:54:20.835 INFO [DB] ******** Begin to close SectionBloomStore. ********
16:54:20.836 INFO [DB] ******** End to close SectionBloomStore. ********
16:54:20.836 INFO [DB] ******** Begin to close TreeBlockIndexStore. ********
16:54:20.836 INFO [DB] ******** End to close TreeBlockIndexStore. ********
16:54:20.836 INFO [DB] ******** Begin to close PbftSignDataStore. ********
16:54:20.836 INFO [DB] ******** End to close PbftSignDataStore. ********
16:54:20.836 INFO [DB] ******** Begin to close CommonDataBase. ********
16:54:20.836 INFO [DB] ******** End to close CommonDataBase. ********
16:54:20.836 INFO [DB] ******** Begin to close TransactionHistoryStore. ********
16:54:20.837 INFO [DB] ******** End to close TransactionHistoryStore. ********
16:54:20.837 INFO [DB] ******** Begin to close RecentBlockStore. ********
16:54:20.838 INFO [DB] ******** End to close RecentBlockStore. ********
16:54:20.838 INFO [DB] ******** Begin to close TransactionRetStore. ********
16:54:20.838 INFO [DB] ******** End to close TransactionRetStore. ********
16:54:20.838 INFO [DB] ******** Begin to close TransactionStore. ********
16:54:20.838 INFO [DB] ******** End to close TransactionStore. ********
16:54:20.838 INFO [DB] ******** Begin to close CommonStore. ********
16:54:20.838 INFO [DB] ******** End to close CommonStore. ********
16:54:20.838 INFO [DB] ******** Begin to close IncrementalMerkleTreeStore. ********
16:54:20.838 INFO [DB] ******** End to close IncrementalMerkleTreeStore. ********
16:54:20.839 INFO [DB] ******** Begin to close ZKProofStore. ********
16:54:20.840 INFO [DB] ******** End to close ZKProofStore. ********
16:54:20.840 INFO [DB] ******** Begin to close NullifierStore. ********
16:54:20.840 INFO [DB] ******** End to close NullifierStore. ********
16:54:20.840 INFO [DB] ******** Begin to close StorageRowStore. ********
16:54:20.840 INFO [DB] ******** End to close StorageRowStore. ********
16:54:20.841 INFO [DB] ******** Begin to close DelegatedResourceAccountIndexStore. ********
16:54:20.842 INFO [DB] ******** End to close DelegatedResourceAccountIndexStore. ********
16:54:20.842 INFO [DB] ******** Begin to close DelegatedResourceStore. ********
16:54:20.842 INFO [DB] ******** End to close DelegatedResourceStore. ********
16:54:20.842 INFO [DB] ******** Begin to close ContractStateStore. ********
16:54:20.842 INFO [DB] ******** End to close ContractStateStore. ********
16:54:20.842 INFO [DB] ******** Begin to close ContractStore. ********
16:54:20.844 INFO [DB] ******** End to close ContractStore. ********
16:54:20.844 INFO [DB] ******** Begin to close CodeStore. ********
16:54:20.844 INFO [DB] ******** End to close CodeStore. ********
16:54:20.844 INFO [DB] ******** Begin to close AbiStore. ********
16:54:20.844 INFO [DB] ******** End to close AbiStore. ********
16:54:20.844 INFO [DB] ******** Begin to close MarketPairToPriceStore. ********
16:54:20.845 INFO [DB] ******** End to close MarketPairToPriceStore. ********
16:54:20.845 INFO [DB] ******** Begin to close MarketPairPriceToOrderStore. ********
16:54:20.846 INFO [DB] ******** End to close MarketPairPriceToOrderStore. ********
16:54:20.846 INFO [DB] ******** Begin to close MarketOrderStore. ********
16:54:20.846 INFO [DB] ******** End to close MarketOrderStore. ********
16:54:20.846 INFO [DB] ******** Begin to close MarketAccountStore. ********
16:54:20.846 INFO [DB] ******** End to close MarketAccountStore. ********
16:54:20.846 INFO [DB] ******** Begin to close ExchangeV2Store. ********
16:54:20.846 INFO [DB] ******** End to close ExchangeV2Store. ********
16:54:20.846 INFO [DB] ******** Begin to close ExchangeStore. ********
16:54:20.846 INFO [DB] ******** End to close ExchangeStore. ********
16:54:20.846 INFO [DB] ******** Begin to close ProposalStore. ********
16:54:20.846 INFO [DB] ******** End to close ProposalStore. ********
16:54:20.846 INFO [DB] ******** Begin to close AccountIndexStore. ********
16:54:20.846 INFO [DB] ******** End to close AccountIndexStore. ********
16:54:20.847 INFO [DB] ******** Begin to close AccountIdIndexStore. ********
16:54:20.847 INFO [DB] ******** End to close AccountIdIndexStore. ********
16:54:20.847 INFO [DB] ******** Begin to close BlockIndexStore. ********
16:54:20.847 INFO [DB] ******** End to close BlockIndexStore. ********
16:54:20.847 INFO [DB] ******** Begin to close AssetIssueV2Store. ********
16:54:20.847 INFO [DB] ******** End to close AssetIssueV2Store. ********
16:54:20.847 INFO [DB] ******** Begin to close AssetIssueStore. ********
16:54:20.847 INFO [DB] ******** End to close AssetIssueStore. ********
16:54:20.847 INFO [DB] ******** Begin to close BlockStore. ********
16:54:20.847 INFO [DB] ******** End to close BlockStore. ********
16:54:20.847 INFO [DB] ******** Begin to close AccountAssetStore. ********
16:54:20.847 INFO [DB] ******** End to close AccountAssetStore. ********
16:54:20.848 INFO [DB] ******** Begin to close VotesStore. ********
16:54:20.848 INFO [DB] ******** End to close VotesStore. ********
16:54:20.848 INFO [DB] ******** Begin to close WitnessScheduleStore. ********
16:54:20.849 INFO [DB] ******** End to close WitnessScheduleStore. ********
16:54:20.849 INFO [DB] ******** Begin to close WitnessStore. ********
16:54:20.850 INFO [DB] ******** End to close WitnessStore. ********
16:54:20.850 INFO [DB] ******** Begin to close AccountStore. ********
16:54:20.854 INFO [DB] ******** End to close AccountStore. ********
16:54:20.860 INFO [DB] ******** Begin to close AccountTraceStore. ********
16:54:20.861 INFO [DB] ******** End to close AccountTraceStore. ********
16:54:20.862 INFO [DB] ******** Begin to close BalanceTraceStore. ********
16:54:20.862 INFO [DB] ******** End to close BalanceTraceStore. ********
16:54:20.862 INFO [DB] ******** Begin to close DelegationStore. ********
16:54:20.862 INFO [DB] ******** End to close DelegationStore. ********
16:54:20.862 INFO [DB] ******** Begin to close AccountStateStoreTrie. ********
16:54:20.862 INFO [DB] ******** End to close AccountStateStoreTrie. ********
16:54:20.862 INFO [DB] ******** Begin to close KhaosDatabase. ********
16:54:20.862 INFO [DB] ******** End to close KhaosDatabase. ********
16:54:20.862 INFO [DB] ******** Begin to close TransactionCache. ********
16:54:20.862 INFO [DB] dump bloomFilters start.
16:54:20.865 INFO [DB] dump bloomFilters[0] to file.
16:54:20.865 INFO [DB] dump bloomFilters[1] to file.
16:54:21.029 ERROR [consensus] Produce block error.
org.iq80.leveldb.DBException: Closed
	at org.fusesource.leveldbjni.internal.JniDB.get(JniDB.java:75)
	at org.tron.common.storage.leveldb.LevelDbDataSourceImpl.getData(LevelDbDataSourceImpl.java:201)
	at org.tron.core.db2.common.LevelDB.get(LevelDB.java:25)
	at org.tron.core.db2.common.LevelDB.get(LevelDB.java:12)
	at org.tron.core.db2.core.SnapshotRoot.get(SnapshotRoot.java:55)
	at org.tron.core.db2.core.Chainbase.getUnchecked(Chainbase.java:153)
	at org.tron.core.db.TronStoreWithRevoking.getUnchecked(TronStoreWithRevoking.java:125)
	at org.tron.core.store.WitnessScheduleStore.getData(WitnessScheduleStore.java:43)
	at org.tron.core.store.WitnessScheduleStore.getActiveWitnesses(WitnessScheduleStore.java:64)
	at org.tron.consensus.ConsensusDelegate.getActiveWitnesses(ConsensusDelegate.java:88)
	at org.tron.consensus.dpos.DposSlot.getScheduledWitness(DposSlot.java:57)
	at org.tron.consensus.dpos.DposTask.produceBlock(DposTask.java:99)
	at org.tron.consensus.dpos.DposTask.lambda$init$0(DposTask.java:61)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:750)
```
# How To Fix
  @ContextConfiguration in spring-test,  instead of using the TronApplicationContext, a testContxt is generated, which would cause the database to close first. 

```java
     @AfterClass
     public static void destroy() {
       appT1.shutdown(); // shutdown service first.
       Args.clearParam();
    }
```
