### PR TITLE
fix(jsonrpc): support blockHash param and genesis block process for eth_getBlockReceipts

### DIFF
--- a/framework/src/main/java/org/tron/core/services/jsonrpc/TronJsonRpc.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/TronJsonRpc.java
@@ -151,7 +151,7 @@ public interface TronJsonRpc {
       @JsonRpcError(exception = JsonRpcInvalidParamsException.class, code = -32602, data = "{}"),
       @JsonRpcError(exception = JsonRpcInternalException.class, code = -32000, data = "{}")
   })
-  List<TransactionReceipt> getBlockReceipts(String blockNumOrTag)
+  List<TransactionReceipt> getBlockReceipts(String blockNumOrHashOrTag)
       throws JsonRpcInvalidParamsException, JsonRpcInternalException;
 
   @JsonRpcMethod("eth_call")

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/TronJsonRpcImpl.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/TronJsonRpcImpl.java
@@ -849,7 +849,9 @@ public class TronJsonRpcImpl implements TronJsonRpc, Closeable {
   public List<TransactionReceipt> getBlockReceipts(String blockNumOrTag)
       throws JsonRpcInvalidParamsException, JsonRpcInternalException {
     Block block = wallet.getByJsonBlockId(blockNumOrTag);
-    if (block == null) {
+
+    // block receipts not available: block is genesis, not produced yet, or pruned in light node
+    if (block == null || block.getBlockHeader().getRawData().getNumber() == 0) {
       return null;
     }
 

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/TronJsonRpcImpl.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/TronJsonRpcImpl.java
@@ -858,7 +858,6 @@ public class TronJsonRpcImpl implements TronJsonRpc, Closeable {
       block = wallet.getByJsonBlockId(blockNumOrHashOrTag);
     }
 
-
     // block receipts not available: block is genesis, not produced yet, or pruned in light node
     if (block == null || block.getBlockHeader().getRawData().getNumber() == 0) {
       return null;
@@ -868,7 +867,7 @@ public class TronJsonRpcImpl implements TronJsonRpc, Closeable {
     long blockNum = blockCapsule.getNum();
     TransactionInfoList transactionInfoList = wallet.getTransactionInfoByBlockNum(blockNum);
 
-    //energy price at the block timestamp
+    // energy price at the block timestamp
     long energyFee = wallet.getEnergyFee(blockCapsule.getTimeStamp());
 
     // Validate transaction list size consistency

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/TronJsonRpcImpl.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/TronJsonRpcImpl.java
@@ -839,16 +839,25 @@ public class TronJsonRpcImpl implements TronJsonRpc, Closeable {
 
   /**
    * Get all transaction receipts for a specific block
-   * @param blockNumOrTag the block number or tag (latest, earliest, pending, finalized)
+   * @param blockNumOrHashOrTag blockNumber or blockHash or tag,
+   * tag includes: latest, earliest, pending, finalized
    * @return List of TransactionReceipt objects for all transactions in the block,
    * null if block not found
    * @throws JsonRpcInvalidParamsException if the parameter format is invalid
    * @throws JsonRpcInternalException if there's an internal error
    */
   @Override
-  public List<TransactionReceipt> getBlockReceipts(String blockNumOrTag)
+  public List<TransactionReceipt> getBlockReceipts(String blockNumOrHashOrTag)
       throws JsonRpcInvalidParamsException, JsonRpcInternalException {
-    Block block = wallet.getByJsonBlockId(blockNumOrTag);
+
+    Block block = null;
+
+    if (Pattern.matches(HASH_REGEX, blockNumOrHashOrTag)) {
+      block = getBlockByJsonHash(blockNumOrHashOrTag);
+    } else {
+      block = wallet.getByJsonBlockId(blockNumOrHashOrTag);
+    }
+
 
     // block receipts not available: block is genesis, not produced yet, or pruned in light node
     if (block == null || block.getBlockHeader().getRawData().getNumber() == 0) {

--- a/framework/src/test/java/org/tron/core/jsonrpc/JsonrpcServiceTest.java
+++ b/framework/src/test/java/org/tron/core/jsonrpc/JsonrpcServiceTest.java
@@ -164,23 +164,6 @@ public class JsonrpcServiceTest extends BaseTest {
     dbManager.getTransactionStore()
         .put(transactionCapsule3.getTransactionId().getBytes(), transactionCapsule3);
 
-    blockCapsule0.getTransactions().forEach(tx -> {
-      TransactionCapsule transactionCapsule = new TransactionCapsule(tx.getInstance());
-      transactionCapsule.setBlockNum(blockCapsule0.getNum());
-      dbManager.getTransactionStore()
-          .put(transactionCapsule.getTransactionId().getBytes(), transactionCapsule);
-    });
-
-    TransactionRetCapsule transactionRetCapsule0 = new TransactionRetCapsule();
-    blockCapsule0.getTransactions().forEach(tx -> {
-      TransactionInfoCapsule transactionInfoCapsule = new TransactionInfoCapsule();
-      transactionInfoCapsule.setId(tx.getTransactionId().getBytes());
-      transactionInfoCapsule.setBlockNumber(blockCapsule0.getNum());
-      transactionRetCapsule0.addTransactionInfo(transactionInfoCapsule.getInstance());
-    });
-    dbManager.getTransactionRetStore().put(
-        ByteArray.fromLong(blockCapsule0.getNum()), transactionRetCapsule0);
-
     List<Protocol.TransactionInfo.Log> logs = new ArrayList<>();
     logs.add(Protocol.TransactionInfo.Log.newBuilder()
         .setAddress(ByteString.copyFrom("address1".getBytes()))
@@ -340,6 +323,8 @@ public class JsonrpcServiceTest extends BaseTest {
     }
     Assert.assertEquals(ByteArray.toJsonHex(0L), blockResult.getNumber());
     Assert.assertEquals(ByteArray.toJsonHex(blockCapsule0.getNum()), blockResult.getNumber());
+    Assert.assertEquals(blockResult.getTransactions().length,
+        blockCapsule0.getTransactions().size());
 
     // latest
     try {
@@ -1048,7 +1033,7 @@ public class JsonrpcServiceTest extends BaseTest {
 
     try {
       List<TransactionReceipt> transactionReceiptList = tronJsonRpc.getBlockReceipts("earliest");
-      Assert.assertFalse(transactionReceiptList.isEmpty());
+      Assert.assertNull(transactionReceiptList);
     } catch (JsonRpcInvalidParamsException | JsonRpcInternalException e) {
       throw new RuntimeException(e);
     }

--- a/framework/src/test/java/org/tron/core/jsonrpc/JsonrpcServiceTest.java
+++ b/framework/src/test/java/org/tron/core/jsonrpc/JsonrpcServiceTest.java
@@ -1073,6 +1073,20 @@ public class JsonrpcServiceTest extends BaseTest {
       throw new RuntimeException(e);
     }
 
+    try {
+      String blockHash = blockCapsule1.getBlockId().toString();
+      List<TransactionReceipt> transactionReceiptList
+          = tronJsonRpc.getBlockReceipts(blockHash);
+      List<TransactionReceipt> transactionReceiptList2
+          = tronJsonRpc.getBlockReceipts("0x" + blockHash);
+
+      Assert.assertFalse(transactionReceiptList.isEmpty());
+      Assert.assertEquals(JSON.toJSONString(transactionReceiptList),
+          JSON.toJSONString(transactionReceiptList2));
+    } catch (JsonRpcInvalidParamsException | JsonRpcInternalException e) {
+      throw new RuntimeException(e);
+    }
+
   }
 
   @Test


### PR DESCRIPTION
**What does this PR do?**

eth_getBlockReceipts api :  1. return null for genesis block 2. support blockHash param

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

