### PR TITLE
fix(CodeQL): resolve warning for implicit narrowing conversion

### DIFF
--- a/chainbase/src/main/java/org/tron/core/service/MortgageService.java
+++ b/chainbase/src/main/java/org/tron/core/service/MortgageService.java
@@ -182,7 +182,7 @@ public class MortgageService {
       }
       long userVote = vote.getValue();
       double voteRate = (double) userVote / totalVote;
-      reward += (long) (voteRate * totalReward);
+      reward = (long) (reward + voteRate * totalReward);
     }
     return reward;
   }

--- a/crypto/src/main/java/org/tron/common/crypto/Rsv.java
+++ b/crypto/src/main/java/org/tron/common/crypto/Rsv.java
@@ -19,7 +19,7 @@ public class Rsv {
     byte[] s = Arrays.copyOfRange(sign, 32, 64);
     byte v = sign[64];
     if (v < 27) {
-      v += (byte) 27; //revId -> v
+      v = (byte) (v + 27); //revId -> v
     }
     return new Rsv(r, s, v);
   }

--- a/framework/src/main/java/org/tron/core/capsule/utils/RLP.java
+++ b/framework/src/main/java/org/tron/core/capsule/utils/RLP.java
@@ -165,7 +165,7 @@ public class RLP {
       byte pow = (byte) (length - 1);
       for (int i = 1; i <= length; ++i) {
         // << (8 * pow) == bit shift to 0 (*1), 8 (*256) , 16 (*65..)
-        value += (short) ((data[index + i] & 0xFF) << (8 * pow));
+        value = (short) (value + ((data[index + i] & 0xFF) << (8 * pow)));
         pow--;
       }
     } else {

--- a/framework/src/main/java/org/tron/core/zen/address/SpendingKey.java
+++ b/framework/src/main/java/org/tron/core/zen/address/SpendingKey.java
@@ -89,7 +89,7 @@ public class SpendingKey {
           throw new BadItemException(
               "librustzcash_check_diversifier does not return valid diversifier");
         }
-        blob[33] += (byte) 1;
+        blob[33] = (byte) (blob[33] + 1);
       } finally {
         JLibsodium.freeState(state);
       }

--- a/framework/src/test/java/org/tron/common/math/ImplicitNarrowingConversionTest.java
+++ b/framework/src/test/java/org/tron/common/math/ImplicitNarrowingConversionTest.java
@@ -1,0 +1,75 @@
+package org.tron.common.math;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @see <a
+ * href="https://codeql.github.com/codeql-query-help/java/java-implicit-cast-in-compound-assignment"
+ * >Implicit narrowing conversion in compound assignment</a>
+ *
+ */
+public class ImplicitNarrowingConversionTest {
+
+  @Test
+  public void test() {
+    long l = 36714;
+    double d = (double) 50 / 64400 * 2210208;
+    long l1 = method1(l,d);
+    long l2 = method2(l,d);
+    long l3 = method3(l,d);
+    // l1 = 38429
+    // l2 = l3 = 38430
+    // d = 1715.9999999999998
+    Assert.assertEquals(l2, l3);
+    Assert.assertNotEquals(l1, l2);
+    Assert.assertNotEquals(l1, l3);
+  }
+
+  /**
+   * code:
+   * <pre>{@code
+   *  0: lload_0 // load long l1
+   *  1: dload_2 // load double d
+   *  2: d2l // convert double d to long ((truncates decimal))
+   *  3: ladd // long + long integer addition
+   *  4: lreturn // return the result
+   * }</pre>
+   */
+  private long method1(long l1, double d) {
+    return l1 + (long) (d);
+  }
+
+  /**
+   * code:
+   * <pre>{@code
+   *  0: lload_0 // load long l2
+   *  1: l2d // promote long l2 to double
+   *  2: dload_2 // load double d
+   *  3: dadd // double + double floating-point addition
+   *  4: d2l // convert the result to long
+   *  5: lstore_0 // store the result back to long l2 (local variable)
+   *  6: lload_0 // reload l2 (for return)
+   *  7: lreturn // return the result
+   * }</pre>
+   */
+  private long method2(long l2, double d) {
+    l2 += d;
+    return l2;
+  }
+
+  /**
+   * code:
+   * <pre>{@code
+   *  0: lload_0 // load long l3
+   *  1: l2d // promote long l3 to double
+   *  2: dload_2 // load double d
+   *  3: dadd // double + double floating-point addition
+   *  4: d2l // convert the result to long
+   *  5: lreturn // return the result
+   * }</pre>
+   */
+  private long method3(long l3, double d) {
+    return (long) (l3 + d);
+  }
+}


### PR DESCRIPTION
**What does this PR do?**
   Fix implicit narrowing conversion, pre PR: #6417
**Why are these changes required?**
    x += y is equivalent to x = (T)(x + y), where T is the type of x,  is not equivalent to x += (T) y
**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

```java
public class Test {

  public static void main(String[] args) {
    long l1 = 36714;
    long l2 = 36714;
    long l3 = 36714;
    double d = (double) 50 / 64400 * 2210208;
    
    l1 = method1(l1, d);
    l2 = method2(l2, d);
    l3 = method3(l3, d);
    
    System.out.println("l1 = " + l1);
    System.out.println("l2 = " + l2);
    System.out.println("l3 = " + l3);
    System.out.println("l2 == l3: " + (l2 == l3));
    System.out.println("l1 != l2: " + (l1 != l2));
    System.out.println("l1 != l3: " + (l1 != l3));
  }
  
  
  public static long method1(long l1, double d) {
    return l1 + (long) (d);
  }
  
  
  public static long method2(long l2, double d) {
    l2 += d;
    return l2;
  }
  
  public static long method3(long l3, double d) {
    return (long) (l3 + d);
  }
}
```
```bash
javac Test.java
javap -c Test.class
```

```
 public static long method1(long, double);
    Code:
       0: lload_0
       1: dload_2
       2: d2l
       3: ladd
       4: lreturn

  public static long method2(long, double);
    Code:
       0: lload_0
       1: l2d
       2: dload_2
       3: dadd
       4: d2l
       5: lstore_0
       6: lload_0
       7: lreturn

  public static long method3(long, double);
    Code:
       0: lload_0
       1: l2d
       2: dload_2
       3: dadd
       4: d2l
       5: lreturn
}
```
