### PR TITLE
Vaild three BlockId's hash's length in HelloMessage more strictly

### DIFF
--- a/framework/src/main/java/org/tron/core/net/message/handshake/HelloMessage.java
+++ b/framework/src/main/java/org/tron/core/net/message/handshake/HelloMessage.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
 import org.tron.common.utils.ByteArray;
 import org.tron.common.utils.DecodeUtil;
+import org.tron.common.utils.Sha256Hash;
 import org.tron.common.utils.StringUtil;
 import org.tron.core.ChainBaseManager;
 import org.tron.core.capsule.BlockCapsule;
@@ -156,17 +157,17 @@ public class HelloMessage extends TronMessage {
 
   public boolean valid() {
     byte[] genesisBlockByte = this.helloMessage.getGenesisBlockId().getHash().toByteArray();
-    if (genesisBlockByte.length == 0) {
+    if (genesisBlockByte.length != Sha256Hash.LENGTH) {
       return false;
     }
 
     byte[] solidBlockId = this.helloMessage.getSolidBlockId().getHash().toByteArray();
-    if (solidBlockId.length == 0) {
+    if (solidBlockId.length != Sha256Hash.LENGTH) {
       return false;
     }
 
     byte[] headBlockId = this.helloMessage.getHeadBlockId().getHash().toByteArray();
-    if (headBlockId.length == 0) {
+    if (headBlockId.length != Sha256Hash.LENGTH) {
       return false;
     }
 

--- a/framework/src/main/java/org/tron/core/net/service/handshake/HandshakeService.java
+++ b/framework/src/main/java/org/tron/core/net/service/handshake/HandshakeService.java
@@ -127,7 +127,7 @@ public class HandshakeService {
         TronNetService.getP2pConfig().getIp(),
         TronNetService.getP2pConfig().getIpv6(),
         TronNetService.getP2pConfig().getPort());
-    HelloMessage message = new HelloMessage(node, time, ChainBaseManager.getChainBaseManager());
+    HelloMessage message = new HelloMessage(node, time, chainBaseManager);
     relayService.fillHelloMessage(message, peer.getChannel());
     peer.sendMessage(message);
     peer.setHelloMessageSend(message);

--- a/framework/src/test/java/org/tron/core/net/services/HandShakeServiceTest.java
+++ b/framework/src/test/java/org/tron/core/net/services/HandShakeServiceTest.java
@@ -123,7 +123,7 @@ public class HandShakeServiceTest {
     Protocol.HelloMessage.Builder builder =
         getHelloMessageBuilder(node, System.currentTimeMillis(),
             ChainBaseManager.getChainBaseManager());
-    //block hash is empty
+    //block hash length is not valid
     try {
       BlockCapsule.BlockId hid = ChainBaseManager.getChainBaseManager().getHeadBlockId();
       Protocol.HelloMessage.BlockId hBlockId = Protocol.HelloMessage.BlockId.newBuilder()
@@ -132,7 +132,15 @@ public class HandShakeServiceTest {
           .build();
       builder.setHeadBlockId(hBlockId);
       HelloMessage helloMessage = new HelloMessage(builder.build().toByteArray());
-      Assert.assertTrue(!helloMessage.valid());
+      Assert.assertFalse(helloMessage.valid());
+
+      hBlockId = Protocol.HelloMessage.BlockId.newBuilder()
+          .setHash(ByteString.copyFrom(new byte[1]))
+          .setNumber(hid.getNum())
+          .build();
+      builder.setHeadBlockId(hBlockId);
+      helloMessage = new HelloMessage(builder.build().toByteArray());
+      Assert.assertFalse(helloMessage.valid());
     } catch (Exception e) {
       Assert.fail();
     }


### PR DESCRIPTION
**What does this PR do?**

1. Valid the received HelloMessage that hash's length of genesisBlockId,solidBlockId,headBlockId must be Sha256Hash.LENGTH, not only NOT NULL.
2. Use the autowired chainBaseManager in HandshakeService.

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

