### PR TITLE
feat(jsonrpc): keep old err_msg when block range is invalid

### DIFF
--- a/framework/src/main/java/org/tron/core/services/jsonrpc/filters/LogFilterWrapper.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/filters/LogFilterWrapper.java
@@ -1,7 +1,6 @@
 package org.tron.core.services.jsonrpc.filters;
 
 import static org.tron.common.math.Maths.min;
-import static org.tron.core.services.jsonrpc.TronJsonRpcImpl.INVALID_BLOCK_RANGE;
 
 import com.google.protobuf.ByteString;
 import lombok.Getter;
@@ -84,7 +83,7 @@ public class LogFilterWrapper {
           toBlockSrc = Long.MAX_VALUE;
         }
         if (fromBlockSrc > toBlockSrc) {
-          throw new JsonRpcInvalidParamsException(INVALID_BLOCK_RANGE);
+          throw new JsonRpcInvalidParamsException("please verify: fromBlock <= toBlock");
         }
       }
     }

--- a/framework/src/test/java/org/tron/core/jsonrpc/JsonrpcServiceTest.java
+++ b/framework/src/test/java/org/tron/core/jsonrpc/JsonrpcServiceTest.java
@@ -605,7 +605,7 @@ public class JsonrpcServiceTest extends BaseTest {
       LogFilterWrapper logFilterWrapper =
           new LogFilterWrapper(new FilterRequest("0x78", "0x14", null, null, null), 100, null);
     } catch (JsonRpcInvalidParamsException e) {
-      Assert.assertEquals("invalid block range params", e.getMessage());
+      Assert.assertEquals("please verify: fromBlock <= toBlock", e.getMessage());
     }
 
     //fromBlock or toBlock is not hex num


### PR DESCRIPTION
**What does this PR do?**
Keep using old version err_msg when block range is invalid(from > to) for eth_getLogs and eth_newFilter

**Why are these changes required?**
To maintain compatibility for legacy users, the original error messages in existing scenarios will remain unchanged.

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

