### PR TITLE
synchronization of sending to zeromq

### DIFF
--- a/framework/src/main/java/org/tron/common/logsfilter/nativequeue/NativeMessageQueue.java
+++ b/framework/src/main/java/org/tron/common/logsfilter/nativequeue/NativeMessageQueue.java
@@ -64,8 +64,10 @@ public class NativeMessageQueue {
     }
 
     try {
-      publisher.sendMore(topic);
-      publisher.send(data);
+      synchronized (this) {
+        publisher.sendMore(topic);
+        publisher.send(data);
+      }
     } catch (RuntimeException e) {
       logger.error("write data to zeromq failed, data:{}, topic:{}, error:{}", data, topic,
           e.getMessage());


### PR DESCRIPTION
solution to the sending problem in NativeMessageQueue#publishTrigger "write data to zeromq failed, error: 256
#5535, passed manual testing

#### System information

OS : Linux
JVM : Red Hat, Inc. 1.8.0_382 amd64
Git : 9e95599de2a9d60f4e706d18d3b71ac8850a0c01
Version : 4.7.2
Code : 18031

#### Expected behaviour
I get an error when topics are enabled (my example transaction, solidityevent topics)

#### Actual behaviour

Error: "write data to zeromq failed, error: 256"


#### Steps to reproduce the behaviour

sync full node and enable native message queue for  transaction and solidityevent topics
run zeromq client, python example
```
socket.setsockopt(zmq.SUBSCRIBE, "".encode("utf-8"))
```


#### Backtrace

more logs have been added to the my code

````
18:33:20.419 ERROR [Thread-5] [o.t.c.l.n.NativeMessageQueue](NativeMessageQueue.java:80) write data to zeromq failed, data: *, topic:transactionTrigger, error:256
java.lang.ArrayIndexOutOfBoundsException: 256
        at zmq.pipe.YQueue.push(YQueue.java:84)
        at zmq.pipe.YPipe.write(YPipe.java:48)
        at zmq.pipe.Pipe.write(Pipe.java:289)
        at zmq.socket.pubsub.Dist.write(Dist.java:177)
        at zmq.socket.pubsub.Dist.distribute(Dist.java:162)
        at zmq.socket.pubsub.Dist.sendToMatching(Dist.java:138)
        at zmq.socket.pubsub.XPub.xsend(XPub.java:253)
        at zmq.SocketBase.send(SocketBase.java:828)
        at zmq.SocketBase.send(SocketBase.java:791)
        at org.zeromq.ZMQ$Socket.send(ZMQ.java:3325)
        at org.zeromq.ZMQ$Socket.send(ZMQ.java:3239)
        at org.tron.common.logsfilter.nativequeue.NativeMessageQueue.publishTrigger(NativeMessageQueue.java:75)
        at org.tron.common.logsfilter.EventPluginLoader.postTransactionTrigger(EventPluginLoader.java:497)
        at org.tron.common.logsfilter.capsule.TransactionLogTriggerCapsule.processTrigger(TransactionLogTriggerCapsule.java:270)
        at org.tron.core.db.Manager.lambda$new$1(Manager.java:293)
        at java.lang.Thread.run(Thread.java:750)

18:33:20.419 ERROR [pool-48-thread-1] [o.t.c.l.n.NativeMessageQueue](NativeMessageQueue.java:80) write data to zeromq failed, data: *, topic:solidityEventTrigger, error:256
java.lang.ArrayIndexOutOfBoundsException: 256
        at zmq.pipe.YQueue.push(YQueue.java:84)
        at zmq.pipe.YPipe.write(YPipe.java:48)
        at zmq.pipe.Pipe.write(Pipe.java:289)
        at zmq.socket.pubsub.Dist.write(Dist.java:177)
        at zmq.socket.pubsub.Dist.distribute(Dist.java:162)
        at zmq.socket.pubsub.Dist.sendToMatching(Dist.java:138)
        at zmq.socket.pubsub.XPub.xsend(XPub.java:253)
        at zmq.SocketBase.send(SocketBase.java:828)
        at zmq.SocketBase.send(SocketBase.java:791)
        at org.zeromq.ZMQ$Socket.send(ZMQ.java:3325)
        at org.zeromq.ZMQ$Socket.send(ZMQ.java:3239)
        at org.tron.common.logsfilter.nativequeue.NativeMessageQueue.publishTrigger(NativeMessageQueue.java:75)
        at org.tron.common.logsfilter.EventPluginLoader.postSolidityEventTrigger(EventPluginLoader.java:487)
        at org.tron.core.db.Manager.postSolidityEventContractTrigger(Manager.java:1856)
        at org.tron.core.db.Manager.postSolidityTrigger(Manager.java:2060)
        at org.tron.core.db.Manager.pushBlock(Manager.java:1303)
        at org.tron.core.net.TronNetDelegate.processBlock(TronNetDelegate.java:260)
        at org.tron.core.net.service.sync.SyncService.processSyncBlock(SyncService.java:301)
        at org.tron.core.net.service.sync.SyncService.lambda$handleSyncBlock$9(SyncService.java:287)
        at java.util.concurrent.ConcurrentHashMap.forEach(ConcurrentHashMap.java:1597)
        at org.tron.core.net.service.sync.SyncService.handleSyncBlock(SyncService.java:266)
        at org.tron.core.net.service.sync.SyncService.lambda$init$1(SyncService.java:85)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:750)
````

