### PR TITLE
feat(jsonrpc): eth_newFilter not supports finalized as block parameter

### DIFF
--- a/framework/src/main/java/org/tron/core/services/jsonrpc/TronJsonRpcImpl.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/TronJsonRpcImpl.java
@@ -1115,14 +1115,6 @@ public class TronJsonRpcImpl implements TronJsonRpc, Closeable {
     }
   }
 
-  public void disableFinalizedBlock(FilterRequest fr) throws JsonRpcInvalidParamsException {
-    // not supports finalized as block parameter
-    if (FINALIZED_STR.equalsIgnoreCase(fr.getFromBlock())
-        || FINALIZED_STR.equalsIgnoreCase(fr.getToBlock())) {
-      throw new JsonRpcInvalidParamsException(INVALID_BLOCK_RANGE);
-    }
-  }
-
   @Override
   public TransactionJson buildTransaction(BuildArguments args)
       throws JsonRpcInvalidParamsException, JsonRpcInvalidRequestException,
@@ -1244,7 +1236,10 @@ public class TronJsonRpcImpl implements TronJsonRpc, Closeable {
     disableInPBFT("eth_newFilter");
 
     // not supports finalized as block parameter
-    disableFinalizedBlock(fr);
+    if (FINALIZED_STR.equalsIgnoreCase(fr.getFromBlock())
+        || FINALIZED_STR.equalsIgnoreCase(fr.getToBlock())) {
+      throw new JsonRpcInvalidParamsException(INVALID_BLOCK_RANGE);
+    }
 
     Map<String, LogFilterAndResult> eventFilter2Result;
     if (getSource() == RequestSource.FULLNODE) {

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/TronJsonRpcImpl.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/TronJsonRpcImpl.java
@@ -138,6 +138,7 @@ public class TronJsonRpcImpl implements TronJsonRpc, Closeable {
   public static final String LATEST_STR = "latest";
   public static final String FINALIZED_STR = "finalized";
   public static final String TAG_PENDING_SUPPORT_ERROR = "TAG pending not supported";
+  public static final String INVALID_BLOCK_RANGE = "invalid block range params";
 
   private static final String JSON_ERROR = "invalid json request";
   private static final String BLOCK_NUM_ERROR = "invalid block number";
@@ -1114,6 +1115,14 @@ public class TronJsonRpcImpl implements TronJsonRpc, Closeable {
     }
   }
 
+  public void disableFinalizedBlock(FilterRequest fr) throws JsonRpcInvalidParamsException {
+    // not supports finalized as block parameter
+    if (FINALIZED_STR.equalsIgnoreCase(fr.getFromBlock())
+        || FINALIZED_STR.equalsIgnoreCase(fr.getToBlock())) {
+      throw new JsonRpcInvalidParamsException(INVALID_BLOCK_RANGE);
+    }
+  }
+
   @Override
   public TransactionJson buildTransaction(BuildArguments args)
       throws JsonRpcInvalidParamsException, JsonRpcInvalidRequestException,
@@ -1233,6 +1242,9 @@ public class TronJsonRpcImpl implements TronJsonRpc, Closeable {
   public String newFilter(FilterRequest fr) throws JsonRpcInvalidParamsException,
       JsonRpcMethodNotFoundException {
     disableInPBFT("eth_newFilter");
+
+    // not supports finalized as block parameter
+    disableFinalizedBlock(fr);
 
     Map<String, LogFilterAndResult> eventFilter2Result;
     if (getSource() == RequestSource.FULLNODE) {

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/filters/LogFilterWrapper.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/filters/LogFilterWrapper.java
@@ -1,6 +1,7 @@
 package org.tron.core.services.jsonrpc.filters;
 
 import static org.tron.common.math.Maths.min;
+import static org.tron.core.services.jsonrpc.TronJsonRpcImpl.INVALID_BLOCK_RANGE;
 
 import com.google.protobuf.ByteString;
 import lombok.Getter;
@@ -83,7 +84,7 @@ public class LogFilterWrapper {
           toBlockSrc = Long.MAX_VALUE;
         }
         if (fromBlockSrc > toBlockSrc) {
-          throw new JsonRpcInvalidParamsException("please verify: fromBlock <= toBlock");
+          throw new JsonRpcInvalidParamsException(INVALID_BLOCK_RANGE);
         }
       }
     }

--- a/framework/src/test/java/org/tron/core/jsonrpc/JsonrpcServiceTest.java
+++ b/framework/src/test/java/org/tron/core/jsonrpc/JsonrpcServiceTest.java
@@ -646,47 +646,6 @@ public class JsonrpcServiceTest extends BaseTest {
   }
 
   @Test
-  public void testDisableFinalizedBlock() {
-
-    try {
-      tronJsonRpc.disableFinalizedBlock(new FilterRequest(null, null, null, null, null));
-    } catch (Exception e) {
-      Assert.fail();
-    }
-
-    try {
-      tronJsonRpc.disableFinalizedBlock(new FilterRequest("finalized", null, null, null, null));
-    } catch (Exception e) {
-      Assert.assertEquals("invalid block range params", e.getMessage());
-    }
-
-    try {
-      tronJsonRpc.disableFinalizedBlock(new FilterRequest(null, "finalized", null, null, null));
-    } catch (Exception e) {
-      Assert.assertEquals("invalid block range params", e.getMessage());
-    }
-
-    try {
-      tronJsonRpc.disableFinalizedBlock(new FilterRequest("finalized", "latest", null, null, null));
-    } catch (Exception e) {
-      Assert.assertEquals("invalid block range params", e.getMessage());
-    }
-
-    try {
-      tronJsonRpc.disableFinalizedBlock(new FilterRequest("0x1", "finalized", null, null, null));
-    } catch (Exception e) {
-      Assert.assertEquals("invalid block range params", e.getMessage());
-    }
-
-    try {
-      tronJsonRpc.disableFinalizedBlock(
-          new FilterRequest("finalized", "finalized", null, null, null));
-    } catch (Exception e) {
-      Assert.assertEquals("invalid block range params", e.getMessage());
-    }
-  }
-
-  @Test
   public void testNewFilterFinalizedBlock() {
 
     try {

--- a/framework/src/test/java/org/tron/core/jsonrpc/JsonrpcServiceTest.java
+++ b/framework/src/test/java/org/tron/core/jsonrpc/JsonrpcServiceTest.java
@@ -605,7 +605,7 @@ public class JsonrpcServiceTest extends BaseTest {
       LogFilterWrapper logFilterWrapper =
           new LogFilterWrapper(new FilterRequest("0x78", "0x14", null, null, null), 100, null);
     } catch (JsonRpcInvalidParamsException e) {
-      Assert.assertEquals("please verify: fromBlock <= toBlock", e.getMessage());
+      Assert.assertEquals("invalid block range params", e.getMessage());
     }
 
     //fromBlock or toBlock is not hex num
@@ -642,6 +642,87 @@ public class JsonrpcServiceTest extends BaseTest {
       new LogFilterWrapper(new FilterRequest("test", null, null, null, null), 100, null);
     } catch (JsonRpcInvalidParamsException e) {
       Assert.assertEquals("Incorrect hex syntax", e.getMessage());
+    }
+  }
+
+  @Test
+  public void testDisableFinalizedBlock() {
+
+    try {
+      tronJsonRpc.disableFinalizedBlock(new FilterRequest(null, null, null, null, null));
+    } catch (Exception e) {
+      Assert.fail();
+    }
+
+    try {
+      tronJsonRpc.disableFinalizedBlock(new FilterRequest("finalized", null, null, null, null));
+    } catch (Exception e) {
+      Assert.assertEquals("invalid block range params", e.getMessage());
+    }
+
+    try {
+      tronJsonRpc.disableFinalizedBlock(new FilterRequest(null, "finalized", null, null, null));
+    } catch (Exception e) {
+      Assert.assertEquals("invalid block range params", e.getMessage());
+    }
+
+    try {
+      tronJsonRpc.disableFinalizedBlock(new FilterRequest("finalized", "latest", null, null, null));
+    } catch (Exception e) {
+      Assert.assertEquals("invalid block range params", e.getMessage());
+    }
+
+    try {
+      tronJsonRpc.disableFinalizedBlock(new FilterRequest("0x1", "finalized", null, null, null));
+    } catch (Exception e) {
+      Assert.assertEquals("invalid block range params", e.getMessage());
+    }
+
+    try {
+      tronJsonRpc.disableFinalizedBlock(
+          new FilterRequest("finalized", "finalized", null, null, null));
+    } catch (Exception e) {
+      Assert.assertEquals("invalid block range params", e.getMessage());
+    }
+  }
+
+  @Test
+  public void testNewFilterFinalizedBlock() {
+
+    try {
+      tronJsonRpc.newFilter(new FilterRequest(null, null, null, null, null));
+    } catch (Exception e) {
+      Assert.fail();
+    }
+
+    try {
+      tronJsonRpc.newFilter(new FilterRequest("finalized", null, null, null, null));
+    } catch (Exception e) {
+      Assert.assertEquals("invalid block range params", e.getMessage());
+    }
+
+    try {
+      tronJsonRpc.newFilter(new FilterRequest(null, "finalized", null, null, null));
+    } catch (Exception e) {
+      Assert.assertEquals("invalid block range params", e.getMessage());
+    }
+
+    try {
+      tronJsonRpc.newFilter(new FilterRequest("finalized", "latest", null, null, null));
+    } catch (Exception e) {
+      Assert.assertEquals("invalid block range params", e.getMessage());
+    }
+
+    try {
+      tronJsonRpc.newFilter(new FilterRequest("0x1", "finalized", null, null, null));
+    } catch (Exception e) {
+      Assert.assertEquals("invalid block range params", e.getMessage());
+    }
+
+    try {
+      tronJsonRpc.newFilter(new FilterRequest("finalized", "finalized", null, null, null));
+    } catch (Exception e) {
+      Assert.assertEquals("invalid block range params", e.getMessage());
     }
   }
 }


### PR DESCRIPTION
**What does this PR do?**
feat(jsonrpc): eth_newFilter not supports finalized as block parameter to be consistent with geth.

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

