### PR TITLE
feat(net): add some log and adjustment of disconnection strategy

### DIFF
--- a/framework/src/main/java/org/tron/core/config/args/Args.java
+++ b/framework/src/main/java/org/tron/core/config/args/Args.java
@@ -848,6 +848,9 @@ public class Args extends CommonParameter {
 
     PARAMETER.inactiveThreshold = config.hasPath(Constant.NODE_INACTIVE_THRESHOLD)
         ? config.getInt(Constant.NODE_INACTIVE_THRESHOLD) : 600;
+    if (PARAMETER.inactiveThreshold < 1) {
+      PARAMETER.inactiveThreshold = 1;
+    }
 
     PARAMETER.maxTransactionPendingSize = config.hasPath(Constant.NODE_MAX_TRANSACTION_PENDING_SIZE)
         ? config.getInt(Constant.NODE_MAX_TRANSACTION_PENDING_SIZE) : 2000;

--- a/framework/src/main/java/org/tron/core/net/peer/PeerConnection.java
+++ b/framework/src/main/java/org/tron/core/net/peer/PeerConnection.java
@@ -230,6 +230,7 @@ public class PeerConnection {
             + "syncBlockRequestedSize:%d\n"
             + "remainNum:%d\n"
             + "syncChainRequested:%d\n"
+            + "inactiveSeconds:%d\n"
             + "blockInProcess:%d\n",
         channel.getInetSocketAddress(),
         (now - channel.getStartTime()) / Constant.ONE_THOUSAND,
@@ -244,6 +245,7 @@ public class PeerConnection {
         remainNum,
         requested == null ? 0 : (now - requested.getValue())
                 / Constant.ONE_THOUSAND,
+        (now - lastActiveTime) / Constant.ONE_THOUSAND,
         syncBlockInProcess.size());
   }
 

--- a/framework/src/main/java/org/tron/core/net/service/effective/ResilienceService.java
+++ b/framework/src/main/java/org/tron/core/net/service/effective/ResilienceService.java
@@ -76,6 +76,7 @@ public class ResilienceService {
       List<PeerConnection> peers = tronNetDelegate.getActivePeer().stream()
           .filter(peer -> now - peer.getLastActiveTime() >= inactiveThreshold)
           .filter(peer -> !peer.getChannel().isTrustPeer())
+          .filter(peer -> !peer.isNeedSyncFromUs() && !peer.isNeedSyncFromPeer())
           .collect(Collectors.toList());
       if (!peers.isEmpty()) {
         int index = new Random().nextInt(peers.size());

--- a/framework/src/main/java/org/tron/core/net/service/effective/ResilienceService.java
+++ b/framework/src/main/java/org/tron/core/net/service/effective/ResilienceService.java
@@ -81,7 +81,7 @@ public class ResilienceService {
       if (!peers.isEmpty()) {
         int index = new Random().nextInt(peers.size());
         disconnectFromPeer(peers.get(index), ReasonCode.RANDOM_ELIMINATION,
-            DisConnectCause.RANDOM_ELIMINATION);
+            DisconnectCause.RANDOM_ELIMINATION);
       }
     }
   }
@@ -101,7 +101,7 @@ public class ResilienceService {
           .collect(Collectors.toList());
       Optional<PeerConnection> one = getEarliestPeer(peers);
       one.ifPresent(
-          peer -> disconnectFromPeer(peer, ReasonCode.BAD_PROTOCOL, DisConnectCause.LAN_NODE));
+          peer -> disconnectFromPeer(peer, ReasonCode.BAD_PROTOCOL, DisconnectCause.LAN_NODE));
     }
   }
 
@@ -121,7 +121,7 @@ public class ResilienceService {
 
       Optional<PeerConnection> one = getEarliestPeer(peers);
       one.ifPresent(peer -> disconnectFromPeer(peer, ReasonCode.BAD_PROTOCOL,
-          DisConnectCause.ISOLATE2_ACTIVE));
+          DisconnectCause.ISOLATE2_ACTIVE));
     }
 
     //disconnect from some passive nodes, make sure retention nodes' num <= 0.8 * maxConnection,
@@ -147,7 +147,7 @@ public class ResilienceService {
       logger.info("All peer Size:{}, plan size:{}, candidate size:{}, real size:{}", peerSize,
           disconnectSize, candidateSize, peers.size());
       peers.forEach(peer -> disconnectFromPeer(peer, ReasonCode.BAD_PROTOCOL,
-          DisConnectCause.ISOLATE2_PASSIVE));
+          DisconnectCause.ISOLATE2_PASSIVE));
     }
   }
 
