### PR TITLE
feat(net): adjust disconnect strategy in isolated scene

### DIFF
--- a/framework/src/main/java/org/tron/core/net/P2pEventHandlerImpl.java
+++ b/framework/src/main/java/org/tron/core/net/P2pEventHandlerImpl.java
@@ -40,7 +40,6 @@ import org.tron.p2p.P2pEventHandler;
 import org.tron.p2p.connection.Channel;
 import org.tron.protos.Protocol;
 import org.tron.protos.Protocol.Inventory.InventoryType;
-import org.tron.protos.Protocol.ReasonCode;
 
 @Slf4j(topic = "net")
 @Component
@@ -207,7 +206,7 @@ public class P2pEventHandlerImpl extends P2pEventHandler {
         default:
           throw new P2pException(P2pException.TypeEnum.NO_SUCH_MESSAGE, msg.getType().toString());
       }
-      updateLastActiveTime(peer, msg);
+      updateLastInteractiveTime(peer, msg);
     } catch (Exception e) {
       processException(peer, msg, e);
     } finally {
@@ -223,7 +222,7 @@ public class P2pEventHandlerImpl extends P2pEventHandler {
     }
   }
 
-  private void updateLastActiveTime(PeerConnection peer, TronMessage msg) {
+  private void updateLastInteractiveTime(PeerConnection peer, TronMessage msg) {
     MessageTypes type = msg.getType();
 
     boolean flag = false;
@@ -240,7 +239,7 @@ public class P2pEventHandlerImpl extends P2pEventHandler {
         break;
     }
     if (flag) {
-      peer.setLastActiveTime(System.currentTimeMillis());
+      peer.setLastInteractiveTime(System.currentTimeMillis());
     }
   }
 

--- a/framework/src/main/java/org/tron/core/net/messagehandler/InventoryMsgHandler.java
+++ b/framework/src/main/java/org/tron/core/net/messagehandler/InventoryMsgHandler.java
@@ -40,7 +40,7 @@ public class InventoryMsgHandler implements TronMsgHandler {
       peer.getAdvInvReceive().put(item, System.currentTimeMillis());
       advService.addInv(item);
       if (type.equals(InventoryType.BLOCK) && peer.getAdvInvSpread().getIfPresent(item) == null) {
-        peer.setLastActiveTime(System.currentTimeMillis());
+        peer.setLastInteractiveTime(System.currentTimeMillis());
       }
     }
   }

--- a/framework/src/main/java/org/tron/core/net/peer/PeerConnection.java
+++ b/framework/src/main/java/org/tron/core/net/peer/PeerConnection.java
@@ -81,7 +81,7 @@ public class PeerConnection {
 
   @Getter
   @Setter
-  private volatile long lastActiveTime;
+  private volatile long lastInteractiveTime;
 
   @Getter
   @Setter
@@ -163,7 +163,7 @@ public class PeerConnection {
       this.isRelayPeer = true;
     }
     this.nodeStatistics = TronStatsManager.getNodeStatistics(channel.getInetAddress());
-    lastActiveTime = System.currentTimeMillis();
+    lastInteractiveTime = System.currentTimeMillis();
   }
 
   public void setBlockBothHave(BlockId blockId) {
@@ -245,7 +245,7 @@ public class PeerConnection {
         remainNum,
         requested == null ? 0 : (now - requested.getValue())
                 / Constant.ONE_THOUSAND,
-        (now - lastActiveTime) / Constant.ONE_THOUSAND,
+        (now - lastInteractiveTime) / Constant.ONE_THOUSAND,
         syncBlockInProcess.size());
   }
 

