### PR TITLE
func(cfg): revert reprioritize for old internal tx switches

### DIFF
--- a/actuator/src/main/java/org/tron/core/vm/nativecontract/UnfreezeBalanceV2Processor.java
+++ b/actuator/src/main/java/org/tron/core/vm/nativecontract/UnfreezeBalanceV2Processor.java
@@ -84,7 +84,7 @@ public class UnfreezeBalanceV2Processor {
 
     if (!checkUnfreezeBalance(accountCapsule, param.getUnfreezeBalance(), param.getResourceType())) {
       throw new ContractValidateException(
-          "Invalid unfreeze_balance, [" + param.getUnfreezeBalance() + "] is too large");
+          "Invalid unfreeze_balance, [" + param.getUnfreezeBalance() + "] is invalid");
     }
   }
 

--- a/framework/src/main/java/org/tron/core/config/args/Args.java
+++ b/framework/src/main/java/org/tron/core/config/args/Args.java
@@ -917,15 +917,13 @@ public class Args extends CommonParameter {
     PARAMETER.vmTrace =
         config.hasPath(Constant.VM_TRACE) && config.getBoolean(Constant.VM_TRACE);
 
-    if (!PARAMETER.saveInternalTx
-        && config.hasPath(Constant.VM_SAVE_INTERNAL_TX)) {
-      PARAMETER.saveInternalTx = config.getBoolean(Constant.VM_SAVE_INTERNAL_TX);
-    }
+    PARAMETER.saveInternalTx =
+        config.hasPath(Constant.VM_SAVE_INTERNAL_TX)
+            && config.getBoolean(Constant.VM_SAVE_INTERNAL_TX);
 
-    if (!PARAMETER.saveFeaturedInternalTx
-        && config.hasPath(Constant.VM_SAVE_FEATURED_INTERNAL_TX)) {
-      PARAMETER.saveFeaturedInternalTx = config.getBoolean(Constant.VM_SAVE_FEATURED_INTERNAL_TX);
-    }
+    PARAMETER.saveFeaturedInternalTx =
+        config.hasPath(Constant.VM_SAVE_FEATURED_INTERNAL_TX)
+            && config.getBoolean(Constant.VM_SAVE_FEATURED_INTERNAL_TX);
 
     if (!PARAMETER.saveCancelAllUnfreezeV2Details
         && config.hasPath(Constant.VM_SAVE_CANCEL_ALL_UNFREEZE_V2_DETAILS)) {

--- a/framework/src/test/java/org/tron/common/runtime/vm/Create2Test.java
+++ b/framework/src/test/java/org/tron/common/runtime/vm/Create2Test.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import lombok.extern.slf4j.Slf4j;
 import org.bouncycastle.util.encoders.Hex;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.tron.common.runtime.TVMTestResult;
 import org.tron.common.runtime.TvmTestUtils;
@@ -23,6 +24,7 @@ import org.tron.core.exception.ReceiptCheckErrException;
 import org.tron.core.exception.VMIllegalException;
 import org.tron.core.services.NodeInfoService;
 import org.tron.core.services.jsonrpc.TronJsonRpcImpl;
+import org.tron.core.vm.config.ConfigLoader;
 import org.tron.protos.Protocol.Transaction;
 
 
@@ -102,6 +104,11 @@ public class Create2Test extends VMTestBase {
 
 
   */
+
+  @Before
+  public void before() {
+    ConfigLoader.disable = false;
+  }
 
   @Test
   public void testCreate2()


### PR DESCRIPTION
In order to respect user habits, we decided to roll back the prioritization of the old internal transaction switches `--save-internaltx` and `--save-featured-internaltx`.