### PR TITLE
feat(witness): sort witness from address hashcode to address

### DIFF
--- a/chainbase/src/main/java/org/tron/core/service/MortgageService.java
+++ b/chainbase/src/main/java/org/tron/core/service/MortgageService.java
@@ -1,8 +1,6 @@
 package org.tron.core.service;
 
-import com.google.protobuf.ByteString;
 import java.math.BigInteger;
-import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.Getter;
@@ -51,7 +49,8 @@ public class MortgageService {
   }
 
   public void payStandbyWitness() {
-    List<WitnessCapsule> witnessStandbys = witnessStore.getWitnessStandby();
+    List<WitnessCapsule> witnessStandbys = witnessStore.getWitnessStandby(
+        dynamicPropertiesStore.allowWitnessSortOptimization());
     long voteSum = witnessStandbys.stream().mapToLong(WitnessCapsule::getVoteCount).sum();
     if (voteSum < 1) {
       return;
@@ -227,10 +226,6 @@ public class MortgageService {
     return reward;
   }
 
-  public WitnessCapsule getWitnessByAddress(ByteString address) {
-    return witnessStore.get(address.toByteArray());
-  }
-
   public void adjustAllowance(byte[] address, long amount) {
     try {
       if (amount <= 0) {
@@ -257,11 +252,6 @@ public class MortgageService {
     }
     account.setAllowance(allowance + amount);
     accountStore.put(account.createDbKey(), account);
-  }
-
-  private void sortWitness(List<ByteString> list) {
-    list.sort(Comparator.comparingLong((ByteString b) -> getWitnessByAddress(b).getVoteCount())
-        .reversed().thenComparing(Comparator.comparingInt(ByteString::hashCode).reversed()));
   }
 
   private long getOldReward(long begin, long end, List<Pair<byte[], Long>> votes) {

--- a/chainbase/src/main/java/org/tron/core/store/DynamicPropertiesStore.java
+++ b/chainbase/src/main/java/org/tron/core/store/DynamicPropertiesStore.java
@@ -2910,6 +2910,10 @@ public class DynamicPropertiesStore extends TronStoreWithRevoking<BytesCapsule> 
     return getConsensusLogicOptimization() == 1L;
   }
 
+  public boolean allowWitnessSortOptimization() {
+    return this.allowConsensusLogicOptimization();
+  }
+
   private static class DynamicResourceProperties {
 
     private static final byte[] ONE_DAY_NET_LIMIT = "ONE_DAY_NET_LIMIT".getBytes();

--- a/consensus/src/main/java/org/tron/consensus/ConsensusDelegate.java
+++ b/consensus/src/main/java/org/tron/consensus/ConsensusDelegate.java
@@ -135,4 +135,8 @@ public class ConsensusDelegate {
   public boolean allowChangeDelegation() {
     return dynamicPropertiesStore.allowChangeDelegation();
   }
+
+  public void sortWitness(List<ByteString> list) {
+    witnessStore.sortWitness(list, dynamicPropertiesStore.allowWitnessSortOptimization());
+  }
 }

--- a/consensus/src/main/java/org/tron/consensus/dpos/DposService.java
+++ b/consensus/src/main/java/org/tron/consensus/dpos/DposService.java
@@ -163,11 +163,7 @@ public class DposService implements ConsensusInterface {
   }
 
   public void updateWitness(List<ByteString> list) {
-    list.sort(Comparator.comparingLong((ByteString b) ->
-        consensusDelegate.getWitness(b.toByteArray()).getVoteCount())
-        .reversed()
-        .thenComparing(Comparator.comparingInt(ByteString::hashCode).reversed()));
-
+    consensusDelegate.sortWitness(list);
     if (list.size() > MAX_ACTIVE_WITNESS_NUM) {
       consensusDelegate
           .saveActiveWitnesses(list.subList(0, MAX_ACTIVE_WITNESS_NUM));

--- a/framework/src/test/java/org/tron/core/actuator/VoteWitnessActuatorTest.java
+++ b/framework/src/test/java/org/tron/core/actuator/VoteWitnessActuatorTest.java
@@ -52,6 +52,7 @@ public class VoteWitnessActuatorTest extends BaseTest {
 
   static {
     Args.setParam(new String[]{"--output-directory", dbPath()}, Constant.TEST_CONF);
+    Args.getInstance().setConsensusLogicOptimization(1);
     OWNER_ADDRESS = Wallet.getAddressPreFixString() + "abd4b9367799eaa3197fecb144eb71de1e049abc";
     WITNESS_ADDRESS = Wallet.getAddressPreFixString() + "548794500882809695a8a687866e76d4271a1abc";
     WITNESS_ADDRESS_NOACCOUNT =

--- a/framework/src/test/java/org/tron/core/db/ManagerTest.java
+++ b/framework/src/test/java/org/tron/core/db/ManagerTest.java
@@ -618,7 +618,8 @@ public class ManagerTest extends BlockGenerate {
     WitnessCapsule witnessCapsule = new WitnessCapsule(ByteString.copyFrom(address));
     chainManager.getWitnessScheduleStore().saveActiveWitnesses(new ArrayList<>());
     chainManager.addWitness(ByteString.copyFrom(address));
-    List<WitnessCapsule> witnessStandby1 = chainManager.getWitnessStore().getWitnessStandby();
+    List<WitnessCapsule> witnessStandby1 = chainManager.getWitnessStore().getWitnessStandby(
+        chainManager.getDynamicPropertiesStore().allowWitnessSortOptimization());
     Block block = getSignedBlock(witnessCapsule.getAddress(), 1533529947843L, privateKey);
     dbManager.pushBlock(new BlockCapsule(block));
 
@@ -656,7 +657,8 @@ public class ManagerTest extends BlockGenerate {
       Assert.assertTrue(e instanceof Exception);
     }
     chainManager.getWitnessStore().put(address, sr2);
-    List<WitnessCapsule> witnessStandby2 = chainManager.getWitnessStore().getWitnessStandby();
+    List<WitnessCapsule> witnessStandby2 = chainManager.getWitnessStore().getWitnessStandby(
+        chainManager.getDynamicPropertiesStore().allowWitnessSortOptimization());
     Assert.assertNotEquals(witnessStandby1, witnessStandby2);
   }
 

--- a/framework/src/test/java/org/tron/core/db/WitnessStoreTest.java
+++ b/framework/src/test/java/org/tron/core/db/WitnessStoreTest.java
@@ -1,6 +1,9 @@
 package org.tron.core.db;
 
 import com.google.protobuf.ByteString;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 import javax.annotation.Resource;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Assert;
@@ -46,5 +49,27 @@ public class WitnessStoreTest extends BaseTest {
     Assert.assertEquals(100L, witnessSource.getVoteCount());
   }
 
-
+  @Test
+  public void testSortWitness() {
+    this.witnessStore.reset();
+    WitnessCapsule s1 = new WitnessCapsule(
+        ByteString.copyFrom(new byte[]{1, 2, 3}), 100L, "URL-1");
+    this.witnessStore.put(s1.getAddress().toByteArray(), s1);
+    WitnessCapsule s2 = new WitnessCapsule(
+        ByteString.copyFrom(new byte[]{1, 1, 34}), 100L, "URL-2");
+    this.witnessStore.put(s2.getAddress().toByteArray(), s2);
+    List<WitnessCapsule> allWitnesses = this.witnessStore.getAllWitnesses();
+    List<ByteString> witnessAddress = allWitnesses.stream().map(WitnessCapsule::getAddress)
+        .collect(Collectors.toList());
+    this.witnessStore.sortWitness(witnessAddress, false);
+    this.witnessStore.sortWitnesses(allWitnesses, false);
+    Assert.assertEquals(witnessAddress, allWitnesses.stream().map(WitnessCapsule::getAddress)
+        .collect(Collectors.toList()));
+    List<ByteString> pre = new ArrayList<>(witnessAddress);
+    this.witnessStore.sortWitness(witnessAddress, true);
+    this.witnessStore.sortWitnesses(allWitnesses, true);
+    Assert.assertEquals(witnessAddress, allWitnesses.stream().map(WitnessCapsule::getAddress)
+        .collect(Collectors.toList()));
+    Assert.assertNotEquals(pre, witnessAddress);
+  }
 }

--- a/framework/src/test/java/org/tron/core/services/DelegationServiceTest.java
+++ b/framework/src/test/java/org/tron/core/services/DelegationServiceTest.java
@@ -107,6 +107,7 @@ public class DelegationServiceTest {
 
   public void test() {
     manager.getDynamicPropertiesStore().saveChangeDelegation(1);
+    manager.getDynamicPropertiesStore().saveConsensusLogicOptimization(1);
     byte[] sr27 = decodeFromBase58Check("TLTDZBcPoJ8tZ6TTEeEqEvwYFk2wgotSfD");
     manager.getDelegationStore().setBrokerage(0, sr27, 10);
     manager.getDelegationStore().setBrokerage(1, sr27, 20);

--- a/framework/src/test/java/org/tron/core/services/ProposalServiceTest.java
+++ b/framework/src/test/java/org/tron/core/services/ProposalServiceTest.java
@@ -112,6 +112,7 @@ public class ProposalServiceTest extends BaseTest {
     long v = dbManager.getDynamicPropertiesStore().getConsensusLogicOptimization();
     Assert.assertEquals(v, 0);
     Assert.assertTrue(!dbManager.getDynamicPropertiesStore().allowConsensusLogicOptimization());
+    Assert.assertFalse(dbManager.getDynamicPropertiesStore().allowWitnessSortOptimization());
 
     long value = 1;
     Proposal proposal =
@@ -125,6 +126,7 @@ public class ProposalServiceTest extends BaseTest {
     Assert.assertEquals(v, value);
 
     Assert.assertTrue(dbManager.getDynamicPropertiesStore().allowConsensusLogicOptimization());
+    Assert.assertTrue(dbManager.getDynamicPropertiesStore().allowWitnessSortOptimization());
   }
 
 }


### PR DESCRIPTION
**What does this PR do?**

  Sort witness from address hashcode to address.
   
**Why are these changes required?**
    Avoid `hashCode` collisions:
    During the maintenance period, votes for the witnesses are aggregated. After performing this vote aggregation, the list of the 27 Super Representatives and 127 Standby Witnesses is extracted, ordered according to the number of votes, and then by the ByteString.hashCode().
  
**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

