### PR TITLE
doc(README): update free space required

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,13 +91,13 @@ Minimum:
 
 - CPU with 8 cores
 - 16GB RAM
-- 2TB free storage space to sync the Mainnet
+- 3TB free storage space to sync the Mainnet
 
 Recommended:
 
 - CPU with 16+ cores(32+ cores for a super representative)
 - 32GB+ RAM(64GB+ for a super representative)
-- High Performance SSD with at least 2.5TB free space
+- High Performance SSD with at least 4TB free space
 - 100+ MB/s download Internet service
 
 ## Running a full node for mainnet


### PR DESCRIPTION
A 2TB drive is no longer sufficient to sync mainnet with default settings. A freshly synced node will consume about 2.2T without pruning. It's not reasonable to expect users to turn off their node every few weeks to prune, especially for SR where an offline node means no generating block. A freshly synced node will consume about 2.2 T today. It's currently increasing by about 1.67 GiB a day.