### PR TITLE
fix(backup): make SR node with backup exit normally by kill -15

### DIFF
--- a/framework/src/main/java/org/tron/common/backup/socket/BackupServer.java
+++ b/framework/src/main/java/org/tron/common/backup/socket/BackupServer.java
@@ -95,7 +95,6 @@ public class BackupServer implements AutoCloseable {
   public void close() {
     logger.info("Closing backup server...");
     shutdown = true;
-    ExecutorServiceManager.shutdownAndAwaitTermination(executor, name);
     backupManager.stop();
     if (channel != null) {
       try {
@@ -104,6 +103,7 @@ public class BackupServer implements AutoCloseable {
         logger.warn("Closing backup server failed.", e);
       }
     }
+    ExecutorServiceManager.shutdownAndAwaitTermination(executor, name);
     logger.info("Backup server closed.");
   }
 }

--- a/framework/src/test/java/org/tron/common/backup/BackupServerTest.java
+++ b/framework/src/test/java/org/tron/common/backup/BackupServerTest.java
@@ -37,8 +37,10 @@ public class BackupServerTest {
     Args.clearParam();
   }
 
-  @Test
+  @Test(timeout = 60_000)
   public void test() throws InterruptedException {
     backupServer.initServer();
+    // wait for the server to start
+    Thread.sleep(1000);
   }
 }


### PR DESCRIPTION
**What does this PR do?**
 Make the thread pool close after the netty channel closes.
**Why are these changes required?**
Make the SR node with [backup](https://tronprotocol.github.io/documentation-en/developers/advanced-configuration/#backup) to be stopped normally by `kill -15`.

```java
channel.closeFuture().sync(); //  wait for the main channel (listening socket) to shutdown (closeFuture().sync()) where closeFuture gives you the "future" on "close" operation (meaning shutdown of the server socket), and sync waiting for this future to be done.
```
<img width="721" alt="image" src="https://github.com/tronprotocol/java-tron/assets/82020050/24e2a788-a9d5-409d-8143-d9cb12a2ff07">


As shown below, the thread pool is closed first, and then the channel is closed. the thread can not exit because it is synchronized waiting for the channel close event, which prevents the thread pool from closing properly.
<img width="609" alt="image" src="https://github.com/tronprotocol/java-tron/assets/82020050/c13085ec-f8c0-495c-b297-093986b3d038">


Finally, after 60 seconds of waiting, the thread pool is forced to close.
<img width="717" alt="image" src="https://github.com/tronprotocol/java-tron/assets/82020050/1d73441e-9505-48c0-a153-d80a68f2babc">


**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

