### PR TITLE
test(plugins/DbCopy): solve directory creation failure due to limited permissions

### DIFF
--- a/plugins/src/test/java/org/tron/plugins/DbCopyTest.java
+++ b/plugins/src/test/java/org/tron/plugins/DbCopyTest.java
@@ -11,7 +11,7 @@ public class DbCopyTest extends DbTest {
   @Test
   public void testRun() {
     String[] args = new String[] { "db", "cp",  INPUT_DIRECTORY,
-        tmpDir + UUID.randomUUID()};
+        genarateTmpDir()};
     Assert.assertEquals(0, cli.execute(args));
   }
 
@@ -32,7 +32,7 @@ public class DbCopyTest extends DbTest {
   @Test
   public void testEmpty() throws IOException {
     String[] args = new String[] {"db", "cp", temporaryFolder.newFolder().toString(),
-        tmpDir + UUID.randomUUID()};
+        genarateTmpDir()};
     Assert.assertEquals(0, cli.execute(args));
   }
 
@@ -46,7 +46,7 @@ public class DbCopyTest extends DbTest {
   @Test
   public void testSrcIsFile() throws IOException {
     String[] args = new String[] {"db", "cp", temporaryFolder.newFile().toString(),
-        tmpDir + UUID.randomUUID()};
+        genarateTmpDir()};
     Assert.assertEquals(403, cli.execute(args));
   }
 

--- a/plugins/src/test/java/org/tron/plugins/DbTest.java
+++ b/plugins/src/test/java/org/tron/plugins/DbTest.java
@@ -86,4 +86,14 @@ public class DbTest {
       }
     }
   }
+
+  /**
+   * Generate a not-exist temporary directory path.
+   * @return temporary path
+   */
+  public String genarateTmpDir() {
+    File dir = Paths.get(tmpDir, UUID.randomUUID().toString()).toFile();
+    dir.deleteOnExit();
+    return dir.getPath();
+  }
 }


### PR DESCRIPTION
**What does this PR do?**
   Solve directory creation failure due to limited permissions on Linux.

**Why are these changes required?**

  ### test

```
org.tron.plugins.DbCopyTest > testRun FAILED
    java.lang.AssertionError: expected:<0> but was:<3>
        at org.junit.Assert.fail(Assert.java:89)
        at org.junit.Assert.failNotEquals(Assert.java:835)
        at org.junit.Assert.assertEquals(Assert.java:647)
        at org.junit.Assert.assertEquals(Assert.java:633)
        at org.tron.plugins.DbCopyTest.testRun(DbCopyTest.java:15)
```


### log
```
java.lang.RuntimeException: java.io.IOException: dest /tmpc92e73f8-c46c-4a6b-a7bf-9113a31c13e9/market_pair_price_to_order create fail 
	at org.tron.plugins.utils.FileUtils.copyDir(FileUtils.java:168)
	at org.tron.plugins.DbCopy$DbCopier.doCopy(DbCopy.java:149)
	at org.tron.plugins.DbCopy.lambda$call$3(DbCopy.java:99)
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
	at java.util.ArrayList$ArrayListSpliterator.tryAdvance(ArrayList.java:1359)
	at me.tongfei.progressbar.wrapped.ProgressBarWrappedSpliterator.tryAdvance(ProgressBarWrappedSpliterator.java:55)
	at java.util.Spliterator.forEachRemaining(Spliterator.java:326)
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:481)
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471)
	at java.util.stream.ReduceOps$ReduceTask.doLeaf(ReduceOps.java:747)
	at java.util.stream.ReduceOps$ReduceTask.doLeaf(ReduceOps.java:721)
	at java.util.stream.AbstractTask.compute(AbstractTask.java:316)
	at java.util.concurrent.CountedCompleter.exec(CountedCompleter.java:731)
	at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
	at java.util.concurrent.ForkJoinTask.doInvoke(ForkJoinTask.java:401)
	at java.util.concurrent.ForkJoinTask.invoke(ForkJoinTask.java:734)
	at java.util.stream.ReduceOps$ReduceOp.evaluateParallel(ReduceOps.java:714)
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:233)
	at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:499)
	at org.tron.plugins.DbCopy.call(DbCopy.java:106)
	at org.tron.plugins.DbCopy.call(DbCopy.java:19)
	at picocli.CommandLine.executeUserObject(CommandLine.java:1953)
	at picocli.CommandLine.access$1300(CommandLine.java:145)
	at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2358)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2352)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2314)
	at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2179)
	at picocli.CommandLine$RunLast.execute(CommandLine.java:2316)
	at picocli.CommandLine.execute(CommandLine.java:2078)
	at org.tron.plugins.DbCopyTest.testRun(DbCopyTest.java:15)
```

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**



