### PR TITLE
RocksDB Linux ARM support.

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     compile group: 'com.beust', name: 'jcommander', version: '1.72'
     compile group: 'com.typesafe', name: 'config', version: '1.3.2'
     compile group: leveldbGroup, name: leveldbName, version: leveldbVersion
-    compile group: 'org.rocksdb', name: 'rocksdbjni', version: '5.15.10'
+    compile group: 'org.rocksdb', name: 'rocksdbjni', version: '5.18.4'
     // https://mvnrepository.com/artifact/org.quartz-scheduler/quartz
     compile group: 'org.quartz-scheduler', name: 'quartz', version: '2.3.2'
     compile group: 'io.prometheus', name: 'simpleclient', version: '0.15.0'

--- a/plugins/build.gradle
+++ b/plugins/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     compile group: 'com.typesafe', name: 'config', version: '1.3.2'
     compile group: 'me.tongfei', name: 'progressbar', version: '0.9.3'
     compile group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: '1.69'
-    compile group: 'org.rocksdb', name: 'rocksdbjni', version: '5.15.10'
+    compile group: 'org.rocksdb', name: 'rocksdbjni', version: '5.18.4'
     compile 'io.github.tronprotocol:leveldbjni-all:1.18.2'
     compile 'io.github.tronprotocol:leveldb:1.18.2'
     compile project(":protocol")

--- a/protocol/build.gradle
+++ b/protocol/build.gradle
@@ -18,6 +18,8 @@ dependencies {
     // end google grpc
 
     compile group: 'com.google.api.grpc', name: 'proto-google-common-protos', version: '2.15.0'
+
+    compile group: 'javax.annotation', name: 'javax.annotation-api', version: '1.3.2'
 }
 
 tasks.matching { it instanceof Test }.all {


### PR DESCRIPTION
**What does this PR do?**

Upgraded version to the latest minor version of rocksdbjni.

**Why are these changes required?**

This upgrade added support for Linux ARM64. Related to https://github.com/tronprotocol/java-tron/issues/4692.

**This PR has been tested by:**
- Unit Tests
- Manual Testing

Can try this docker image, it built with these changes, it works on amd64/arm64 linux: https://hub.docker.com/r/donbeave/docker-tron-full-node

Here are Dockerfiles for this docker build: 
1) ARM64/AArch64: https://github.com/ChainArgos/docker-tron-full-node/blob/main/Dockerfile.arm64
2) x86-64: https://github.com/ChainArgos/docker-tron-full-node/blob/main/Dockerfile.amd64