### PR TITLE
feat(jsonrpc): check maxSubTopics and maxBlockRange to be consistent with eth

### DIFF
--- a/common/src/main/java/org/tron/common/parameter/CommonParameter.java
+++ b/common/src/main/java/org/tron/common/parameter/CommonParameter.java
@@ -8,9 +8,9 @@ import java.util.List;
 import java.util.Set;
 import lombok.Getter;
 import lombok.Setter;
-import org.tron.common.cron.CronExpression;
 import org.tron.common.args.GenesisBlock;
 import org.tron.common.config.DbBackupConfig;
+import org.tron.common.cron.CronExpression;
 import org.tron.common.logsfilter.EventPluginConfig;
 import org.tron.common.logsfilter.FilterQuery;
 import org.tron.common.setting.RocksDbSettings;
@@ -495,6 +495,13 @@ public class CommonParameter {
   @Getter
   @Setter
   public boolean jsonRpcHttpPBFTNodeEnable = false;
+  @Getter
+  @Setter
+  public int jsonRpcMaxBlockRange = 5000;
+  @Getter
+  @Setter
+  public int jsonRpcMaxSubTopics = 1000;
+
   @Getter
   @Setter
   public int maxTransactionPendingSize;

--- a/common/src/main/java/org/tron/common/utils/ByteUtil.java
+++ b/common/src/main/java/org/tron/common/utils/ByteUtil.java
@@ -479,40 +479,41 @@ public class ByteUtil {
 
   public static byte[] compress(byte[] data) throws EventBloomException {
     Deflater deflater = new Deflater();
-    deflater.setInput(data);
 
-    ByteArrayOutputStream outputStream = new ByteArrayOutputStream(data.length);
+    try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream(data.length)) {
+      deflater.setInput(data);
+      deflater.finish();
+      byte[] buffer = new byte[1024];
 
-    deflater.finish();
-    byte[] buffer = new byte[1024];
-    while (!deflater.finished()) {
-      int count = deflater.deflate(buffer); // returns the generated code... index
-      outputStream.write(buffer, 0, count);
-    }
-    try {
-      outputStream.close();
+      while (!deflater.finished()) {
+        int count = deflater.deflate(buffer);  // returns the generated code... index
+        outputStream.write(buffer, 0, count);
+      }
+
+      return outputStream.toByteArray();
     } catch (IOException e) {
       throw new EventBloomException("compress data failed");
+    } finally {
+      deflater.end();
     }
-    byte[] output = outputStream.toByteArray();
-
-    return output;
   }
 
   public static byte[] decompress(byte[] data) throws IOException, DataFormatException {
     Inflater inflater = new Inflater();
-    inflater.setInput(data);
 
-    ByteArrayOutputStream outputStream = new ByteArrayOutputStream(data.length);
-    byte[] buffer = new byte[1024];
-    while (!inflater.finished()) {
-      int count = inflater.inflate(buffer);
-      outputStream.write(buffer, 0, count);
+    try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream(data.length)) {
+      inflater.setInput(data);
+      byte[] buffer = new byte[1024];
+
+      while (!inflater.finished()) {
+        int count = inflater.inflate(buffer);
+        outputStream.write(buffer, 0, count);
+      }
+
+      return outputStream.toByteArray();
+    } finally {
+      inflater.end();
     }
-    outputStream.close();
-    byte[] output = outputStream.toByteArray();
-
-    return output;
   }
 
 }

--- a/common/src/main/java/org/tron/core/Constant.java
+++ b/common/src/main/java/org/tron/core/Constant.java
@@ -145,6 +145,8 @@ public class Constant {
   public static final String NODE_JSONRPC_HTTP_SOLIDITY_PORT = "node.jsonrpc.httpSolidityPort";
   public static final String NODE_JSONRPC_HTTP_PBFT_ENABLE = "node.jsonrpc.httpPBFTEnable";
   public static final String NODE_JSONRPC_HTTP_PBFT_PORT = "node.jsonrpc.httpPBFTPort";
+  public static final String NODE_JSONRPC_MAX_BLOCK_RANGE = "node.jsonrpc.maxBlockRange";
+  public static final String NODE_JSONRPC_MAX_SUB_TOPICS = "node.jsonrpc.maxSubTopics";
 
   public static final String NODE_DISABLED_API_LIST = "node.disabledApi";
 

--- a/framework/src/main/java/org/tron/core/config/args/Args.java
+++ b/framework/src/main/java/org/tron/core/config/args/Args.java
@@ -202,6 +202,8 @@ public class Args extends CommonParameter {
     PARAMETER.jsonRpcHttpFullNodeEnable = false;
     PARAMETER.jsonRpcHttpSolidityNodeEnable = false;
     PARAMETER.jsonRpcHttpPBFTNodeEnable = false;
+    PARAMETER.jsonRpcMaxBlockRange = 5000;
+    PARAMETER.jsonRpcMaxSubTopics = 1000;
     PARAMETER.nodeMetricsEnable = false;
     PARAMETER.metricsStorageEnable = false;
     PARAMETER.metricsPrometheusEnable = false;
@@ -505,6 +507,16 @@ public class Args extends CommonParameter {
     if (config.hasPath(Constant.NODE_JSONRPC_HTTP_PBFT_ENABLE)) {
       PARAMETER.jsonRpcHttpPBFTNodeEnable =
           config.getBoolean(Constant.NODE_JSONRPC_HTTP_PBFT_ENABLE);
+    }
+
+    if (config.hasPath(Constant.NODE_JSONRPC_MAX_BLOCK_RANGE)) {
+      PARAMETER.jsonRpcMaxBlockRange =
+          config.getInt(Constant.NODE_JSONRPC_MAX_BLOCK_RANGE);
+    }
+
+    if (config.hasPath(Constant.NODE_JSONRPC_MAX_SUB_TOPICS)) {
+      PARAMETER.jsonRpcMaxSubTopics =
+          config.getInt(Constant.NODE_JSONRPC_MAX_SUB_TOPICS);
     }
 
     if (config.hasPath(Constant.VM_MIN_TIME_RATIO)) {

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/TronJsonRpcImpl.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/TronJsonRpcImpl.java
@@ -1327,7 +1327,7 @@ public class TronJsonRpcImpl implements TronJsonRpc, Closeable {
 
     long currentMaxBlockNum = wallet.getNowBlock().getBlockHeader().getRawData().getNumber();
     //convert FilterRequest to LogFilterWrapper
-    LogFilterWrapper logFilterWrapper = new LogFilterWrapper(fr, currentMaxBlockNum, wallet);
+    LogFilterWrapper logFilterWrapper = new LogFilterWrapper(fr, currentMaxBlockNum, wallet, true);
 
     return getLogsByLogFilterWrapper(logFilterWrapper, currentMaxBlockNum);
   }

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/filters/LogFilter.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/filters/LogFilter.java
@@ -13,6 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.tron.common.bloom.Bloom;
 import org.tron.common.crypto.Hash;
 import org.tron.common.runtime.vm.DataWord;
+import org.tron.core.config.args.Args;
 import org.tron.core.exception.JsonRpcInvalidParamsException;
 import org.tron.core.services.jsonrpc.TronJsonRpc.FilterRequest;
 import org.tron.protos.Protocol.TransactionInfo.Log;
@@ -35,6 +36,8 @@ public class LogFilter {
   @Setter
   private Bloom[][] filterBlooms;
 
+  // The maximum number of topic criteria allowed, vm.LOG4 - vm.LOG0
+  private final int maxTopics = 4;
 
   public LogFilter() {
   }
@@ -66,7 +69,7 @@ public class LogFilter {
 
     if (fr.getTopics() != null) {
       //restrict depth of topics, because event has a signature and most 3 indexed parameters
-      if (fr.getTopics().length > 4) {
+      if (fr.getTopics().length > maxTopics) {
         throw new JsonRpcInvalidParamsException("topics size should be <= 4");
       }
       for (Object topic : fr.getTopics()) {
@@ -79,6 +82,10 @@ public class LogFilter {
             throw new JsonRpcInvalidParamsException("invalid topic(s): " + topic);
           }
         } else if (topic instanceof ArrayList) {
+          int maxSubTopics = Args.getInstance().getJsonRpcMaxSubTopics();
+          if (maxSubTopics > 0 && ((ArrayList<?>) topic).size() > maxSubTopics) {
+            throw new JsonRpcInvalidParamsException("exceed max topics: " + maxSubTopics);
+          }
 
           List<byte[]> t = new ArrayList<>();
           for (Object s : ((ArrayList) topic)) {

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/filters/LogFilterAndResult.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/filters/LogFilterAndResult.java
@@ -16,7 +16,8 @@ public class LogFilterAndResult extends FilterResult<LogFilterElement> {
 
   public LogFilterAndResult(FilterRequest fr, long currentMaxBlockNum, Wallet wallet)
       throws JsonRpcInvalidParamsException {
-    this.logFilterWrapper = new LogFilterWrapper(fr, currentMaxBlockNum, wallet);
+    // eth_newFilter, no need to check block range
+    this.logFilterWrapper = new LogFilterWrapper(fr, currentMaxBlockNum, wallet, false);
     result = new LinkedBlockingQueue<>();
     this.updateExpireTime();
   }

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/filters/LogFilterWrapper.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/filters/LogFilterWrapper.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
 import org.tron.common.utils.ByteArray;
 import org.tron.core.Wallet;
+import org.tron.core.config.args.Args;
 import org.tron.core.exception.JsonRpcInvalidParamsException;
 import org.tron.core.services.jsonrpc.JsonRpcApiUtil;
 import org.tron.core.services.jsonrpc.TronJsonRpc.FilterRequest;
@@ -23,8 +24,8 @@ public class LogFilterWrapper {
   @Getter
   private final long toBlock;
 
-  public LogFilterWrapper(FilterRequest fr, long currentMaxBlockNum, Wallet wallet)
-      throws JsonRpcInvalidParamsException {
+  public LogFilterWrapper(FilterRequest fr, long currentMaxBlockNum, Wallet wallet,
+      boolean checkBlockRange) throws JsonRpcInvalidParamsException {
 
     // 1.convert FilterRequest to LogFilter
     this.logFilter = new LogFilter(fr);
@@ -85,6 +86,12 @@ public class LogFilterWrapper {
         if (fromBlockSrc > toBlockSrc) {
           throw new JsonRpcInvalidParamsException("please verify: fromBlock <= toBlock");
         }
+      }
+
+      // till now, it needs to check block range for eth_getLogs
+      int maxBlockRange = Args.getInstance().getJsonRpcMaxBlockRange();
+      if (checkBlockRange && maxBlockRange > 0 && (toBlockSrc - fromBlockSrc) > maxBlockRange) {
+        throw new JsonRpcInvalidParamsException("exceed max block range: " + maxBlockRange);
       }
     }
 

--- a/framework/src/main/resources/config-localtest.conf
+++ b/framework/src/main/resources/config-localtest.conf
@@ -161,6 +161,8 @@ node {
     # httpSolidityPort = 8555
     # httpPBFTEnable = true
     # httpPBFTPort = 8565
+    # maxBlockRange = 5000
+    # maxSubTopics = 1000
   }
 
 }

--- a/framework/src/main/resources/config.conf
+++ b/framework/src/main/resources/config.conf
@@ -291,6 +291,14 @@ node {
     # httpSolidityPort = 8555
     # httpPBFTEnable = true
     # httpPBFTPort = 8565
+
+    # The maximum blocks range to retrieve logs for eth_getLogs, default value is 5000,
+    # should be >= 0, 0 means no limit.
+    # maxBlockRange = 5000
+
+    # The maximum number of allowed topics within a topic criteria, default value is 1000,
+    # should be >= 0, 0 means no limit.
+    # maxSubTopics = 1000
   }
 
   # Disabled api list, it will work for http, rpc and pbft, both fullnode and soliditynode,

--- a/framework/src/test/java/org/tron/core/config/args/ArgsTest.java
+++ b/framework/src/test/java/org/tron/core/config/args/ArgsTest.java
@@ -173,6 +173,8 @@ public class ArgsTest {
     Assert.assertFalse(Args.getInstance().isJsonRpcHttpFullNodeEnable());
     Assert.assertFalse(Args.getInstance().isJsonRpcHttpSolidityNodeEnable());
     Assert.assertFalse(Args.getInstance().isJsonRpcHttpPBFTNodeEnable());
+    Assert.assertEquals(5000, Args.getInstance().getJsonRpcMaxBlockRange());
+    Assert.assertEquals(1000, Args.getInstance().getJsonRpcMaxSubTopics());
     Args.clearParam();
     // test set all true value
     storage.put("node.rpc.enable", "true");
@@ -184,6 +186,8 @@ public class ArgsTest {
     storage.put("node.jsonrpc.httpFullNodeEnable", "true");
     storage.put("node.jsonrpc.httpSolidityEnable", "true");
     storage.put("node.jsonrpc.httpPBFTEnable", "true");
+    storage.put("node.jsonrpc.maxBlockRange", "10");
+    storage.put("node.jsonrpc.maxSubTopics", "20");
     config = ConfigFactory.defaultOverrides().withFallback(ConfigFactory.parseMap(storage));
     // test value
     Args.setParam(config);
@@ -196,6 +200,8 @@ public class ArgsTest {
     Assert.assertTrue(Args.getInstance().isJsonRpcHttpFullNodeEnable());
     Assert.assertTrue(Args.getInstance().isJsonRpcHttpSolidityNodeEnable());
     Assert.assertTrue(Args.getInstance().isJsonRpcHttpPBFTNodeEnable());
+    Assert.assertEquals(10, Args.getInstance().getJsonRpcMaxBlockRange());
+    Assert.assertEquals(20, Args.getInstance().getJsonRpcMaxSubTopics());
     Args.clearParam();
     // test set all false value
     storage.put("node.rpc.enable", "false");
@@ -207,6 +213,8 @@ public class ArgsTest {
     storage.put("node.jsonrpc.httpFullNodeEnable", "false");
     storage.put("node.jsonrpc.httpSolidityEnable", "false");
     storage.put("node.jsonrpc.httpPBFTEnable", "false");
+    storage.put("node.jsonrpc.maxBlockRange", "5000");
+    storage.put("node.jsonrpc.maxSubTopics", "1000");
     config = ConfigFactory.defaultOverrides().withFallback(ConfigFactory.parseMap(storage));
     // test value
     Args.setParam(config);
@@ -219,6 +227,8 @@ public class ArgsTest {
     Assert.assertFalse(Args.getInstance().isJsonRpcHttpFullNodeEnable());
     Assert.assertFalse(Args.getInstance().isJsonRpcHttpSolidityNodeEnable());
     Assert.assertFalse(Args.getInstance().isJsonRpcHttpPBFTNodeEnable());
+    Assert.assertEquals(5000, Args.getInstance().getJsonRpcMaxBlockRange());
+    Assert.assertEquals(1000, Args.getInstance().getJsonRpcMaxSubTopics());
     Args.clearParam();
     // test set random value
     storage.put("node.rpc.enable", "false");
@@ -230,6 +240,8 @@ public class ArgsTest {
     storage.put("node.jsonrpc.httpFullNodeEnable", "true");
     storage.put("node.jsonrpc.httpSolidityEnable", "false");
     storage.put("node.jsonrpc.httpPBFTEnable", "true");
+    storage.put("node.jsonrpc.maxBlockRange", "30");
+    storage.put("node.jsonrpc.maxSubTopics", "40");
     config = ConfigFactory.defaultOverrides().withFallback(ConfigFactory.parseMap(storage));
     // test value
     Args.setParam(config);
@@ -242,6 +254,8 @@ public class ArgsTest {
     Assert.assertTrue(Args.getInstance().isJsonRpcHttpFullNodeEnable());
     Assert.assertFalse(Args.getInstance().isJsonRpcHttpSolidityNodeEnable());
     Assert.assertTrue(Args.getInstance().isJsonRpcHttpPBFTNodeEnable());
+    Assert.assertEquals(30, Args.getInstance().getJsonRpcMaxBlockRange());
+    Assert.assertEquals(40, Args.getInstance().getJsonRpcMaxSubTopics());
     Args.clearParam();
   }
 }

--- a/framework/src/test/java/org/tron/core/jsonrpc/JsonRpcTest.java
+++ b/framework/src/test/java/org/tron/core/jsonrpc/JsonRpcTest.java
@@ -284,7 +284,8 @@ public class JsonRpcTest {
               topics,
               null),
               100,
-              null);
+              null,
+              false);
 
       LogBlockQuery logBlockQuery = new LogBlockQuery(logFilterWrapper, null, 100, null);
       int[][][] conditions = logBlockQuery.getConditions();
@@ -331,7 +332,8 @@ public class JsonRpcTest {
               topics,
               null),
               100,
-              null);
+              null,
+              false);
 
       LogBlockQuery logBlockQuery = new LogBlockQuery(logFilterWrapper, null, 100, null);
       int[][][] conditions = logBlockQuery.getConditions();

--- a/framework/src/test/java/org/tron/core/jsonrpc/SectionBloomStoreTest.java
+++ b/framework/src/test/java/org/tron/core/jsonrpc/SectionBloomStoreTest.java
@@ -132,7 +132,7 @@ public class SectionBloomStoreTest extends BaseTest {
     try {
       LogFilterWrapper logFilterWrapper = new LogFilterWrapper(
           new FilterRequest("earliest", "latest", ByteArray.toJsonHex(address1), null, null),
-          currentMaxBlockNum, null);
+          currentMaxBlockNum, null, false);
       LogBlockQuery logBlockQuery =
           new LogBlockQuery(logFilterWrapper, sectionBloomStore, currentMaxBlockNum,
               sectionExecutor);
@@ -149,7 +149,7 @@ public class SectionBloomStoreTest extends BaseTest {
     try {
       LogFilterWrapper logFilterWrapper = new LogFilterWrapper(
           new FilterRequest("earliest", "latest", addressList, null, null),
-          currentMaxBlockNum, null);
+          currentMaxBlockNum, null, false);
       LogBlockQuery logBlockQuery =
           new LogBlockQuery(logFilterWrapper, sectionBloomStore, currentMaxBlockNum,
               sectionExecutor);
@@ -165,7 +165,7 @@ public class SectionBloomStoreTest extends BaseTest {
       LogFilterWrapper logFilterWrapper = new LogFilterWrapper(
           new FilterRequest("earliest", "latest", null,
               new String[] {ByteArray.toHexString(topic1)}, null),
-          currentMaxBlockNum, null);
+          currentMaxBlockNum, null, false);
       LogBlockQuery logBlockQuery =
           new LogBlockQuery(logFilterWrapper, sectionBloomStore, currentMaxBlockNum,
               sectionExecutor);
@@ -181,7 +181,7 @@ public class SectionBloomStoreTest extends BaseTest {
       LogFilterWrapper logFilterWrapper = new LogFilterWrapper(
           new FilterRequest("earliest", "latest", null,
               new String[] {ByteArray.toHexString(topic2)}, null),
-          currentMaxBlockNum, null);
+          currentMaxBlockNum, null, false);
       LogBlockQuery logBlockQuery =
           new LogBlockQuery(logFilterWrapper, sectionBloomStore, currentMaxBlockNum,
               sectionExecutor);
@@ -199,7 +199,7 @@ public class SectionBloomStoreTest extends BaseTest {
       LogFilterWrapper logFilterWrapper = new LogFilterWrapper(
           new FilterRequest("earliest", "latest", null,
               new Object[] {topicList}, null),
-          currentMaxBlockNum, null);
+          currentMaxBlockNum, null, false);
       LogBlockQuery logBlockQuery =
           new LogBlockQuery(logFilterWrapper, sectionBloomStore, currentMaxBlockNum,
               sectionExecutor);
@@ -226,7 +226,7 @@ public class SectionBloomStoreTest extends BaseTest {
       LogFilterWrapper logFilterWrapper = new LogFilterWrapper(
           new FilterRequest("earliest", "latest", null,
               new Object[] {ByteArray.toJsonHex(topic1), ByteArray.toJsonHex(topic2)}, null),
-          currentMaxBlockNum, null);
+          currentMaxBlockNum, null, false);
       LogBlockQuery logBlockQuery =
           new LogBlockQuery(logFilterWrapper, sectionBloomStore, currentMaxBlockNum,
               sectionExecutor);

--- a/framework/src/test/resources/config-localtest.conf
+++ b/framework/src/test/resources/config-localtest.conf
@@ -125,15 +125,6 @@ node {
     PBFTPort = 8092
   }
 
-  jsonrpc {
-    httpFullNodeEnable = false
-    httpFullNodePort = 8545
-    httpSolidityEnable = false
-    httpSolidityPort = 8555
-    httpPBFTEnable = false
-    httpPBFTPort = 8565
-  }
-
   rpc {
     enable = false
     port = 50051
@@ -174,6 +165,8 @@ node {
     # httpSolidityPort = 8555
     # httpPBFTEnable = true
     # httpPBFTPort = 8565
+    # maxBlockRange = 5000
+    # maxSubTopics = 1000
   }
 
 }

--- a/framework/src/test/resources/config-test-index.conf
+++ b/framework/src/test/resources/config-test-index.conf
@@ -86,6 +86,8 @@ node {
     httpFullNodeEnable = false
     httpSolidityEnable = false
     httpPBFTEnable = false
+    # maxBlockRange = 5000
+    # maxSubTopics = 1000
   }
 
   rpc {

--- a/framework/src/test/resources/config-test-mainnet.conf
+++ b/framework/src/test/resources/config-test-mainnet.conf
@@ -92,6 +92,8 @@ node {
     httpFullNodeEnable = false
     httpSolidityEnable = false
     httpPBFTEnable = false
+    # maxBlockRange = 5000
+    # maxSubTopics = 1000
   }
 
   rpc {

--- a/framework/src/test/resources/config-test.conf
+++ b/framework/src/test/resources/config-test.conf
@@ -116,6 +116,8 @@ node {
     httpFullNodeEnable = false
     httpSolidityEnable = false
     httpPBFTEnable = false
+    # maxBlockRange = 5000
+    # maxSubTopics = 1000
   }
 
   # use your ipv6 address for node discovery and tcp connection, default false


### PR DESCRIPTION
**What does this PR do?**
check maxSubTopics and maxBlockRange to be consistent with eth.

**Why are these changes required?**
Add maxSubTopics and maxBlockRange to be consistent with eth.

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**
check maxSubTopics for `eth_newFilter` and `eth_getLogs`.
check maxBlockRange for `eth_getLogs`.

