### PR TITLE
fix(tvm): revert tstore in staticcall

### DIFF
--- a/actuator/src/main/java/org/tron/core/vm/OperationActions.java
+++ b/actuator/src/main/java/org/tron/core/vm/OperationActions.java
@@ -656,6 +656,9 @@ public class OperationActions {
   }
 
   public static void tStoreAction(Program program) {
+    if (program.isStaticCall()) {
+      throw new Program.StaticCallModificationException();
+    }
     DataWord key = program.stackPop();
     DataWord value = program.stackPop();
     DataWord address = program.getContractAddress();

--- a/actuator/src/main/java/org/tron/core/vm/program/invoke/ProgramInvokeMockImpl.java
+++ b/actuator/src/main/java/org/tron/core/vm/program/invoke/ProgramInvokeMockImpl.java
@@ -210,6 +210,10 @@ public class ProgramInvokeMockImpl implements ProgramInvoke {
     this.ownerAddress = Arrays.clone(ownerAddress);
   }
 
+  public void setStaticCall(boolean isStatic) {
+    isStaticCall = isStatic;
+  }
+
   @Override
   public boolean isStaticCall() {
     return isStaticCall;

--- a/framework/src/test/java/org/tron/common/runtime/vm/OperationsTest.java
+++ b/framework/src/test/java/org/tron/common/runtime/vm/OperationsTest.java
@@ -953,6 +953,15 @@ public class OperationsTest extends BaseTest {
 
     // TSTORE = 0x5d;
     op = new byte[] {0x60, 0x01, 0x60, 0x01, 0x5d};
+
+    invoke.setStaticCall(true);
+    program = new Program(op, op, invoke, interTrx);
+    testOperations(program);
+    Assert.assertEquals(20000, program.getResult().getEnergyUsed());
+    Assert.assertTrue(program.getResult().getException()
+        instanceof Program.StaticCallModificationException);
+
+    invoke.setStaticCall(false);
     program = new Program(op, op, invoke, interTrx);
     testOperations(program);
     Assert.assertEquals(106, program.getResult().getEnergyUsed());


### PR DESCRIPTION
**What does this PR do?**
revert tstore in staticcall

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

