### PR TITLE
test(grpc): mitigate GRPC test hangs with timeout rule

### DIFF
--- a/framework/src/test/java/org/tron/core/services/RpcApiServicesTest.java
+++ b/framework/src/test/java/org/tron/core/services/RpcApiServicesTest.java
@@ -11,13 +11,16 @@ import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import java.io.IOException;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.FixMethodOrder;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.rules.Timeout;
 import org.junit.runners.MethodSorters;
 import org.tron.api.DatabaseGrpc;
 import org.tron.api.DatabaseGrpc.DatabaseBlockingStub;
@@ -125,6 +128,8 @@ public class RpcApiServicesTest {
   private static WalletSolidityBlockingStub blockingStubPBFT = null;
   @ClassRule
   public static TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @Rule
+  public Timeout timeout = new Timeout(30, TimeUnit.SECONDS);
   private static ByteString ownerAddress;
   private static ByteString sk;
   private static ByteString ask;

--- a/framework/src/test/java/org/tron/core/services/WalletApiTest.java
+++ b/framework/src/test/java/org/tron/core/services/WalletApiTest.java
@@ -8,8 +8,10 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.rules.Timeout;
 import org.tron.api.GrpcAPI.EmptyMessage;
 import org.tron.api.WalletGrpc;
 import org.tron.common.application.Application;
@@ -27,6 +29,9 @@ public class WalletApiTest {
 
   @ClassRule
   public static TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Rule
+  public Timeout timeout = new Timeout(30, TimeUnit.SECONDS);
 
   private static TronApplicationContext context;
   private static Application appT;

--- a/framework/src/test/java/org/tron/core/services/filter/LiteFnQueryGrpcInterceptorTest.java
+++ b/framework/src/test/java/org/tron/core/services/filter/LiteFnQueryGrpcInterceptorTest.java
@@ -14,6 +14,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
+import org.junit.rules.Timeout;
 import org.tron.api.GrpcAPI;
 import org.tron.api.WalletGrpc;
 import org.tron.api.WalletSolidityGrpc;
@@ -46,6 +47,9 @@ public class LiteFnQueryGrpcInterceptorTest {
 
   @ClassRule
   public static final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Rule
+  public Timeout timeout = new Timeout(30, TimeUnit.SECONDS);
 
   /**
    * init logic.

--- a/framework/src/test/java/org/tron/core/services/filter/RpcApiAccessInterceptorTest.java
+++ b/framework/src/test/java/org/tron/core/services/filter/RpcApiAccessInterceptorTest.java
@@ -19,8 +19,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.rules.Timeout;
 import org.tron.api.GrpcAPI.BlockExtention;
 import org.tron.api.GrpcAPI.BlockReq;
 import org.tron.api.GrpcAPI.BytesMessage;
@@ -52,6 +54,9 @@ public class RpcApiAccessInterceptorTest {
   private static WalletSolidityGrpc.WalletSolidityBlockingStub blockingStubPBFT = null;
   @ClassRule
   public static final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Rule
+  public Timeout timeout = new Timeout(30, TimeUnit.SECONDS);
 
   /**
    * init logic.

--- a/framework/src/test/java/org/tron/program/SolidityNodeTest.java
+++ b/framework/src/test/java/org/tron/program/SolidityNodeTest.java
@@ -3,10 +3,13 @@ package org.tron.program;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
+import java.util.concurrent.TimeUnit;
 import javax.annotation.Resource;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 import org.tron.common.BaseTest;
 import org.tron.common.client.DatabaseGrpcClient;
 import org.tron.common.utils.PublicMethod;
@@ -27,6 +30,9 @@ public class SolidityNodeTest extends BaseTest {
   SolidityNodeHttpApiService solidityNodeHttpApiService;
   static int rpcPort = PublicMethod.chooseRandomPort();
   static int solidityHttpPort = PublicMethod.chooseRandomPort();
+
+  @Rule
+  public Timeout timeout = new Timeout(30, TimeUnit.SECONDS);
 
   static {
     Args.setParam(new String[] {"-d", dbPath(), "--solidity"}, Constant.TEST_CONF);


### PR DESCRIPTION
   

**What does this PR do?**
    Add a 30-second timeout rule as a workaround to prevent GRPC unit tests hanging at `ThreadlessExecutor.waitAndDrain`.
**Why are these changes required?**
    Mitigate GRPC test hangs.
**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**
   [grpc-java:ThreadlessExecutor.waitAndDrain related issue](https://github.com/grpc/grpc-java/issues?q=is%3Aissue%20state%3Aclosed%20ThreadlessExecutor.waitAndDrain)

**Extra details**

  ```
  java.lang.Thread.State: WAITING (parking)
        at jdk.internal.misc.Unsafe.park(java.base@17.0.15/Native Method)
        - parking to wait for  <0x00000000c12000f8> (a io.grpc.stub.ClientCalls$ThreadlessExecutor)
        at java.util.concurrent.locks.LockSupport.park(java.base@17.0.15/LockSupport.java:211)
        at io.grpc.stub.ClientCalls$ThreadlessExecutor.waitAndDrain(ClientCalls.java:817)
        at io.grpc.stub.ClientCalls.blockingUnaryCall(ClientCalls.java:166)
        at org.tron.api.WalletGrpc$WalletBlockingStub.accountPermissionUpdate(WalletGrpc.java:7983)
        at org.tron.core.services.RpcApiServicesTest.testAccountPermissionUpdate(RpcApiServicesTest.java:1102)


  java.lang.Thread.State: WAITING (parking)
        at jdk.internal.misc.Unsafe.park(java.base@17.0.9/Native Method)
        - parking to wait for  <0x00000000c8f00108> (a io.grpc.stub.ClientCalls$ThreadlessExecutor)
        at java.util.concurrent.locks.LockSupport.park(java.base@17.0.9/LockSupport.java:211)
        at io.grpc.stub.ClientCalls$ThreadlessExecutor.waitAndDrain(ClientCalls.java:717)
        at io.grpc.stub.ClientCalls.blockingUnaryCall(ClientCalls.java:159)
        at org.tron.api.WalletGrpc$WalletBlockingStub.createWitness2(WalletGrpc.java:7323)
        at org.tron.core.services.RpcApiServicesTest.testCreateWitness(RpcApiServicesTest.java:800)

  java.lang.Thread.State: WAITING (parking)
        at jdk.internal.misc.Unsafe.park(java.base@17.0.12/Native Method)
        - parking to wait for  <0x00000000c50df010> (a io.grpc.stub.ClientCalls$ThreadlessExecutor)
        at java.util.concurrent.locks.LockSupport.park(java.base@17.0.12/LockSupport.java:211)
        at io.grpc.stub.ClientCalls$ThreadlessExecutor.waitAndDrain(ClientCalls.java:817)
        at io.grpc.stub.ClientCalls.blockingUnaryCall(ClientCalls.java:166)
        at org.tron.api.DatabaseGrpc$DatabaseBlockingStub.getNowBlock(DatabaseGrpc.java:336)
        at org.tron.common.client.DatabaseGrpcClient.getBlock(DatabaseGrpcClient.java:40)
        at org.tron.program.SolidityNodeTest.testSolidityGrpcCall(SolidityNodeTest.java:67)

java.lang.Thread.State: WAITING (parking)
        at jdk.internal.misc.Unsafe.park(java.base@17.0.13/Native Method)
        - parking to wait for  <0x00000000c67000f8> (a io.grpc.stub.ClientCalls$ThreadlessExecutor)
        at java.util.concurrent.locks.LockSupport.park(java.base@17.0.13/LockSupport.java:211)
        at io.grpc.stub.ClientCalls$ThreadlessExecutor.waitAndDrain(ClientCalls.java:817)
        at io.grpc.stub.ClientCalls.blockingUnaryCall(ClientCalls.java:166)
        at org.tron.api.WalletGrpc$WalletBlockingStub.getExpandedSpendingKey(WalletGrpc.java:8077)
        at org.tron.core.services.RpcApiServicesTest.test02GetExpandedSpendingKey(RpcApiServicesTest.java:1140)

java.lang.Thread.State: WAITING (parking)
        at jdk.internal.misc.Unsafe.park(java.base@17.0.9/Native Method)
        - parking to wait for  <0x00000000e9c000a0> (a io.grpc.stub.ClientCalls$ThreadlessExecutor)
        at java.util.concurrent.locks.LockSupport.park(java.base@17.0.9/LockSupport.java:211)
        at io.grpc.stub.ClientCalls$ThreadlessExecutor.waitAndDrain(ClientCalls.java:817)
        at io.grpc.stub.ClientCalls.blockingUnaryCall(ClientCalls.java:166)
        at org.tron.api.WalletGrpc$WalletBlockingStub.estimateEnergy(WalletGrpc.java:7822)
        at org.tron.core.services.RpcApiServicesTest.testEstimateEnergy(RpcApiServicesTest.java:1026)
 ```

