### PR TITLE
fix(api): fix the bug of determine if triggerConstantContract succeeds

### DIFF
--- a/framework/src/main/java/org/tron/core/Wallet.java
+++ b/framework/src/main/java/org/tron/core/Wallet.java
@@ -226,6 +226,7 @@ import org.tron.protos.Protocol.Transaction;
 import org.tron.protos.Protocol.Transaction.Contract;
 import org.tron.protos.Protocol.Transaction.Contract.ContractType;
 import org.tron.protos.Protocol.Transaction.Result.code;
+import org.tron.protos.Protocol.Transaction.Result.contractResult;
 import org.tron.protos.Protocol.TransactionInfo;
 import org.tron.protos.contract.AssetIssueContractOuterClass.AssetIssueContract;
 import org.tron.protos.contract.BalanceContract;
@@ -4126,11 +4127,12 @@ public class Wallet {
     TransactionExtention.Builder trxExtBuilder = TransactionExtention.newBuilder();
     Return.Builder retBuilder = Return.newBuilder();
     TransactionExtention trxExt;
+    Transaction trx;
 
     try {
       TransactionCapsule trxCap = createTransactionCapsule(trigger,
           ContractType.TriggerSmartContract);
-      Transaction trx = triggerConstantContract(trigger, trxCap, trxExtBuilder, retBuilder);
+      trx = triggerConstantContract(trigger, trxCap, trxExtBuilder, retBuilder);
 
       retBuilder.setResult(true).setCode(response_code.SUCCESS);
       trxExtBuilder.setTransaction(trx);
@@ -4153,10 +4155,11 @@ public class Wallet {
       logger.warn("Unknown exception caught: " + e.getMessage(), e);
     } finally {
       trxExt = trxExtBuilder.build();
+      trx = trxExt.getTransaction();
     }
 
-    String code = trxExt.getResult().getCode().toString();
-    if ("SUCCESS".equals(code)) {
+    if (response_code.SUCCESS == trxExt.getResult().getCode()
+        && contractResult.SUCCESS == trx.getRet(0).getContractRet()) {
       List<ByteString> list = trxExt.getConstantResultList();
       byte[] listBytes = new byte[0];
       for (ByteString bs : list) {

--- a/framework/src/main/java/org/tron/core/Wallet.java
+++ b/framework/src/main/java/org/tron/core/Wallet.java
@@ -3862,11 +3862,12 @@ public class Wallet {
     TransactionExtention.Builder trxExtBuilder = TransactionExtention.newBuilder();
     Return.Builder retBuilder = Return.newBuilder();
     TransactionExtention trxExt;
+    Transaction trx;
 
     try {
       TransactionCapsule trxCap = createTransactionCapsule(trigger,
           ContractType.TriggerSmartContract);
-      Transaction trx = triggerConstantContract(trigger, trxCap, trxExtBuilder, retBuilder);
+      trx = triggerConstantContract(trigger, trxCap, trxExtBuilder, retBuilder);
 
       retBuilder.setResult(true).setCode(response_code.SUCCESS);
       trxExtBuilder.setTransaction(trx);
@@ -3889,10 +3890,10 @@ public class Wallet {
       logger.warn("unknown exception caught: " + e.getMessage(), e);
     } finally {
       trxExt = trxExtBuilder.build();
+      trx = trxExt.getTransaction();
     }
 
-    String code = trxExt.getResult().getCode().toString();
-    if ("SUCCESS".equals(code)) {
+    if (code.SUCESS == trx.getRet(0).getRet()) {
       List<ByteString> list = trxExt.getConstantResultList();
       byte[] listBytes = new byte[0];
       for (ByteString bs : list) {

--- a/framework/src/main/java/org/tron/core/Wallet.java
+++ b/framework/src/main/java/org/tron/core/Wallet.java
@@ -226,7 +226,6 @@ import org.tron.protos.Protocol.Transaction;
 import org.tron.protos.Protocol.Transaction.Contract;
 import org.tron.protos.Protocol.Transaction.Contract.ContractType;
 import org.tron.protos.Protocol.Transaction.Result.code;
-import org.tron.protos.Protocol.Transaction.Result.contractResult;
 import org.tron.protos.Protocol.TransactionInfo;
 import org.tron.protos.contract.AssetIssueContractOuterClass.AssetIssueContract;
 import org.tron.protos.contract.BalanceContract;
@@ -4158,8 +4157,7 @@ public class Wallet {
       trx = trxExt.getTransaction();
     }
 
-    if (response_code.SUCCESS == trxExt.getResult().getCode()
-        && contractResult.SUCCESS == trx.getRet(0).getContractRet()) {
+    if (code.SUCESS == trx.getRet(0).getRet()) {
       List<ByteString> list = trxExt.getConstantResultList();
       byte[] listBytes = new byte[0];
       for (ByteString bs : list) {

--- a/framework/src/test/java/org/tron/core/capsule/utils/RLPListTest.java
+++ b/framework/src/test/java/org/tron/core/capsule/utils/RLPListTest.java
@@ -2,6 +2,9 @@ package org.tron.core.capsule.utils;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.math.BigInteger;
+import java.util.Random;
+import org.bouncycastle.util.BigIntegers;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -34,5 +37,10 @@ public class RLPListTest {
     byte[] aBytes = new byte[10];
     byte[] bBytes = (byte[]) method.invoke(RLP.class, aBytes);
     Assert.assertArrayEquals(aBytes, bBytes);
+
+    int i = new Random().nextInt();
+    byte[] cBytes = BigIntegers.asUnsignedByteArray(BigInteger.valueOf(i));
+    byte[] dBytes = (byte[]) method.invoke(RLP.class, i);
+    Assert.assertArrayEquals(cBytes, dBytes);
   }
 }

--- a/framework/src/test/java/org/tron/core/capsule/utils/RLPListTest.java
+++ b/framework/src/test/java/org/tron/core/capsule/utils/RLPListTest.java
@@ -7,6 +7,7 @@ import java.util.Random;
 import org.bouncycastle.util.BigIntegers;
 import org.junit.Assert;
 import org.junit.Test;
+import org.tron.common.utils.Value;
 
 public class RLPListTest {
 
@@ -52,5 +53,23 @@ public class RLPListTest {
     byte[] gBytes = test.getBytes();
     byte[] hBytes = (byte[]) method.invoke(RLP.class, test);
     Assert.assertArrayEquals(gBytes, hBytes);
+
+    BigInteger bigInteger = BigInteger.valueOf(100);
+    byte[] iBytes = BigIntegers.asUnsignedByteArray(bigInteger);
+    byte[] jBytes = (byte[]) method.invoke(RLP.class, bigInteger);
+    Assert.assertArrayEquals(iBytes, jBytes);
+
+    Value v =  new Value(new byte[0]);
+    byte[] kBytes = v.asBytes();
+    byte[] lBytes = (byte[]) method.invoke(RLP.class, v);
+    Assert.assertArrayEquals(kBytes, lBytes);
+
+    char c = 'a';
+    try {
+      method.invoke(RLP.class, c);
+      Assert.fail();
+    } catch (Exception e) {
+      Assert.assertTrue(true);
+    }
   }
 }

--- a/framework/src/test/java/org/tron/core/capsule/utils/RLPListTest.java
+++ b/framework/src/test/java/org/tron/core/capsule/utils/RLPListTest.java
@@ -59,7 +59,7 @@ public class RLPListTest {
     byte[] jBytes = (byte[]) method.invoke(RLP.class, bigInteger);
     Assert.assertArrayEquals(iBytes, jBytes);
 
-    Value v =  new Value(new byte[0]);
+    Value v = new Value(new byte[0]);
     byte[] kBytes = v.asBytes();
     byte[] lBytes = (byte[]) method.invoke(RLP.class, v);
     Assert.assertArrayEquals(kBytes, lBytes);
@@ -71,5 +71,11 @@ public class RLPListTest {
     } catch (Exception e) {
       Assert.assertTrue(true);
     }
+  }
+
+  @Test
+  public void testEncode() {
+    byte[] aBytes = RLP.encode(new byte[1]);
+    Assert.assertEquals(1, aBytes.length);
   }
 }

--- a/framework/src/test/java/org/tron/core/capsule/utils/RLPListTest.java
+++ b/framework/src/test/java/org/tron/core/capsule/utils/RLPListTest.java
@@ -42,5 +42,15 @@ public class RLPListTest {
     byte[] cBytes = BigIntegers.asUnsignedByteArray(BigInteger.valueOf(i));
     byte[] dBytes = (byte[]) method.invoke(RLP.class, i);
     Assert.assertArrayEquals(cBytes, dBytes);
+
+    long j = new Random().nextInt();
+    byte[] eBytes = BigIntegers.asUnsignedByteArray(BigInteger.valueOf(j));
+    byte[] fBytes = (byte[]) method.invoke(RLP.class, j);
+    Assert.assertArrayEquals(eBytes, fBytes);
+
+    String test = "testA";
+    byte[] gBytes = test.getBytes();
+    byte[] hBytes = (byte[]) method.invoke(RLP.class, test);
+    Assert.assertArrayEquals(gBytes, hBytes);
   }
 }


### PR DESCRIPTION
**What does this PR do?**

- fix the bug of determine if triggerConstantContract succeeds

**Why are these changes required?**

- If contractResult from triggerConstantContract is revert , the method `getShieldedContractScalingFactor` mistakenly believes it to be correct. If we give a random parameter contractAddress to `getShieldedContractScalingFactor`, transaction's result of triggerConstantContract will be revert. 
-  This bug also occurs in method `isShieldedTRC20NoteSpent`.

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**
 There are logs as following in version 4.7.3:
```
08:35:47.595 ERROR [rpc-full-executor-0] [API](RpcApiService.java:2485) createShieldedContractParameters: 
java.lang.ArithmeticException: BigInteger: modulus not positive
        at java.math.BigInteger.mod(BigInteger.java:2458)
        at org.tron.core.Wallet.checkPublicAmount(Wallet.java:4090)
        at org.tron.core.Wallet.createShieldedContractParameters(Wallet.java:3504)
        at org.tron.core.Wallet$$FastClassBySpringCGLIB$$3f6b5781.invoke(<generated>)
        at org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:218)
        at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.invokeJoinpoint(CglibAopProxy.java:783)
        at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163)
        at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:753)
        at org.springframework.aop.aspectj.MethodInvocationProceedingJoinPoint.proceed(MethodInvocationProceedingJoinPoint.java:89)
        at org.tron.common.prometheus.MetricAspect.walletAroundAdvice(MetricAspect.java:43)
        at sun.reflect.GeneratedMethodAccessor27.invoke(Unknown Source)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.springframework.aop.aspectj.AbstractAspectJAdvice.invokeAdviceMethodWithGivenArgs(AbstractAspectJAdvice.java:634)
        at org.springframework.aop.aspectj.AbstractAspectJAdvice.invokeAdviceMethod(AbstractAspectJAdvice.java:624)
        at org.springframework.aop.aspectj.AspectJAroundAdvice.invoke(AspectJAroundAdvice.java:72)
        at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
        at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:753)
        at org.springframework.aop.interceptor.ExposeInvocationInterceptor.invoke(ExposeInvocationInterceptor.java:97)
        at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
        at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:753)
        at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:698)
        at org.tron.core.Wallet$$EnhancerBySpringCGLIB$$be58bc4b.createShieldedContractParameters(<generated>)
        at org.tron.core.services.RpcApiService$WalletApi.createShieldedContractParameters(RpcApiService.java:2477)
        at org.tron.api.WalletGrpc$MethodHandlers.invoke(WalletGrpc.java:11234)
        at io.grpc.stub.ServerCalls$UnaryServerCallHandler$UnaryServerCallListener.onHalfClose(ServerCalls.java:182)
        at io.grpc.PartialForwardingServerCallListener.onHalfClose(PartialForwardingServerCallListener.java:35)
        at io.grpc.ForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:23)
        at io.grpc.ForwardingServerCallListener$SimpleForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:40)
        at io.grpc.internal.ServerCallImpl$ServerStreamListenerImpl.halfClosed(ServerCallImpl.java:355)
        at io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1HalfClosed.runInContext(ServerImpl.java:867)
        at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
        at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
```

