### PR TITLE
opt(framework): optimization Help Instruction

### DIFF
--- a/framework/src/main/java/org/tron/core/config/args/Args.java
+++ b/framework/src/main/java/org/tron/core/config/args/Args.java
@@ -373,6 +373,13 @@ public class Args extends CommonParameter {
       exit(0);
     }
 
+    if (PARAMETER.isHelp()) {
+      JCommander jCommander = JCommander.newBuilder().addObject(Args.PARAMETER).build();
+      jCommander.parse(args);
+      Args.printHelp(jCommander);
+      exit(0);
+    }
+
     Config config = Configuration.getByFileName(PARAMETER.shellConfFileName, confFileName);
     setParam(config);
   }

--- a/framework/src/main/java/org/tron/program/FullNode.java
+++ b/framework/src/main/java/org/tron/program/FullNode.java
@@ -1,6 +1,5 @@
 package org.tron.program;
 
-import com.beust.jcommander.JCommander;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.tron.common.application.Application;
@@ -27,13 +26,6 @@ public class FullNode {
     CommonParameter parameter = Args.getInstance();
 
     LogService.load(parameter.getLogbackPath());
-
-    if (parameter.isHelp()) {
-      JCommander jCommander = JCommander.newBuilder().addObject(Args.PARAMETER).build();
-      jCommander.parse(args);
-      Args.printHelp(jCommander);
-      return;
-    }
 
     if (Args.getInstance().isDebug()) {
       logger.info("in debug mode, it won't check energy time");


### PR DESCRIPTION
**What does this PR do?**

optimization Help Instruction

**Why are these changes required?**

When users want to view help information through the - h command, they do not need to perform any other business processing, so it can be placed at the front and quickly exited, just like the - v command

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

