### PR TITLE
feat(db/trans-cache): add switch for transaction cache initialization optimization

### DIFF
--- a/common/src/main/java/org/tron/core/config/args/Storage.java
+++ b/common/src/main/java/org/tron/core/config/args/Storage.java
@@ -77,6 +77,7 @@ public class Storage {
   private static final String CHECKPOINT_SYNC_KEY = "storage.checkpoint.sync";
 
   private static final String CACHE_STRATEGIES = "storage.cache.strategies";
+  public static final String TX_CACHE_INIT_OPTIMIZATION = "storage.txCache.initOptimization";
 
   /**
    * Default values of directory
@@ -144,6 +145,10 @@ public class Storage {
   @Getter
   @Setter
   private int estimatedBlockTransactions;
+
+  @Getter
+  @Setter
+  private boolean txCacheInitOptimization = false;
 
   // second cache
   private final Map<CacheType, String> cacheStrategies = Maps.newConcurrentMap();
@@ -233,6 +238,11 @@ public class Storage {
       estimatedTransactions = 100;
     }
     return estimatedTransactions;
+  }
+
+  public static boolean getTxCacheInitOptimizationFromConfig(final Config config) {
+    return config.hasPath(TX_CACHE_INIT_OPTIMIZATION)
+        && config.getBoolean(TX_CACHE_INIT_OPTIMIZATION);
   }
 
 

--- a/framework/src/main/java/org/tron/core/config/args/Args.java
+++ b/framework/src/main/java/org/tron/core/config/args/Args.java
@@ -520,6 +520,8 @@ public class Args extends CommonParameter {
 
     PARAMETER.storage.setEstimatedBlockTransactions(
         Storage.getEstimatedTransactionsFromConfig(config));
+    PARAMETER.storage.setTxCacheInitOptimization(
+        Storage.getTxCacheInitOptimizationFromConfig(config));
     PARAMETER.storage.setMaxFlushCount(Storage.getSnapshotMaxFlushCountFromConfig(config));
 
     PARAMETER.storage.setDefaultDbOptions(config);

--- a/framework/src/main/resources/config.conf
+++ b/framework/src/main/resources/config.conf
@@ -95,6 +95,8 @@ storage {
   # the estimated number of block transactions (default 1000, min 100, max 10000).
   # so the total number of cached transactions is 65536 * txCache.estimatedTransactions
   # txCache.estimatedTransactions = 1000
+  # if true, transaction cache initialization will be faster. default false
+  # txCache.initOptimization = true
 }
 
 node.discovery = {

--- a/framework/src/test/resources/config-test.conf
+++ b/framework/src/test/resources/config-test.conf
@@ -66,6 +66,8 @@ storage {
   # the estimated number of block transactions (default 1000, min 100, max 10000).
   # so the total number of cached transactions is 65536 * txCache.estimatedTransactions
   txCache.estimatedTransactions = 50
+  # if true, transaction cache initialization will be faster. default false
+  txCache.initOptimization = true
 
 }
 


### PR DESCRIPTION
config.conf
```  
  # if true, transaction cache initialization will be faster. default false
  # storage.txCache.initOptimization = true
```