### PR TITLE
feat(net): add transaction expiration time check before execution

### DIFF
--- a/chainbase/src/main/java/org/tron/core/capsule/TransactionCapsule.java
+++ b/chainbase/src/main/java/org/tron/core/capsule/TransactionCapsule.java
@@ -59,6 +59,7 @@ import org.tron.core.exception.ContractValidateException;
 import org.tron.core.exception.P2pException;
 import org.tron.core.exception.PermissionException;
 import org.tron.core.exception.SignatureFormatException;
+import org.tron.core.exception.TransactionExpirationException;
 import org.tron.core.exception.ValidateSignatureException;
 import org.tron.core.store.AccountStore;
 import org.tron.core.store.DynamicPropertiesStore;
@@ -867,6 +868,14 @@ public class TransactionCapsule implements ProtoCapsule<Transaction> {
         transactionBuilder.addRet(result);
       }
       this.transaction = transactionBuilder.build();
+    }
+  }
+
+  public void checkExpiration(long nextSlotTime) throws TransactionExpirationException {
+    if (getExpiration() < nextSlotTime) {
+      throw new TransactionExpirationException(String.format(
+          "Transaction expiration time is %d, but next slot time is %d",
+          getExpiration(), nextSlotTime));
     }
   }
 }

--- a/framework/src/main/java/org/tron/core/Wallet.java
+++ b/framework/src/main/java/org/tron/core/Wallet.java
@@ -549,6 +549,7 @@ public class Wallet {
         throw new ContractValidateException(ActuatorConstant.CONTRACT_NOT_EXIST);
       }
       TransactionMessage message = new TransactionMessage(trx.getInstance().toByteArray());
+      trx.checkExpiration(tronNetDelegate.getNextBlockSlotTime());
       dbManager.pushTransaction(trx);
       int num = tronNetService.fastBroadcastTransaction(message);
       if (num == 0 && minEffectiveConnection != 0) {

--- a/framework/src/main/java/org/tron/core/net/TronNetDelegate.java
+++ b/framework/src/main/java/org/tron/core/net/TronNetDelegate.java
@@ -380,4 +380,12 @@ public class TronNetDelegate {
     return headNum - solidNum >= maxUnsolidifiedBlocks;
   }
 
+  public long getNextBlockSlotTime() {
+    long slotCount = 1;
+    if (chainBaseManager.getDynamicPropertiesStore().getStateFlag() == 1) {
+      slotCount += chainBaseManager.getDynamicPropertiesStore().getMaintenanceSkipSlots();
+    }
+    return chainBaseManager.getDynamicPropertiesStore().getLatestBlockHeaderTimestamp()
+        + slotCount * BLOCK_PRODUCED_INTERVAL;
+  }
 }

--- a/framework/src/main/java/org/tron/core/net/messagehandler/TransactionsMsgHandler.java
+++ b/framework/src/main/java/org/tron/core/net/messagehandler/TransactionsMsgHandler.java
@@ -13,6 +13,7 @@ import org.tron.common.es.ExecutorServiceManager;
 import org.tron.core.config.args.Args;
 import org.tron.core.exception.P2pException;
 import org.tron.core.exception.P2pException.TypeEnum;
+import org.tron.core.exception.TransactionExpirationException;
 import org.tron.core.net.TronNetDelegate;
 import org.tron.core.net.message.TronMessage;
 import org.tron.core.net.message.adv.TransactionMessage;
