### PR TITLE
feat(proposal): prevent re-submission after ALLOW_OLD_REWARD_OPT is approved

### DIFF
--- a/actuator/src/main/java/org/tron/core/utils/ProposalUtil.java
+++ b/actuator/src/main/java/org/tron/core/utils/ProposalUtil.java
@@ -733,6 +733,10 @@ public class ProposalUtil {
           throw new ContractValidateException(
               "Bad chain parameter id [ALLOW_OLD_REWARD_OPT]");
         }
+        if (dynamicPropertiesStore.allowOldRewardOpt()) {
+          throw new ContractValidateException(
+              "[ALLOW_OLD_REWARD_OPT] has been valid, no need to propose again");
+        }
         if (value != 1) {
           throw new ContractValidateException(
               "This value[ALLOW_OLD_REWARD_OPT] is only allowed to be 1");


### PR DESCRIPTION
**What does this PR do?**

  Prevent re-submission after ALLOW_OLD_REWARD_OPT is approved.

**Why are these changes required?**

  Avoid unnecessary submissions.

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