@@ -180,14 +180,14 @@ public class ResilienceService {
   }
 
   private void disconnectFromPeer(PeerConnection peer, ReasonCode reasonCode,
-      DisConnectCause cause) {
+      DisconnectCause cause) {
     int inactiveSeconds = (int) ((System.currentTimeMillis() - peer.getLastActiveTime()) / 1000);
     logger.info("Disconnect from peer {}, inactive seconds {}, cause: {}",
         peer.getInetSocketAddress(), inactiveSeconds, cause);
     peer.disconnect(reasonCode);
   }
 
-  private enum DisConnectCause {
+  private enum DisconnectCause {
     RANDOM_ELIMINATION,
     LAN_NODE,
     ISOLATE2_ACTIVE,

--- a/framework/src/main/java/org/tron/core/net/service/effective/ResilienceService.java
+++ b/framework/src/main/java/org/tron/core/net/service/effective/ResilienceService.java
@@ -80,7 +80,8 @@ public class ResilienceService {
           .collect(Collectors.toList());
       if (!peers.isEmpty()) {
         int index = new Random().nextInt(peers.size());
-        disconnectFromPeer(peers.get(index), ReasonCode.RANDOM_ELIMINATION, "random");
+        disconnectFromPeer(peers.get(index), ReasonCode.RANDOM_ELIMINATION,
+            DisConnectCause.RANDOM_ELIMINATION);
       }
     }
   }
@@ -99,7 +100,8 @@ public class ResilienceService {
           .filter(peer -> !peer.getChannel().isTrustPeer())
           .collect(Collectors.toList());
       Optional<PeerConnection> one = getEarliestPeer(peers);
-      one.ifPresent(peer -> disconnectFromPeer(peer, ReasonCode.BAD_PROTOCOL, "lan node"));
+      one.ifPresent(
+          peer -> disconnectFromPeer(peer, ReasonCode.BAD_PROTOCOL, DisConnectCause.LAN_NODE));
     }
   }
 
@@ -118,8 +120,8 @@ public class ResilienceService {
           .collect(Collectors.toList());
 
       Optional<PeerConnection> one = getEarliestPeer(peers);
-      one.ifPresent(
-          peer -> disconnectFromPeer(peer, ReasonCode.BAD_PROTOCOL, "isolate2 and active"));
+      one.ifPresent(peer -> disconnectFromPeer(peer, ReasonCode.BAD_PROTOCOL,
+          DisConnectCause.ISOLATE2_ACTIVE));
     }
 
     //disconnect from some passive nodes, make sure retention nodes' num <= 0.8 * maxConnection,
@@ -144,8 +146,8 @@ public class ResilienceService {
       }
       logger.info("All peer Size:{}, plan size:{}, candidate size:{}, real size:{}", peerSize,
           disconnectSize, candidateSize, peers.size());
-      peers.forEach(
-          peer -> disconnectFromPeer(peer, ReasonCode.BAD_PROTOCOL, "isolate2 and passive"));
+      peers.forEach(peer -> disconnectFromPeer(peer, ReasonCode.BAD_PROTOCOL,
+          DisConnectCause.ISOLATE2_PASSIVE));
     }
   }
 
@@ -177,11 +179,19 @@ public class ResilienceService {
     return advPeerCount >= 1 && diff >= blockNotChangeThreshold;
   }
 
