### PR TITLE
feat(db): optimize calculation services for reward when the node starts

### DIFF
--- a/chainbase/src/main/java/org/tron/core/service/RewardViCalService.java
+++ b/chainbase/src/main/java/org/tron/core/service/RewardViCalService.java
@@ -176,7 +176,7 @@ public class RewardViCalService {
 
     Sha256Hash rewardViRootLocal = MerkleTree.getInstance().createTree(ids).getRoot().getHash();
     if (!Objects.equals(rewardViRoot, rewardViRootLocal)) {
-      logger.error("merkle root mismatch, expect: {}, actual: {}",
+      logger.warn("merkle root mismatch, expect: {}, actual: {}",
           rewardViRoot, rewardViRootLocal);
     }
     logger.info("calcMerkleRoot: {}", rewardViRootLocal);

--- a/chainbase/src/main/java/org/tron/core/service/RewardViCalService.java
+++ b/chainbase/src/main/java/org/tron/core/service/RewardViCalService.java
@@ -17,7 +17,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
-import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -75,8 +74,14 @@ public class RewardViCalService {
     this.witnessStore = witnessStore.getDb();
   }
 
-  @PostConstruct
-  private void init() {
+  public void init() {
+    // after init, we can get the latest block header number from db
+    this.newRewardCalStartCycle = this.getNewRewardAlgorithmEffectiveCycle();
+    boolean ret = this.newRewardCalStartCycle != Long.MAX_VALUE;
+    if (ret) {
+      // checkpoint is flushed to db, we can start rewardViCalService immediately
+      lastBlockNumber = Long.MAX_VALUE;
+    }
     es.scheduleWithFixedDelay(this::maybeRun, 0, 3, TimeUnit.SECONDS);
   }
 
@@ -100,7 +105,8 @@ public class RewardViCalService {
           this.clearUp(true);
           logger.info("rewardViCalService is already done");
         } else {
-          if (this.getLatestBlockHeaderNumber() > lastBlockNumber) {
+          if (lastBlockNumber ==  Long.MAX_VALUE // start rewardViCalService immediately
+              || this.getLatestBlockHeaderNumber() > lastBlockNumber) {
             // checkpoint is flushed to db, so we can start rewardViCalService
             startRewardCal();
             clearUp(true);

--- a/framework/src/main/java/org/tron/core/db/Manager.java
+++ b/framework/src/main/java/org/tron/core/db/Manager.java
@@ -130,6 +130,7 @@ import org.tron.core.exception.ZksnarkException;
 import org.tron.core.metrics.MetricsKey;
 import org.tron.core.metrics.MetricsUtil;
 import org.tron.core.service.MortgageService;
+import org.tron.core.service.RewardViCalService;
 import org.tron.core.store.AccountAssetStore;
 import org.tron.core.store.AccountIdIndexStore;
 import org.tron.core.store.AccountIndexStore;
@@ -259,6 +260,9 @@ public class Manager {
   private static final String triggerEsName = "event-trigger";
   private ExecutorService filterEs;
   private static final String filterEsName = "filter";
+
+  @Autowired
+  private RewardViCalService rewardViCalService;
 
   /**
    * Cycle thread to rePush Transactions
@@ -465,6 +469,7 @@ public class Manager {
     revokingStore.disable();
     revokingStore.check();
     transactionCache.initCache();
+    rewardViCalService.init();
     this.setProposalController(ProposalController.createInstance(this));
     this.setMerkleContainer(
         merkleContainer.createInstance(chainBaseManager.getMerkleTreeStore(),

--- a/framework/src/test/java/org/tron/core/services/ComputeRewardTest.java
+++ b/framework/src/test/java/org/tron/core/services/ComputeRewardTest.java
@@ -22,7 +22,6 @@ import org.tron.common.application.TronApplicationContext;
 import org.tron.common.error.TronDBException;
 import org.tron.common.es.ExecutorServiceManager;
 import org.tron.common.utils.ByteArray;
-import org.tron.common.utils.Sha256Hash;
 import org.tron.core.Constant;
 import org.tron.core.capsule.AccountCapsule;
 import org.tron.core.capsule.WitnessCapsule;
@@ -251,9 +250,6 @@ public class ComputeRewardTest {
     } catch (ExecutionException e) {
       throw new TronDBException(e);
     }
-
-    rewardViCalService.setRewardViRoot(Sha256Hash.wrap(
-        ByteString.fromHex("e0ebe2f3243391ed674dff816a07f589a3279420d6d88bc823b6a9d5778337ce")));
   }
 
   @Test


### PR DESCRIPTION
We can start working on computational tasks immediately without waiting for a minimum of one block to synchronize if the new reward algorithm is already in effect when the node starts.