### PR TITLE
feat(jsonrpc): jsonrpc supports finalized

### DIFF
--- a/framework/src/main/java/org/tron/core/Wallet.java
+++ b/framework/src/main/java/org/tron/core/Wallet.java
@@ -696,7 +696,7 @@ public class Wallet {
   }
 
   public long getSolidBlockNum() {
-      return chainBaseManager.getDynamicPropertiesStore().getLatestSolidifiedBlockNum();
+    return chainBaseManager.getDynamicPropertiesStore().getLatestSolidifiedBlockNum();
   }
 
   public BlockCapsule getBlockCapsuleByNum(long blockNum) {

--- a/framework/src/main/java/org/tron/core/Wallet.java
+++ b/framework/src/main/java/org/tron/core/Wallet.java
@@ -29,6 +29,10 @@ import static org.tron.core.config.Parameter.DatabaseConstants.MARKET_COUNT_LIMI
 import static org.tron.core.config.Parameter.DatabaseConstants.PROPOSAL_COUNT_LIMIT_MAX;
 import static org.tron.core.services.jsonrpc.JsonRpcApiUtil.parseEnergyFee;
 import static org.tron.core.services.jsonrpc.TronJsonRpcImpl.EARLIEST_STR;
+import static org.tron.core.services.jsonrpc.TronJsonRpcImpl.FINALIZED_STR;
+import static org.tron.core.services.jsonrpc.TronJsonRpcImpl.LATEST_STR;
+import static org.tron.core.services.jsonrpc.TronJsonRpcImpl.PENDING_STR;
+import static org.tron.core.services.jsonrpc.TronJsonRpcImpl.TAG_PENDING_SUPPORT_ERROR;
 import static org.tron.core.vm.utils.FreezeV2Util.getV2EnergyUsage;
 import static org.tron.core.vm.utils.FreezeV2Util.getV2NetUsage;
 import static org.tron.protos.contract.Common.ResourceCode;
@@ -681,6 +685,16 @@ public class Wallet {
     }
   }
 
