### PR TITLE
feat(jsonrpc): eth_newFilter not supports finalized for block parameter

### DIFF
--- a/framework/src/main/java/org/tron/core/services/jsonrpc/JsonRpcApiUtil.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/JsonRpcApiUtil.java
@@ -2,6 +2,7 @@ package org.tron.core.services.jsonrpc;
 
 import static org.tron.core.services.jsonrpc.TronJsonRpcImpl.EARLIEST_STR;
 import static org.tron.core.services.jsonrpc.TronJsonRpcImpl.FINALIZED_STR;
+import static org.tron.core.services.jsonrpc.TronJsonRpcImpl.INVALID_BLOCK_RANGE;
 import static org.tron.core.services.jsonrpc.TronJsonRpcImpl.LATEST_STR;
 import static org.tron.core.services.jsonrpc.TronJsonRpcImpl.PENDING_STR;
 import static org.tron.core.services.jsonrpc.TronJsonRpcImpl.TAG_PENDING_SUPPORT_ERROR;
@@ -515,7 +516,7 @@ public class JsonRpcApiUtil {
     return -1;
   }
 
-  public static long getByJsonBlockId(String blockNumOrTag, Wallet wallet)
+  public static long getByJsonBlockId(String blockNumOrTag, Wallet wallet, boolean supportFinalized)
       throws JsonRpcInvalidParamsException {
     if (PENDING_STR.equalsIgnoreCase(blockNumOrTag)) {
       throw new JsonRpcInvalidParamsException(TAG_PENDING_SUPPORT_ERROR);
@@ -525,7 +526,11 @@ public class JsonRpcApiUtil {
     } else if (EARLIEST_STR.equalsIgnoreCase(blockNumOrTag)) {
       return 0;
     } else if (FINALIZED_STR.equalsIgnoreCase(blockNumOrTag)) {
-      return wallet.getSolidBlockNum();
+      if (supportFinalized) {
+        return wallet.getSolidBlockNum();
+      } else {
+        throw new JsonRpcInvalidParamsException(INVALID_BLOCK_RANGE);
+      }
     } else {
       return ByteArray.jsonHexToLong(blockNumOrTag);
     }

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/TronJsonRpcImpl.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/TronJsonRpcImpl.java
@@ -138,6 +138,7 @@ public class TronJsonRpcImpl implements TronJsonRpc, Closeable {
   public static final String LATEST_STR = "latest";
   public static final String FINALIZED_STR = "finalized";
   public static final String TAG_PENDING_SUPPORT_ERROR = "TAG pending not supported";
+  public static final String INVALID_BLOCK_RANGE = "invalid block range params";
 
   private static final String JSON_ERROR = "invalid json request";
   private static final String BLOCK_NUM_ERROR = "invalid block number";
@@ -1320,7 +1321,7 @@ public class TronJsonRpcImpl implements TronJsonRpc, Closeable {
 
     long currentMaxBlockNum = wallet.getNowBlock().getBlockHeader().getRawData().getNumber();
     //convert FilterRequest to LogFilterWrapper
-    LogFilterWrapper logFilterWrapper = new LogFilterWrapper(fr, currentMaxBlockNum, wallet);
+    LogFilterWrapper logFilterWrapper = new LogFilterWrapper(fr, currentMaxBlockNum, wallet, true);
 
     return getLogsByLogFilterWrapper(logFilterWrapper, currentMaxBlockNum);
   }

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/filters/LogFilterAndResult.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/filters/LogFilterAndResult.java
@@ -16,7 +16,7 @@ public class LogFilterAndResult extends FilterResult<LogFilterElement> {
 
   public LogFilterAndResult(FilterRequest fr, long currentMaxBlockNum, Wallet wallet)
       throws JsonRpcInvalidParamsException {
-    this.logFilterWrapper = new LogFilterWrapper(fr, currentMaxBlockNum, wallet);
+    this.logFilterWrapper = new LogFilterWrapper(fr, currentMaxBlockNum, wallet, false);
     result = new LinkedBlockingQueue<>();
     this.updateExpireTime();
   }

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/filters/LogFilterWrapper.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/filters/LogFilterWrapper.java
@@ -1,6 +1,7 @@
 package org.tron.core.services.jsonrpc.filters;
 
 import static org.tron.common.math.Maths.min;
+import static org.tron.core.services.jsonrpc.TronJsonRpcImpl.INVALID_BLOCK_RANGE;
 
 import com.google.protobuf.ByteString;
 import lombok.Getter;
@@ -23,8 +24,8 @@ public class LogFilterWrapper {
   @Getter
   private final long toBlock;
 
-  public LogFilterWrapper(FilterRequest fr, long currentMaxBlockNum, Wallet wallet)
-      throws JsonRpcInvalidParamsException {
+  public LogFilterWrapper(FilterRequest fr, long currentMaxBlockNum, Wallet wallet,
+      boolean supportFinalized) throws JsonRpcInvalidParamsException {
 
     // 1.convert FilterRequest to LogFilter
     this.logFilter = new LogFilter(fr);
@@ -53,7 +54,7 @@ public class LogFilterWrapper {
       // then if toBlock < maxBlockNum, set fromBlock = toBlock
       // then if toBlock >= maxBlockNum, set fromBlock = maxBlockNum
       if (StringUtils.isEmpty(fr.getFromBlock()) && StringUtils.isNotEmpty(fr.getToBlock())) {
-        toBlockSrc = JsonRpcApiUtil.getByJsonBlockId(fr.getToBlock(), wallet);
+        toBlockSrc = JsonRpcApiUtil.getByJsonBlockId(fr.getToBlock(), wallet, supportFinalized);
         if (toBlockSrc == -1) {
           toBlockSrc = Long.MAX_VALUE;
         }
@@ -61,7 +62,7 @@ public class LogFilterWrapper {
 
       } else if (StringUtils.isNotEmpty(fr.getFromBlock())
           && StringUtils.isEmpty(fr.getToBlock())) {
-        fromBlockSrc = JsonRpcApiUtil.getByJsonBlockId(fr.getFromBlock(), wallet);
+        fromBlockSrc = JsonRpcApiUtil.getByJsonBlockId(fr.getFromBlock(), wallet, supportFinalized);
         if (fromBlockSrc == -1) {
           fromBlockSrc = currentMaxBlockNum;
         }
@@ -72,8 +73,8 @@ public class LogFilterWrapper {
         toBlockSrc = Long.MAX_VALUE;
 
       } else {
-        fromBlockSrc = JsonRpcApiUtil.getByJsonBlockId(fr.getFromBlock(), wallet);
-        toBlockSrc = JsonRpcApiUtil.getByJsonBlockId(fr.getToBlock(), wallet);
+        fromBlockSrc = JsonRpcApiUtil.getByJsonBlockId(fr.getFromBlock(), wallet, supportFinalized);
+        toBlockSrc = JsonRpcApiUtil.getByJsonBlockId(fr.getToBlock(), wallet, supportFinalized);
         if (fromBlockSrc == -1 && toBlockSrc == -1) {
           fromBlockSrc = currentMaxBlockNum;
           toBlockSrc = Long.MAX_VALUE;
@@ -83,7 +84,7 @@ public class LogFilterWrapper {
           toBlockSrc = Long.MAX_VALUE;
         }
         if (fromBlockSrc > toBlockSrc) {
-          throw new JsonRpcInvalidParamsException("please verify: fromBlock <= toBlock");
+          throw new JsonRpcInvalidParamsException(INVALID_BLOCK_RANGE);
         }
       }
     }

--- a/framework/src/test/java/org/tron/core/jsonrpc/JsonRpcTest.java
+++ b/framework/src/test/java/org/tron/core/jsonrpc/JsonRpcTest.java
@@ -284,7 +284,8 @@ public class JsonRpcTest {
               topics,
               null),
               100,
-              null);
+              null,
+              true);
 
       LogBlockQuery logBlockQuery = new LogBlockQuery(logFilterWrapper, null, 100, null);
       int[][][] conditions = logBlockQuery.getConditions();
@@ -331,7 +332,8 @@ public class JsonRpcTest {
               topics,
               null),
               100,
-              null);
+              null,
+              true);
 
       LogBlockQuery logBlockQuery = new LogBlockQuery(logFilterWrapper, null, 100, null);
       int[][][] conditions = logBlockQuery.getConditions();

--- a/framework/src/test/java/org/tron/core/jsonrpc/JsonrpcServiceTest.java
+++ b/framework/src/test/java/org/tron/core/jsonrpc/JsonrpcServiceTest.java
@@ -384,47 +384,92 @@ public class JsonrpcServiceTest extends BaseTest {
     long blkNum = 0;
 
     try {
-      getByJsonBlockId("pending", wallet);
+      getByJsonBlockId("pending", wallet, true);
     } catch (Exception e) {
       Assert.assertEquals("TAG pending not supported", e.getMessage());
     }
 
     try {
-      blkNum = getByJsonBlockId(null, wallet);
+      getByJsonBlockId("pending", wallet, false);
+    } catch (Exception e) {
+      Assert.assertEquals("TAG pending not supported", e.getMessage());
+    }
+
+    try {
+      blkNum = getByJsonBlockId(null, wallet, true);
     } catch (Exception e) {
       Assert.fail();
     }
     Assert.assertEquals(-1, blkNum);
 
     try {
-      blkNum = getByJsonBlockId("latest", wallet);
+      blkNum = getByJsonBlockId(null, wallet, false);
     } catch (Exception e) {
       Assert.fail();
     }
     Assert.assertEquals(-1, blkNum);
 
     try {
-      blkNum = getByJsonBlockId("finalized", wallet);
+      blkNum = getByJsonBlockId("latest", wallet, true);
+    } catch (Exception e) {
+      Assert.fail();
+    }
+    Assert.assertEquals(-1, blkNum);
+
+    try {
+      blkNum = getByJsonBlockId("latest", wallet, false);
+    } catch (Exception e) {
+      Assert.fail();
+    }
+    Assert.assertEquals(-1, blkNum);
+
+    try {
+      blkNum = getByJsonBlockId("finalized", wallet, true);
     } catch (Exception e) {
       Assert.fail();
     }
     Assert.assertEquals(LATEST_SOLIDIFIED_BLOCK_NUM, blkNum);
 
     try {
-      blkNum = getByJsonBlockId("0xa", wallet);
+      blkNum = getByJsonBlockId("finalized", wallet, true);
+    } catch (Exception e) {
+      Assert.assertEquals("invalid block range params", e.getMessage());
+    }
+
+    try {
+      blkNum = getByJsonBlockId("0xa", wallet, true);
     } catch (Exception e) {
       Assert.fail();
     }
     Assert.assertEquals(10L, blkNum);
 
     try {
-      getByJsonBlockId("abc", wallet);
+      blkNum = getByJsonBlockId("0xa", wallet, false);
+    } catch (Exception e) {
+      Assert.fail();
+    }
+    Assert.assertEquals(10L, blkNum);
+
+    try {
+      getByJsonBlockId("abc", wallet, true);
     } catch (Exception e) {
       Assert.assertEquals("Incorrect hex syntax", e.getMessage());
     }
 
     try {
-      getByJsonBlockId("0xxabc", wallet);
+      getByJsonBlockId("abc", wallet, false);
+    } catch (Exception e) {
+      Assert.assertEquals("Incorrect hex syntax", e.getMessage());
+    }
+
+    try {
+      getByJsonBlockId("0xxabc", wallet, true);
+    } catch (Exception e) {
+      Assert.assertEquals("For input string: \"xabc\"", e.getMessage());
+    }
+
+    try {
+      getByJsonBlockId("0xxabc", wallet, false);
     } catch (Exception e) {
       Assert.assertEquals("For input string: \"xabc\"", e.getMessage());
     }
@@ -545,7 +590,16 @@ public class JsonrpcServiceTest extends BaseTest {
     // fromBlock and toBlock are both empty
     try {
       LogFilterWrapper logFilterWrapper =
-          new LogFilterWrapper(new FilterRequest(null, null, null, null, null), 100, null);
+          new LogFilterWrapper(new FilterRequest(null, null, null, null, null), 100, null, true);
+      Assert.assertEquals(100, logFilterWrapper.getFromBlock());
+      Assert.assertEquals(Long.MAX_VALUE, logFilterWrapper.getToBlock());
+    } catch (JsonRpcInvalidParamsException e) {
+      Assert.fail();
+    }
+
+    try {
+      LogFilterWrapper logFilterWrapper =
+          new LogFilterWrapper(new FilterRequest(null, null, null, null, null), 100, null, false);
       Assert.assertEquals(100, logFilterWrapper.getFromBlock());
       Assert.assertEquals(Long.MAX_VALUE, logFilterWrapper.getToBlock());
     } catch (JsonRpcInvalidParamsException e) {
@@ -555,7 +609,16 @@ public class JsonrpcServiceTest extends BaseTest {
     // fromBlock is not empty and smaller than currentMaxBlockNum, toBlock is empty
     try {
       LogFilterWrapper logFilterWrapper =
-          new LogFilterWrapper(new FilterRequest("0x14", null, null, null, null), 100, null);
+          new LogFilterWrapper(new FilterRequest("0x14", null, null, null, null), 100, null, true);
+      Assert.assertEquals(20, logFilterWrapper.getFromBlock());
+      Assert.assertEquals(Long.MAX_VALUE, logFilterWrapper.getToBlock());
+    } catch (JsonRpcInvalidParamsException e) {
+      Assert.fail();
+    }
+
+    try {
+      LogFilterWrapper logFilterWrapper =
+          new LogFilterWrapper(new FilterRequest("0x14", null, null, null, null), 100, null, false);
       Assert.assertEquals(20, logFilterWrapper.getFromBlock());
       Assert.assertEquals(Long.MAX_VALUE, logFilterWrapper.getToBlock());
     } catch (JsonRpcInvalidParamsException e) {
@@ -565,7 +628,16 @@ public class JsonrpcServiceTest extends BaseTest {
     // fromBlock is not empty and bigger than currentMaxBlockNum, toBlock is empty
     try {
       LogFilterWrapper logFilterWrapper =
-          new LogFilterWrapper(new FilterRequest("0x78", null, null, null, null), 100, null);
+          new LogFilterWrapper(new FilterRequest("0x78", null, null, null, null), 100, null, true);
+      Assert.assertEquals(120, logFilterWrapper.getFromBlock());
+      Assert.assertEquals(Long.MAX_VALUE, logFilterWrapper.getToBlock());
+    } catch (JsonRpcInvalidParamsException e) {
+      Assert.fail();
+    }
+
+    try {
+      LogFilterWrapper logFilterWrapper =
+          new LogFilterWrapper(new FilterRequest("0x78", null, null, null, null), 100, null, false);
       Assert.assertEquals(120, logFilterWrapper.getFromBlock());
       Assert.assertEquals(Long.MAX_VALUE, logFilterWrapper.getToBlock());
     } catch (JsonRpcInvalidParamsException e) {
@@ -575,7 +647,16 @@ public class JsonrpcServiceTest extends BaseTest {
     // fromBlock is empty, toBlock is not empty and smaller than currentMaxBlockNum
     try {
       LogFilterWrapper logFilterWrapper =
-          new LogFilterWrapper(new FilterRequest(null, "0x14", null, null, null), 100, null);
+          new LogFilterWrapper(new FilterRequest(null, "0x14", null, null, null), 100, null, true);
+      Assert.assertEquals(20, logFilterWrapper.getFromBlock());
+      Assert.assertEquals(20, logFilterWrapper.getToBlock());
+    } catch (JsonRpcInvalidParamsException e) {
+      Assert.fail();
+    }
+
+    try {
+      LogFilterWrapper logFilterWrapper =
+          new LogFilterWrapper(new FilterRequest(null, "0x14", null, null, null), 100, null, false);
       Assert.assertEquals(20, logFilterWrapper.getFromBlock());
       Assert.assertEquals(20, logFilterWrapper.getToBlock());
     } catch (JsonRpcInvalidParamsException e) {
@@ -585,7 +666,16 @@ public class JsonrpcServiceTest extends BaseTest {
     // fromBlock is empty, toBlock is not empty and bigger than currentMaxBlockNum
     try {
       LogFilterWrapper logFilterWrapper =
-          new LogFilterWrapper(new FilterRequest(null, "0x78", null, null, null), 100, null);
+          new LogFilterWrapper(new FilterRequest(null, "0x78", null, null, null), 100, null, true);
+      Assert.assertEquals(100, logFilterWrapper.getFromBlock());
+      Assert.assertEquals(120, logFilterWrapper.getToBlock());
+    } catch (JsonRpcInvalidParamsException e) {
+      Assert.fail();
+    }
+
+    try {
+      LogFilterWrapper logFilterWrapper =
+          new LogFilterWrapper(new FilterRequest(null, "0x78", null, null, null), 100, null, false);
       Assert.assertEquals(100, logFilterWrapper.getFromBlock());
       Assert.assertEquals(120, logFilterWrapper.getToBlock());
     } catch (JsonRpcInvalidParamsException e) {
@@ -595,7 +685,8 @@ public class JsonrpcServiceTest extends BaseTest {
     // fromBlock is not empty, toBlock is not empty
     try {
       LogFilterWrapper logFilterWrapper =
-          new LogFilterWrapper(new FilterRequest("0x14", "0x78", null, null, null), 100, null);
+          new LogFilterWrapper(new FilterRequest("0x14", "0x78", null, null, null), 100, null,
+              true);
       Assert.assertEquals(20, logFilterWrapper.getFromBlock());
       Assert.assertEquals(120, logFilterWrapper.getToBlock());
     } catch (JsonRpcInvalidParamsException e) {
@@ -603,15 +694,34 @@ public class JsonrpcServiceTest extends BaseTest {
     }
     try {
       LogFilterWrapper logFilterWrapper =
-          new LogFilterWrapper(new FilterRequest("0x78", "0x14", null, null, null), 100, null);
+          new LogFilterWrapper(new FilterRequest("0x78", "0x14", null, null, null), 100, null,
+              true);
     } catch (JsonRpcInvalidParamsException e) {
-      Assert.assertEquals("please verify: fromBlock <= toBlock", e.getMessage());
+      Assert.assertEquals("invalid block range params", e.getMessage());
+    }
+
+    try {
+      LogFilterWrapper logFilterWrapper =
+          new LogFilterWrapper(new FilterRequest("0x14", "0x78", null, null, null), 100, null,
+              false);
+      Assert.assertEquals(20, logFilterWrapper.getFromBlock());
+      Assert.assertEquals(120, logFilterWrapper.getToBlock());
+    } catch (JsonRpcInvalidParamsException e) {
+      Assert.fail();
+    }
+    try {
+      LogFilterWrapper logFilterWrapper =
+          new LogFilterWrapper(new FilterRequest("0x78", "0x14", null, null, null), 100, null,
+              false);
+    } catch (JsonRpcInvalidParamsException e) {
+      Assert.assertEquals("invalid block range params", e.getMessage());
     }
 
     //fromBlock or toBlock is not hex num
     try {
       LogFilterWrapper logFilterWrapper =
-          new LogFilterWrapper(new FilterRequest("earliest", null, null, null, null), 100, null);
+          new LogFilterWrapper(new FilterRequest("earliest", null, null, null, null), 100, null,
+              true);
       Assert.assertEquals(0, logFilterWrapper.getFromBlock());
       Assert.assertEquals(Long.MAX_VALUE, logFilterWrapper.getToBlock());
     } catch (JsonRpcInvalidParamsException e) {
@@ -619,27 +729,74 @@ public class JsonrpcServiceTest extends BaseTest {
     }
     try {
       LogFilterWrapper logFilterWrapper =
-          new LogFilterWrapper(new FilterRequest("latest", null, null, null, null), 100, null);
+          new LogFilterWrapper(new FilterRequest("earliest", null, null, null, null), 100, null,
+              false);
+      Assert.assertEquals(0, logFilterWrapper.getFromBlock());
+      Assert.assertEquals(Long.MAX_VALUE, logFilterWrapper.getToBlock());
+    } catch (JsonRpcInvalidParamsException e) {
+      Assert.fail();
+    }
+
+    try {
+      LogFilterWrapper logFilterWrapper =
+          new LogFilterWrapper(new FilterRequest("latest", null, null, null, null), 100, null,
+              true);
       Assert.assertEquals(100, logFilterWrapper.getFromBlock());
       Assert.assertEquals(Long.MAX_VALUE, logFilterWrapper.getToBlock());
     } catch (JsonRpcInvalidParamsException e) {
       Assert.fail();
     }
     try {
-      new LogFilterWrapper(new FilterRequest("pending", null, null, null, null), 100, null);
+      LogFilterWrapper logFilterWrapper =
+          new LogFilterWrapper(new FilterRequest("latest", null, null, null, null), 100, null,
+              false);
+      Assert.assertEquals(100, logFilterWrapper.getFromBlock());
+      Assert.assertEquals(Long.MAX_VALUE, logFilterWrapper.getToBlock());
+    } catch (JsonRpcInvalidParamsException e) {
+      Assert.fail();
+    }
+
+    try {
+      new LogFilterWrapper(new FilterRequest("pending", null, null, null, null), 100, null,
+          true);
     } catch (JsonRpcInvalidParamsException e) {
       Assert.assertEquals("TAG pending not supported", e.getMessage());
     }
     try {
+      new LogFilterWrapper(new FilterRequest("pending", null, null, null, null), 100, null,
+          false);
+    } catch (JsonRpcInvalidParamsException e) {
+      Assert.assertEquals("TAG pending not supported", e.getMessage());
+    }
+
+    try {
       LogFilterWrapper logFilterWrapper =
-          new LogFilterWrapper(new FilterRequest("finalized", null, null, null, null), 100, wallet);
+          new LogFilterWrapper(new FilterRequest("finalized", null, null, null, null), 100, wallet,
+              true);
       Assert.assertEquals(LATEST_SOLIDIFIED_BLOCK_NUM, logFilterWrapper.getFromBlock());
       Assert.assertEquals(Long.MAX_VALUE, logFilterWrapper.getToBlock());
     } catch (JsonRpcInvalidParamsException e) {
       Assert.fail();
     }
     try {
-      new LogFilterWrapper(new FilterRequest("test", null, null, null, null), 100, null);
+      LogFilterWrapper logFilterWrapper =
+          new LogFilterWrapper(new FilterRequest("finalized", null, null, null, null), 100, wallet,
+              true);
+      Assert.assertEquals(LATEST_SOLIDIFIED_BLOCK_NUM, logFilterWrapper.getFromBlock());
+      Assert.assertEquals(Long.MAX_VALUE, logFilterWrapper.getToBlock());
+    } catch (JsonRpcInvalidParamsException e) {
+      Assert.assertEquals("invalid block range param", e.getMessage());
+    }
+
+    try {
+      new LogFilterWrapper(new FilterRequest("test", null, null, null, null), 100, null,
+          true);
+    } catch (JsonRpcInvalidParamsException e) {
+      Assert.assertEquals("Incorrect hex syntax", e.getMessage());
+    }
+    try {
+      new LogFilterWrapper(new FilterRequest("test", null, null, null, null), 100, null,
+          false);
     } catch (JsonRpcInvalidParamsException e) {
       Assert.assertEquals("Incorrect hex syntax", e.getMessage());
     }

--- a/framework/src/test/java/org/tron/core/jsonrpc/SectionBloomStoreTest.java
+++ b/framework/src/test/java/org/tron/core/jsonrpc/SectionBloomStoreTest.java
@@ -132,7 +132,7 @@ public class SectionBloomStoreTest extends BaseTest {
     try {
       LogFilterWrapper logFilterWrapper = new LogFilterWrapper(
           new FilterRequest("earliest", "latest", ByteArray.toJsonHex(address1), null, null),
-          currentMaxBlockNum, null);
+          currentMaxBlockNum, null, true);
       LogBlockQuery logBlockQuery =
           new LogBlockQuery(logFilterWrapper, sectionBloomStore, currentMaxBlockNum,
               sectionExecutor);
@@ -149,7 +149,7 @@ public class SectionBloomStoreTest extends BaseTest {
     try {
       LogFilterWrapper logFilterWrapper = new LogFilterWrapper(
           new FilterRequest("earliest", "latest", addressList, null, null),
-          currentMaxBlockNum, null);
+          currentMaxBlockNum, null, true);
       LogBlockQuery logBlockQuery =
           new LogBlockQuery(logFilterWrapper, sectionBloomStore, currentMaxBlockNum,
               sectionExecutor);
@@ -165,7 +165,7 @@ public class SectionBloomStoreTest extends BaseTest {
       LogFilterWrapper logFilterWrapper = new LogFilterWrapper(
           new FilterRequest("earliest", "latest", null,
               new String[] {ByteArray.toHexString(topic1)}, null),
-          currentMaxBlockNum, null);
+          currentMaxBlockNum, null, true);
       LogBlockQuery logBlockQuery =
           new LogBlockQuery(logFilterWrapper, sectionBloomStore, currentMaxBlockNum,
               sectionExecutor);
@@ -181,7 +181,7 @@ public class SectionBloomStoreTest extends BaseTest {
       LogFilterWrapper logFilterWrapper = new LogFilterWrapper(
           new FilterRequest("earliest", "latest", null,
               new String[] {ByteArray.toHexString(topic2)}, null),
-          currentMaxBlockNum, null);
+          currentMaxBlockNum, null, true);
       LogBlockQuery logBlockQuery =
           new LogBlockQuery(logFilterWrapper, sectionBloomStore, currentMaxBlockNum,
               sectionExecutor);
@@ -199,7 +199,7 @@ public class SectionBloomStoreTest extends BaseTest {
       LogFilterWrapper logFilterWrapper = new LogFilterWrapper(
           new FilterRequest("earliest", "latest", null,
               new Object[] {topicList}, null),
-          currentMaxBlockNum, null);
+          currentMaxBlockNum, null, true);
       LogBlockQuery logBlockQuery =
           new LogBlockQuery(logFilterWrapper, sectionBloomStore, currentMaxBlockNum,
               sectionExecutor);
@@ -226,7 +226,7 @@ public class SectionBloomStoreTest extends BaseTest {
       LogFilterWrapper logFilterWrapper = new LogFilterWrapper(
           new FilterRequest("earliest", "latest", null,
               new Object[] {ByteArray.toJsonHex(topic1), ByteArray.toJsonHex(topic2)}, null),
-          currentMaxBlockNum, null);
+          currentMaxBlockNum, null, true);
       LogBlockQuery logBlockQuery =
           new LogBlockQuery(logFilterWrapper, sectionBloomStore, currentMaxBlockNum,
               sectionExecutor);


### PR DESCRIPTION
**What does this PR do?**
eth_newFilter not supports finalized for block parameter to be consistent with geth.


**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

