### PR TITLE
fix(chainbase): Implicit narrowing conversion in compound assignment

### DIFF
--- a/chainbase/src/main/java/org/tron/core/capsule/TransactionCapsule.java
+++ b/chainbase/src/main/java/org/tron/core/capsule/TransactionCapsule.java
@@ -460,7 +460,7 @@ public class TransactionCapsule implements ProtoCapsule<Transaction> {
     byte[] s = sign.substring(32, 64).toByteArray();
     byte v = sign.byteAt(64);
     if (v < 27) {
-      v += 27; //revId -> v
+      v = (byte)(v + 27); //revId -> v
     }
     ECDSASignature signature = ECDSASignature.fromComponents(r, s, v);
     return signature.toBase64();


### PR DESCRIPTION

Compound assignment statements of the form x += y or x *= y perform an implicit narrowing conversion if the type of x is narrower than the type of y. For example, x += y is equivalent to x = (T)(x + y), where T is the type of x. This can result in information loss and numeric errors such as overflows.

---

fix the problem, we should avoid the implicit narrowing conversion in the compound assignment. Instead of using `v += 27;` (which implicitly casts the result of `v + 27` from `int` to `byte`), we should perform the addition in `int` and then explicitly cast the result to `byte` when assigning it back to `v`. This makes the narrowing conversion explicit and clear to readers and static analysis tools.

Specifically, in `getBase64FromByteString`, replace:
```java
if (v < 27) {
  v += 27; //revId -> v
}
```
with:
```java
if (v < 27) {
  v = (byte)(v + 27); //revId -> v
}
```
No new imports or method definitions are needed.


References

[Compound Assignment Operators](https://docs.oracle.com/javase/specs/jls/se11/html/jls-15.html#jls-15.26.2), [Narrowing Primitive Conversion](https://docs.oracle.com/javase/specs/jls/se11/html/jls-5.html#jls-5.1.3)
SEI CERT Oracle Coding Standard for Java: [NUM00-J. Detect or prevent integer overflow](https://wiki.sei.cmu.edu/confluence/display/java/NUM00-J.+Detect+or+prevent+integer+overflow)