### PR TITLE
feat(service): exit when params init failed

### DIFF
--- a/common/src/main/java/org/tron/core/exception/TronError.java
+++ b/common/src/main/java/org/tron/core/exception/TronError.java
@@ -45,6 +45,8 @@ public class TronError extends Error {
     TRON_NET_SERVICE_INIT(1),
     ZCASH_INIT(1),
     LOG_LOAD(1),
+    WITNESS_INIT(1),
+    RATE_LIMITER_INIT(1),
     SOLID_NODE_INIT(0);
 
     private final int code;

--- a/framework/src/main/java/org/tron/core/config/args/Args.java
+++ b/framework/src/main/java/org/tron/core/config/args/Args.java
@@ -450,7 +450,8 @@ public class Args extends CommonParameter {
 
     if (PARAMETER.isWitness()
         && CollectionUtils.isEmpty(localWitnesses.getPrivateKeys())) {
-      logger.warn("This is a witness node, but localWitnesses is null");
+      throw new TronError("This is a witness node, but localWitnesses is null",
+          TronError.ErrCode.WITNESS_INIT);
     }
 
     if (config.hasPath(Constant.VM_SUPPORT_CONSTANT)) {
@@ -1141,7 +1142,7 @@ public class Args extends CommonParameter {
         PARAMETER.shutdownBlockTime = new CronExpression(config.getString(
             Constant.NODE_SHUTDOWN_BLOCK_TIME));
       } catch (ParseException e) {
-        logger.error(e.getMessage(), e);
+        throw new TronError(e, TronError.ErrCode.AUTO_STOP_PARAMS);
       }
     }
 

--- a/framework/src/test/java/org/tron/common/runtime/vm/BandWidthRuntimeOutOfTimeTest.java
+++ b/framework/src/test/java/org/tron/common/runtime/vm/BandWidthRuntimeOutOfTimeTest.java
@@ -73,7 +73,6 @@ public class BandWidthRuntimeOutOfTimeTest extends BaseTest {
             "--output-directory", dbPath(),
             "--storage-db-directory", dbDirectory,
             "--storage-index-directory", indexDirectory,
-            "-w",
             "--debug"
         },
         "config-test-mainnet.conf"

--- a/framework/src/test/java/org/tron/common/runtime/vm/BandWidthRuntimeOutOfTimeWithCheckTest.java
+++ b/framework/src/test/java/org/tron/common/runtime/vm/BandWidthRuntimeOutOfTimeWithCheckTest.java
@@ -74,7 +74,6 @@ public class BandWidthRuntimeOutOfTimeWithCheckTest extends BaseTest {
             "--output-directory", dbPath(),
             "--storage-db-directory", dbDirectory,
             "--storage-index-directory", indexDirectory,
-            "-w",
             "--debug"
         },
         "config-test-mainnet.conf"

--- a/framework/src/test/java/org/tron/common/runtime/vm/BandWidthRuntimeTest.java
+++ b/framework/src/test/java/org/tron/common/runtime/vm/BandWidthRuntimeTest.java
@@ -69,7 +69,6 @@ public class BandWidthRuntimeTest extends BaseTest {
             "--output-directory", dbPath(),
             "--storage-db-directory", dbDirectory,
             "--storage-index-directory", indexDirectory,
-            "-w"
         },
         "config-test-mainnet.conf"
     );

--- a/framework/src/test/java/org/tron/common/runtime/vm/BandWidthRuntimeWithCheckTest.java
+++ b/framework/src/test/java/org/tron/common/runtime/vm/BandWidthRuntimeWithCheckTest.java
@@ -76,7 +76,6 @@ public class BandWidthRuntimeWithCheckTest extends BaseTest {
             "--output-directory", dbPath(),
             "--storage-db-directory", dbDirectory,
             "--storage-index-directory", indexDirectory,
-            "-w"
         },
         "config-test-mainnet.conf"
     );

--- a/framework/src/test/java/org/tron/common/storage/leveldb/LevelDbDataSourceImplTest.java
+++ b/framework/src/test/java/org/tron/common/storage/leveldb/LevelDbDataSourceImplTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -41,9 +42,7 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 import org.tron.common.utils.ByteArray;
 import org.tron.common.utils.FileUtil;
