### PR TITLE
feat(net): fix bug of concurrent usage of toString in TransactionCapsule

### DIFF
--- a/chainbase/src/main/java/org/tron/core/capsule/TransactionCapsule.java
+++ b/chainbase/src/main/java/org/tron/core/capsule/TransactionCapsule.java
@@ -102,7 +102,6 @@ public class TransactionCapsule implements ProtoCapsule<Transaction> {
   @Setter
   private TransactionTrace trxTrace;
 
-  private StringBuilder toStringBuff = new StringBuilder();
   @Getter
   @Setter
   private long time;
@@ -738,7 +737,7 @@ public class TransactionCapsule implements ProtoCapsule<Transaction> {
 
   @Override
   public String toString() {
-
+    StringBuilder toStringBuff = new StringBuilder();
     toStringBuff.setLength(0);
     toStringBuff.append("TransactionCapsule \n[ ");
 

--- a/framework/src/test/java/org/tron/core/actuator/utils/TransactionUtilTest.java
+++ b/framework/src/test/java/org/tron/core/actuator/utils/TransactionUtilTest.java
@@ -14,6 +14,7 @@ import static org.tron.core.utils.TransactionUtil.validTokenAbbrName;
 
 import com.google.protobuf.ByteString;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Assert;
@@ -430,5 +431,23 @@ public class TransactionUtilTest extends BaseTest {
         builder.build().getSerializedSize() - builder2.build().getSerializedSize(), 0L);
     long actual = TransactionUtil.estimateConsumeBandWidthSize(dps, balance);
     Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testConcurrentToString() throws InterruptedException {
+    Transaction.Builder builder = Transaction.newBuilder();
+    TransactionCapsule trx = new TransactionCapsule(builder.build());
+    List<Thread> threadList = new ArrayList<>();
+    int n = 10;
+    for (int i = 0; i < n; i++) {
+      threadList.add(new Thread(() -> trx.toString()));
+    }
+    for (int i = 0; i < n; i++) {
+      threadList.get(i).start();
+    }
+    for (int i = 0; i < n; i++) {
+      threadList.get(i).join();
+    }
+    Assert.assertTrue(true);
   }
 }


### PR DESCRIPTION
**What does this PR do?**

- fix the bug of concurrent usage of toString in TransactionCapsule

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

