### PR TITLE
fix(http/metric): fix race condition for HTTP net traffic metric

### DIFF
--- a/framework/src/main/java/org/tron/core/services/filter/HttpInterceptor.java
+++ b/framework/src/main/java/org/tron/core/services/filter/HttpInterceptor.java
@@ -18,7 +18,6 @@ import org.tron.core.metrics.MetricsUtil;
 @Slf4j(topic = "httpInterceptor")
 public class HttpInterceptor implements Filter {
 
-  private String endpoint;
   private final int HTTP_SUCCESS = 200;
   private final int HTTP_BAD_REQUEST = 400;
   private final int HTTP_NOT_ACCEPTABLE = 406;
@@ -29,6 +28,7 @@ public class HttpInterceptor implements Filter {
 
   @Override
   public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) {
+    String endpoint = MetricLabels.UNDEFINED;
     try {
       if (!(request instanceof HttpServletRequest)) {
         chain.doFilter(request, response);


### PR DESCRIPTION
**What does this PR do?**
   Fix net traffic metric tracking for HTTP: change endpoint variable from member to local.
**Why are these changes required?**
    The class `HttpInterceptor` is a singleton, so the member field `endpoint` is shared between users. The single instance is used and re-used to handle multiple requests processed simultaneously by different threads. The result is that one user could see another user's data. In other words, storing user data in Servlet member fields introduces a data access race condition. 
<img width="749" alt="image" src="https://github.com/tronprotocol/java-tron/assets/82020050/54923f11-4cb4-43e5-ad7f-8b069f726ab8">


The `endpoint`  is used for the HTTP net traffic metric, so this statistic is probably wrong.
<img width="732" alt="image" src="https://github.com/tronprotocol/java-tron/assets/82020050/f6aa4004-7dc7-4bac-b3b6-3c3c564920ec">

    
**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