+  public Block getFinalizedBlock() {
+    try {
+      long blockNum = chainBaseManager.getDynamicPropertiesStore().getLatestSolidifiedBlockNum();
+      return chainBaseManager.getBlockByNum(blockNum).getInstance();
+    } catch (StoreException e) {
+      logger.info(e.getMessage());
+      return null;
+    }
+  }
+
   public BlockCapsule getBlockCapsuleByNum(long blockNum) {
     try {
       return chainBaseManager.getBlockByNum(blockNum);
@@ -706,10 +720,12 @@ public class Wallet {
   public Block getByJsonBlockId(String id) throws JsonRpcInvalidParamsException {
     if (EARLIEST_STR.equalsIgnoreCase(id)) {
       return getBlockByNum(0);
-    } else if ("latest".equalsIgnoreCase(id)) {
+    } else if (LATEST_STR.equalsIgnoreCase(id)) {
       return getNowBlock();
-    } else if ("pending".equalsIgnoreCase(id)) {
-      throw new JsonRpcInvalidParamsException("TAG pending not supported");
+    } else if (FINALIZED_STR.equalsIgnoreCase(id)) {
+      return getFinalizedBlock();
+    } else if (PENDING_STR.equalsIgnoreCase(id)) {
+      throw new JsonRpcInvalidParamsException(TAG_PENDING_SUPPORT_ERROR);
     } else {
       long blockNumber;
       try {
@@ -724,8 +740,8 @@ public class Wallet {
 
   public List<Transaction> getTransactionsByJsonBlockId(String id)
       throws JsonRpcInvalidParamsException {
-    if ("pending".equalsIgnoreCase(id)) {
-      throw new JsonRpcInvalidParamsException("TAG pending not supported");
+    if (PENDING_STR.equalsIgnoreCase(id)) {
+      throw new JsonRpcInvalidParamsException(TAG_PENDING_SUPPORT_ERROR);
     } else {
       Block block = getByJsonBlockId(id);
       return block != null ? block.getTransactionsList() : null;

--- a/framework/src/main/java/org/tron/core/Wallet.java
+++ b/framework/src/main/java/org/tron/core/Wallet.java
@@ -685,14 +685,18 @@ public class Wallet {
     }
   }
 
-  public Block getFinalizedBlock() {
+  public Block getSolidBlock() {
     try {
-      long blockNum = chainBaseManager.getDynamicPropertiesStore().getLatestSolidifiedBlockNum();
+      long blockNum = getSolidBlockNum();
       return chainBaseManager.getBlockByNum(blockNum).getInstance();
     } catch (StoreException e) {
       logger.info(e.getMessage());
       return null;
     }
+  }
+
+  public long getSolidBlockNum() {
+      return chainBaseManager.getDynamicPropertiesStore().getLatestSolidifiedBlockNum();
   }
 
   public BlockCapsule getBlockCapsuleByNum(long blockNum) {
@@ -723,7 +727,7 @@ public class Wallet {
     } else if (LATEST_STR.equalsIgnoreCase(id)) {
       return getNowBlock();
     } else if (FINALIZED_STR.equalsIgnoreCase(id)) {
-      return getFinalizedBlock();
+      return getSolidBlock();
     } else if (PENDING_STR.equalsIgnoreCase(id)) {
       throw new JsonRpcInvalidParamsException(TAG_PENDING_SUPPORT_ERROR);
     } else {

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/JsonRpcApiUtil.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/JsonRpcApiUtil.java
@@ -1,6 +1,7 @@
 package org.tron.core.services.jsonrpc;
 
 import static org.tron.core.services.jsonrpc.TronJsonRpcImpl.EARLIEST_STR;
+import static org.tron.core.services.jsonrpc.TronJsonRpcImpl.FINALIZED_STR;
 import static org.tron.core.services.jsonrpc.TronJsonRpcImpl.LATEST_STR;
 import static org.tron.core.services.jsonrpc.TronJsonRpcImpl.PENDING_STR;
 import static org.tron.core.services.jsonrpc.TronJsonRpcImpl.TAG_PENDING_SUPPORT_ERROR;
@@ -514,7 +515,8 @@ public class JsonRpcApiUtil {
     return -1;
   }
 
-  public static long getByJsonBlockId(String blockNumOrTag) throws JsonRpcInvalidParamsException {
+  public static long getByJsonBlockId(String blockNumOrTag, Wallet wallet)
+      throws JsonRpcInvalidParamsException {
     if (PENDING_STR.equalsIgnoreCase(blockNumOrTag)) {
       throw new JsonRpcInvalidParamsException(TAG_PENDING_SUPPORT_ERROR);
     }
@@ -522,6 +524,8 @@ public class JsonRpcApiUtil {
       return -1;
     } else if (EARLIEST_STR.equalsIgnoreCase(blockNumOrTag)) {
       return 0;
+    } else if (FINALIZED_STR.equalsIgnoreCase(blockNumOrTag)) {
+      return wallet.getSolidBlockNum();
     } else {
       return ByteArray.jsonHexToLong(blockNumOrTag);
     }

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/JsonRpcApiUtil.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/JsonRpcApiUtil.java
@@ -3,6 +3,7 @@ package org.tron.core.services.jsonrpc;
 import static org.tron.core.services.jsonrpc.TronJsonRpcImpl.EARLIEST_STR;
 import static org.tron.core.services.jsonrpc.TronJsonRpcImpl.LATEST_STR;
 import static org.tron.core.services.jsonrpc.TronJsonRpcImpl.PENDING_STR;
+import static org.tron.core.services.jsonrpc.TronJsonRpcImpl.TAG_PENDING_SUPPORT_ERROR;
 
 import com.google.common.base.Throwables;
 import com.google.common.primitives.Longs;
@@ -515,7 +516,7 @@ public class JsonRpcApiUtil {
 
   public static long getByJsonBlockId(String blockNumOrTag) throws JsonRpcInvalidParamsException {
     if (PENDING_STR.equalsIgnoreCase(blockNumOrTag)) {
-      throw new JsonRpcInvalidParamsException("TAG pending not supported");
+      throw new JsonRpcInvalidParamsException(TAG_PENDING_SUPPORT_ERROR);
     }
     if (StringUtils.isEmpty(blockNumOrTag) || LATEST_STR.equalsIgnoreCase(blockNumOrTag)) {
       return -1;

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/TronJsonRpcImpl.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/TronJsonRpcImpl.java
@@ -141,7 +141,8 @@ public class TronJsonRpcImpl implements TronJsonRpc, Closeable {
 
   private static final String JSON_ERROR = "invalid json request";
   private static final String BLOCK_NUM_ERROR = "invalid block number";
-  private static final String TAG_NOT_SUPPORT_ERROR = "TAG [earliest | pending] not supported";
+  private static final String TAG_NOT_SUPPORT_ERROR =
+      "TAG [earliest | pending | finalized] not supported";
   private static final String QUANTITY_NOT_SUPPORT_ERROR =
       "QUANTITY not supported, just support TAG as latest";
   private static final String NO_BLOCK_HEADER = "header not found";
@@ -353,7 +354,8 @@ public class TronJsonRpcImpl implements TronJsonRpc, Closeable {
   public String getTrxBalance(String address, String blockNumOrTag)
       throws JsonRpcInvalidParamsException {
     if (EARLIEST_STR.equalsIgnoreCase(blockNumOrTag)
-        || PENDING_STR.equalsIgnoreCase(blockNumOrTag)) {
+        || PENDING_STR.equalsIgnoreCase(blockNumOrTag)
+        || FINALIZED_STR.equalsIgnoreCase(blockNumOrTag)) {
       throw new JsonRpcInvalidParamsException(TAG_NOT_SUPPORT_ERROR);
     } else if (LATEST_STR.equalsIgnoreCase(blockNumOrTag)) {
       byte[] addressData = addressCompatibleToByteArray(address);
@@ -490,7 +492,8 @@ public class TronJsonRpcImpl implements TronJsonRpc, Closeable {
   public String getStorageAt(String address, String storageIdx, String blockNumOrTag)
       throws JsonRpcInvalidParamsException {
     if (EARLIEST_STR.equalsIgnoreCase(blockNumOrTag)
-        || PENDING_STR.equalsIgnoreCase(blockNumOrTag)) {
+        || PENDING_STR.equalsIgnoreCase(blockNumOrTag)
+        || FINALIZED_STR.equalsIgnoreCase(blockNumOrTag)) {
       throw new JsonRpcInvalidParamsException(TAG_NOT_SUPPORT_ERROR);
     } else if (LATEST_STR.equalsIgnoreCase(blockNumOrTag)) {
       byte[] addressByte = addressCompatibleToByteArray(address);
@@ -525,7 +528,8 @@ public class TronJsonRpcImpl implements TronJsonRpc, Closeable {
   public String getABIOfSmartContract(String contractAddress, String blockNumOrTag)
       throws JsonRpcInvalidParamsException {
     if (EARLIEST_STR.equalsIgnoreCase(blockNumOrTag)
-        || PENDING_STR.equalsIgnoreCase(blockNumOrTag)) {
+        || PENDING_STR.equalsIgnoreCase(blockNumOrTag)
+        || FINALIZED_STR.equalsIgnoreCase(blockNumOrTag)) {
       throw new JsonRpcInvalidParamsException(TAG_NOT_SUPPORT_ERROR);
     } else if (LATEST_STR.equalsIgnoreCase(blockNumOrTag)) {
       byte[] addressData = addressCompatibleToByteArray(contractAddress);
@@ -825,7 +829,8 @@ public class TronJsonRpcImpl implements TronJsonRpc, Closeable {
     }
 
     if (EARLIEST_STR.equalsIgnoreCase(blockNumOrTag)
-        || PENDING_STR.equalsIgnoreCase(blockNumOrTag)) {
+        || PENDING_STR.equalsIgnoreCase(blockNumOrTag)
+        || FINALIZED_STR.equalsIgnoreCase(blockNumOrTag)) {
       throw new JsonRpcInvalidParamsException(TAG_NOT_SUPPORT_ERROR);
     } else if (LATEST_STR.equalsIgnoreCase(blockNumOrTag)) {
       byte[] addressData = addressCompatibleToByteArray(transactionCall.getFrom());

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/TronJsonRpcImpl.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/TronJsonRpcImpl.java
@@ -136,6 +136,8 @@ public class TronJsonRpcImpl implements TronJsonRpc, Closeable {
   public static final String EARLIEST_STR = "earliest";
   public static final String PENDING_STR = "pending";
   public static final String LATEST_STR = "latest";
+  public static final String FINALIZED_STR = "finalized";
+  public static final String TAG_PENDING_SUPPORT_ERROR = "TAG pending not supported";
 
   private static final String JSON_ERROR = "invalid json request";
   private static final String BLOCK_NUM_ERROR = "invalid block number";

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/filters/LogFilterWrapper.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/filters/LogFilterWrapper.java
@@ -51,7 +51,7 @@ public class LogFilterWrapper {
       // then if toBlock < maxBlockNum, set fromBlock = toBlock
       // then if toBlock >= maxBlockNum, set fromBlock = maxBlockNum
       if (StringUtils.isEmpty(fr.getFromBlock()) && StringUtils.isNotEmpty(fr.getToBlock())) {
-        toBlockSrc = JsonRpcApiUtil.getByJsonBlockId(fr.getToBlock());
+        toBlockSrc = JsonRpcApiUtil.getByJsonBlockId(fr.getToBlock(), wallet);
         if (toBlockSrc == -1) {
           toBlockSrc = Long.MAX_VALUE;
         }
@@ -59,7 +59,7 @@ public class LogFilterWrapper {
 
       } else if (StringUtils.isNotEmpty(fr.getFromBlock())
           && StringUtils.isEmpty(fr.getToBlock())) {
-        fromBlockSrc = JsonRpcApiUtil.getByJsonBlockId(fr.getFromBlock());
+        fromBlockSrc = JsonRpcApiUtil.getByJsonBlockId(fr.getFromBlock(), wallet);
         if (fromBlockSrc == -1) {
           fromBlockSrc = currentMaxBlockNum;
         }
@@ -70,8 +70,8 @@ public class LogFilterWrapper {
         toBlockSrc = Long.MAX_VALUE;
 
       } else {
-        fromBlockSrc = JsonRpcApiUtil.getByJsonBlockId(fr.getFromBlock());
-        toBlockSrc = JsonRpcApiUtil.getByJsonBlockId(fr.getToBlock());
+        fromBlockSrc = JsonRpcApiUtil.getByJsonBlockId(fr.getFromBlock(), wallet);
+        toBlockSrc = JsonRpcApiUtil.getByJsonBlockId(fr.getToBlock(), wallet);
         if (fromBlockSrc == -1 && toBlockSrc == -1) {
           fromBlockSrc = currentMaxBlockNum;
           toBlockSrc = Long.MAX_VALUE;

--- a/framework/src/test/java/org/tron/core/WalletTest.java
+++ b/framework/src/test/java/org/tron/core/WalletTest.java
@@ -139,7 +139,7 @@ public class WalletTest extends BaseTest {
   private static boolean init;
 
   static {
-    Args.setParam(new String[]{"-d", dbPath()}, Constant.TEST_CONF);
+    Args.setParam(new String[] {"-d", dbPath()}, Constant.TEST_CONF);
     OWNER_ADDRESS = Wallet.getAddressPreFixString() + "548794500882809695a8a687866e76d4271a1abc";
     RECEIVER_ADDRESS = Wallet.getAddressPreFixString() + "abd4b9367799eaa3197fecb144eb71de1e049150";
   }
@@ -152,7 +152,8 @@ public class WalletTest extends BaseTest {
     }
     initTransaction();
     initBlock();
-    chainBaseManager.getDynamicPropertiesStore().saveLatestBlockHeaderNumber(5);
+    chainBaseManager.getDynamicPropertiesStore().saveLatestBlockHeaderNumber(BLOCK_NUM_FIVE);
+    chainBaseManager.getDynamicPropertiesStore().saveLatestSolidifiedBlockNum(BLOCK_NUM_TWO);
     chainBaseManager.getDelegatedResourceStore().reset();
     init = true;
   }
@@ -166,6 +167,7 @@ public class WalletTest extends BaseTest {
         TRANSACTION_TIMESTAMP_ONE, BLOCK_NUM_ONE);
     addTransactionToStore(transaction1);
 
+    // solidified
     transaction2 = getBuildTransaction(
         getBuildTransferContract(ACCOUNT_ADDRESS_TWO, ACCOUNT_ADDRESS_THREE),
         TRANSACTION_TIMESTAMP_TWO, BLOCK_NUM_TWO);
@@ -284,6 +286,7 @@ public class WalletTest extends BaseTest {
 
   private void addBlockToStore(Block block) {
     BlockCapsule blockCapsule = new BlockCapsule(block);
+    chainBaseManager.getBlockIndexStore().put(blockCapsule.getBlockId());
     chainBaseManager.getBlockStore().put(blockCapsule.getBlockId().getBytes(), blockCapsule);
   }
 
@@ -1169,19 +1172,19 @@ public class WalletTest extends BaseTest {
    *    delegate_balance = 1000_000L; => 277
    *    delegate_balance = 1000_000_000L; => 279
    *    delegate_balance = 1000_000_000_000L => 280
-   *
+   * <p>
    *  We initialize account information as follows
    *    account balance = 1000_000_000_000L
    *    account frozen_balance = 1000_000_000L
-   *
+   * <p>
    *  then estimateConsumeBandWidthSize cost 279
-   *
+   * <p>
    *  so we have following result:
    *  TransactionUtil.estimateConsumeBandWidthSize(
    *    dynamicStore,ownerCapsule.getBalance())   ===> false
    *  TransactionUtil.estimateConsumeBandWidthSize(
    *    dynamicStore,ownerCapsule.getFrozenV2BalanceForBandwidth()) ===> true
-   *
+   * <p>
    *  This test case is used to verify the above conclusions
    */
   @Test
@@ -1206,5 +1209,13 @@ public class WalletTest extends BaseTest {
     chainBaseManager.getDynamicPropertiesStore().saveMaxDelegateLockPeriod(DELEGATE_PERIOD / 3000);
   }
 
+  @Test
+  public void testGetSolidBlock() {
+    long blkNum = wallet.getSolidBlockNum();
+    Assert.assertEquals(BLOCK_NUM_TWO, blkNum);
+
+    Block block = wallet.getSolidBlock();
+    assertEquals(block2, block);
+  }
 }
 

--- a/framework/src/test/java/org/tron/core/jsonrpc/JsonRpcTest.java
+++ b/framework/src/test/java/org/tron/core/jsonrpc/JsonRpcTest.java
@@ -190,6 +190,7 @@ public class JsonRpcTest {
     } catch (JsonRpcInvalidParamsException e) {
       Assert.fail();
     }
+
     try {
       new LogFilter(new FilterRequest(null, null, null, new String[] {"0x0"}, null));
     } catch (JsonRpcInvalidParamsException e) {
@@ -237,109 +238,6 @@ public class JsonRpcTest {
               null));
     } catch (JsonRpcInvalidParamsException e) {
       Assert.assertTrue(e.getMessage().contains("invalid address"));
-    }
-  }
-
-  /**
-   * test fromBlock and toBlock parameters
-   */
-  @Test
-  public void testLogFilterWrapper() {
-
-    // fromBlock and toBlock are both empty
-    try {
-      LogFilterWrapper logFilterWrapper =
-          new LogFilterWrapper(new FilterRequest(null, null, null, null, null), 100, null);
-      Assert.assertEquals(logFilterWrapper.getFromBlock(), 100);
-      Assert.assertEquals(logFilterWrapper.getToBlock(), Long.MAX_VALUE);
-    } catch (JsonRpcInvalidParamsException e) {
-      Assert.fail();
-    }
-
-    // fromBlock is not empty and smaller than currentMaxBlockNum, toBlock is empty
-    try {
-      LogFilterWrapper logFilterWrapper =
-          new LogFilterWrapper(new FilterRequest("0x14", null, null, null, null), 100, null);
-      Assert.assertEquals(logFilterWrapper.getFromBlock(), 20);
-      Assert.assertEquals(logFilterWrapper.getToBlock(), Long.MAX_VALUE);
-    } catch (JsonRpcInvalidParamsException e) {
-      Assert.fail();
-    }
-
-    // fromBlock is not empty and bigger than currentMaxBlockNum, toBlock is empty
-    try {
-      LogFilterWrapper logFilterWrapper =
-          new LogFilterWrapper(new FilterRequest("0x78", null, null, null, null), 100, null);
-      Assert.assertEquals(logFilterWrapper.getFromBlock(), 120);
-      Assert.assertEquals(logFilterWrapper.getToBlock(), Long.MAX_VALUE);
-    } catch (JsonRpcInvalidParamsException e) {
-      Assert.fail();
-    }
-
-    // fromBlock is empty, toBlock is not empty and smaller than currentMaxBlockNum
-    try {
-      LogFilterWrapper logFilterWrapper =
-          new LogFilterWrapper(new FilterRequest(null, "0x14", null, null, null), 100, null);
-      Assert.assertEquals(logFilterWrapper.getFromBlock(), 20);
-      Assert.assertEquals(logFilterWrapper.getToBlock(), 20);
-    } catch (JsonRpcInvalidParamsException e) {
-      Assert.fail();
-    }
-
-    // fromBlock is empty, toBlock is not empty and bigger than currentMaxBlockNum
-    try {
-      LogFilterWrapper logFilterWrapper =
-          new LogFilterWrapper(new FilterRequest(null, "0x78", null, null, null), 100, null);
-      Assert.assertEquals(logFilterWrapper.getFromBlock(), 100);
-      Assert.assertEquals(logFilterWrapper.getToBlock(), 120);
-    } catch (JsonRpcInvalidParamsException e) {
-      Assert.fail();
-    }
-
-    // fromBlock is not empty, toBlock is not empty
-    try {
-      LogFilterWrapper logFilterWrapper =
-          new LogFilterWrapper(new FilterRequest("0x14", "0x78", null, null, null), 100, null);
-      Assert.assertEquals(logFilterWrapper.getFromBlock(), 20);
-      Assert.assertEquals(logFilterWrapper.getToBlock(), 120);
-    } catch (JsonRpcInvalidParamsException e) {
-      Assert.fail();
-    }
-    try {
-      LogFilterWrapper logFilterWrapper =
-          new LogFilterWrapper(new FilterRequest("0x78", "0x14", null, null, null), 100, null);
-    } catch (JsonRpcInvalidParamsException e) {
-      Assert.assertEquals("please verify: fromBlock <= toBlock", e.getMessage());
-    }
-
-    //fromBlock or toBlock is not hex num
-    try {
-      LogFilterWrapper logFilterWrapper =
-          new LogFilterWrapper(new FilterRequest("earliest", null, null, null, null), 100, null);
-      Assert.assertEquals(logFilterWrapper.getFromBlock(), 0);
-      Assert.assertEquals(logFilterWrapper.getToBlock(), Long.MAX_VALUE);
-    } catch (JsonRpcInvalidParamsException e) {
-      Assert.fail();
-    }
-    try {
-      LogFilterWrapper logFilterWrapper =
-          new LogFilterWrapper(new FilterRequest("latest", null, null, null, null), 100, null);
-      Assert.assertEquals(logFilterWrapper.getFromBlock(), 100);
-      Assert.assertEquals(logFilterWrapper.getToBlock(), Long.MAX_VALUE);
-    } catch (JsonRpcInvalidParamsException e) {
-      Assert.fail();
-    }
-    try {
-      LogFilterWrapper logFilterWrapper =
-          new LogFilterWrapper(new FilterRequest("pending", null, null, null, null), 100, null);
-    } catch (JsonRpcInvalidParamsException e) {
-      Assert.assertEquals("TAG pending not supported", e.getMessage());
-    }
-    try {
-      LogFilterWrapper logFilterWrapper =
-          new LogFilterWrapper(new FilterRequest("test", null, null, null, null), 100, null);
-    } catch (JsonRpcInvalidParamsException e) {
-      Assert.assertEquals("Incorrect hex syntax", e.getMessage());
     }
   }
 

--- a/framework/src/test/java/org/tron/core/jsonrpc/JsonrpcServiceTest.java
+++ b/framework/src/test/java/org/tron/core/jsonrpc/JsonrpcServiceTest.java
@@ -1,5 +1,7 @@
 package org.tron.core.jsonrpc;
 
+import static org.tron.core.services.jsonrpc.JsonRpcApiUtil.getByJsonBlockId;
+
 import com.alibaba.fastjson.JSON;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
@@ -27,12 +29,16 @@ import org.tron.core.Wallet;
 import org.tron.core.capsule.AccountCapsule;
 import org.tron.core.capsule.BlockCapsule;
 import org.tron.core.capsule.TransactionCapsule;
+import org.tron.core.capsule.utils.BlockUtil;
 import org.tron.core.config.args.Args;
+import org.tron.core.exception.JsonRpcInvalidParamsException;
 import org.tron.core.services.NodeInfoService;
 import org.tron.core.services.interfaceJsonRpcOnPBFT.JsonRpcServiceOnPBFT;
 import org.tron.core.services.interfaceJsonRpcOnSolidity.JsonRpcServiceOnSolidity;
 import org.tron.core.services.jsonrpc.FullNodeJsonRpcHttpService;
+import org.tron.core.services.jsonrpc.TronJsonRpc.FilterRequest;
 import org.tron.core.services.jsonrpc.TronJsonRpcImpl;
+import org.tron.core.services.jsonrpc.filters.LogFilterWrapper;
 import org.tron.core.services.jsonrpc.types.BlockResult;
 import org.tron.core.services.jsonrpc.types.TransactionResult;
 import org.tron.protos.Protocol;
@@ -42,14 +48,19 @@ import org.tron.protos.contract.BalanceContract.TransferContract;
 
 @Slf4j
 public class JsonrpcServiceTest extends BaseTest {
+
   private static final String OWNER_ADDRESS;
   private static final String OWNER_ADDRESS_ACCOUNT_NAME = "first";
+  private static final long LATEST_BLOCK_NUM = 10L;
+  private static final long LATEST_SOLIDIFIED_BLOCK_NUM = 4L;
 
   private static TronJsonRpcImpl tronJsonRpc;
   @Resource
   private NodeInfoService nodeInfoService;
 
-  private static BlockCapsule blockCapsule;
+  private static BlockCapsule blockCapsule0;
+  private static BlockCapsule blockCapsule1;
+  private static BlockCapsule blockCapsule2;
   private static TransactionCapsule transactionCapsule1;
   @Resource
   private Wallet wallet;
@@ -64,65 +75,77 @@ public class JsonrpcServiceTest extends BaseTest {
   private JsonRpcServiceOnSolidity jsonRpcServiceOnSolidity;
 
   static {
-    Args.setParam(new String[]{"--output-directory", dbPath()}, Constant.TEST_CONF);
+    Args.setParam(new String[] {"--output-directory", dbPath()}, Constant.TEST_CONF);
     CommonParameter.getInstance().setJsonRpcHttpFullNodeEnable(true);
     CommonParameter.getInstance().setJsonRpcHttpPBFTNodeEnable(true);
     CommonParameter.getInstance().setJsonRpcHttpSolidityNodeEnable(true);
     CommonParameter.getInstance().setMetricsPrometheusEnable(true);
     Metrics.init();
 
-    OWNER_ADDRESS =
-        Wallet.getAddressPreFixString() + "abd4b9367799eaa3197fecb144eb71de1e049abc";
+    OWNER_ADDRESS = Wallet.getAddressPreFixString() + "abd4b9367799eaa3197fecb144eb71de1e049abc";
   }
 
   @Before
   public void init() {
     AccountCapsule accountCapsule =
-        new AccountCapsule(
-            ByteString.copyFromUtf8(OWNER_ADDRESS_ACCOUNT_NAME),
+        new AccountCapsule(ByteString.copyFromUtf8(OWNER_ADDRESS_ACCOUNT_NAME),
             ByteString.copyFrom(ByteArray.fromHexString(OWNER_ADDRESS)),
-            Protocol.AccountType.Normal,
-            10000_000_000L);
+            Protocol.AccountType.Normal, 10000_000_000L);
     dbManager.getAccountStore().put(accountCapsule.getAddress().toByteArray(), accountCapsule);
 
-    blockCapsule = new BlockCapsule(
-        1,
-        Sha256Hash.wrap(ByteString.copyFrom(
-            ByteArray.fromHexString(
-                "0304f784e4e7bae517bcab94c3e0c9214fb4ac7ff9d7d5a937d1f40031f87b81"))),
-        1,
+    blockCapsule0 = BlockUtil.newGenesisBlockCapsule();
+    blockCapsule1 = new BlockCapsule(LATEST_BLOCK_NUM, Sha256Hash.wrap(ByteString.copyFrom(
+        ByteArray.fromHexString(
+            "0304f784e4e7bae517bcab94c3e0c9214fb4ac7ff9d7d5a937d1f40031f87b81"))), 1,
         ByteString.copyFromUtf8("testAddress"));
-    TransferContract transferContract1 = TransferContract.newBuilder()
-        .setAmount(1L)
-        .setOwnerAddress(ByteString.copyFrom("0x0000000000000000000".getBytes()))
-        .setToAddress(ByteString.copyFrom(ByteArray.fromHexString(
-            (Wallet.getAddressPreFixString() + "A389132D6639FBDA4FBC8B659264E6B7C90DB086"))))
+    blockCapsule2 = new BlockCapsule(LATEST_SOLIDIFIED_BLOCK_NUM, Sha256Hash.wrap(
+        ByteString.copyFrom(ByteArray.fromHexString(
+            "9938a342238077182498b464ac029222ae169360e540d1fd6aee7c2ae9575a06"))), 1,
+        ByteString.copyFromUtf8("testAddress"));
+
+    TransferContract transferContract1 = TransferContract.newBuilder().setAmount(1L)
+        .setOwnerAddress(ByteString.copyFrom("0x0000000000000000000".getBytes())).setToAddress(
+            ByteString.copyFrom(ByteArray.fromHexString(
+                (Wallet.getAddressPreFixString() + "A389132D6639FBDA4FBC8B659264E6B7C90DB086"))))
+        .build();
+    TransferContract transferContract2 = TransferContract.newBuilder().setAmount(2L)
+        .setOwnerAddress(ByteString.copyFrom("0x0000000000000000000".getBytes())).setToAddress(
+            ByteString.copyFrom(ByteArray.fromHexString(
+                (Wallet.getAddressPreFixString() + "ED738B3A0FE390EAA71B768B6D02CDBD18FB207B"))))
+        .build();
+    TransferContract transferContract3 = TransferContract.newBuilder().setAmount(3L)
+        .setOwnerAddress(ByteString.copyFrom("0x0000000000000000000".getBytes())).setToAddress(
+            ByteString.copyFrom(ByteArray.fromHexString(
+                (Wallet.getAddressPreFixString() + "ED738B3A0FE390EAA71B768B6D02CDBD18FB207B"))))
         .build();
 
-    TransferContract transferContract2 = TransferContract.newBuilder()
-        .setAmount(2L)
-        .setOwnerAddress(ByteString.copyFrom("0x0000000000000000000".getBytes()))
-        .setToAddress(ByteString.copyFrom(ByteArray.fromHexString(
-            (Wallet.getAddressPreFixString() + "ED738B3A0FE390EAA71B768B6D02CDBD18FB207B"))))
-        .build();
-
-    transactionCapsule1 =
-        new TransactionCapsule(transferContract1, ContractType.TransferContract);
-    transactionCapsule1.setBlockNum(blockCapsule.getNum());
+    transactionCapsule1 = new TransactionCapsule(transferContract1, ContractType.TransferContract);
+    transactionCapsule1.setBlockNum(blockCapsule1.getNum());
     TransactionCapsule transactionCapsule2 = new TransactionCapsule(transferContract2,
         ContractType.TransferContract);
-    transactionCapsule2.setBlockNum(2L);
+    transactionCapsule2.setBlockNum(blockCapsule1.getNum());
+    TransactionCapsule transactionCapsule3 = new TransactionCapsule(transferContract3,
+        ContractType.TransferContract);
+    transactionCapsule3.setBlockNum(blockCapsule2.getNum());
 
-    blockCapsule.addTransaction(transactionCapsule1);
-    blockCapsule.addTransaction(transactionCapsule2);
-    dbManager.getDynamicPropertiesStore().saveLatestBlockHeaderNumber(1L);
-    dbManager.getBlockIndexStore().put(blockCapsule.getBlockId());
-    dbManager.getBlockStore().put(blockCapsule.getBlockId().getBytes(), blockCapsule);
+    blockCapsule1.addTransaction(transactionCapsule1);
+    blockCapsule1.addTransaction(transactionCapsule2);
+    blockCapsule2.addTransaction(transactionCapsule3);
+
+    dbManager.getDynamicPropertiesStore().saveLatestBlockHeaderNumber(LATEST_BLOCK_NUM);
+    dbManager.getBlockIndexStore().put(blockCapsule1.getBlockId());
+    dbManager.getBlockStore().put(blockCapsule1.getBlockId().getBytes(), blockCapsule1);
+
+    dbManager.getDynamicPropertiesStore().saveLatestSolidifiedBlockNum(LATEST_SOLIDIFIED_BLOCK_NUM);
+    dbManager.getBlockIndexStore().put(blockCapsule2.getBlockId());
+    dbManager.getBlockStore().put(blockCapsule2.getBlockId().getBytes(), blockCapsule2);
 
     dbManager.getTransactionStore()
         .put(transactionCapsule1.getTransactionId().getBytes(), transactionCapsule1);
     dbManager.getTransactionStore()
         .put(transactionCapsule2.getTransactionId().getBytes(), transactionCapsule2);
+    dbManager.getTransactionStore()
+        .put(transactionCapsule3.getTransactionId().getBytes(), transactionCapsule3);
 
     tronJsonRpc = new TronJsonRpcImpl(nodeInfoService, wallet, dbManager);
   }
@@ -165,11 +188,11 @@ public class JsonrpcServiceTest extends BaseTest {
 
     try {
       result = tronJsonRpc.ethGetBlockTransactionCountByHash(
-          Hex.toHexString((blockCapsule.getBlockId().getBytes())));
+          Hex.toHexString((blockCapsule1.getBlockId().getBytes())));
     } catch (Exception e) {
       Assert.fail();
     }
-    Assert.assertEquals(ByteArray.toJsonHex(blockCapsule.getTransactions().size()), result);
+    Assert.assertEquals(ByteArray.toJsonHex(blockCapsule1.getTransactions().size()), result);
 
   }
 
@@ -199,15 +222,15 @@ public class JsonrpcServiceTest extends BaseTest {
     } catch (Exception e) {
       Assert.fail();
     }
-    Assert.assertEquals(ByteArray.toJsonHex(blockCapsule.getTransactions().size()), result);
+    Assert.assertEquals(ByteArray.toJsonHex(blockCapsule1.getTransactions().size()), result);
 
     try {
-      result = tronJsonRpc
-          .ethGetBlockTransactionCountByNumber(ByteArray.toJsonHex(blockCapsule.getNum()));
+      result = tronJsonRpc.ethGetBlockTransactionCountByNumber(
+          ByteArray.toJsonHex(blockCapsule1.getNum()));
     } catch (Exception e) {
       Assert.fail();
     }
-    Assert.assertEquals(ByteArray.toJsonHex(blockCapsule.getTransactions().size()), result);
+    Assert.assertEquals(ByteArray.toJsonHex(blockCapsule1.getTransactions().size()), result);
 
   }
 
@@ -215,32 +238,74 @@ public class JsonrpcServiceTest extends BaseTest {
   public void testGetBlockByHash() {
     BlockResult blockResult = null;
     try {
-      blockResult = tronJsonRpc
-          .ethGetBlockByHash(Hex.toHexString((blockCapsule.getBlockId().getBytes())), false);
+      blockResult =
+          tronJsonRpc.ethGetBlockByHash(Hex.toHexString((blockCapsule1.getBlockId().getBytes())),
+              false);
     } catch (Exception e) {
       Assert.fail();
     }
-    Assert.assertEquals(ByteArray.toJsonHex(blockCapsule.getNum()), blockResult.getNumber());
-    Assert
-        .assertEquals(blockCapsule.getTransactions().size(), blockResult.getTransactions().length);
+    Assert.assertEquals(ByteArray.toJsonHex(blockCapsule1.getNum()), blockResult.getNumber());
+    Assert.assertEquals(blockCapsule1.getTransactions().size(),
+        blockResult.getTransactions().length);
   }
 
   @Test
   public void testGetBlockByNumber() {
     BlockResult blockResult = null;
+
+    // by number
     try {
-      blockResult = tronJsonRpc
-          .ethGetBlockByNumber(ByteArray.toJsonHex(blockCapsule.getNum()), false);
+      blockResult =
+          tronJsonRpc.ethGetBlockByNumber(ByteArray.toJsonHex(blockCapsule1.getNum()), false);
     } catch (Exception e) {
       Assert.fail();
     }
-
-    Assert.assertEquals(ByteArray.toJsonHex(blockCapsule.getNum()), blockResult.getNumber());
-    Assert
-        .assertEquals(blockCapsule.getTransactions().size(), blockResult.getTransactions().length);
+    Assert.assertEquals(ByteArray.toJsonHex(blockCapsule1.getNum()), blockResult.getNumber());
+    Assert.assertEquals(blockCapsule1.getTransactions().size(),
+        blockResult.getTransactions().length);
     Assert.assertEquals("0x0000000000000000", blockResult.getNonce());
-  }
 
+    // earliest
+    try {
+      blockResult = tronJsonRpc.ethGetBlockByNumber("earliest", false);
+    } catch (Exception e) {
+      Assert.fail();
+    }
+    Assert.assertEquals(ByteArray.toJsonHex(0L), blockResult.getNumber());
+    Assert.assertEquals(ByteArray.toJsonHex(blockCapsule0.getNum()), blockResult.getNumber());
+
+    // latest
+    try {
+      blockResult = tronJsonRpc.ethGetBlockByNumber("latest", false);
+    } catch (Exception e) {
+      Assert.fail();
+    }
+    Assert.assertEquals(ByteArray.toJsonHex(LATEST_BLOCK_NUM), blockResult.getNumber());
+    Assert.assertEquals(ByteArray.toJsonHex(blockCapsule1.getNum()), blockResult.getNumber());
+
+    // finalized
+    try {
+      blockResult = tronJsonRpc.ethGetBlockByNumber("finalized", false);
+    } catch (Exception e) {
+      Assert.fail();
+    }
+    Assert.assertEquals(ByteArray.toJsonHex(LATEST_SOLIDIFIED_BLOCK_NUM), blockResult.getNumber());
+    Assert.assertEquals(ByteArray.toJsonHex(blockCapsule2.getNum()), blockResult.getNumber());
+
+    // pending
+    try {
+      tronJsonRpc.ethGetBlockByNumber("pending", false);
+    } catch (Exception e) {
+      Assert.assertEquals("TAG pending not supported", e.getMessage());
+    }
+
+    // invalid
+    try {
+      tronJsonRpc.ethGetBlockByNumber("0x", false);
+    } catch (Exception e) {
+      Assert.assertEquals("invalid block number", e.getMessage());
+    }
+  }
 
   @Test
   public void testGetTransactionByHash() {
@@ -268,7 +333,7 @@ public class JsonrpcServiceTest extends BaseTest {
     fullNodeJsonRpcHttpService.init(Args.getInstance());
     fullNodeJsonRpcHttpService.start();
     JsonArray params = new JsonArray();
-    params.add(ByteArray.toJsonHex(blockCapsule.getNum()));
+    params.add(ByteArray.toJsonHex(blockCapsule1.getNum()));
     params.add(false);
     JsonObject requestBody = new JsonObject();
     requestBody.addProperty("jsonrpc", "2.0");
@@ -283,16 +348,14 @@ public class JsonrpcServiceTest extends BaseTest {
       response = httpClient.execute(httpPost);
       String resp = EntityUtils.toString(response.getEntity());
       BlockResult blockResult = JSON.parseObject(resp).getObject("result", BlockResult.class);
-      Assert.assertEquals(ByteArray.toJsonHex(blockCapsule.getNum()),
-          blockResult.getNumber());
-      Assert.assertEquals(blockCapsule.getTransactions().size(),
+      Assert.assertEquals(ByteArray.toJsonHex(blockCapsule1.getNum()), blockResult.getNumber());
+      Assert.assertEquals(blockCapsule1.getTransactions().size(),
           blockResult.getTransactions().length);
-      Assert.assertEquals("0x0000000000000000",
-          blockResult.getNonce());
+      Assert.assertEquals("0x0000000000000000", blockResult.getNonce());
       response.close();
       Assert.assertEquals(1, CollectorRegistry.defaultRegistry.getSampleValue(
-          "tron:jsonrpc_service_latency_seconds_count",
-          new String[] {"method"}, new String[] {"eth_getBlockByNumber"}).intValue());
+          "tron:jsonrpc_service_latency_seconds_count", new String[] {"method"},
+          new String[] {"eth_getBlockByNumber"}).intValue());
     } catch (Exception e) {
       Assert.fail(e.getMessage());
     } finally {
@@ -313,4 +376,269 @@ public class JsonrpcServiceTest extends BaseTest {
     }
   }
 
+  @Test
+  public void testGetByJsonBlockId() {
+    long blkNum = 0;
+
+    try {
+      getByJsonBlockId("pending", wallet);
+    } catch (Exception e) {
+      Assert.assertEquals("TAG pending not supported", e.getMessage());
+    }
+
+    try {
+      blkNum = getByJsonBlockId(null, wallet);
+    } catch (Exception e) {
+      Assert.fail();
+    }
+    Assert.assertEquals(-1, blkNum);
+
+    try {
+      blkNum = getByJsonBlockId("latest", wallet);
+    } catch (Exception e) {
+      Assert.fail();
+    }
+    Assert.assertEquals(-1, blkNum);
+
+    try {
+      blkNum = getByJsonBlockId("finalized", wallet);
+    } catch (Exception e) {
+      Assert.fail();
+    }
+    Assert.assertEquals(LATEST_SOLIDIFIED_BLOCK_NUM, blkNum);
+
+    try {
+      blkNum = getByJsonBlockId("0xa", wallet);
+    } catch (Exception e) {
+      Assert.fail();
+    }
+    Assert.assertEquals(10L, blkNum);
+
+    try {
+      getByJsonBlockId("abc", wallet);
+    } catch (Exception e) {
+      Assert.assertEquals("Incorrect hex syntax", e.getMessage());
+    }
+
+    try {
+      getByJsonBlockId("0xxabc", wallet);
+    } catch (Exception e) {
+      Assert.assertEquals("For input string: \"xabc\"", e.getMessage());
+    }
+  }
+
+  @Test
+  public void testGetTrxBalance() {
+    String balance = "";
+
+    try {
+      tronJsonRpc.getTrxBalance("", "earliest");
+    } catch (Exception e) {
+      Assert.assertEquals("TAG [earliest | pending | finalized] not supported",
+          e.getMessage());
+    }
+
+    try {
+      tronJsonRpc.getTrxBalance("", "pending");
+    } catch (Exception e) {
+      Assert.assertEquals("TAG [earliest | pending | finalized] not supported",
+          e.getMessage());
+    }
+
+    try {
+      tronJsonRpc.getTrxBalance("", "finalized");
+    } catch (Exception e) {
+      Assert.assertEquals("TAG [earliest | pending | finalized] not supported",
+          e.getMessage());
+    }
+
+    try {
+      balance = tronJsonRpc.getTrxBalance("0xabd4b9367799eaa3197fecb144eb71de1e049abc",
+          "latest");
+    } catch (Exception e) {
+      Assert.fail();
+    }
+    Assert.assertEquals("0x2540be400", balance);
+  }
+
+  @Test
+  public void testGetStorageAt() {
+    try {
+      tronJsonRpc.getStorageAt("", "", "earliest");
+    } catch (Exception e) {
+      Assert.assertEquals("TAG [earliest | pending | finalized] not supported",
+          e.getMessage());
+    }
+
+    try {
+      tronJsonRpc.getStorageAt("", "", "pending");
+    } catch (Exception e) {
+      Assert.assertEquals("TAG [earliest | pending | finalized] not supported",
+          e.getMessage());
+    }
+
+    try {
+      tronJsonRpc.getStorageAt("", "", "finalized");
+    } catch (Exception e) {
+      Assert.assertEquals("TAG [earliest | pending | finalized] not supported",
+          e.getMessage());
+    }
+  }
+
+  @Test
+  public void testGetABIOfSmartContract() {
+    try {
+      tronJsonRpc.getABIOfSmartContract("", "earliest");
+    } catch (Exception e) {
+      Assert.assertEquals("TAG [earliest | pending | finalized] not supported",
+          e.getMessage());
+    }
+
+    try {
+      tronJsonRpc.getABIOfSmartContract("", "pending");
+    } catch (Exception e) {
+      Assert.assertEquals("TAG [earliest | pending | finalized] not supported",
+          e.getMessage());
+    }
+
+    try {
+      tronJsonRpc.getABIOfSmartContract("", "finalized");
+    } catch (Exception e) {
+      Assert.assertEquals("TAG [earliest | pending | finalized] not supported",
+          e.getMessage());
+    }
+  }
+
+  @Test
+  public void testGetCall() {
+    try {
+      tronJsonRpc.getCall(null, "earliest");
+    } catch (Exception e) {
+      Assert.assertEquals("TAG [earliest | pending | finalized] not supported",
+          e.getMessage());
+    }
+
+    try {
+      tronJsonRpc.getCall(null, "pending");
+    } catch (Exception e) {
+      Assert.assertEquals("TAG [earliest | pending | finalized] not supported",
+          e.getMessage());
+    }
+
+    try {
+      tronJsonRpc.getCall(null, "finalized");
+    } catch (Exception e) {
+      Assert.assertEquals("TAG [earliest | pending | finalized] not supported",
+          e.getMessage());
+    }
+  }
+
+  /**
+   * test fromBlock and toBlock parameters
+   */
+  @Test
+  public void testLogFilterWrapper() {
+
+    // fromBlock and toBlock are both empty
+    try {
+      LogFilterWrapper logFilterWrapper =
+          new LogFilterWrapper(new FilterRequest(null, null, null, null, null), 100, null);
+      Assert.assertEquals(100, logFilterWrapper.getFromBlock());
+      Assert.assertEquals(Long.MAX_VALUE, logFilterWrapper.getToBlock());
+    } catch (JsonRpcInvalidParamsException e) {
+      Assert.fail();
+    }
+
+    // fromBlock is not empty and smaller than currentMaxBlockNum, toBlock is empty
+    try {
+      LogFilterWrapper logFilterWrapper =
+          new LogFilterWrapper(new FilterRequest("0x14", null, null, null, null), 100, null);
+      Assert.assertEquals(20, logFilterWrapper.getFromBlock());
+      Assert.assertEquals(Long.MAX_VALUE, logFilterWrapper.getToBlock());
+    } catch (JsonRpcInvalidParamsException e) {
+      Assert.fail();
+    }
+
+    // fromBlock is not empty and bigger than currentMaxBlockNum, toBlock is empty
+    try {
+      LogFilterWrapper logFilterWrapper =
+          new LogFilterWrapper(new FilterRequest("0x78", null, null, null, null), 100, null);
+      Assert.assertEquals(120, logFilterWrapper.getFromBlock());
+      Assert.assertEquals(Long.MAX_VALUE, logFilterWrapper.getToBlock());
+    } catch (JsonRpcInvalidParamsException e) {
+      Assert.fail();
+    }
+
+    // fromBlock is empty, toBlock is not empty and smaller than currentMaxBlockNum
+    try {
+      LogFilterWrapper logFilterWrapper =
+          new LogFilterWrapper(new FilterRequest(null, "0x14", null, null, null), 100, null);
+      Assert.assertEquals(20, logFilterWrapper.getFromBlock());
+      Assert.assertEquals(20, logFilterWrapper.getToBlock());
+    } catch (JsonRpcInvalidParamsException e) {
+      Assert.fail();
+    }
+
+    // fromBlock is empty, toBlock is not empty and bigger than currentMaxBlockNum
+    try {
+      LogFilterWrapper logFilterWrapper =
+          new LogFilterWrapper(new FilterRequest(null, "0x78", null, null, null), 100, null);
+      Assert.assertEquals(100, logFilterWrapper.getFromBlock());
+      Assert.assertEquals(120, logFilterWrapper.getToBlock());
+    } catch (JsonRpcInvalidParamsException e) {
+      Assert.fail();
+    }
+
+    // fromBlock is not empty, toBlock is not empty
+    try {
+      LogFilterWrapper logFilterWrapper =
+          new LogFilterWrapper(new FilterRequest("0x14", "0x78", null, null, null), 100, null);
+      Assert.assertEquals(20, logFilterWrapper.getFromBlock());
+      Assert.assertEquals(120, logFilterWrapper.getToBlock());
+    } catch (JsonRpcInvalidParamsException e) {
+      Assert.fail();
+    }
+    try {
+      LogFilterWrapper logFilterWrapper =
+          new LogFilterWrapper(new FilterRequest("0x78", "0x14", null, null, null), 100, null);
+    } catch (JsonRpcInvalidParamsException e) {
+      Assert.assertEquals("please verify: fromBlock <= toBlock", e.getMessage());
+    }
+
+    //fromBlock or toBlock is not hex num
+    try {
+      LogFilterWrapper logFilterWrapper =
+          new LogFilterWrapper(new FilterRequest("earliest", null, null, null, null), 100, null);
+      Assert.assertEquals(0, logFilterWrapper.getFromBlock());
+      Assert.assertEquals(Long.MAX_VALUE, logFilterWrapper.getToBlock());
+    } catch (JsonRpcInvalidParamsException e) {
+      Assert.fail();
+    }
+    try {
+      LogFilterWrapper logFilterWrapper =
+          new LogFilterWrapper(new FilterRequest("latest", null, null, null, null), 100, null);
+      Assert.assertEquals(100, logFilterWrapper.getFromBlock());
+      Assert.assertEquals(Long.MAX_VALUE, logFilterWrapper.getToBlock());
+    } catch (JsonRpcInvalidParamsException e) {
+      Assert.fail();
+    }
+    try {
+      new LogFilterWrapper(new FilterRequest("pending", null, null, null, null), 100, null);
+    } catch (JsonRpcInvalidParamsException e) {
+      Assert.assertEquals("TAG pending not supported", e.getMessage());
+    }
+    try {
+      LogFilterWrapper logFilterWrapper =
+          new LogFilterWrapper(new FilterRequest("finalized", null, null, null, null), 100, wallet);
+      Assert.assertEquals(LATEST_SOLIDIFIED_BLOCK_NUM, logFilterWrapper.getFromBlock());
+      Assert.assertEquals(Long.MAX_VALUE, logFilterWrapper.getToBlock());
+    } catch (JsonRpcInvalidParamsException e) {
+      Assert.fail();
+    }
+    try {
+      new LogFilterWrapper(new FilterRequest("test", null, null, null, null), 100, null);
+    } catch (JsonRpcInvalidParamsException e) {
+      Assert.assertEquals("Incorrect hex syntax", e.getMessage());
+    }
+  }
 }


### PR DESCRIPTION
**What does this PR do?**
make ethGetBlockByNumber and other jsonrpc methods support finalized


**Why are these changes required?**
For many developers, they need to get the latest solidified/finalized block number, then fetch other data by this number.

For more details, visit [issue #5953 ](https://github.com/tronprotocol/java-tron/issues/5953)


**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

