### PR TITLE
fix(api):rollback due to insufficient compatibility

### DIFF
--- a/framework/src/main/java/org/tron/core/services/http/GetAssetIssueListServlet.java
+++ b/framework/src/main/java/org/tron/core/services/http/GetAssetIssueListServlet.java
@@ -1,8 +1,5 @@
 package org.tron.core.services.http;
 
-import static org.tron.core.services.http.Util.existVisible;
-
-import java.io.IOException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
@@ -22,7 +19,12 @@ public class GetAssetIssueListServlet extends RateLimiterServlet {
   protected void doGet(HttpServletRequest request, HttpServletResponse response) {
     try {
       boolean visible = Util.getVisible(request);
-      response(response, visible);
+      AssetIssueList reply = wallet.getAssetIssueList();
+      if (reply != null) {
+        response.getWriter().println(JsonFormat.printToString(reply, visible));
+      } else {
+        response.getWriter().println("{}");
+      }
     } catch (Exception e) {
       Util.processError(e, response);
     }
@@ -30,24 +32,6 @@ public class GetAssetIssueListServlet extends RateLimiterServlet {
 
   @Override
   protected void doPost(HttpServletRequest request, HttpServletResponse response) {
-    try {
-      PostParams params = PostParams.getPostParams(request);
-      boolean visible = Util.getVisible(request);
-      if (!existVisible(request)) {
-        visible = params.isVisible();
-      }
-      response(response, visible);
-    } catch (Exception e) {
-      Util.processError(e, response);
-    }
-  }
-
-  private void response(HttpServletResponse response, boolean visible) throws IOException {
-    AssetIssueList reply = wallet.getAssetIssueList();
-    if (reply != null) {
-      response.getWriter().println(JsonFormat.printToString(reply, visible));
-    } else {
-      response.getWriter().println("{}");
-    }
+    doGet(request, response);
   }
 }

--- a/framework/src/main/java/org/tron/core/services/http/GetNowBlockServlet.java
+++ b/framework/src/main/java/org/tron/core/services/http/GetNowBlockServlet.java
@@ -1,9 +1,5 @@
 package org.tron.core.services.http;
 
-import static org.tron.core.services.http.Util.existVisible;
-import static org.tron.core.services.http.Util.getVisible;
-
-import java.io.IOException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
@@ -22,8 +18,13 @@ public class GetNowBlockServlet extends RateLimiterServlet {
   @Override
   protected void doGet(HttpServletRequest request, HttpServletResponse response) {
     try {
-      boolean visible = getVisible(request);
-      response(response, visible);
+      boolean visible = Util.getVisible(request);
+      Block reply = wallet.getNowBlock();
+      if (reply != null) {
+        response.getWriter().println(Util.printBlock(reply, visible));
+      } else {
+        response.getWriter().println("{}");
+      }
     } catch (Exception e) {
       Util.processError(e, response);
     }
@@ -31,24 +32,6 @@ public class GetNowBlockServlet extends RateLimiterServlet {
 
   @Override
   protected void doPost(HttpServletRequest request, HttpServletResponse response) {
-    try {
-      PostParams params = PostParams.getPostParams(request);
-      boolean visible = getVisible(request);
-      if (!existVisible(request)) {
-        visible = params.isVisible();
-      }
-      response(response, visible);
-    } catch (Exception e) {
-      Util.processError(e, response);
-    }
-  }
-
-  private void response(HttpServletResponse response, boolean visible) throws IOException {
-    Block reply = wallet.getNowBlock();
-    if (reply != null) {
-      response.getWriter().println(Util.printBlock(reply, visible));
-    } else {
-      response.getWriter().println("{}");
-    }
+    doGet(request, response);
   }
 }

--- a/framework/src/main/java/org/tron/core/services/http/ListNodesServlet.java
+++ b/framework/src/main/java/org/tron/core/services/http/ListNodesServlet.java
@@ -1,8 +1,5 @@
 package org.tron.core.services.http;
 
-import static org.tron.core.services.http.Util.existVisible;
-
-import java.io.IOException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
@@ -22,7 +19,12 @@ public class ListNodesServlet extends RateLimiterServlet {
   protected void doGet(HttpServletRequest request, HttpServletResponse response) {
     try {
       boolean visible = Util.getVisible(request);
-      response(response, visible);
+      NodeList reply = wallet.listNodes();
+      if (reply != null) {
+        response.getWriter().println(JsonFormat.printToString(reply, visible));
+      } else {
+        response.getWriter().println("{}");
+      }
     } catch (Exception e) {
       Util.processError(e, response);
     }
@@ -30,24 +32,6 @@ public class ListNodesServlet extends RateLimiterServlet {
 
   @Override
   protected void doPost(HttpServletRequest request, HttpServletResponse response) {
-    try {
-      PostParams params = PostParams.getPostParams(request);
-      boolean visible = Util.getVisible(request);
-      if (!existVisible(request)) {
-        visible = params.isVisible();
-      }
-      response(response, visible);
-    } catch (Exception e) {
-      Util.processError(e, response);
-    }
-  }
-
-  private void response(HttpServletResponse response, boolean visible) throws IOException {
-    NodeList reply = wallet.listNodes();
-    if (reply != null) {
-      response.getWriter().println(JsonFormat.printToString(reply, visible));
-    } else {
-      response.getWriter().println("{}");
-    }
+    doGet(request, response);
   }
 }

--- a/framework/src/main/java/org/tron/core/services/http/ListProposalsServlet.java
+++ b/framework/src/main/java/org/tron/core/services/http/ListProposalsServlet.java
@@ -1,8 +1,5 @@
 package org.tron.core.services.http;
 
-import static org.tron.core.services.http.Util.existVisible;
-
-import java.io.IOException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
@@ -22,7 +19,12 @@ public class ListProposalsServlet extends RateLimiterServlet {
   protected void doGet(HttpServletRequest request, HttpServletResponse response) {
     try {
       boolean visible = Util.getVisible(request);
-      response(response, visible);
+      ProposalList reply = wallet.getProposalList();
+      if (reply != null) {
+        response.getWriter().println(JsonFormat.printToString(reply, visible));
+      } else {
+        response.getWriter().println("{}");
+      }
     } catch (Exception e) {
       Util.processError(e, response);
     }
@@ -30,24 +32,6 @@ public class ListProposalsServlet extends RateLimiterServlet {
 
   @Override
   protected void doPost(HttpServletRequest request, HttpServletResponse response) {
-    try {
-      PostParams params = PostParams.getPostParams(request);
-      boolean visible = Util.getVisible(request);
-      if (!existVisible(request)) {
-        visible = params.isVisible();
-      }
-      response(response, visible);
-    } catch (Exception e) {
-      Util.processError(e, response);
-    }
-  }
-
-  private void response(HttpServletResponse response, boolean visible) throws IOException {
-    ProposalList reply = wallet.getProposalList();
-    if (reply != null) {
-      response.getWriter().println(JsonFormat.printToString(reply, visible));
-    } else {
-      response.getWriter().println("{}");
-    }
+    doGet(request, response);
   }
 }


### PR DESCRIPTION
**What does this PR do?**
rollback to previous version due to insufficient compatibility,in the history of this interface, its post method directly called the get method. At this time, if parameters in JSON format are passed in, the post method will not be able to handle the input parameters correctly. However, if the post method is optimized to handle the input parameters correctly, continuing to call the interface in the previous way will result in inconsistent return results. Therefore, in order to maintain compatibility, the optimization of this interface has been rolled back.

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

