### PR TITLE
feat(net) : optimize the isIdle method

### DIFF
--- a/framework/src/main/java/org/tron/core/net/peer/PeerConnection.java
+++ b/framework/src/main/java/org/tron/core/net/peer/PeerConnection.java
@@ -167,6 +167,10 @@ public class PeerConnection {
   }
 
   public boolean isIdle() {
+    return advInvRequest.isEmpty() && isSyncIdle();
+  }
+
+  public boolean isSyncIdle() {
     return syncBlockRequested.isEmpty() && syncChainRequested == null;
   }
 

--- a/framework/src/main/java/org/tron/core/net/peer/PeerConnection.java
+++ b/framework/src/main/java/org/tron/core/net/peer/PeerConnection.java
@@ -167,7 +167,7 @@ public class PeerConnection {
   }
 
   public boolean isIdle() {
-    return advInvRequest.isEmpty() && syncBlockRequested.isEmpty() && syncChainRequested == null;
+    return syncBlockRequested.isEmpty() && syncChainRequested == null;
   }
 
   public void sendMessage(Message message) {

--- a/framework/src/main/java/org/tron/core/net/service/sync/SyncService.java
+++ b/framework/src/main/java/org/tron/core/net/service/sync/SyncService.java
@@ -134,7 +134,7 @@ public class SyncService {
       blockJustReceived.put(blockMessage, peer);
     }
     handleFlag = true;
-    if (peer.isIdle()) {
+    if (peer.isSyncIdle()) {
       if (peer.getRemainNum() > 0
           && peer.getSyncBlockToFetch().size() <= syncFetchBatchNum) {
         syncNext(peer);
@@ -226,7 +226,7 @@ public class SyncService {
   private void startFetchSyncBlock() {
     HashMap<PeerConnection, List<BlockId>> send = new HashMap<>();
     tronNetDelegate.getActivePeer().stream()
-        .filter(peer -> peer.isNeedSyncFromPeer() && peer.isIdle())
+        .filter(peer -> peer.isNeedSyncFromPeer() && peer.isSyncIdle())
         .filter(peer -> peer.isFetchAble())
         .forEach(peer -> {
           if (!send.containsKey(peer)) {

--- a/framework/src/test/java/org/tron/core/net/peer/PeerConnectionTest.java
+++ b/framework/src/test/java/org/tron/core/net/peer/PeerConnectionTest.java
@@ -78,7 +78,7 @@ public class PeerConnectionTest {
     Long time = System.currentTimeMillis();
     peerConnection.getAdvInvRequest().put(item, time);
     f = peerConnection.isIdle();
-    Assert.assertTrue(!f);
+    Assert.assertTrue(f);
 
     peerConnection.getAdvInvRequest().clear();
     f = peerConnection.isIdle();

--- a/framework/src/test/java/org/tron/core/net/peer/PeerConnectionTest.java
+++ b/framework/src/test/java/org/tron/core/net/peer/PeerConnectionTest.java
@@ -78,7 +78,7 @@ public class PeerConnectionTest {
     Long time = System.currentTimeMillis();
     peerConnection.getAdvInvRequest().put(item, time);
     f = peerConnection.isIdle();
-    Assert.assertTrue(f);
+    Assert.assertTrue(!f);
 
     peerConnection.getAdvInvRequest().clear();
     f = peerConnection.isIdle();
@@ -95,6 +95,36 @@ public class PeerConnectionTest {
 
     peerConnection.setSyncChainRequested(new Pair<>(new LinkedList<>(), time));
     f = peerConnection.isIdle();
+    Assert.assertTrue(!f);
+  }
+
+  @Test
+  public void testIsSyncIdle() {
+    PeerConnection peerConnection = new PeerConnection();
+    boolean f = peerConnection.isSyncIdle();
+    Assert.assertTrue(f);
+
+    Item item = new Item(Sha256Hash.ZERO_HASH, Protocol.Inventory.InventoryType.TRX);
+    Long time = System.currentTimeMillis();
+    peerConnection.getAdvInvRequest().put(item, time);
+    f = peerConnection.isSyncIdle();
+    Assert.assertTrue(f);
+
+    peerConnection.getAdvInvRequest().clear();
+    f = peerConnection.isSyncIdle();
+    Assert.assertTrue(f);
+
+    BlockCapsule.BlockId blockId = new BlockCapsule.BlockId();
+    peerConnection.getSyncBlockRequested().put(blockId, time);
+    f = peerConnection.isSyncIdle();
+    Assert.assertTrue(!f);
+
+    peerConnection.getSyncBlockRequested().clear();
+    f = peerConnection.isSyncIdle();
+    Assert.assertTrue(f);
+
+    peerConnection.setSyncChainRequested(new Pair<>(new LinkedList<>(), time));
+    f = peerConnection.isSyncIdle();
     Assert.assertTrue(!f);
   }
 


### PR DESCRIPTION
**What does this PR do?**
Optimize the isIdle method. refer to issue https://github.com/tronprotocol/java-tron/issues/5913

**Why are these changes required?**
During the block synchronization process, if the broadcast list has not been received, the synchronization may fail. The detailed process is as follows:
1. After processing the `chain inventory` message, set `fetchFlag` to true.
2. The scheduler will execute the `startFetchSyncBlock` method to fetch the block, and at this time, `fetchFlag` will be set to false.
```
etchExecutor.scheduleWithFixedDelay(() -> {
 try {
   if (fetchFlag) {
     fetchFlag = false;
     startFetchSyncBlock();
   }
 } catch (Exception e) {
   logger.error("Fetch sync block error", e);
 }
}, 10, 1, TimeUnit.SECONDS);
```
3. Since `advInvRequest` is not empty at this time, `peer.isIdle()` returns false, so after this scheduling, the block is not obtained, but `fetchFlag` is set to false and cannot be set back, so the block cannot be obtained later.
```
private void startFetchSyncBlock() {
 HashMap<PeerConnection, List<BlockId>> send = new HashMap<>();
 tronNetDelegate.getActivePeer().stream()
     .filter(peer -> peer.isNeedSyncFromPeer() && peer.isIdle())
     .filter(peer -> peer.isFetchAble())
```
4. Since the block is not obtained, the peer status cannot be updated, the status check will fail, and the connection will be disconnected.

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**
