### PR TITLE
feat(exit): throw TronError if JDK does not support

### DIFF
--- a/common/src/main/java/org/tron/core/exception/TronError.java
+++ b/common/src/main/java/org/tron/core/exception/TronError.java
@@ -47,6 +47,7 @@ public class TronError extends Error {
     LOG_LOAD(1),
     WITNESS_INIT(1),
     RATE_LIMITER_INIT(1),
+    JDK_VERSION(1),
     SOLID_NODE_INIT(0);
 
     private final int code;

--- a/framework/src/main/java/org/tron/core/config/args/Args.java
+++ b/framework/src/main/java/org/tron/core/config/args/Args.java
@@ -1,6 +1,7 @@
 package org.tron.core.config.args;
 
 import static java.lang.System.exit;
+import static org.fusesource.jansi.Ansi.ansi;
 import static org.tron.common.math.Maths.max;
 import static org.tron.common.math.Maths.min;
 import static org.tron.core.Constant.ADD_PRE_FIX_BYTE_MAINNET;
@@ -45,6 +46,7 @@ import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.fusesource.jansi.AnsiConsole;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.tron.common.arch.Arch;
@@ -374,7 +376,17 @@ public class Args extends CommonParameter {
    * set parameters.
    */
   public static void setParam(final String[] args, final String confFileName) {
-    Arch.throwIfUnsupportedJavaVersion();
+    try {
+      Arch.throwIfUnsupportedJavaVersion();
+    } catch (UnsupportedOperationException e) {
+      AnsiConsole.systemInstall();
+      // To avoid confusion caused by silent execution when using -h or -v flags,
+      // errors are explicitly logged to the console in this context.
+      // Console output is not required for errors in other scenarios.
+      System.out.println(ansi().fgRed().a(e.getMessage()).reset());
+      AnsiConsole.systemUninstall();
+      throw new TronError(e, TronError.ErrCode.JDK_VERSION);
+    }
     clearParam(); // reset all parameters to avoid the influence in test
     JCommander.newBuilder().addObject(PARAMETER).build().parse(args);
     if (PARAMETER.version) {

--- a/platform/src/main/java/common/org/tron/common/arch/Arch.java
+++ b/platform/src/main/java/common/org/tron/common/arch/Arch.java
@@ -73,8 +73,8 @@ public final class Arch {
     if (isX86() && !isJava8()) {
       logger.info(withAll());
       throw new UnsupportedOperationException(String.format(
-          "Java %s is required for %s architecture. Detected version %s",
-          "1.8 ", getOsArch(), javaSpecificationVersion()));
+          "Java %s is required for %s architecture. Detected version %s", "1.8",
+          getOsArch(), javaSpecificationVersion()));
     }
   }
 


### PR DESCRIPTION
**What does this PR do?**
    Replace the UnsupportedOperationException with TronError if the JDK does not support.
**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

