### PR TITLE
fix(jsonrpc): ensure toJsonHex returns valid hex for empty byte arrays

### DIFF
--- a/common/src/main/java/org/tron/common/utils/ByteArray.java
+++ b/common/src/main/java/org/tron/common/utils/ByteArray.java
@@ -114,7 +114,7 @@ public class ByteArray {
    * null for empty []
    */
   public static String toJsonHex(byte[] x) {
-    return x == null || x.length == 0 ? "0x" : "0x" + Hex.toHexString(x);
+    return x == null || x.length == 0 ? "0x00" : "0x" + Hex.toHexString(x);
   }
 
   // ignore the 41


### PR DESCRIPTION
**What does this PR do?**
This PR fixes the toJsonHex method to return "0x00" instead of "0x" when the input byte array is empty or null. This ensures that all returned hex values follow a valid format.

**Why are these changes required?**
Previously, when an empty byte array (new byte[0]) was passed, the method returned "0x", which is not a valid hex representation. This could cause issues with JSON-RPC clients that expect an even-length hex string. **The fix ensures compatibility and proper formatting, which causes error, when parsing incorrect hex string.**

**This PR has been tested by:**
✅ Unit Tests
✅ Manual Testing

**Follow up**
No additional changes are required at this time. However, it may be beneficial to audit other methods returning hex strings to ensure consistency across the project.

