### PR TITLE
feat(command): change newly added "--keystore" parameter to "--keystore-factory"

### DIFF
--- a/common/src/main/java/org/tron/common/parameter/CommonParameter.java
+++ b/common/src/main/java/org/tron/common/parameter/CommonParameter.java
@@ -211,8 +211,8 @@ public class CommonParameter {
   //If you are running KeystoreFactory, this flag is set to true
   @Getter
   @Setter
-  @Parameter(names = {"--keystore"}, description = "running KeystoreFactory")
-  public boolean keystore = false;
+  @Parameter(names = {"--keystore-factory"}, description = "running KeystoreFactory")
+  public boolean keystoreFactory = false;
 
   @Getter
   @Setter

--- a/framework/src/main/java/org/tron/core/config/args/Args.java
+++ b/framework/src/main/java/org/tron/core/config/args/Args.java
@@ -168,7 +168,7 @@ public class Args extends CommonParameter {
     PARAMETER.tcpNettyWorkThreadNum = 0;
     PARAMETER.udpNettyWorkThreadNum = 0;
     PARAMETER.solidityNode = false;
-    PARAMETER.keystore = false;
+    PARAMETER.keystoreFactory = false;
     PARAMETER.trustNodeAddr = "";
     PARAMETER.walletExtensionApi = false;
     PARAMETER.estimateEnergy = false;

--- a/framework/src/main/java/org/tron/program/FullNode.java
+++ b/framework/src/main/java/org/tron/program/FullNode.java
@@ -30,7 +30,7 @@ public class FullNode {
       SolidityNode.start();
       return;
     }
-    if (parameter.isKeystore()) {
+    if (parameter.isKeystoreFactory()) {
       KeystoreFactory.start();
       return;
     }

--- a/framework/src/test/java/org/tron/core/config/args/ArgsTest.java
+++ b/framework/src/test/java/org/tron/core/config/args/ArgsTest.java
@@ -57,7 +57,8 @@ public class ArgsTest {
 
   @Test
   public void get() {
-    Args.setParam(new String[] {"-c", Constant.TEST_CONF, "--keystore"}, Constant.TESTNET_CONF);
+    Args.setParam(new String[] {"-c", Constant.TEST_CONF, "--keystore-factory"},
+        Constant.TESTNET_CONF);
 
     CommonParameter parameter = Args.getInstance();
 
@@ -128,7 +129,7 @@ public class ArgsTest {
         ByteArray.toHexString(Args.getLocalWitnesses()
             .getWitnessAccountAddress()));
 
-    Assert.assertTrue(parameter.isKeystore());
+    Assert.assertTrue(parameter.isKeystoreFactory());
   }
 
   @Test


### PR DESCRIPTION
**What does this PR do?**
     Rename `--keystore` parameter to `--keystore-factory`, pre-PR: #6397.
**Why are these changes required?**

The `--keystore` parameter name could be misleading, as it typically refers to encrypted key storage files or wallets, while this parameter actually runs a KeystoreFactory. The new name `--keystore-factory` makes the parameter's purpose more explicit and avoids potential confusion.

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