@@ -128,6 +129,7 @@ public class TransactionsMsgHandler implements TronMsgHandler {
     }
 
     try {
+      trx.getTransactionCapsule().checkExpiration(tronNetDelegate.getNextBlockSlotTime());
       tronNetDelegate.pushTransaction(trx.getTransactionCapsule());
       advService.broadcast(trx);
     } catch (P2pException e) {
@@ -137,6 +139,9 @@ public class TransactionsMsgHandler implements TronMsgHandler {
         peer.setBadPeer(true);
         peer.disconnect(ReasonCode.BAD_TX);
       }
+    } catch (TransactionExpirationException e) {
+      logger.warn("{}. trx: {}, peer: {}",
+          e.getMessage(), trx.getMessageId(), peer.getInetAddress());
     } catch (Exception e) {
       logger.error("Trx {} from peer {} process failed", trx.getMessageId(), peer.getInetAddress(),
           e);

--- a/framework/src/test/java/org/tron/core/net/messagehandler/TransactionsMsgHandlerTest.java
+++ b/framework/src/test/java/org/tron/core/net/messagehandler/TransactionsMsgHandlerTest.java
@@ -6,13 +6,18 @@ import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import lombok.Getter;
 import org.joda.time.DateTime;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.tron.common.BaseTest;
+import org.tron.common.runtime.TvmTestUtils;
 import org.tron.common.utils.ByteArray;
 import org.tron.core.Constant;
 import org.tron.core.config.args.Args;
@@ -75,10 +80,48 @@ public class TransactionsMsgHandlerTest extends BaseTest {
       transactionsMsgHandler.processMessage(peer, new TransactionsMessage(transactionList));
       Assert.assertNull(advInvRequest.get(item));
       //Thread.sleep(10);
+      transactionsMsgHandler.close();
+      BlockingQueue<TrxEvent> smartContractQueue =
+          new LinkedBlockingQueue(2);
+      smartContractQueue.offer(new TrxEvent(null, null));
+      smartContractQueue.offer(new TrxEvent(null, null));
+      Field field1 = TransactionsMsgHandler.class.getDeclaredField("smartContractQueue");
+      field1.setAccessible(true);
+      field1.set(transactionsMsgHandler, smartContractQueue);
+      Protocol.Transaction trx1 = TvmTestUtils.generateTriggerSmartContractAndGetTransaction(
+          ByteArray.fromHexString("121212a9cf"),
+          ByteArray.fromHexString("121212a9cf"),
+          ByteArray.fromHexString("123456"),
+          100, 100000000, 0, 0);
+      Map<Item, Long> advInvRequest1 = new ConcurrentHashMap<>();
+      Item item1 = new Item(new TransactionMessage(trx1).getMessageId(),
+          Protocol.Inventory.InventoryType.TRX);
+      advInvRequest1.put(item1, 0L);
+      Mockito.when(peer.getAdvInvRequest()).thenReturn(advInvRequest1);
+      List<Protocol.Transaction> transactionList1 = new ArrayList<>();
+      transactionList1.add(trx1);
+      transactionsMsgHandler.processMessage(peer, new TransactionsMessage(transactionList1));
+      Assert.assertNull(advInvRequest.get(item1));
     } catch (Exception e) {
       Assert.fail();
     } finally {
       transactionsMsgHandler.close();
+    }
+  }
+
+  class TrxEvent {
+
+    @Getter
+    private PeerConnection peer;
+    @Getter
+    private TransactionMessage msg;
+    @Getter
+    private long time;
+
+    public TrxEvent(PeerConnection peer, TransactionMessage msg) {
+      this.peer = peer;
+      this.msg = msg;
+      this.time = System.currentTimeMillis();
     }
   }
 }

--- a/framework/src/test/java/org/tron/core/net/services/AdvServiceTest.java
+++ b/framework/src/test/java/org/tron/core/net/services/AdvServiceTest.java
@@ -4,6 +4,8 @@ import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+
+import com.google.protobuf.Any;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -105,12 +107,28 @@ public class AdvServiceTest {
   }
 
   private void testTrxBroadcast() {
-    Protocol.Transaction trx = Protocol.Transaction.newBuilder().build();
+    Protocol.Transaction trx = Protocol.Transaction.newBuilder()
+        .setRawData(
+        Protocol.Transaction.raw.newBuilder()
+            .setRefBlockNum(1)
+            .setExpiration(System.currentTimeMillis() + 3000).build()).build();
     CommonParameter.getInstance().setValidContractProtoThreadNum(1);
     TransactionMessage msg = new TransactionMessage(trx);
     service.broadcast(msg);
     Item item = new Item(msg.getMessageId(), InventoryType.TRX);
     Assert.assertNotNull(service.getMessage(item));
+
+    Protocol.Transaction expiredTrx = Protocol.Transaction.newBuilder()
+        .setRawData(
+            Protocol.Transaction.raw.newBuilder()
+            .setRefBlockNum(1)
+            .setExpiration(System.currentTimeMillis() - 1).build())
+        .build();
+    CommonParameter.getInstance().setValidContractProtoThreadNum(1);
+    TransactionMessage msg1 = new TransactionMessage(expiredTrx);
+    service.broadcast(msg);
+    Item item1 = new Item(msg1.getMessageId(), InventoryType.TRX);
+    Assert.assertNull(service.getMessage(item1));
   }
 
 }


### PR DESCRIPTION
**What does this PR do?**
Add transaction expiration time check before execution.
**Why are these changes required?**
Prevent expired transactions from continuing to be broadcast, avoiding unnecessary consumption of network resources.
**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

