### PR TITLE
feat(net): disconnect from inactive nodes if necessary

### DIFF
--- a/chainbase/src/main/java/org/tron/core/ChainBaseManager.java
+++ b/chainbase/src/main/java/org/tron/core/ChainBaseManager.java
@@ -244,6 +244,10 @@ public class ChainBaseManager {
   @Setter
   private long lowestBlockNum = -1; // except num = 0.
 
+  @Getter
+  @Setter
+  private long latestSaveBlockTime;
+
   // for test only
   public List<ByteString> getWitnesses() {
     return witnessScheduleStore.getActiveWitnesses();
@@ -381,6 +385,7 @@ public class ChainBaseManager {
     this.lowestBlockNum = this.blockIndexStore.getLimitNumber(1, 1).stream()
             .map(BlockId::getNum).findFirst().orElse(0L);
     this.nodeType = getLowestBlockNum() > 1 ? NodeType.LITE : NodeType.FULL;
+    this.latestSaveBlockTime = System.currentTimeMillis();
   }
 
   public void shutdown() {

--- a/common/src/main/java/org/tron/common/parameter/CommonParameter.java
+++ b/common/src/main/java/org/tron/common/parameter/CommonParameter.java
@@ -333,6 +333,9 @@ public class CommonParameter {
   public boolean isOpenFullTcpDisconnect;
   @Getter
   @Setter
+  public int inactiveThreshold;
+  @Getter
+  @Setter
   public boolean nodeDetectEnable;
   @Getter
   @Setter

--- a/common/src/main/java/org/tron/core/Constant.java
+++ b/common/src/main/java/org/tron/core/Constant.java
@@ -198,6 +198,8 @@ public class Constant {
 
   public static final String NODE_IS_OPEN_FULL_TCP_DISCONNECT = "node.isOpenFullTcpDisconnect";
 
+  public static final String NODE_INACTIVE_THRESHOLD = "node.inactiveThreshold";
+
   public static final String NODE_DETECT_ENABLE = "node.nodeDetectEnable";
 
   public static final String NODE_MAX_TRANSACTION_PENDING_SIZE = "node.maxTransactionPendingSize";

--- a/framework/src/main/java/org/tron/core/config/args/Args.java
+++ b/framework/src/main/java/org/tron/core/config/args/Args.java
@@ -172,6 +172,7 @@ public class Args extends CommonParameter {
     PARAMETER.estimateEnergyMaxRetry = 3;
     PARAMETER.receiveTcpMinDataLength = 2048;
     PARAMETER.isOpenFullTcpDisconnect = false;
+    PARAMETER.inactiveThreshold = 600;
     PARAMETER.nodeDetectEnable = false;
     PARAMETER.supportConstant = false;
     PARAMETER.debug = false;
@@ -841,6 +842,9 @@ public class Args extends CommonParameter {
 
     PARAMETER.isOpenFullTcpDisconnect = config.hasPath(Constant.NODE_IS_OPEN_FULL_TCP_DISCONNECT)
         && config.getBoolean(Constant.NODE_IS_OPEN_FULL_TCP_DISCONNECT);
+
+    PARAMETER.inactiveThreshold = config.hasPath(Constant.NODE_INACTIVE_THRESHOLD)
+        ? config.getInt(Constant.NODE_INACTIVE_THRESHOLD) : 600;
 
     PARAMETER.nodeDetectEnable = config.hasPath(Constant.NODE_DETECT_ENABLE)
           && config.getBoolean(Constant.NODE_DETECT_ENABLE);

--- a/framework/src/main/java/org/tron/core/db/Manager.java
+++ b/framework/src/main/java/org/tron/core/db/Manager.java
@@ -1391,6 +1391,7 @@ public class Manager {
         (chainBaseManager.getDynamicPropertiesStore().getLatestBlockHeaderNumber()
             - chainBaseManager.getDynamicPropertiesStore().getLatestSolidifiedBlockNum()
             + 1));
+    chainBaseManager.setLatestSaveBlockTime(System.currentTimeMillis());
     Metrics.gaugeSet(MetricKeys.Gauge.HEADER_HEIGHT, block.getNum());
     Metrics.gaugeSet(MetricKeys.Gauge.HEADER_TIME, block.getTimeStamp());
   }

--- a/framework/src/main/java/org/tron/core/net/TronNetService.java
+++ b/framework/src/main/java/org/tron/core/net/TronNetService.java
@@ -22,6 +22,7 @@ import org.tron.core.net.peer.PeerManager;
 import org.tron.core.net.peer.PeerStatusCheck;
 import org.tron.core.net.service.adv.AdvService;
 import org.tron.core.net.service.effective.EffectiveCheckService;
+import org.tron.core.net.service.effective.ResilienceService;
 import org.tron.core.net.service.fetchblock.FetchBlockService;
 import org.tron.core.net.service.nodepersist.NodePersistService;
 import org.tron.core.net.service.relay.RelayService;
@@ -49,6 +50,9 @@ public class TronNetService {
 
   @Autowired
   private PeerStatusCheck peerStatusCheck;
+
+  @Autowired
+  private ResilienceService resilienceService;
 
   @Autowired
   private TransactionsMsgHandler transactionsMsgHandler;
@@ -88,6 +92,7 @@ public class TronNetService {
       advService.init();
       syncService.init();
       peerStatusCheck.init();
+      resilienceService.init();
       transactionsMsgHandler.init();
       fetchBlockService.init();
       nodePersistService.init();
@@ -110,6 +115,7 @@ public class TronNetService {
     nodePersistService.close();
     advService.close();
     syncService.close();
+    resilienceService.close();
     peerStatusCheck.close();
     transactionsMsgHandler.close();
     fetchBlockService.close();
@@ -177,7 +183,7 @@ public class TronNetService {
     config.setMaxConnectionsWithSameIp(parameter.getMaxConnectionsWithSameIp());
     config.setPort(parameter.getNodeListenPort());
     config.setNetworkId(parameter.getNodeP2pVersion());
-    config.setDisconnectionPolicyEnable(parameter.isOpenFullTcpDisconnect());
+    config.setDisconnectionPolicyEnable(false);
     config.setNodeDetectEnable(parameter.isNodeDetectEnable());
     config.setDiscoverEnable(parameter.isNodeDiscoveryEnable());
     if (StringUtils.isEmpty(config.getIp()) && hasIpv4Stack(NetUtil.getAllLocalAddress())) {

--- a/framework/src/main/java/org/tron/core/net/messagehandler/BlockMsgHandler.java
+++ b/framework/src/main/java/org/tron/core/net/messagehandler/BlockMsgHandler.java
@@ -76,6 +76,7 @@ public class BlockMsgHandler implements TronMsgHandler {
     if (!fastForward && !peer.isRelayPeer()) {
       check(peer, blockMessage);
     }
+    peer.setLastActiveTime(System.currentTimeMillis());
 
     if (peer.getSyncBlockRequested().containsKey(blockId)) {
       peer.getSyncBlockRequested().remove(blockId);

--- a/framework/src/main/java/org/tron/core/net/messagehandler/ChainInventoryMsgHandler.java
+++ b/framework/src/main/java/org/tron/core/net/messagehandler/ChainInventoryMsgHandler.java
@@ -142,6 +142,7 @@ public class ChainInventoryMsgHandler implements TronMsgHandler {
             + msg.getRemainNum() + " > futureMaxNum: " + maxFutureNum);
       }
     }
+    peer.setLastActiveTime(System.currentTimeMillis());
   }
 
 }

--- a/framework/src/main/java/org/tron/core/net/messagehandler/FetchInvDataMsgHandler.java
+++ b/framework/src/main/java/org/tron/core/net/messagehandler/FetchInvDataMsgHandler.java
@@ -171,6 +171,7 @@ public class FetchInvDataMsgHandler implements TronMsgHandler {
           peer.getSyncBlockIdCache().put(hash, System.currentTimeMillis());
         }
       }
+      peer.setLastActiveTime(System.currentTimeMillis());
     }
   }
 

--- a/framework/src/main/java/org/tron/core/net/messagehandler/InventoryMsgHandler.java
+++ b/framework/src/main/java/org/tron/core/net/messagehandler/InventoryMsgHandler.java
@@ -39,6 +39,9 @@ public class InventoryMsgHandler implements TronMsgHandler {
       Item item = new Item(id, type);
       peer.getAdvInvReceive().put(item, System.currentTimeMillis());
       advService.addInv(item);
+      if (type.equals(InventoryType.BLOCK) && peer.getAdvInvSpread().getIfPresent(item) == null) {
+        peer.setLastActiveTime(System.currentTimeMillis());
+      }
     }
   }
 

--- a/framework/src/main/java/org/tron/core/net/messagehandler/SyncBlockChainMsgHandler.java
+++ b/framework/src/main/java/org/tron/core/net/messagehandler/SyncBlockChainMsgHandler.java
@@ -33,7 +33,7 @@ public class SyncBlockChainMsgHandler implements TronMsgHandler {
       peer.disconnect(Protocol.ReasonCode.BAD_PROTOCOL);
       return;
     }
-
+    peer.setLastActiveTime(System.currentTimeMillis());
     long remainNum = 0;
 
     List<BlockId> summaryChainIds = syncBlockChainMessage.getBlockIds();

--- a/framework/src/main/java/org/tron/core/net/peer/PeerConnection.java
+++ b/framework/src/main/java/org/tron/core/net/peer/PeerConnection.java
@@ -81,6 +81,10 @@ public class PeerConnection {
 
   @Getter
   @Setter
+  private long lastActiveTime;
+
+  @Getter
+  @Setter
   private TronState tronState = TronState.INIT;
 
   @Autowired
@@ -158,6 +162,7 @@ public class PeerConnection {
     if (relayNodes.stream().anyMatch(n -> n.getAddress().equals(channel.getInetAddress()))) {
       this.isRelayPeer = true;
     }
+    lastActiveTime = System.currentTimeMillis();
     this.nodeStatistics = TronStatsManager.getNodeStatistics(channel.getInetAddress());
   }
 
@@ -220,6 +225,7 @@ public class PeerConnection {
             + "syncToFetchSizePeekNum:%d\n"
             + "syncBlockRequestedSize:%d\n"
             + "remainNum:%d\n"
+            + "inactiveSeconds:%d\n"
             + "syncChainRequested:%d\n"
             + "blockInProcess:%d\n",
         channel.getInetSocketAddress(),
@@ -232,6 +238,7 @@ public class PeerConnection {
         syncBlockId != null ? syncBlockId.getNum() : -1,
         syncBlockRequested.size(),
         remainNum,
+        (int) ((System.currentTimeMillis() - lastActiveTime) / 1000),
         requested == null ? 0 : (now - requested.getValue())
                 / Constant.ONE_THOUSAND,
         syncBlockInProcess.size());

--- a/framework/src/main/java/org/tron/core/net/service/effective/ResilienceService.java
+++ b/framework/src/main/java/org/tron/core/net/service/effective/ResilienceService.java
@@ -1,0 +1,164 @@
+package org.tron.core.net.service.effective;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.tron.common.es.ExecutorServiceManager;
+import org.tron.common.parameter.CommonParameter;
+import org.tron.core.ChainBaseManager;
+import org.tron.core.config.args.Args;
+import org.tron.core.net.TronNetDelegate;
+import org.tron.core.net.peer.PeerConnection;
+import org.tron.protos.Protocol.ReasonCode;
+
+@Slf4j(topic = "net")
+@Component
+public class ResilienceService {
+
+  private final long inactiveThreshold =
+      CommonParameter.getInstance().getInactiveThreshold() * 1000L;
+  @Autowired
+  private TronNetDelegate tronNetDelegate;
+  @Autowired
+  private ChainBaseManager chainBaseManager;
+
+  private final String esName = "resilience-service";
+  private ScheduledExecutorService executor;
+  private static final int initialDelay = 300;
+
+  public void init() {
+    executor = ExecutorServiceManager.newSingleThreadScheduledExecutor(esName);
+
+    if (Args.getInstance().isOpenFullTcpDisconnect) {
+      executor.scheduleWithFixedDelay(() -> {
+        try {
+          disconnectRandom();
+        } catch (Exception e) {
+          logger.error("DisconnectRandom node failed", e);
+        }
+      }, initialDelay, 60, TimeUnit.SECONDS);
+    } else {
+      logger.info("OpenFullTcpDisconnect is disabled");
+    }
+
+    executor.scheduleWithFixedDelay(() -> {
+      try {
+        disconnectLan();
+      } catch (Exception e) {
+        logger.error("DisconnectLan node failed", e);
+      }
+    }, initialDelay, 10, TimeUnit.SECONDS);
+
+    executor.scheduleWithFixedDelay(() -> {
+      try {
+        disconnectIsolated2();
+      } catch (Exception e) {
+        logger.error("DisconnectIsolated node failed", e);
+      }
+    }, initialDelay, 30, TimeUnit.SECONDS);
+  }
+
+  private void disconnectRandom() {
+    int peerSize = tronNetDelegate.getActivePeer().size();
+    if (peerSize >= CommonParameter.getInstance().getMaxConnections()) {
+      long now = System.currentTimeMillis();
+      List<PeerConnection> peers = tronNetDelegate.getActivePeer().stream()
+          .filter(peer -> !peer.isDisconnect())
+          .filter(peer -> now - peer.getLastActiveTime() >= inactiveThreshold)
+          .filter(peer -> !peer.getChannel().isTrustPeer())
+          .collect(Collectors.toList());
+      if (!peers.isEmpty()) {
+        int index = new Random().nextInt(peers.size());
+        disconnectFromPeer(peers.get(index), ReasonCode.RANDOM_ELIMINATION);
+      }
+    }
+  }
+
+  private void disconnectLan() {
+    if (isLanNode()) {
+      // disconnect from the node that has keep inactive for more than inactiveThreshold
+      // and its lastActiveTime is smallest
+      int peerSize = tronNetDelegate.getActivePeer().size();
+      if (peerSize >= CommonParameter.getInstance().getMaxConnections()) {
+        long now = System.currentTimeMillis();
+        Optional<PeerConnection> one = tronNetDelegate.getActivePeer().stream()
+            .filter(peer -> !peer.isDisconnect())
+            .filter(peer -> now - peer.getLastActiveTime() >= inactiveThreshold)
+            .filter(peer -> !peer.getChannel().isTrustPeer())
+            .min(Comparator.comparing(PeerConnection::getLastActiveTime, Long::compareTo));
+
+        one.ifPresent(peer -> disconnectFromPeer(peer, ReasonCode.BAD_PROTOCOL));
+      }
+    }
+  }
+
+  private void disconnectIsolated2() {
+    if (isIsolateLand2()) {
+      logger.info("Node is isolated, try to disconnect from peers");
+      int peerSize = tronNetDelegate.getActivePeer().size();
+
+      //disconnect from the node whose lastActiveTime is smallest
+      if (peerSize >= CommonParameter.getInstance().getMinActiveConnections()) {
+        Optional<PeerConnection> one = tronNetDelegate.getActivePeer().stream()
+            .filter(peer -> !peer.isDisconnect())
+            .filter(peer -> !peer.getChannel().isTrustPeer())
+            .filter(peer -> peer.getChannel().isActive())
+            .min(Comparator.comparing(PeerConnection::getLastActiveTime, Long::compareTo));
+
+        one.ifPresent(peer -> disconnectFromPeer(peer, ReasonCode.BAD_PROTOCOL));
+      }
+
+      //disconnect from some Not Active nodes, make sure that left nodes' num <= 0.8 * maxConnection
+      peerSize = tronNetDelegate.getActivePeer().size();
+      int threshold = (int) (CommonParameter.getInstance().getMaxConnections() * 0.8);
+      if (peerSize > threshold) {
+        int disconnectSize = peerSize - threshold;
+        List<PeerConnection> peers = tronNetDelegate.getActivePeer().stream()
+            .filter(peer -> !peer.isDisconnect())
+            .filter(peer -> !peer.getChannel().isTrustPeer())
+            .filter(peer -> !peer.getChannel().isActive())
+            .sorted(Comparator.comparing(PeerConnection::getLastActiveTime, Long::compareTo))
+            .collect(Collectors.toList());
+
+        if (peers.size() > disconnectSize) {
+          peers = peers.subList(0, disconnectSize);
+        }
+        peers.forEach(peer -> disconnectFromPeer(peer, ReasonCode.BAD_PROTOCOL));
+      }
+    }
+  }
+
+  private boolean isLanNode() {
+    int peerSize = tronNetDelegate.getActivePeer().size();
+    int activePeerSize = (int) tronNetDelegate.getActivePeer().stream()
+        .filter(peer -> peer.getChannel().isActive())
+        .count();
+    return peerSize == activePeerSize;
+  }
+
+  private boolean isIsolateLand2() {
+    int advPeerCount = (int) tronNetDelegate.getActivePeer().stream()
+        .filter(peer -> !peer.isNeedSyncFromPeer() && !peer.isNeedSyncFromUs())
+        .count();
+    long diff = System.currentTimeMillis() - chainBaseManager.getLatestSaveBlockTime();
+    return advPeerCount >= 1 && diff >= inactiveThreshold;
+  }
+
+  private void disconnectFromPeer(PeerConnection peer, ReasonCode reasonCode) {
+    int inactiveSeconds = (int) ((System.currentTimeMillis() - peer.getLastActiveTime()) / 1000);
+    logger.info("Disconnect from peer {}, inactive seconds {}", peer.getInetSocketAddress(),
+        inactiveSeconds);
+    peer.disconnect(reasonCode);
+  }
+
+  public void close() {
+    ExecutorServiceManager.shutdownAndAwaitTermination(executor, esName);
+  }
+}

--- a/framework/src/main/resources/config-localtest.conf
+++ b/framework/src/main/resources/config-localtest.conf
@@ -99,6 +99,7 @@ node {
 
   # check the peer data transfer ,disconnect factor
   isOpenFullTcpDisconnect = true
+  inactiveThreshold = 600
 
   p2p {
     version = 333 # 11111: mainnet; 20180622: testnet

--- a/framework/src/main/resources/config.conf
+++ b/framework/src/main/resources/config.conf
@@ -180,6 +180,7 @@ node {
   minParticipationRate = 15
 
   isOpenFullTcpDisconnect = false
+  inactiveThreshold = 600
 
   p2p {
     version = 11111 # 11111: mainnet; 20180622: testnet

--- a/framework/src/test/java/org/tron/core/net/services/ResilienceServiceTest.java
+++ b/framework/src/test/java/org/tron/core/net/services/ResilienceServiceTest.java
@@ -1,0 +1,182 @@
+package org.tron.core.net.services;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.spy;
+
+import io.netty.channel.ChannelHandlerContext;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.Mockito;
+import org.tron.common.application.TronApplicationContext;
+import org.tron.common.utils.ReflectUtils;
+import org.tron.core.ChainBaseManager;
+import org.tron.core.Constant;
+import org.tron.core.config.DefaultConfig;
+import org.tron.core.config.args.Args;
+import org.tron.core.net.peer.PeerConnection;
+import org.tron.core.net.peer.PeerManager;
+import org.tron.core.net.service.effective.ResilienceService;
+import org.tron.p2p.connection.Channel;
+
+public class ResilienceServiceTest {
+
+  protected TronApplicationContext context;
+  private ResilienceService service;
+  private ChainBaseManager chainBaseManager;
+
+  @Rule
+  public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Before
+  public void init() throws IOException {
+    Args.setParam(new String[] {"--output-directory",
+        temporaryFolder.newFolder().toString(), "--debug"}, Constant.TEST_CONF);
+    context = new TronApplicationContext(DefaultConfig.class);
+    chainBaseManager = context.getBean(ChainBaseManager.class);
+    service = context.getBean(ResilienceService.class);
+  }
+
+  @Test
+  public void testDisconnectRandom() {
+    int maxConnection = 30;
+    Assert.assertEquals(maxConnection, Args.getInstance().getMaxConnections());
+    clearPeers();
+    Assert.assertEquals(0, PeerManager.getPeers().size());
+
+    for (int i = 0; i < maxConnection; i++) {
+      InetSocketAddress inetSocketAddress = new InetSocketAddress("201.0.0." + i, 10001);
+      Channel c1 = spy(Channel.class);
+      ReflectUtils.setFieldValue(c1, "inetSocketAddress", inetSocketAddress);
+      ReflectUtils.setFieldValue(c1, "inetAddress", inetSocketAddress.getAddress());
+      ReflectUtils.setFieldValue(c1, "ctx", spy(ChannelHandlerContext.class));
+      Mockito.doNothing().when(c1).send((byte[]) any());
+
+      PeerManager.add(context, c1);
+    }
+    ReflectUtils.invokeMethod(service, "disconnectRandom");
+    Assert.assertEquals(maxConnection, PeerManager.getPeers().size());
+
+    PeerConnection p1 = PeerManager.getPeers().get(1);
+    p1.setLastActiveTime(
+        System.currentTimeMillis() - Args.getInstance().inactiveThreshold * 1000L - 1000);
+    PeerConnection p2 = PeerManager.getPeers().get(10);
+    p2.setLastActiveTime(
+        System.currentTimeMillis() - Args.getInstance().inactiveThreshold * 1000L - 2000);
+
+    ReflectUtils.invokeMethod(service, "disconnectRandom");
+    Assert.assertEquals(maxConnection - 1, PeerManager.getPeers().size());
+  }
+
+  @Test
+  public void testDisconnectLan() {
+    int minConnection = 8;
+    Assert.assertEquals(minConnection, Args.getInstance().getMinConnections());
+    clearPeers();
+    Assert.assertEquals(0, PeerManager.getPeers().size());
+
+    for (int i = 0; i < 9; i++) {
+      InetSocketAddress inetSocketAddress = new InetSocketAddress("201.0.0." + i, 10001);
+      Channel c1 = spy(Channel.class);
+      ReflectUtils.setFieldValue(c1, "inetSocketAddress", inetSocketAddress);
+      ReflectUtils.setFieldValue(c1, "inetAddress", inetSocketAddress.getAddress());
+      ReflectUtils.setFieldValue(c1, "isActive", true);
+      ReflectUtils.setFieldValue(c1, "ctx", spy(ChannelHandlerContext.class));
+      Mockito.doNothing().when(c1).send((byte[]) any());
+
+      PeerManager.add(context, c1);
+    }
+
+    Assert.assertEquals(9, PeerManager.getPeers().size());
+
+    boolean isLan = ReflectUtils.invokeMethod(service, "isLanNode");
+    Assert.assertTrue(isLan);
+
+    PeerConnection p1 = PeerManager.getPeers().get(1);
+    InetSocketAddress address1 = p1.getChannel().getInetSocketAddress();
+    p1.setLastActiveTime(
+        System.currentTimeMillis() - Args.getInstance().inactiveThreshold * 1000L - 1000);
+    PeerConnection p2 = PeerManager.getPeers().get(2);
+    InetSocketAddress address2 = p2.getChannel().getInetSocketAddress();
+    p2.setLastActiveTime(
+        System.currentTimeMillis() - Args.getInstance().inactiveThreshold * 1000L - 2000);
+
+    ReflectUtils.invokeMethod(service, "disconnectLan");
+    Assert.assertEquals(8, PeerManager.getPeers().size());
+    Set<InetSocketAddress> addressSet = new HashSet<>();
+    PeerManager.getPeers()
+        .forEach(p -> addressSet.add(p.getChannel().getInetSocketAddress()));
+    Assert.assertTrue(addressSet.contains(address1));
+    Assert.assertFalse(addressSet.contains(address2));
+
+    ReflectUtils.invokeMethod(service, "disconnectLan");
+    Assert.assertEquals(7, PeerManager.getPeers().size());
+    addressSet.clear();
+    PeerManager.getPeers()
+        .forEach(p -> addressSet.add(p.getChannel().getInetSocketAddress()));
+    Assert.assertFalse(addressSet.contains(address1));
+
+    ReflectUtils.invokeMethod(service, "disconnectLan");
+    Assert.assertEquals(7, PeerManager.getPeers().size());
+  }
+
+  @Test
+  public void testDisconnectIsolated2() {
+    int maxConnection = 30;
+    Assert.assertEquals(maxConnection, Args.getInstance().getMaxConnections());
+    clearPeers();
+    Assert.assertEquals(0, PeerManager.getPeers().size());
+
+    int addSize = (int) (maxConnection * ResilienceService.retentionPercent) + 2; //26
+    for (int i = 0; i < addSize; i++) {
+      InetSocketAddress inetSocketAddress = new InetSocketAddress("201.0.0." + i, 10001);
+      Channel c1 = spy(Channel.class);
+      ReflectUtils.setFieldValue(c1, "inetSocketAddress", inetSocketAddress);
+      ReflectUtils.setFieldValue(c1, "inetAddress", inetSocketAddress.getAddress());
+      // 1 ~ 3 is active, 4 ~ 26 is not active
+      ReflectUtils.setFieldValue(c1, "isActive", i <= 2);
+      ReflectUtils.setFieldValue(c1, "ctx", spy(ChannelHandlerContext.class));
+      Mockito.doNothing().when(c1).send((byte[]) any());
+
+      PeerManager.add(context, c1);
+    }
+    PeerManager.getPeers().get(10).setNeedSyncFromUs(false);
+    PeerManager.getPeers().get(10).setNeedSyncFromPeer(false);
+    chainBaseManager.setLatestSaveBlockTime(
+        System.currentTimeMillis() - ResilienceService.blockNotChangeThreshold - 100L);
+    boolean isIsolated = ReflectUtils.invokeMethod(service, "isIsolateLand2");
+    Assert.assertTrue(isIsolated);
+
+    ReflectUtils.invokeMethod(service, "disconnectIsolated2");
+    int activeNodeSize = (int) PeerManager.getPeers().stream()
+        .filter(p -> p.getChannel().isActive())
+        .count();
+    int passiveSize = (int) PeerManager.getPeers().stream()
+        .filter(p -> !p.getChannel().isActive())
+        .count();
+    Assert.assertEquals(2, activeNodeSize);
+    Assert.assertEquals((int) (maxConnection * ResilienceService.retentionPercent),
+        activeNodeSize + passiveSize);
+    Assert.assertEquals((int) (maxConnection * ResilienceService.retentionPercent),
+        PeerManager.getPeers().size());
+  }
+
+  private void clearPeers() {
+    for (PeerConnection p : PeerManager.getPeers()) {
+      PeerManager.remove(p.getChannel());
+    }
+  }
+
+  @After
+  public void destroy() {
+    Args.clearParam();
+    context.destroy();
+  }
+}

--- a/framework/src/test/resources/args-test.conf
+++ b/framework/src/test/resources/args-test.conf
@@ -93,6 +93,8 @@ node {
   minConnections = 8
   minActiveConnections = 3
 
+  inactiveThreshold = 600
+
   p2p {
     version = 43 # 43: testnet; 101: debug
   }

--- a/framework/src/test/resources/config-localtest.conf
+++ b/framework/src/test/resources/config-localtest.conf
@@ -96,6 +96,7 @@ node {
 
   # check the peer data transfer ,disconnect factor
   isOpenFullTcpDisconnect = true
+  inactiveThreshold = 600
 
   p2p {
     version = 333 # 11111: mainnet; 20180622: testnet

--- a/framework/src/test/resources/config-test.conf
+++ b/framework/src/test/resources/config-test.conf
@@ -100,6 +100,7 @@ node {
     #    nodeId = e437a4836b77ad9d9ffe73ee782ef2614e6d8370fcf62191a6e488276e23717147073a7ce0b444d485fff5a0c34c4577251a7a990cf80d8542e21b95aa8c5e6c
     # }
   ]
+  inactiveThreshold = 600
 
   p2p {
     version = 43 # 43: testnet; 101: debug


### PR DESCRIPTION
**What does this PR do?**

To maintain the stability of the network and prevent node isolation, the node needs to be disconnected from inactive nodes on a regular basis. Three strategies are adopted:
 
1. If the node is in a LAN and the number of peers is greater than or equal to minConnection, disconnect from the earliest inactive peer that has been inactive for more than the threshold time.
2. If the node is isolated, disconnect from one active peer if the active number is greater than or equal to minActiveConnection. At the same time, disconnect from some passive peers but ensure that the retention percentage of peers is greater than or equal to 80%.
3. Optimize the random disconnect policy and only disconnect from the peer that has remained inactive for too long.

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

