### PR TITLE
fix(jsonrpc): use min(to, currentMaxBlock) to compare with maxBlockRange

### DIFF
--- a/framework/src/main/java/org/tron/core/services/jsonrpc/filters/LogFilterWrapper.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/filters/LogFilterWrapper.java
@@ -1,6 +1,6 @@
 package org.tron.core.services.jsonrpc.filters;
 
-import static org.tron.common.math.Maths.min;
+import static org.tron.common.math.StrictMathWrapper.min;
 
 import com.google.protobuf.ByteString;
 import lombok.Getter;
@@ -58,7 +58,7 @@ public class LogFilterWrapper {
         if (toBlockSrc == -1) {
           toBlockSrc = Long.MAX_VALUE;
         }
-        fromBlockSrc = min(toBlockSrc, currentMaxBlockNum, true);
+        fromBlockSrc = min(toBlockSrc, currentMaxBlockNum);
 
       } else if (StringUtils.isNotEmpty(fr.getFromBlock())
           && StringUtils.isEmpty(fr.getToBlock())) {
@@ -90,7 +90,8 @@ public class LogFilterWrapper {
 
       // till now, it needs to check block range for eth_getLogs
       int maxBlockRange = Args.getInstance().getJsonRpcMaxBlockRange();
-      if (checkBlockRange && maxBlockRange > 0 && (toBlockSrc - fromBlockSrc) > maxBlockRange) {
+      if (checkBlockRange && maxBlockRange > 0
+          && min(toBlockSrc, currentMaxBlockNum) - fromBlockSrc > maxBlockRange) {
         throw new JsonRpcInvalidParamsException("exceed max block range: " + maxBlockRange);
       }
     }

--- a/framework/src/test/java/org/tron/core/config/args/ArgsTest.java
+++ b/framework/src/test/java/org/tron/core/config/args/ArgsTest.java
@@ -256,6 +256,25 @@ public class ArgsTest {
     Assert.assertTrue(Args.getInstance().isJsonRpcHttpPBFTNodeEnable());
     Assert.assertEquals(30, Args.getInstance().getJsonRpcMaxBlockRange());
     Assert.assertEquals(40, Args.getInstance().getJsonRpcMaxSubTopics());
+
+    // test set invalid value
+    storage.put("node.jsonrpc.maxBlockRange", "0");
+    storage.put("node.jsonrpc.maxSubTopics", "0");
+    config = ConfigFactory.defaultOverrides().withFallback(ConfigFactory.parseMap(storage));
+    // check value
+    Args.setParam(config);
+    Assert.assertEquals(0, Args.getInstance().getJsonRpcMaxBlockRange());
+    Assert.assertEquals(0, Args.getInstance().getJsonRpcMaxSubTopics());
+
+    // test set invalid value
+    storage.put("node.jsonrpc.maxBlockRange", "-2");
+    storage.put("node.jsonrpc.maxSubTopics", "-4");
+    config = ConfigFactory.defaultOverrides().withFallback(ConfigFactory.parseMap(storage));
+    // check value
+    Args.setParam(config);
+    Assert.assertEquals(-2, Args.getInstance().getJsonRpcMaxBlockRange());
+    Assert.assertEquals(-4, Args.getInstance().getJsonRpcMaxSubTopics());
+
     Args.clearParam();
   }
 }

--- a/framework/src/test/java/org/tron/core/jsonrpc/JsonrpcServiceTest.java
+++ b/framework/src/test/java/org/tron/core/jsonrpc/JsonrpcServiceTest.java
@@ -55,7 +55,7 @@ public class JsonrpcServiceTest extends BaseTest {
 
   private static final String OWNER_ADDRESS;
   private static final String OWNER_ADDRESS_ACCOUNT_NAME = "first";
-  private static final long LATEST_BLOCK_NUM = 10L;
+  private static final long LATEST_BLOCK_NUM = 10_000L;
   private static final long LATEST_SOLIDIFIED_BLOCK_NUM = 4L;
 
   private static TronJsonRpcImpl tronJsonRpc;
@@ -303,6 +303,7 @@ public class JsonrpcServiceTest extends BaseTest {
     // pending
     try {
       tronJsonRpc.ethGetBlockByNumber("pending", false);
+      Assert.fail("Expected to be thrown");
     } catch (Exception e) {
       Assert.assertEquals("TAG pending not supported", e.getMessage());
     }
@@ -310,6 +311,7 @@ public class JsonrpcServiceTest extends BaseTest {
     // invalid
     try {
       tronJsonRpc.ethGetBlockByNumber("0x", false);
+      Assert.fail("Expected to be thrown");
     } catch (Exception e) {
       Assert.assertEquals("invalid block number", e.getMessage());
     }
@@ -388,6 +390,7 @@ public class JsonrpcServiceTest extends BaseTest {
 
     try {
       getByJsonBlockId("pending", wallet);
+      Assert.fail("Expected to be thrown");
     } catch (Exception e) {
       Assert.assertEquals("TAG pending not supported", e.getMessage());
     }
@@ -422,12 +425,14 @@ public class JsonrpcServiceTest extends BaseTest {
 
     try {
       getByJsonBlockId("abc", wallet);
+      Assert.fail("Expected to be thrown");
     } catch (Exception e) {
       Assert.assertEquals("Incorrect hex syntax", e.getMessage());
     }
 
     try {
       getByJsonBlockId("0xxabc", wallet);
+      Assert.fail("Expected to be thrown");
     } catch (Exception e) {
       Assert.assertEquals("For input string: \"xabc\"", e.getMessage());
     }
@@ -439,6 +444,7 @@ public class JsonrpcServiceTest extends BaseTest {
 
     try {
       tronJsonRpc.getTrxBalance("", "earliest");
+      Assert.fail("Expected to be thrown");
     } catch (Exception e) {
       Assert.assertEquals("TAG [earliest | pending | finalized] not supported",
           e.getMessage());
@@ -446,6 +452,7 @@ public class JsonrpcServiceTest extends BaseTest {
 
     try {
       tronJsonRpc.getTrxBalance("", "pending");
+      Assert.fail("Expected to be thrown");
     } catch (Exception e) {
       Assert.assertEquals("TAG [earliest | pending | finalized] not supported",
           e.getMessage());
@@ -453,6 +460,7 @@ public class JsonrpcServiceTest extends BaseTest {
 
     try {
       tronJsonRpc.getTrxBalance("", "finalized");
+      Assert.fail("Expected to be thrown");
     } catch (Exception e) {
       Assert.assertEquals("TAG [earliest | pending | finalized] not supported",
           e.getMessage());
@@ -471,6 +479,7 @@ public class JsonrpcServiceTest extends BaseTest {
   public void testGetStorageAt() {
     try {
       tronJsonRpc.getStorageAt("", "", "earliest");
+      Assert.fail("Expected to be thrown");
     } catch (Exception e) {
       Assert.assertEquals("TAG [earliest | pending | finalized] not supported",
           e.getMessage());
@@ -478,6 +487,7 @@ public class JsonrpcServiceTest extends BaseTest {
 
     try {
       tronJsonRpc.getStorageAt("", "", "pending");
+      Assert.fail("Expected to be thrown");
     } catch (Exception e) {
       Assert.assertEquals("TAG [earliest | pending | finalized] not supported",
           e.getMessage());
@@ -485,6 +495,7 @@ public class JsonrpcServiceTest extends BaseTest {
 
     try {
       tronJsonRpc.getStorageAt("", "", "finalized");
+      Assert.fail("Expected to be thrown");
     } catch (Exception e) {
       Assert.assertEquals("TAG [earliest | pending | finalized] not supported",
           e.getMessage());
@@ -495,6 +506,7 @@ public class JsonrpcServiceTest extends BaseTest {
   public void testGetABIOfSmartContract() {
     try {
       tronJsonRpc.getABIOfSmartContract("", "earliest");
+      Assert.fail("Expected to be thrown");
     } catch (Exception e) {
       Assert.assertEquals("TAG [earliest | pending | finalized] not supported",
           e.getMessage());
@@ -502,6 +514,7 @@ public class JsonrpcServiceTest extends BaseTest {
 
     try {
       tronJsonRpc.getABIOfSmartContract("", "pending");
+      Assert.fail("Expected to be thrown");
     } catch (Exception e) {
       Assert.assertEquals("TAG [earliest | pending | finalized] not supported",
           e.getMessage());
@@ -509,6 +522,7 @@ public class JsonrpcServiceTest extends BaseTest {
 
     try {
       tronJsonRpc.getABIOfSmartContract("", "finalized");
+      Assert.fail("Expected to be thrown");
     } catch (Exception e) {
       Assert.assertEquals("TAG [earliest | pending | finalized] not supported",
           e.getMessage());
@@ -519,6 +533,7 @@ public class JsonrpcServiceTest extends BaseTest {
   public void testGetCall() {
     try {
       tronJsonRpc.getCall(null, "earliest");
+      Assert.fail("Expected to be thrown");
     } catch (Exception e) {
       Assert.assertEquals("TAG [earliest | pending | finalized] not supported",
           e.getMessage());
@@ -526,6 +541,7 @@ public class JsonrpcServiceTest extends BaseTest {
 
     try {
       tronJsonRpc.getCall(null, "pending");
+      Assert.fail("Expected to be thrown");
     } catch (Exception e) {
       Assert.assertEquals("TAG [earliest | pending | finalized] not supported",
           e.getMessage());
@@ -533,6 +549,7 @@ public class JsonrpcServiceTest extends BaseTest {
 
     try {
       tronJsonRpc.getCall(null, "finalized");
+      Assert.fail("Expected to be thrown");
     } catch (Exception e) {
       Assert.assertEquals("TAG [earliest | pending | finalized] not supported",
           e.getMessage());
@@ -607,6 +624,7 @@ public class JsonrpcServiceTest extends BaseTest {
     try {
       new LogFilterWrapper(new FilterRequest("0x78", "0x14",
           null, null, null), 100, null, false);
+      Assert.fail("Expected to be thrown");
     } catch (JsonRpcInvalidParamsException e) {
       Assert.assertEquals("please verify: fromBlock <= toBlock", e.getMessage());
     }
@@ -631,6 +649,7 @@ public class JsonrpcServiceTest extends BaseTest {
     try {
       new LogFilterWrapper(new FilterRequest("pending", null, null, null, null),
           100, null, false);
+      Assert.fail("Expected to be thrown");
     } catch (JsonRpcInvalidParamsException e) {
       Assert.assertEquals("TAG pending not supported", e.getMessage());
     }
@@ -645,37 +664,115 @@ public class JsonrpcServiceTest extends BaseTest {
     try {
       new LogFilterWrapper(new FilterRequest("test", null, null, null, null),
           100, null, false);
+      Assert.fail("Expected to be thrown");
     } catch (JsonRpcInvalidParamsException e) {
       Assert.assertEquals("Incorrect hex syntax", e.getMessage());
     }
 
+    // to = 8000
     try {
       new LogFilterWrapper(new FilterRequest("0x0", "0x1f40", null,
-          null, null), 10_000, null, false);
+          null, null), LATEST_BLOCK_NUM, null, false);
     } catch (JsonRpcInvalidParamsException e) {
       Assert.fail();
     }
 
     try {
       new LogFilterWrapper(new FilterRequest("0x0", "0x1f40", null,
-          null, null), 10_000, null, true);
+          null, null), LATEST_BLOCK_NUM, null, true);
+      Assert.fail("Expected to be thrown");
     } catch (JsonRpcInvalidParamsException e) {
       Assert.assertEquals(
           "exceed max block range: " + Args.getInstance().jsonRpcMaxBlockRange,
           e.getMessage());
     }
 
+    try {
+      new LogFilterWrapper(new FilterRequest("0x0", "latest", null,
+          null, null), LATEST_BLOCK_NUM, null, false);
+    } catch (JsonRpcInvalidParamsException e) {
+      Assert.fail();
+    }
+
+    try {
+      new LogFilterWrapper(new FilterRequest("0x0", "latest", null,
+          null, null), LATEST_BLOCK_NUM, null, true);
+      Assert.fail("Expected to be thrown");
+    } catch (JsonRpcInvalidParamsException e) {
+      Assert.assertEquals(
+          "exceed max block range: " + Args.getInstance().jsonRpcMaxBlockRange,
+          e.getMessage());
+    }
+
+    // from = 100, current = 5_000, to = Long.MAX_VALUE
+    try {
+      new LogFilterWrapper(new FilterRequest("0x64", "latest", null,
+          null, null), 5_000, null, true);
+    } catch (JsonRpcInvalidParamsException e) {
+      Assert.fail();
+    }
+    try {
+      new LogFilterWrapper(new FilterRequest("0x64", "latest", null,
+          null, null), LATEST_BLOCK_NUM, null, false);
+    } catch (Exception e) {
+      Assert.fail();
+    }
+
+    // from = 100
+    try {
+      new LogFilterWrapper(new FilterRequest("0x64", "latest", null,
+          null, null), LATEST_BLOCK_NUM, null, true);
+      Assert.fail("Expected to be thrown");
+    } catch (JsonRpcInvalidParamsException e) {
+      Assert.assertEquals(
+          "exceed max block range: " + Args.getInstance().jsonRpcMaxBlockRange,
+          e.getMessage());
+    }
+    try {
+      new LogFilterWrapper(new FilterRequest("0x64", "latest", null,
+          null, null), LATEST_BLOCK_NUM, null, false);
+    } catch (Exception e) {
+      Assert.fail();
+    }
+
+    // from = 9_000
+    try {
+      new LogFilterWrapper(new FilterRequest("0x2328", "latest", null,
+          null, null), LATEST_BLOCK_NUM, null, true);
+    } catch (Exception e) {
+      Assert.fail();
+    }
+    try {
+      new LogFilterWrapper(new FilterRequest("0x2328", "latest", null,
+          null, null), LATEST_BLOCK_NUM, null, false);
+    } catch (Exception e) {
+      Assert.fail();
+    }
+
+    try {
+      new LogFilterWrapper(new FilterRequest("latest", "latest", null,
+          null, null), LATEST_BLOCK_NUM, null, true);
+    } catch (JsonRpcInvalidParamsException e) {
+      Assert.fail();
+    }
+    try {
+      new LogFilterWrapper(new FilterRequest("latest", "latest", null,
+          null, null), LATEST_BLOCK_NUM, null, false);
+    } catch (JsonRpcInvalidParamsException e) {
+      Assert.fail();
+    }
+
     int oldMaxBlockRange = Args.getInstance().getJsonRpcMaxBlockRange();
     Args.getInstance().setJsonRpcMaxBlockRange(10_000);
     try {
       new LogFilterWrapper(new FilterRequest("0x0", "0x1f40", null,
-          null, null), 10_000, null, true);
+          null, null), LATEST_BLOCK_NUM, null, true);
     } catch (JsonRpcInvalidParamsException e) {
       Assert.fail();
     }
     try {
       new LogFilterWrapper(new FilterRequest("0x0", "0x1f40", null,
-          null, null), 10_000, null, false);
+          null, null), LATEST_BLOCK_NUM, null, false);
     } catch (JsonRpcInvalidParamsException e) {
       Assert.fail();
     }
@@ -683,13 +780,13 @@ public class JsonrpcServiceTest extends BaseTest {
     Args.getInstance().setJsonRpcMaxBlockRange(0);
     try {
       new LogFilterWrapper(new FilterRequest("0x0", "0x1f40", null,
-          null, null), 10_000, null, true);
+          null, null), LATEST_BLOCK_NUM, null, true);
     } catch (JsonRpcInvalidParamsException e) {
       Assert.fail();
     }
     try {
       new LogFilterWrapper(new FilterRequest("0x0", "0x1f40", null,
-          null, null), 10_000, null, false);
+          null, null), LATEST_BLOCK_NUM, null, false);
     } catch (JsonRpcInvalidParamsException e) {
       Assert.fail();
     }
@@ -697,13 +794,13 @@ public class JsonrpcServiceTest extends BaseTest {
     Args.getInstance().setJsonRpcMaxBlockRange(-2);
     try {
       new LogFilterWrapper(new FilterRequest("0x0", "0x1f40", null,
-          null, null), 10_000, null, true);
+          null, null), LATEST_BLOCK_NUM, null, true);
     } catch (JsonRpcInvalidParamsException e) {
       Assert.fail();
     }
     try {
       new LogFilterWrapper(new FilterRequest("0x0", "0x1f40", null,
-          null, null), 10_000, null, false);
+          null, null), LATEST_BLOCK_NUM, null, false);
     } catch (JsonRpcInvalidParamsException e) {
       Assert.fail();
     }
@@ -726,7 +823,8 @@ public class JsonrpcServiceTest extends BaseTest {
 
     try {
       new LogFilterWrapper(new FilterRequest("0xbb8", "0x1f40",
-          null, topics.toArray(), null), 10_000, null, false);
+          null, topics.toArray(), null), LATEST_BLOCK_NUM, null, false);
+      Assert.fail("Expected to be thrown");
     } catch (JsonRpcInvalidParamsException e) {
       Assert.assertEquals(
           "exceed max topics: " + Args.getInstance().getJsonRpcMaxSubTopics(),
@@ -736,6 +834,7 @@ public class JsonrpcServiceTest extends BaseTest {
     try {
       tronJsonRpc.getLogs(new FilterRequest("0xbb8", "0x1f40",
           null, topics.toArray(), null));
+      Assert.fail("Expected to be thrown");
     } catch (JsonRpcInvalidParamsException e) {
       Assert.assertEquals(
           "exceed max topics: " + Args.getInstance().getJsonRpcMaxSubTopics(),
@@ -747,6 +846,7 @@ public class JsonrpcServiceTest extends BaseTest {
     try {
       tronJsonRpc.newFilter(new FilterRequest("0xbb8", "0x1f40",
           null, topics.toArray(), null));
+      Assert.fail("Expected to be thrown");
     } catch (JsonRpcInvalidParamsException e) {
       Assert.assertEquals(
           "exceed max topics: " + Args.getInstance().getJsonRpcMaxSubTopics(),
@@ -759,7 +859,7 @@ public class JsonrpcServiceTest extends BaseTest {
     Args.getInstance().setJsonRpcMaxSubTopics(2_000);
     try {
       new LogFilterWrapper(new FilterRequest("0xbb8", "0x1f40",
-          null, topics.toArray(), null), 10_000, null, false);
+          null, topics.toArray(), null), LATEST_BLOCK_NUM, null, false);
     } catch (JsonRpcInvalidParamsException e) {
       Assert.fail();
     }
@@ -767,8 +867,28 @@ public class JsonrpcServiceTest extends BaseTest {
     Args.getInstance().setJsonRpcMaxSubTopics(0);
     try {
       new LogFilterWrapper(new FilterRequest("0xbb8", "0x1f40",
-          null, topics.toArray(), null), 10_000, null, false);
+          null, topics.toArray(), null), LATEST_BLOCK_NUM, null, false);
     } catch (JsonRpcInvalidParamsException e) {
+      Assert.fail();
+    }
+    try {
+      tronJsonRpc.newFilter(new FilterRequest("0xbb8", "0x1f40",
+          null, topics.toArray(), null));
+    } catch (Exception e) {
+      Assert.fail();
+    }
+
+    Args.getInstance().setJsonRpcMaxSubTopics(-2);
+    try {
+      new LogFilterWrapper(new FilterRequest("0xbb8", "0x1f40",
+          null, topics.toArray(), null), LATEST_BLOCK_NUM, null, false);
+    } catch (JsonRpcInvalidParamsException e) {
+      Assert.fail();
+    }
+    try {
+      tronJsonRpc.newFilter(new FilterRequest("0xbb8", "0x1f40",
+          null, topics.toArray(), null));
+    } catch (Exception e) {
       Assert.fail();
     }
 
@@ -780,6 +900,7 @@ public class JsonrpcServiceTest extends BaseTest {
     try {
       tronJsonRpc.getLogs(new FilterRequest("0x0", "0x1f40", null,
           null, null));
+      Assert.fail("Expected to be thrown");
     } catch (JsonRpcInvalidParamsException e) {
       Assert.assertEquals(
           "exceed max block range: " + Args.getInstance().jsonRpcMaxBlockRange,
@@ -814,30 +935,35 @@ public class JsonrpcServiceTest extends BaseTest {
 
     try {
       tronJsonRpc.newFilter(new FilterRequest("finalized", null, null, null, null));
+      Assert.fail("Expected to be thrown");
     } catch (Exception e) {
       Assert.assertEquals("invalid block range params", e.getMessage());
     }
 
     try {
       tronJsonRpc.newFilter(new FilterRequest(null, "finalized", null, null, null));
+      Assert.fail("Expected to be thrown");
     } catch (Exception e) {
       Assert.assertEquals("invalid block range params", e.getMessage());
     }
 
     try {
       tronJsonRpc.newFilter(new FilterRequest("finalized", "latest", null, null, null));
+      Assert.fail("Expected to be thrown");
     } catch (Exception e) {
       Assert.assertEquals("invalid block range params", e.getMessage());
     }
 
     try {
       tronJsonRpc.newFilter(new FilterRequest("0x1", "finalized", null, null, null));
+      Assert.fail("Expected to be thrown");
     } catch (Exception e) {
       Assert.assertEquals("invalid block range params", e.getMessage());
     }
 
     try {
       tronJsonRpc.newFilter(new FilterRequest("finalized", "finalized", null, null, null));
+      Assert.fail("Expected to be thrown");
     } catch (Exception e) {
       Assert.assertEquals("invalid block range params", e.getMessage());
     }


### PR DESCRIPTION
**What does this PR do?**
use min(to, currentMaxBlock) to compare with maxBlockRange

**Why are these changes required?**
When input `to` is "latest", it will be set to Long.MAX_VALUE, so we need to use min(to, currentMaxBlock) to compare with maxBlockRange

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

