### PR TITLE
feat(metric): add interceptors to monitor gRPC using Prometheus

### DIFF
--- a/framework/src/main/java/org/tron/core/services/RpcApiService.java
+++ b/framework/src/main/java/org/tron/core/services/RpcApiService.java
@@ -98,6 +98,7 @@ import org.tron.core.exception.VMIllegalException;
 import org.tron.core.exception.ZksnarkException;
 import org.tron.core.metrics.MetricsApiService;
 import org.tron.core.services.filter.LiteFnQueryGrpcInterceptor;
+import org.tron.core.services.ratelimiter.PrometheusInterceptor;
 import org.tron.core.services.ratelimiter.RateLimiterInterceptor;
 import org.tron.core.services.ratelimiter.RpcApiAccessInterceptor;
 import org.tron.core.utils.TransactionUtil;
@@ -189,6 +190,8 @@ public class RpcApiService extends RpcService {
   private RpcApiAccessInterceptor apiAccessInterceptor;
   @Autowired
   private MetricsApiService metricsApiService;
+  @Autowired
+  private PrometheusInterceptor prometheusInterceptor;
   @Getter
   private DatabaseApi databaseApi = new DatabaseApi();
   private WalletApi walletApi = new WalletApi();
@@ -251,6 +254,11 @@ public class RpcApiService extends RpcService {
 
       // add lite fullnode query interceptor
       serverBuilder.intercept(liteFnQueryGrpcInterceptor);
+
+      // add prometheus interceptor
+      if (parameter.isMetricsPrometheusEnable()) {
+        serverBuilder.intercept(prometheusInterceptor);
+      }
 
       if (parameter.isRpcReflectionServiceEnable()) {
         serverBuilder.addService(ProtoReflectionService.newInstance());

--- a/framework/src/main/java/org/tron/core/services/interfaceOnPBFT/RpcApiServiceOnPBFT.java
+++ b/framework/src/main/java/org/tron/core/services/interfaceOnPBFT/RpcApiServiceOnPBFT.java
@@ -41,6 +41,7 @@ import org.tron.common.parameter.CommonParameter;
 import org.tron.core.config.args.Args;
 import org.tron.core.services.RpcApiService;
 import org.tron.core.services.filter.LiteFnQueryGrpcInterceptor;
+import org.tron.core.services.ratelimiter.PrometheusInterceptor;
 import org.tron.core.services.ratelimiter.RateLimiterInterceptor;
 import org.tron.core.services.ratelimiter.RpcApiAccessInterceptor;
 import org.tron.protos.Protocol.Account;
@@ -78,6 +79,9 @@ public class RpcApiServiceOnPBFT extends RpcService {
 
   @Autowired
   private RpcApiAccessInterceptor apiAccessInterceptor;
+
+  @Autowired
+  private PrometheusInterceptor prometheusInterceptor;
 
   private final String executorName = "rpc-pbft-executor";
 
@@ -123,6 +127,11 @@ public class RpcApiServiceOnPBFT extends RpcService {
 
       // add lite fullnode query interceptor
       serverBuilder.intercept(liteFnQueryGrpcInterceptor);
+
+      // add prometheus interceptor
+      if (args.isMetricsPrometheusEnable()) {
+        serverBuilder.intercept(prometheusInterceptor);
+      }
 
       if (args.isRpcReflectionServiceEnable()) {
         serverBuilder.addService(ProtoReflectionService.newInstance());

--- a/framework/src/main/java/org/tron/core/services/interfaceOnSolidity/RpcApiServiceOnSolidity.java
+++ b/framework/src/main/java/org/tron/core/services/interfaceOnSolidity/RpcApiServiceOnSolidity.java
@@ -42,6 +42,7 @@ import org.tron.core.capsule.BlockCapsule;
 import org.tron.core.config.args.Args;
 import org.tron.core.services.RpcApiService;
 import org.tron.core.services.filter.LiteFnQueryGrpcInterceptor;
+import org.tron.core.services.ratelimiter.PrometheusInterceptor;
 import org.tron.core.services.ratelimiter.RateLimiterInterceptor;
 import org.tron.core.services.ratelimiter.RpcApiAccessInterceptor;
 import org.tron.protos.Protocol.Account;
@@ -80,6 +81,9 @@ public class RpcApiServiceOnSolidity extends RpcService {
 
   @Autowired
   private RpcApiAccessInterceptor apiAccessInterceptor;
+
+  @Autowired
+  private PrometheusInterceptor prometheusInterceptor;
 
   private final String executorName = "rpc-solidity-executor";
 
@@ -124,6 +128,11 @@ public class RpcApiServiceOnSolidity extends RpcService {
 
       // add lite fullnode query interceptor
       serverBuilder.intercept(liteFnQueryGrpcInterceptor);
+
+      // add prometheus interceptor
+      if (parameter.isMetricsPrometheusEnable()) {
+        serverBuilder.intercept(prometheusInterceptor);
+      }
 
       if (parameter.isRpcReflectionServiceEnable()) {
         serverBuilder.addService(ProtoReflectionService.newInstance());

--- a/framework/src/main/java/org/tron/core/services/ratelimiter/PrometheusInterceptor.java
+++ b/framework/src/main/java/org/tron/core/services/ratelimiter/PrometheusInterceptor.java
@@ -1,0 +1,46 @@
+
+package org.tron.core.services.ratelimiter;
+
+import io.grpc.ForwardingServerCall;
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.Status;
+import io.prometheus.client.Histogram;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.tron.common.prometheus.MetricKeys;
+import org.tron.common.prometheus.Metrics;
+
+/**
+ * A {@link ServerInterceptor} which sends latency stats about incoming grpc calls to Prometheus.
+ */
+@Slf4j(topic = "metrics")
+@Component
+public class PrometheusInterceptor implements ServerInterceptor {
+
+  @Override
+  public <R, S> ServerCall.Listener<R> interceptCall(
+      ServerCall<R, S> call, Metadata requestMetadata, ServerCallHandler<R, S> next) {
+    return next.startCall(new MonitoringServerCall<>(call), requestMetadata);
+  }
+
+  static class MonitoringServerCall<R, S> extends ForwardingServerCall
+      .SimpleForwardingServerCall<R, S> {
+
+    private final Histogram.Timer requestTimer;
+
+    MonitoringServerCall(ServerCall<R, S> delegate) {
+      super(delegate);
+      this.requestTimer = Metrics.histogramStartTimer(
+          MetricKeys.Histogram.GRPC_SERVICE_LATENCY, getMethodDescriptor().getFullMethodName());
+    }
+
+    @Override
+    public void close(Status status, Metadata responseHeaders) {
+      Metrics.histogramObserve(requestTimer);
+      super.close(status, responseHeaders);
+    }
+  }
+}

--- a/framework/src/main/java/org/tron/core/services/ratelimiter/RpcApiAccessInterceptor.java
+++ b/framework/src/main/java/org/tron/core/services/ratelimiter/RpcApiAccessInterceptor.java
@@ -6,13 +6,10 @@ import io.grpc.ServerCall.Listener;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 import io.grpc.Status;
-import io.prometheus.client.Histogram;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.tron.common.parameter.CommonParameter;
-import org.tron.common.prometheus.MetricKeys;
-import org.tron.common.prometheus.Metrics;
 
 @Slf4j
 @Component
@@ -32,11 +29,7 @@ public class RpcApiAccessInterceptor implements ServerInterceptor {
         return new ServerCall.Listener<ReqT>() {};
 
       } else {
-        Histogram.Timer requestTimer = Metrics.histogramStartTimer(
-            MetricKeys.Histogram.GRPC_SERVICE_LATENCY, endpoint);
-        Listener<ReqT> res = next.startCall(call, headers);
-        Metrics.histogramObserve(requestTimer);
-        return res;
+        return next.startCall(call, headers);
       }
     } catch (Exception e) {
       logger.error("check rpc api access Error: {}", e.getMessage());


### PR DESCRIPTION
**What does this PR do?**
  Add interceptors to monitor gRPC services using Prometheus, inspired by https://github.com/grpc-ecosystem/java-grpc-prometheus
**Why are these changes required?**
    1. Decoupled from the ApiAccessInterceptor.
    2. Fix the response latency monitor of RPCs handled by the server, the `startCall` is asynchronous, so the latency is not recorded correctly.
  
  ```java
      Histogram.Timer requestTimer = Metrics.histogramStartTimer(
            MetricKeys.Histogram.GRPC_SERVICE_LATENCY, endpoint);
        Listener<ReqT> res = next.startCall(call, headers); //  Starts asynchronous processing of an incoming call.
        Metrics.histogramObserve(requestTimer);
        return res;
   ```
**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

