### PR TITLE
opt(framework): delete useless code

### DIFF
--- a/framework/src/main/java/org/tron/program/SolidityNode.java
+++ b/framework/src/main/java/org/tron/program/SolidityNode.java
@@ -152,7 +152,6 @@ public class SolidityNode {
       } catch (Exception e) {
         logger.error("Failed to process block {}.", new BlockCapsule(block), e);
         sleep(exceptionSleepTime);
-        block = getBlockByNum(blockNum);
       }
     }
   }


### PR DESCRIPTION
**What does this PR do?**
getBlockByNum() is useless in this place，He should completely hand it over to the producer getBlock() method

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