@@ -73,9 +72,6 @@ public class LevelDbDataSourceImplTest {
   private byte[] key4 = "00000004aa".getBytes();
   private byte[] key5 = "00000005aa".getBytes();
   private byte[] key6 = "00000006aa".getBytes();
-
-  @Rule
-  public final ExpectedException exception = ExpectedException.none();
 
   /**
    * Release resources.
@@ -351,12 +347,11 @@ public class LevelDbDataSourceImplTest {
 
   @Test
   public void initDbTest() {
-    exception.expect(TronError.class);
     makeExceptionDb("test_initDb");
     LevelDbDataSourceImpl dataSource = new LevelDbDataSourceImpl(
         Args.getInstance().getOutputDirectory(), "test_initDb");
-    dataSource.initDB();
-    dataSource.closeDB();
+    TronError thrown = assertThrows(TronError.class, dataSource::initDB);
+    assertEquals(TronError.ErrCode.LEVELDB_INIT, thrown.getErrCode());
   }
 
   private void makeExceptionDb(String dbName) {

--- a/framework/src/test/java/org/tron/common/storage/leveldb/RocksDbDataSourceImplTest.java
+++ b/framework/src/test/java/org/tron/common/storage/leveldb/RocksDbDataSourceImplTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -23,9 +24,7 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 import org.tron.common.storage.rocksdb.RocksDbDataSourceImpl;
 import org.tron.common.utils.ByteArray;
@@ -55,9 +54,6 @@ public class RocksDbDataSourceImplTest {
   private byte[] key4 = "00000004aa".getBytes();
   private byte[] key5 = "00000005aa".getBytes();
   private byte[] key6 = "00000006aa".getBytes();
-
-  @Rule
-  public final ExpectedException exception = ExpectedException.none();
 
   /**
    * Release resources.
@@ -393,12 +389,11 @@ public class RocksDbDataSourceImplTest {
 
   @Test
   public void initDbTest() {
-    exception.expect(TronError.class);
     makeExceptionDb("test_initDb");
     RocksDbDataSourceImpl dataSource = new RocksDbDataSourceImpl(
         Args.getInstance().getOutputDirectory(), "test_initDb");
-    dataSource.initDB();
-    dataSource.closeDB();
+    TronError thrown = assertThrows(TronError.class, dataSource::initDB);
+    assertEquals(TronError.ErrCode.ROCKSDB_INIT, thrown.getErrCode());
   }
 
   private void makeExceptionDb(String dbName) {

--- a/framework/src/test/java/org/tron/core/ForkControllerTest.java
+++ b/framework/src/test/java/org/tron/core/ForkControllerTest.java
@@ -31,7 +31,7 @@ public class ForkControllerTest {
   @Before
   public void init() throws IOException {
     Args.setParam(new String[]{"-d",
-        temporaryFolder.newFolder().toString(), "-w"}, Constant.TEST_CONF);
+        temporaryFolder.newFolder().toString()}, Constant.TEST_CONF);
     context = new TronApplicationContext(DefaultConfig.class);
     dynamicPropertiesStore = context.getBean(DynamicPropertiesStore.class);
     chainBaseManager = context.getBean(ChainBaseManager.class);

--- a/framework/src/test/java/org/tron/core/capsule/AccountCapsuleTest.java
+++ b/framework/src/test/java/org/tron/core/capsule/AccountCapsuleTest.java
@@ -36,7 +36,7 @@ public class AccountCapsuleTest extends BaseTest {
   static AccountCapsule accountCapsule;
 
   static {
-    Args.setParam(new String[]{"-d",  dbPath(), "-w"}, Constant.TEST_CONF);
+    Args.setParam(new String[]{"-d",  dbPath()}, Constant.TEST_CONF);
     OWNER_ADDRESS = Wallet.getAddressPreFixString() + "a06a17a49648a8ad32055c06f60fa14ae46df91234";
   }
 

--- a/framework/src/test/java/org/tron/core/capsule/utils/AssetUtilTest.java
+++ b/framework/src/test/java/org/tron/core/capsule/utils/AssetUtilTest.java
@@ -24,7 +24,7 @@ public class AssetUtilTest extends BaseTest {
 
 
   static {
-    Args.setParam(new String[] {"-d", dbPath(), "-w"}, Constant.TEST_CONF);
+    Args.setParam(new String[] {"-d", dbPath()}, Constant.TEST_CONF);
   }
 
   public static byte[] randomBytes(int length) {

--- a/framework/src/test/java/org/tron/core/config/args/ArgsTest.java
+++ b/framework/src/test/java/org/tron/core/config/args/ArgsTest.java
@@ -57,7 +57,7 @@ public class ArgsTest {
 
   @Test
   public void get() {
-    Args.setParam(new String[] {"-w", "-c", Constant.TEST_CONF}, Constant.TESTNET_CONF);
+    Args.setParam(new String[] {"-c", Constant.TEST_CONF}, Constant.TESTNET_CONF);
 
     CommonParameter parameter = Args.getInstance();
 
@@ -132,7 +132,7 @@ public class ArgsTest {
   @Test
   public void testIpFromLibP2p()
       throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
-    Args.setParam(new String[] {"-w"}, Constant.TEST_CONF);
+    Args.setParam(new String[] {}, Constant.TEST_CONF);
     CommonParameter parameter = Args.getInstance();
 
     String configuredExternalIp = parameter.getNodeExternalIp();
@@ -153,7 +153,7 @@ public class ArgsTest {
   @Test
   public void testOldRewardOpt() {
     thrown.expect(IllegalArgumentException.class);
-    Args.setParam(new String[] {"-w", "-c", "args-test.conf"}, Constant.TESTNET_CONF);
+    Args.setParam(new String[] {"-c", "args-test.conf"}, Constant.TESTNET_CONF);
   }
 
   @Test

--- a/framework/src/test/java/org/tron/core/consensus/DposServiceTest.java
+++ b/framework/src/test/java/org/tron/core/consensus/DposServiceTest.java
@@ -4,6 +4,7 @@ import static org.mockito.Mockito.mock;
 
 import com.google.protobuf.ByteString;
 import java.lang.reflect.Field;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -20,6 +21,12 @@ import org.tron.protos.Protocol;
 
 public class DposServiceTest {
   DposService service = new DposService();
+
+
+  @AfterClass
+  public static void destroy() {
+    Args.clearParam();
+  }
 
   @Test
   public void testValidBlockTime() throws Exception {
@@ -53,8 +60,7 @@ public class DposServiceTest {
 
   @Test
   public void testValidSlot() throws Exception {
-    Args.setParam(new String[] {"-w"}, Constant.TEST_CONF);
-    CommonParameter parameter = Args.getInstance();
+    Args.setParam(new String[] {}, Constant.TEST_CONF);
     long headTime = 1724036757000L;
     ByteString witness = ByteString.copyFrom(NetUtil.getNodeId());
     ByteString witness2 = ByteString.copyFrom(NetUtil.getNodeId());

--- a/framework/src/test/java/org/tron/core/db/ManagerTest.java
+++ b/framework/src/test/java/org/tron/core/db/ManagerTest.java
@@ -32,7 +32,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 import org.tron.common.application.TronApplicationContext;
 import org.tron.common.crypto.ECKey;
@@ -115,8 +114,6 @@ public class ManagerTest extends BlockGenerate {
   private static BlockCapsule blockCapsule2;
   @Rule
   public TemporaryFolder temporaryFolder = new TemporaryFolder();
-  @Rule
-  public final ExpectedException exception = ExpectedException.none();
   private static AtomicInteger port = new AtomicInteger(0);
   private static String accountAddress =
       Wallet.getAddressPreFixString() + "548794500882809695a8a687866e76d4271a1abc";
@@ -126,7 +123,7 @@ public class ManagerTest extends BlockGenerate {
   @Before
   public void init() throws IOException {
     Args.setParam(new String[]{"-d",
-        temporaryFolder.newFolder().toString(), "-w"}, Constant.TEST_CONF);
+        temporaryFolder.newFolder().toString()}, Constant.TEST_CONF);
     Args.getInstance().setNodeListenPort(10000 + port.incrementAndGet());
     context = new TronApplicationContext(DefaultConfig.class);
 
@@ -726,7 +723,7 @@ public class ManagerTest extends BlockGenerate {
       BadBlockException, TaposException, BadNumberBlockException, NonCommonBlockException,
       ReceiptCheckErrException, VMIllegalException, TooBigTransactionResultException,
       ZksnarkException, EventBloomException {
-    Args.setParam(new String[]{"--witness"}, Constant.TEST_CONF);
+    Args.setParam(new String[]{}, Constant.TEST_CONF);
     long size = chainManager.getBlockStore().size();
     //  System.out.print("block store size:" + size + "\n");
     String key = PublicMethod.getRandomPrivateKey();
@@ -873,7 +870,7 @@ public class ManagerTest extends BlockGenerate {
       TaposException, BadNumberBlockException, NonCommonBlockException,
       ReceiptCheckErrException, VMIllegalException, TooBigTransactionResultException,
       ZksnarkException, EventBloomException {
-    Args.setParam(new String[]{"--witness"}, Constant.TEST_CONF);
+    Args.setParam(new String[]{}, Constant.TEST_CONF);
     long size = chainManager.getBlockStore().size();
     System.out.print("block store size:" + size + "\n");
     String key = PublicMethod.getRandomPrivateKey();
@@ -985,7 +982,7 @@ public class ManagerTest extends BlockGenerate {
       BadBlockException, TaposException, BadNumberBlockException, NonCommonBlockException,
       ReceiptCheckErrException, VMIllegalException, TooBigTransactionResultException,
       ZksnarkException, EventBloomException {
-    Args.setParam(new String[]{"--witness"}, Constant.TEST_CONF);
+    Args.setParam(new String[]{}, Constant.TEST_CONF);
     long size = chainManager.getBlockStore().size();
     System.out.print("block store size:" + size + "\n");
     String key = PublicMethod.getRandomPrivateKey();;
@@ -1238,10 +1235,11 @@ public class ManagerTest extends BlockGenerate {
 
   @Test
   public void blockTrigger() {
-    exception.expect(TronError.class);
     Manager manager = spy(new Manager());
     doThrow(new RuntimeException("postBlockTrigger mock")).when(manager).postBlockTrigger(any());
-    manager.blockTrigger(new BlockCapsule(Block.newBuilder().build()), 1, 1);
+    TronError thrown = Assert.assertThrows(TronError.class, () ->
+        manager.blockTrigger(new BlockCapsule(Block.newBuilder().build()), 1, 1));
+    Assert.assertEquals(TronError.ErrCode.EVENT_SUBSCRIBE_ERROR, thrown.getErrCode());
   }
 
   public void adjustBalance(AccountStore accountStore, byte[] accountAddress, long amount)

--- a/framework/src/test/java/org/tron/core/db/TransactionStoreTest.java
+++ b/framework/src/test/java/org/tron/core/db/TransactionStoreTest.java
@@ -50,7 +50,7 @@ public class TransactionStoreTest extends BaseTest {
    */
   @BeforeClass
   public static void init() {
-    Args.setParam(new String[]{"--output-directory", dbPath(), "-w"}, Constant.TEST_CONF);
+    Args.setParam(new String[]{"--output-directory", dbPath()}, Constant.TEST_CONF);
   }
 
   /**

--- a/framework/src/test/java/org/tron/core/db/TransactionTraceTest.java
+++ b/framework/src/test/java/org/tron/core/db/TransactionTraceTest.java
@@ -65,7 +65,6 @@ public class TransactionTraceTest extends BaseTest {
             "--output-directory", dbPath(),
             "--storage-db-directory", dbDirectory,
             "--storage-index-directory", indexDirectory,
-            "-w",
             "--debug"
         },
         "config-test-mainnet.conf"

--- a/framework/src/test/java/org/tron/core/db/TxCacheDBTest.java
+++ b/framework/src/test/java/org/tron/core/db/TxCacheDBTest.java
@@ -20,7 +20,7 @@ public class TxCacheDBTest extends BaseTest {
     String dbDirectory = "db_TransactionCache_test";
     String indexDirectory = "index_TransactionCache_test";
     Args.setParam(new String[]{"--output-directory", dbPath(), "--storage-db-directory",
-        dbDirectory, "--storage-index-directory", indexDirectory, "-w"}, Constant.TEST_CONF);
+        dbDirectory, "--storage-index-directory", indexDirectory}, Constant.TEST_CONF);
   }
 
   @Test

--- a/framework/src/test/java/org/tron/core/db/api/AssetUpdateHelperTest.java
+++ b/framework/src/test/java/org/tron/core/db/api/AssetUpdateHelperTest.java
@@ -27,7 +27,7 @@ public class AssetUpdateHelperTest extends BaseTest {
   private static boolean init;
 
   static {
-    Args.setParam(new String[]{"-d", dbPath(), "-w"}, "config-test-index.conf");
+    Args.setParam(new String[]{"-d", dbPath()}, "config-test-index.conf");
     Args.getInstance().setSolidityNode(true);
   }
 

--- a/framework/src/test/java/org/tron/core/db2/SnapshotManagerTest.java
+++ b/framework/src/test/java/org/tron/core/db2/SnapshotManagerTest.java
@@ -15,9 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.tron.common.application.Application;
 import org.tron.common.application.ApplicationFactory;
 import org.tron.common.application.TronApplicationContext;
@@ -43,8 +41,6 @@ public class SnapshotManagerTest {
   private Application appT;
   private TestRevokingTronStore tronDatabase;
 
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
 
   @Before
   public void init() {
@@ -122,19 +118,19 @@ public class SnapshotManagerTest {
 
   @Test
   public void testCheckError() {
-    thrown.expect(TronError.class);
     SnapshotManager manager = spy(new SnapshotManager(""));
     when(manager.getCheckpointList()).thenReturn(Arrays.asList("check1", "check2"));
-    manager.check();
+    TronError thrown = Assert.assertThrows(TronError.class, manager::check);
+    Assert.assertEquals(TronError.ErrCode.CHECKPOINT_VERSION, thrown.getErrCode());
   }
 
   @Test
   public void testFlushError() {
-    thrown.expect(TronError.class);
     SnapshotManager manager = spy(new SnapshotManager(""));
     manager.setUnChecked(false);
     when(manager.getCheckpointList()).thenReturn(Arrays.asList("check1", "check2"));
     when(manager.shouldBeRefreshed()).thenReturn(true);
-    manager.flush();
+    TronError thrown = Assert.assertThrows(TronError.class, manager::flush);
+    Assert.assertEquals(TronError.ErrCode.DB_FLUSH, thrown.getErrCode());
   }
 }

--- a/framework/src/test/java/org/tron/core/event/BlockEventGetTest.java
+++ b/framework/src/test/java/org/tron/core/event/BlockEventGetTest.java
@@ -78,7 +78,7 @@ public class BlockEventGetTest extends BlockGenerate {
   public void before() throws IOException {
     initDbPath();
     logger.info("Full node running.");
-    Args.setParam(new String[] {"-d", dbPath, "-w"}, Constant.TEST_CONF);
+    Args.setParam(new String[] {"-d", dbPath}, Constant.TEST_CONF);
     Args.getInstance().setNodeListenPort(10000 + port.incrementAndGet());
 
     context = new TronApplicationContext(DefaultConfig.class);

--- a/framework/src/test/java/org/tron/core/exception/TronErrorTest.java
+++ b/framework/src/test/java/org/tron/core/exception/TronErrorTest.java
@@ -5,8 +5,14 @@ import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mockStatic;
 
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigObject;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -17,7 +23,13 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.tron.common.log.LogService;
+import org.tron.common.parameter.RateLimiterInitialization;
+import org.tron.common.utils.ReflectUtils;
 import org.tron.common.zksnark.JLibrustzcash;
+import org.tron.core.Constant;
+import org.tron.core.config.args.Args;
+import org.tron.core.services.http.GetBlockServlet;
+import org.tron.core.services.http.RateLimiterServlet;
 import org.tron.core.zen.ZksnarkInitService;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -29,6 +41,7 @@ public class TronErrorTest {
   @After
   public void  clearMocks() {
     Mockito.clearAllCaches();
+    Args.clearParam();
   }
 
   @Test
@@ -63,5 +76,42 @@ public class TronErrorTest {
     Path path = temporaryFolder.newFile("logback.xml").toPath();
     TronError thrown = assertThrows(TronError.class, () -> LogService.load(path.toString()));
     assertEquals(TronError.ErrCode.LOG_LOAD, thrown.getErrCode());
+  }
+
+  @Test
+  public void witnessInitTest() {
+    TronError thrown = assertThrows(TronError.class, () -> {
+      Args.setParam(new String[]{"--witness"}, Constant.TEST_CONF);
+    });
+    assertEquals(TronError.ErrCode.WITNESS_INIT, thrown.getErrCode());
+  }
+
+  @Test
+  public void rateLimiterServletInitTest() {
+    Args.setParam(new String[]{}, Constant.TEST_CONF);
+    RateLimiterInitialization rateLimiter = new RateLimiterInitialization();
+    Args.getInstance().setRateLimiterInitialization(rateLimiter);
+    Map<String, String> item = new HashMap<>();
+    item.put("strategy", "strategy");
+    item.put("paramString", "params");
+    item.put("component", "GetBlockServlet");
+    ConfigObject config = ConfigFactory.parseMap(item).root();
+    rateLimiter.setHttpMap(
+        Collections.singletonList(new RateLimiterInitialization.HttpRateLimiterItem(config)));
+    RateLimiterServlet servlet = new GetBlockServlet();
+    TronError thrown = assertThrows(TronError.class, () ->
+        ReflectUtils.invokeMethod(servlet, "addRateContainer"));
+    assertEquals(TronError.ErrCode.RATE_LIMITER_INIT, thrown.getErrCode());
+  }
+
+  @Test
+  public void shutdownBlockTimeInitTest() {
+    Map<String,String> params = new HashMap<>();
+    params.put(Constant.NODE_SHUTDOWN_BLOCK_TIME, "0");
+    params.put("storage.db.directory", "database");
+    Config config = ConfigFactory.defaultOverrides().withFallback(
+        ConfigFactory.parseMap(params));
+    TronError thrown = assertThrows(TronError.class, () -> Args.setParam(config));
+    assertEquals(TronError.ErrCode.AUTO_STOP_PARAMS, thrown.getErrCode());
   }
 }

--- a/framework/src/test/java/org/tron/core/metrics/prometheus/PrometheusApiServiceTest.java
+++ b/framework/src/test/java/org/tron/core/metrics/prometheus/PrometheusApiServiceTest.java
@@ -55,7 +55,7 @@ public class PrometheusApiServiceTest extends BaseTest {
   private ChainBaseManager chainManager;
 
   static {
-    Args.setParam(new String[] {"-d", dbPath(), "-w"}, Constant.TEST_CONF);
+    Args.setParam(new String[] {"-d", dbPath()}, Constant.TEST_CONF);
     Args.getInstance().setNodeListenPort(10000 + port.incrementAndGet());
     initParameter(Args.getInstance());
     Metrics.init();

--- a/framework/src/test/java/org/tron/core/net/TronNetDelegateTest.java
+++ b/framework/src/test/java/org/tron/core/net/TronNetDelegateTest.java
@@ -17,7 +17,7 @@ public class TronNetDelegateTest {
 
   @Test
   public void test() throws Exception {
-    Args.setParam(new String[] {"-w"}, Constant.TEST_CONF);
+    Args.setParam(new String[] {}, Constant.TEST_CONF);
     CommonParameter parameter = Args.getInstance();
     Args.logConfig();
     parameter.setUnsolidifiedBlockCheck(true);

--- a/framework/src/test/java/org/tron/core/net/messagehandler/InventoryMsgHandlerTest.java
+++ b/framework/src/test/java/org/tron/core/net/messagehandler/InventoryMsgHandlerTest.java
@@ -21,7 +21,7 @@ public class InventoryMsgHandlerTest {
   @Test
   public void testProcessMessage() throws Exception {
     InventoryMsgHandler handler = new InventoryMsgHandler();
-    Args.setParam(new String[] {"-w"}, Constant.TEST_CONF);
+    Args.setParam(new String[] {}, Constant.TEST_CONF);
     Args.logConfig();
 
     InventoryMessage msg = new InventoryMessage(new ArrayList<>(), InventoryType.TRX);

--- a/framework/src/test/java/org/tron/core/pbft/PbftApiTest.java
+++ b/framework/src/test/java/org/tron/core/pbft/PbftApiTest.java
@@ -37,7 +37,7 @@ public class PbftApiTest extends BaseTest {
 
   @BeforeClass
   public static void init() {
-    Args.setParam(new String[]{"-d", dbPath(), "-w"}, Constant.TEST_CONF);
+    Args.setParam(new String[]{"-d", dbPath()}, Constant.TEST_CONF);
     CommonParameter.getInstance().setPBFTHttpEnable(true);
     CommonParameter.getInstance().setPBFTHttpPort(PublicMethod.chooseRandomPort());
   }

--- a/framework/src/test/java/org/tron/core/services/ComputeRewardTest.java
+++ b/framework/src/test/java/org/tron/core/services/ComputeRewardTest.java
@@ -17,7 +17,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 import org.tron.common.application.TronApplicationContext;
 import org.tron.common.error.TronDBException;
@@ -114,9 +113,6 @@ public class ComputeRewardTest {
   private static RewardViStore rewardViStore;
   @Rule
   public final TemporaryFolder temporaryFolder = new TemporaryFolder();
-
-  @Rule
-  public final ExpectedException exception = ExpectedException.none();
 
   @After
   public void destroy() {
@@ -264,7 +260,6 @@ public class ComputeRewardTest {
 
   @Test
   public void query() {
-    exception.expect(TronError.class);
     Assert.assertEquals(3189, mortgageService.queryReward(OWNER_ADDRESS));
     // mock root is error
     rewardViStore.put("test".getBytes(), "test".getBytes());
@@ -288,8 +283,9 @@ public class ComputeRewardTest {
     propertiesStore.saveNewRewardAlgorithmEffectiveCycle();
     propertiesStore.saveCurrentCycleNumber(5);
     rewardViStore.close();
-    ReflectUtils.invokeMethod(rewardViCalService,"maybeRun");
-
+    TronError thrown = Assert.assertThrows(TronError.class, () ->
+        ReflectUtils.invokeMethod(rewardViCalService,"maybeRun"));
+    Assert.assertEquals(TronError.ErrCode.REWARD_VI_CALCULATOR, thrown.getErrCode());
   }
 
   static class Vote {

--- a/framework/src/test/java/org/tron/core/services/http/TriggerSmartContractServletTest.java
+++ b/framework/src/test/java/org/tron/core/services/http/TriggerSmartContractServletTest.java
@@ -31,7 +31,7 @@ public class TriggerSmartContractServletTest extends BaseTest {
   @BeforeClass
   public static void init() throws Exception {
     Args.setParam(
-        new String[]{"--output-directory", dbPath(), "--debug", "--witness"}, Constant.TEST_CONF);
+        new String[]{"--output-directory", dbPath(), "--debug"}, Constant.TEST_CONF);
     Args.getInstance().needSyncCheck = false;
     Args.getInstance().setFullNodeHttpEnable(true);
     Args.getInstance().setFullNodeHttpPort(PublicMethod.chooseRandomPort());

--- a/framework/src/test/java/org/tron/core/services/stop/ConditionallyStopTest.java
+++ b/framework/src/test/java/org/tron/core/services/stop/ConditionallyStopTest.java
@@ -82,7 +82,7 @@ public abstract class ConditionallyStopTest extends BlockGenerate {
 
     initDbPath();
     logger.info("Full node running.");
-    Args.setParam(new String[] {"-d", dbPath, "-w"}, Constant.TEST_CONF);
+    Args.setParam(new String[] {"-d", dbPath}, Constant.TEST_CONF);
     Args.getInstance().setNodeListenPort(10000 + port.incrementAndGet());
 
     initParameter(Args.getInstance());

--- a/framework/src/test/java/org/tron/core/zksnark/LibrustzcashTest.java
+++ b/framework/src/test/java/org/tron/core/zksnark/LibrustzcashTest.java
@@ -80,7 +80,6 @@ public class LibrustzcashTest extends BaseTest {
             "--output-directory", dbPath(),
             "--storage-db-directory", dbDirectory,
             "--storage-index-directory", indexDirectory,
-            "-w",
             "--debug"
         },
         "config-test-mainnet.conf"

--- a/framework/src/test/java/org/tron/core/zksnark/MerkleTreeTest.java
+++ b/framework/src/test/java/org/tron/core/zksnark/MerkleTreeTest.java
@@ -36,7 +36,6 @@ public class MerkleTreeTest extends BaseTest {
             "--output-directory", dbPath(),
             "--storage-db-directory", dbDirectory,
             "--storage-index-directory", indexDirectory,
-            "-w",
             "--debug"
         },
         "config-test-mainnet.conf"


### PR DESCRIPTION


**What does this PR do?**
    Exit when params init failed: 
   1. The node is `witness`, but no `private key` is configured
   2. The configured `rate limiter` is not working as expected.
   3. Configured `auto-stop block time` parsing error

**Why are these changes required?**

   To ensure a healthy node startup, exit in time when the user input parameters are not as expected.

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

