### PR TITLE
feat(dependency): dependencies upgrade for security

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     api "com.cedarsoftware:java-util:1.8.0"
     api group: 'org.apache.httpcomponents', name: 'httpasyncclient', version: '4.1.1'
     api group: 'commons-codec', name: 'commons-codec', version: '1.11'
-    api group: 'com.beust', name: 'jcommander', version: '1.72'
+    api group: 'com.beust', name: 'jcommander', version: '1.78'
     api group: 'com.typesafe', name: 'config', version: '1.3.2'
     api group: leveldbGroup, name: leveldbName, version: leveldbVersion
     api group: 'org.rocksdb', name: 'rocksdbjni', version: '5.15.10'

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     api 'org.aspectj:aspectjrt:1.8.13'
     api 'org.aspectj:aspectjweaver:1.8.13'
     api 'org.aspectj:aspectjtools:1.8.13'
-    api group: 'io.github.tronprotocol', name: 'libp2p', version: '2.2.4',{
+    api group: 'io.github.tronprotocol', name: 'libp2p', version: '2.2.5',{
         exclude group: 'io.grpc', module: 'grpc-context'
         exclude group: 'io.grpc', module: 'grpc-core'
         exclude group: 'io.grpc', module: 'grpc-netty'
@@ -60,6 +60,8 @@ dependencies {
         exclude group: 'net.java.dev.msv', module: 'xsdlib'
         exclude group: 'pull-parser', module: 'pull-parser'
         exclude group: 'xpp3', module: 'xpp3'
+        exclude group: 'org.bouncycastle', module: 'bcprov-jdk18on'
+        exclude group: 'org.bouncycastle', module: 'bcutil-jdk18on'
     }
     api project(":protocol")
 }

--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -57,7 +57,9 @@ dependencies {
     compileOnly group: 'javax.portlet', name: 'portlet-api', version: '3.0.1'
 
     implementation "io.vavr:vavr:0.9.2"
-    implementation group: 'org.pf4j', name: 'pf4j', version: '2.5.0'
+    implementation (group: 'org.pf4j', name: 'pf4j', version: '3.10.0') {
+        exclude group: "org.slf4j", module: "slf4j-api"
+    }
 
     testImplementation group: 'org.springframework', name: 'spring-test', version: '5.2.0.RELEASE'
     testImplementation group: 'org.springframework', name: 'spring-web', version: '5.2.0.RELEASE'

--- a/framework/src/main/java/org/tron/common/client/DatabaseGrpcClient.java
+++ b/framework/src/main/java/org/tron/common/client/DatabaseGrpcClient.java
@@ -1,7 +1,9 @@
 package org.tron.common.client;
 
+import io.grpc.LoadBalancerRegistry;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
+import io.grpc.internal.PickFirstLoadBalancerProvider;
 import org.tron.api.DatabaseGrpc;
 import org.tron.api.GrpcAPI.EmptyMessage;
 import org.tron.api.GrpcAPI.NumberMessage;
@@ -12,6 +14,12 @@ public class DatabaseGrpcClient {
 
   private final ManagedChannel channel;
   private final DatabaseGrpc.DatabaseBlockingStub databaseBlockingStub;
+
+  static {
+    LoadBalancerRegistry
+        .getDefaultRegistry()
+        .register(new PickFirstLoadBalancerProvider());
+  }
 
   public DatabaseGrpcClient(String host, int port) {
     channel = ManagedChannelBuilder.forAddress(host, port)

--- a/framework/src/main/java/org/tron/core/config/args/Args.java
+++ b/framework/src/main/java/org/tron/core/config/args/Args.java
@@ -260,14 +260,15 @@ public class Args extends CommonParameter {
     } catch (IOException e) {
       logger.error(e.getMessage());
     }
-    JCommander.getConsole().println("OS : " + System.getProperty("os.name"));
-    JCommander.getConsole().println("JVM : " + System.getProperty("java.vendor") + " "
+    JCommander jCommander = new JCommander();
+    jCommander.getConsole().println("OS : " + System.getProperty("os.name"));
+    jCommander.getConsole().println("JVM : " + System.getProperty("java.vendor") + " "
         + System.getProperty("java.version") + " " + System.getProperty("os.arch"));
     if (!noGitProperties) {
-      JCommander.getConsole().println("Git : " + properties.getProperty("git.commit.id"));
+      jCommander.getConsole().println("Git : " + properties.getProperty("git.commit.id"));
     }
-    JCommander.getConsole().println("Version : " + Version.getVersion());
-    JCommander.getConsole().println("Code : " + Version.VERSION_CODE);
+    jCommander.getConsole().println("Version : " + Version.getVersion());
+    jCommander.getConsole().println("Code : " + Version.VERSION_CODE);
   }
 
   public static void printHelp(JCommander jCommander) {
@@ -311,7 +312,7 @@ public class Args extends CommonParameter {
         helpStr.append(tmpOptionDesc);
       }
     }
-    JCommander.getConsole().println(helpStr.toString());
+    jCommander.getConsole().println(helpStr.toString());
   }
 
   public static String upperFirst(String name) {

--- a/protocol/build.gradle
+++ b/protocol/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.google.protobuf'
 
 def protobufVersion = '3.25.5'
-def grpcVersion = '1.52.1'
+def grpcVersion = '1.60.0'
 
 dependencies {
     api group: 'com.google.protobuf', name: 'protobuf-java', version: protobufVersion


### PR DESCRIPTION
**What does this PR do?**

- bump jcommander from 1.72 to 1.78

- bump pf4j from 2.5.0 to 3.10.0

- bump grpc from 1.52.1 to 1.60.0

- bump libp2p from 2.2.4 to 2.2.5

**Why are these changes required?**
    dependencies upgrade for security
**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