--- a/framework/src/main/java/org/tron/core/net/service/effective/ResilienceService.java
+++ b/framework/src/main/java/org/tron/core/net/service/effective/ResilienceService.java
@@ -74,7 +74,7 @@ public class ResilienceService {
     if (peerSize >= CommonParameter.getInstance().getMaxConnections()) {
       long now = System.currentTimeMillis();
       List<PeerConnection> peers = tronNetDelegate.getActivePeer().stream()
-          .filter(peer -> now - peer.getLastActiveTime() >= inactiveThreshold)
+          .filter(peer -> now - peer.getLastInteractiveTime() >= inactiveThreshold)
           .filter(peer -> !peer.getChannel().isTrustPeer())
           .filter(peer -> !peer.isNeedSyncFromUs() && !peer.isNeedSyncFromPeer())
           .collect(Collectors.toList());
@@ -96,7 +96,7 @@ public class ResilienceService {
     if (peerSize >= CommonParameter.getInstance().getMinConnections()) {
       long now = System.currentTimeMillis();
       List<PeerConnection> peers = tronNetDelegate.getActivePeer().stream()
-          .filter(peer -> now - peer.getLastActiveTime() >= inactiveThreshold)
+          .filter(peer -> now - peer.getLastInteractiveTime() >= inactiveThreshold)
           .filter(peer -> !peer.isNeedSyncFromPeer() && !peer.isNeedSyncFromUs())
           .filter(peer -> !peer.getChannel().isTrustPeer())
           .collect(Collectors.toList());
@@ -138,7 +138,7 @@ public class ResilienceService {
           .filter(peer -> !peer.getChannel().isActive())
           .collect(Collectors.toList());
       try {
-        peers.sort(Comparator.comparing(PeerConnection::getLastActiveTime, Long::compareTo));
+        peers.sort(Comparator.comparing(PeerConnection::getLastInteractiveTime, Long::compareTo));
       } catch (Exception e) {
         logger.warn("Sort disconnectIsolated2 peers failed: {}", e.getMessage());
         return;
@@ -158,7 +158,7 @@ public class ResilienceService {
     Optional<PeerConnection> one = Optional.empty();
     try {
       one = pees.stream()
-          .min(Comparator.comparing(PeerConnection::getLastActiveTime, Long::compareTo));
+          .min(Comparator.comparing(PeerConnection::getLastInteractiveTime, Long::compareTo));
     } catch (Exception e) {
       logger.warn("Get earliest peer failed: {}", e.getMessage());
     }
@@ -184,7 +184,8 @@ public class ResilienceService {
 
   private void disconnectFromPeer(PeerConnection peer, ReasonCode reasonCode,
       DisconnectCause cause) {
-    int inactiveSeconds = (int) ((System.currentTimeMillis() - peer.getLastActiveTime()) / 1000);
+    int inactiveSeconds = (int) ((System.currentTimeMillis() - peer.getLastInteractiveTime())
+        / 1000);
     logger.info("Disconnect from peer {}, inactive seconds {}, cause: {}",
         peer.getInetSocketAddress(), inactiveSeconds, cause);
     peer.disconnect(reasonCode);

--- a/framework/src/main/java/org/tron/core/net/service/effective/ResilienceService.java
+++ b/framework/src/main/java/org/tron/core/net/service/effective/ResilienceService.java
@@ -111,10 +111,12 @@ public class ResilienceService {
       return;
     }
     logger.warn("Node is isolated, try to disconnect from peers");
-    int peerSize = tronNetDelegate.getActivePeer().size();
 
     //disconnect from the node whose lastActiveTime is smallest
-    if (peerSize >= CommonParameter.getInstance().getMinActiveConnections()) {
+    int activePeerSize = (int) tronNetDelegate.getActivePeer().stream()
+        .filter(peer -> peer.getChannel().isActive())
+        .count();
+    if (activePeerSize >= CommonParameter.getInstance().getMinActiveConnections()) {
       List<PeerConnection> peers = tronNetDelegate.getActivePeer().stream()
           .filter(peer -> !peer.getChannel().isTrustPeer())
           .filter(peer -> peer.getChannel().isActive())
@@ -127,7 +129,7 @@ public class ResilienceService {
 
     //disconnect from some passive nodes, make sure retention nodes' num <= 0.8 * maxConnection,
     //so new peers can come in
-    peerSize = tronNetDelegate.getActivePeer().size();
+    int peerSize = tronNetDelegate.getActivePeer().size();
     int threshold = (int) (CommonParameter.getInstance().getMaxConnections() * retentionPercent);
     if (peerSize > threshold) {
       int disconnectSize = peerSize - threshold;

--- a/framework/src/test/java/org/tron/core/net/P2pEventHandlerImplTest.java
+++ b/framework/src/test/java/org/tron/core/net/P2pEventHandlerImplTest.java
@@ -113,7 +113,7 @@ public class P2pEventHandlerImplTest {
   }
 
   @Test
-  public void testUpdateLastActiveTime() throws Exception {
+  public void testUpdateLastInteractiveTime() throws Exception {
     String[] a = new String[0];
     Args.setParam(a, Constant.TESTNET_CONF);
 
@@ -127,6 +127,6 @@ public class P2pEventHandlerImplTest {
     long t1 = System.currentTimeMillis();
     FetchInvDataMessage message = new FetchInvDataMessage(new ArrayList<>(), InventoryType.BLOCK);
     method.invoke(p2pEventHandler, peer, message);
-    Assert.assertTrue(peer.getLastActiveTime() >= t1);
+    Assert.assertTrue(peer.getLastInteractiveTime() >= t1);
   }
 }

--- a/framework/src/test/java/org/tron/core/net/P2pEventHandlerImplTest.java
+++ b/framework/src/test/java/org/tron/core/net/P2pEventHandlerImplTest.java
@@ -121,7 +121,7 @@ public class P2pEventHandlerImplTest {
     P2pEventHandlerImpl p2pEventHandler = new P2pEventHandlerImpl();
 
     Method method = p2pEventHandler.getClass()
-        .getDeclaredMethod("updateLastActiveTime", PeerConnection.class, TronMessage.class);
+        .getDeclaredMethod("updateLastInteractiveTime", PeerConnection.class, TronMessage.class);
     method.setAccessible(true);
 
     long t1 = System.currentTimeMillis();

--- a/framework/src/test/java/org/tron/core/net/services/ResilienceServiceTest.java
+++ b/framework/src/test/java/org/tron/core/net/services/ResilienceServiceTest.java
@@ -69,10 +69,10 @@ public class ResilienceServiceTest {
     Assert.assertEquals(maxConnection, PeerManager.getPeers().size());
 
     PeerConnection p1 = PeerManager.getPeers().get(1);
-    p1.setLastActiveTime(
+    p1.setLastInteractiveTime(
         System.currentTimeMillis() - Args.getInstance().inactiveThreshold * 1000L - 1000);
     PeerConnection p2 = PeerManager.getPeers().get(10);
-    p2.setLastActiveTime(
+    p2.setLastInteractiveTime(
         System.currentTimeMillis() - Args.getInstance().inactiveThreshold * 1000L - 2000);
 
     ReflectUtils.invokeMethod(service, "disconnectRandom");
@@ -108,11 +108,11 @@ public class ResilienceServiceTest {
 
     PeerConnection p1 = PeerManager.getPeers().get(1);
     InetSocketAddress address1 = p1.getChannel().getInetSocketAddress();
-    p1.setLastActiveTime(
+    p1.setLastInteractiveTime(
         System.currentTimeMillis() - Args.getInstance().inactiveThreshold * 1000L - 1000);
     PeerConnection p2 = PeerManager.getPeers().get(2);
     InetSocketAddress address2 = p2.getChannel().getInetSocketAddress();
-    p2.setLastActiveTime(
+    p2.setLastInteractiveTime(
         System.currentTimeMillis() - Args.getInstance().inactiveThreshold * 1000L - 2000);
 
     ReflectUtils.invokeMethod(service, "disconnectLan");


### PR DESCRIPTION
**What does this PR do?**

- only disconnect from active peers if active peer size is larger or equal to minActiveConnections in isolated scene.

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

