### PR TITLE
fix(config): correct config path of RPC reflection service

### DIFF
--- a/framework/src/main/resources/config.conf
+++ b/framework/src/main/resources/config.conf
@@ -243,6 +243,9 @@ node {
 
     # Transactions can only be broadcast if the number of effective connections is reached.
     minEffectiveConnection = 1
+
+    # The switch of the reflection service, effective for all gRPC services
+    # reflectionService = true
   }
 
   # number of solidity thread in the FullNode.
@@ -285,8 +288,6 @@ node {
   #   "getnowblock2"
   # ]
 
-  # The switch of the reflection service, effective for all gRPC services
-  # reflectionService = true
 }
 
 ## rate limiter config


### PR DESCRIPTION
**What does this PR do?**

RPC reflection service can be activated with the config path: `node.rpc.reflectionService`.

But it has been configured with the wrong path in the `config.conf` of the `framework`: `node.reflectionService`.

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

