### PR TITLE
fix(command): add missing help message for '--keystore-factory'

### DIFF
--- a/framework/src/main/java/org/tron/core/config/args/Args.java
+++ b/framework/src/main/java/org/tron/core/config/args/Args.java
@@ -347,7 +347,7 @@ public class Args extends CommonParameter {
 
   private static Map<String, String[]> getOptionGroup() {
     String[] tronOption = new String[] {"version", "help", "shellConfFileName", "logbackPath",
-        "eventSubscribe", "solidityNode", "keystore"};
+        "eventSubscribe", "solidityNode", "keystoreFactory"};
     String[] dbOption = new String[] {"outputDirectory"};
     String[] witnessOption = new String[] {"witness", "privateKey"};
     String[] vmOption = new String[] {"debug"};


### PR DESCRIPTION
**What does this PR do?**
    Add missing help message for '--keystore-factory', pre-PR #6446.
**Why are these changes required?**
     `java -jar FullNode.jar -h` show  `--keystore-factory`
     
```
 Name:
 FullNode - the java-tron command line interface

Usage: java -jar FullNode.jar [options] [seedNode <seedNode> ...]

VERSION: 
4.8.1-74118c1

TRON OPTIONS:
-v, --version                           Output code version
-h, --help                              Show help message
-c, --config                            Config file (default:config.conf)
--log-config                            Logback config file
--es                                    Start event subscribe server
--solidity                              Running a solidity node for java tron
--keystore-factory                      Running KeystoreFactory

DB OPTIONS:
-d, --output-directory                  Data directory for the databases (default:output-directory)

WITNESS OPTIONS:
-w, --witness                           Is witness node
-p, --private-key                       Witness private key

VIRTUAL MACHINE OPTIONS:
--debug                 Switch for TVM debug mode. In debug model, TVM will not check for timeout. (default: false)

```
**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

