### PR TITLE
feat(log): verify columns' length of HelloMessage

### DIFF
--- a/framework/src/main/java/org/tron/core/net/message/handshake/HelloMessage.java
+++ b/framework/src/main/java/org/tron/core/net/message/handshake/HelloMessage.java
@@ -4,6 +4,7 @@ import com.google.protobuf.ByteString;
 import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
 import org.tron.common.utils.ByteArray;
+import org.tron.common.utils.DecodeUtil;
 import org.tron.common.utils.StringUtil;
 import org.tron.core.ChainBaseManager;
 import org.tron.core.capsule.BlockCapsule;
@@ -166,6 +167,22 @@ public class HelloMessage extends TronMessage {
 
     byte[] headBlockId = this.helloMessage.getHeadBlockId().getHash().toByteArray();
     if (headBlockId.length == 0) {
+      return false;
+    }
+
+    int maxByteSize = 200;
+    ByteString address = this.helloMessage.getAddress();
+    if (!address.isEmpty() && address.toByteArray().length > maxByteSize) {
+      return false;
+    }
+
+    ByteString sig = this.helloMessage.getSignature();
+    if (!sig.isEmpty() && sig.toByteArray().length > maxByteSize) {
+      return false;
+    }
+
+    ByteString codeVersion = this.helloMessage.getCodeVersion();
+    if (!codeVersion.isEmpty() && codeVersion.toByteArray().length > maxByteSize) {
       return false;
     }
 

--- a/framework/src/main/java/org/tron/core/net/service/handshake/HandshakeService.java
+++ b/framework/src/main/java/org/tron/core/net/service/handshake/HandshakeService.java
@@ -48,12 +48,15 @@ public class HandshakeService {
     }
 
     if (!msg.valid()) {
-      logger.warn("Peer {} invalid hello message parameters, "
-                      + "GenesisBlockId: {}, SolidBlockId: {}, HeadBlockId: {}",
-              peer.getInetSocketAddress(),
-              ByteArray.toHexString(msg.getInstance().getGenesisBlockId().getHash().toByteArray()),
-              ByteArray.toHexString(msg.getInstance().getSolidBlockId().getHash().toByteArray()),
-              ByteArray.toHexString(msg.getInstance().getHeadBlockId().getHash().toByteArray()));
+      logger.warn("Peer {} invalid hello message parameters, GenesisBlockId: {}, SolidBlockId: {}, "
+              + "HeadBlockId: {}, address: {}, sig: {}, codeVersion: {}",
+          peer.getInetSocketAddress(),
+          ByteArray.toHexString(msg.getInstance().getGenesisBlockId().getHash().toByteArray()),
+          ByteArray.toHexString(msg.getInstance().getSolidBlockId().getHash().toByteArray()),
+          ByteArray.toHexString(msg.getInstance().getHeadBlockId().getHash().toByteArray()),
+          msg.getInstance().getAddress().toByteArray().length,
+          msg.getInstance().getSignature().toByteArray().length,
+          msg.getInstance().getCodeVersion().toByteArray().length);
       peer.disconnect(ReasonCode.UNEXPECTED_IDENTITY);
       return;
     }


### PR DESCRIPTION
**What does this PR do?**

-  verify columns of hellomessage, including address, sig & codeVersio, length should not be over 200

**Why are these changes required?**

- avoid too long log for HelloMessage

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