-  private void disconnectFromPeer(PeerConnection peer, ReasonCode reasonCode, String cause) {
+  private void disconnectFromPeer(PeerConnection peer, ReasonCode reasonCode,
+      DisConnectCause cause) {
     int inactiveSeconds = (int) ((System.currentTimeMillis() - peer.getLastActiveTime()) / 1000);
     logger.info("Disconnect from peer {}, inactive seconds {}, cause: {}",
         peer.getInetSocketAddress(), inactiveSeconds, cause);
     peer.disconnect(reasonCode);
+  }
+
+  private enum DisConnectCause {
+    RANDOM_ELIMINATION,
+    LAN_NODE,
+    ISOLATE2_ACTIVE,
+    ISOLATE2_PASSIVE,
   }
 
   public void close() {

--- a/framework/src/main/java/org/tron/core/net/service/effective/ResilienceService.java
+++ b/framework/src/main/java/org/tron/core/net/service/effective/ResilienceService.java
@@ -97,6 +97,7 @@ public class ResilienceService {
       long now = System.currentTimeMillis();
       List<PeerConnection> peers = tronNetDelegate.getActivePeer().stream()
           .filter(peer -> now - peer.getLastActiveTime() >= inactiveThreshold)
+          .filter(peer -> !peer.isNeedSyncFromPeer() && !peer.isNeedSyncFromUs())
           .filter(peer -> !peer.getChannel().isTrustPeer())
           .collect(Collectors.toList());
       Optional<PeerConnection> one = getEarliestPeer(peers);

--- a/framework/src/main/java/org/tron/core/net/service/effective/ResilienceService.java
+++ b/framework/src/main/java/org/tron/core/net/service/effective/ResilienceService.java
@@ -138,12 +138,12 @@ public class ResilienceService {
           logger.warn("Sort disconnectIsolated2 peers failed: {}", e.getMessage());
           return;
         }
-
+        int candidateSize = peers.size();
         if (peers.size() > disconnectSize) {
           peers = peers.subList(0, disconnectSize);
         }
-        logger.info("All peer Size:{}, avail:{}, disconnectSize:{}, ", peerSize, peers.size(),
-            disconnectSize);
+        logger.info("All peer Size:{}, plan size:{}, candidate size:{}, real size:{}", peerSize,
+            disconnectSize, candidateSize, peers.size());
         peers.forEach(
             peer -> disconnectFromPeer(peer, ReasonCode.BAD_PROTOCOL, "isolate2 and passive"));
       }

--- a/framework/src/main/java/org/tron/core/net/service/effective/ResilienceService.java
+++ b/framework/src/main/java/org/tron/core/net/service/effective/ResilienceService.java
@@ -167,7 +167,7 @@ public class ResilienceService {
     int activePeerSize = (int) tronNetDelegate.getActivePeer().stream()
         .filter(peer -> peer.getChannel().isActive())
         .count();
-    return peerSize > CommonParameter.getInstance().getMinActiveConnections()
+    return peerSize >= CommonParameter.getInstance().getMinActiveConnections()
         && peerSize == activePeerSize;
   }
 

--- a/framework/src/main/java/org/tron/core/net/service/effective/ResilienceService.java
+++ b/framework/src/main/java/org/tron/core/net/service/effective/ResilienceService.java
@@ -74,7 +74,6 @@ public class ResilienceService {
     if (peerSize >= CommonParameter.getInstance().getMaxConnections()) {
       long now = System.currentTimeMillis();
       List<PeerConnection> peers = tronNetDelegate.getActivePeer().stream()
-          .filter(peer -> !peer.isDisconnect())
           .filter(peer -> now - peer.getLastActiveTime() >= inactiveThreshold)
           .filter(peer -> !peer.getChannel().isTrustPeer())
           .collect(Collectors.toList());
@@ -95,7 +94,6 @@ public class ResilienceService {
     if (peerSize >= CommonParameter.getInstance().getMinConnections()) {
       long now = System.currentTimeMillis();
       List<PeerConnection> peers = tronNetDelegate.getActivePeer().stream()
-          .filter(peer -> !peer.isDisconnect())
           .filter(peer -> now - peer.getLastActiveTime() >= inactiveThreshold)
           .filter(peer -> !peer.getChannel().isTrustPeer())
           .collect(Collectors.toList());
@@ -114,7 +112,6 @@ public class ResilienceService {
     //disconnect from the node whose lastActiveTime is smallest
     if (peerSize >= CommonParameter.getInstance().getMinActiveConnections()) {
       List<PeerConnection> peers = tronNetDelegate.getActivePeer().stream()
-          .filter(peer -> !peer.isDisconnect())
           .filter(peer -> !peer.getChannel().isTrustPeer())
           .filter(peer -> peer.getChannel().isActive())
           .collect(Collectors.toList());
@@ -131,7 +128,6 @@ public class ResilienceService {
     if (peerSize > threshold) {
       int disconnectSize = peerSize - threshold;
       List<PeerConnection> peers = tronNetDelegate.getActivePeer().stream()
-          .filter(peer -> !peer.isDisconnect())
           .filter(peer -> !peer.getChannel().isTrustPeer())
           .filter(peer -> !peer.getChannel().isActive())
           .collect(Collectors.toList());

--- a/framework/src/test/java/org/tron/core/net/services/ResilienceServiceTest.java
+++ b/framework/src/test/java/org/tron/core/net/services/ResilienceServiceTest.java
@@ -61,6 +61,10 @@ public class ResilienceServiceTest {
 
       PeerManager.add(context, c1);
     }
+    for (PeerConnection peer : PeerManager.getPeers()) {
+      peer.setNeedSyncFromPeer(false);
+      peer.setNeedSyncFromUs(false);
+    }
     ReflectUtils.invokeMethod(service, "disconnectRandom");
     Assert.assertEquals(maxConnection, PeerManager.getPeers().size());
 
@@ -93,7 +97,10 @@ public class ResilienceServiceTest {
 
       PeerManager.add(context, c1);
     }
-
+    for (PeerConnection peer : PeerManager.getPeers()) {
+      peer.setNeedSyncFromPeer(false);
+      peer.setNeedSyncFromUs(false);
+    }
     Assert.assertEquals(9, PeerManager.getPeers().size());
 
     boolean isLan = ReflectUtils.invokeMethod(service, "isLanNode");


### PR DESCRIPTION
**What does this PR do?**

- add some log for isolated2 disconnection
- only disconnect from broadcasting peers when node is a lan node or isOpenFullTcpDisconnect is true.

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

