### PR TITLE
feat(api): adjust API services to start first at startup

### DIFF
--- a/framework/src/main/java/org/tron/common/application/ApplicationImpl.java
+++ b/framework/src/main/java/org/tron/common/application/ApplicationImpl.java
@@ -54,13 +54,13 @@ public class ApplicationImpl implements Application {
    * start up the app.
    */
   public void startup() {
+    this.initServices(Args.getInstance());
+    this.startServices();
     if ((!Args.getInstance().isSolidityNode()) && (!Args.getInstance().isP2pDisable())) {
       tronNetService.start();
     }
     consensusService.start();
     MetricsUtil.init();
-    this.initServices(Args.getInstance());
-    this.startServices();
   }
 
   @Override


### PR DESCRIPTION
**What does this PR do?**
Adjust API services to start first at startup.

**Why are these changes required?**
To avoid the API service port occupied by other services, such as the P2P service.

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

