### PR TITLE
feat(jsonrpc): add "input" as field for transaction input

### DIFF
--- a/framework/src/main/java/org/tron/core/services/jsonrpc/JsonRpcApiUtil.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/JsonRpcApiUtil.java
@@ -537,4 +537,22 @@ public class JsonRpcApiUtil {
     random.nextBytes(uid);
     return ByteArray.toHexString(uid);
   }
+
+   /**
+   * Check if transaction data parameter is null or empty
+   * Supports both 'data' and 'input' parameters
+   */
+  public static boolean paramTransactionDataIsNull(String data, String input) {
+    return paramStringIsNull(data) && paramStringIsNull(input);
+  }
+  
+  /**
+   * Get transaction data with priority: input > data
+   */
+  public static String getTransactionData(String data, String input) {
+    if (!paramStringIsNull(input)) {
+      return input;
+    }
+    return data;
+  }
 }

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/TronJsonRpcImpl.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/TronJsonRpcImpl.java
@@ -604,7 +604,7 @@ public class TronJsonRpcImpl implements TronJsonRpc, Closeable {
         estimateEnergy(ownerAddress,
             contractAddress,
             args.parseValue(),
-            ByteArray.fromHexString(args.getData()),
+            ByteArray.fromHexString(args.getTransactionData()),
             trxExtBuilder,
             retBuilder,
             estimateBuilder);
@@ -612,7 +612,7 @@ public class TronJsonRpcImpl implements TronJsonRpc, Closeable {
         callTriggerConstantContract(ownerAddress,
             contractAddress,
             args.parseValue(),
-            ByteArray.fromHexString(args.getData()),
+            ByteArray.fromHexString(args.getTransactionData()),
             trxExtBuilder,
             retBuilder);
       }
@@ -838,7 +838,7 @@ public class TronJsonRpcImpl implements TronJsonRpc, Closeable {
       byte[] contractAddressData = addressCompatibleToByteArray(transactionCall.getTo());
 
       return call(addressData, contractAddressData, transactionCall.parseValue(),
-          ByteArray.fromHexString(transactionCall.getData()));
+          ByteArray.fromHexString(transactionCall.getTransactionData()));
     } else {
       try {
         ByteArray.hexToBigInteger(blockNumOrTag);
@@ -954,7 +954,7 @@ public class TronJsonRpcImpl implements TronJsonRpc, Closeable {
       smartBuilder.setOriginAddress(ByteString.copyFrom(ownerAddress));
 
       // bytecode + parameter
-      smartBuilder.setBytecode(ByteString.copyFrom(ByteArray.fromHexString(args.getData())));
+      smartBuilder.setBytecode(ByteString.copyFrom(ByteArray.fromHexString(args.getTransactionData())));
 
       if (StringUtils.isNotEmpty(args.getName())) {
         smartBuilder.setName(args.getName());
@@ -999,8 +999,8 @@ public class TronJsonRpcImpl implements TronJsonRpc, Closeable {
       build.setOwnerAddress(ByteString.copyFrom(ownerAddress))
           .setContractAddress(ByteString.copyFrom(contractAddress));
 
-      if (StringUtils.isNotEmpty(args.getData())) {
-        build.setData(ByteString.copyFrom(ByteArray.fromHexString(args.getData())));
+      if (StringUtils.isNotEmpty(args.getTransactionData())) {
+        build.setData(ByteString.copyFrom(ByteArray.fromHexString(args.getTransactionData())));
       } else {
         build.setData(ByteString.copyFrom(new byte[0]));
       }

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/types/BuildArguments.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/types/BuildArguments.java
@@ -44,6 +44,9 @@ public class BuildArguments {
   private String data;
   @Getter
   @Setter
+  private String input;
+  @Getter
+  @Setter
   private String nonce = ""; //not used
 
   @Getter
@@ -82,7 +85,20 @@ public class BuildArguments {
     gas = args.getGas();
     gasPrice = args.getGasPrice();
     value = args.getValue();
-    data = args.getData();
+
+    // Use the new unified method to get transaction data for compatibility
+    data = args.getTransactionData();
+    input = args.getTransactionData();
+  }
+
+  /**
+   * Get the transaction data, supporting both 'data' and 'input' params
+   */
+  public String getTransactionData() {
+    if (StringUtils.isNotEmpty(input)) {
+      return input;
+    }
+    return data;
   }
 
   public ContractType getContractType(Wallet wallet) throws JsonRpcInvalidRequestException,
@@ -92,7 +108,7 @@ public class BuildArguments {
     // to is null
     if (paramStringIsNull(to)) {
       // data is null
-      if (paramStringIsNull(data)) {
+      if (paramStringIsNull(getTransactionData())) {
         throw new JsonRpcInvalidRequestException("invalid json request");
       }
 

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/types/BuildArguments.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/types/BuildArguments.java
@@ -44,9 +44,6 @@ public class BuildArguments {
   private String data;
   @Getter
   @Setter
-  private String input;
-  @Getter
-  @Setter
   private String nonce = ""; //not used
 
   @Getter
@@ -78,6 +75,10 @@ public class BuildArguments {
   @Getter
   @Setter
   private boolean visible = false;
+
+  @Getter
+  @Setter
+  private String input;
 
   public BuildArguments(CallArguments args) {
     from = args.getFrom();

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/types/CallArguments.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/types/CallArguments.java
@@ -43,6 +43,9 @@ public class CallArguments {
   private String data;
   @Getter
   @Setter
+  private String input; //Add input parameter to align with Ethereum https://github.com/ethereum/go-ethereum/pull/28078
+  @Getter
+  @Setter
   private String nonce; // not used
 
   /**
@@ -57,8 +60,11 @@ public class CallArguments {
       throw new JsonRpcInvalidRequestException("invalid json request");
     } else if (paramStringIsNull(to)) {
       // data is null
-      if (paramStringIsNull(data)) {
-        throw new JsonRpcInvalidRequestException("invalid json request");
+      if (paramStringIsNull(input)) {
+        if(paramStringIsNull(data))
+        {
+          throw new JsonRpcInvalidRequestException("invalid json request"); //If both input and data are bnull throw an error, take input as priority
+        }
       }
 
       contractType = ContractType.CreateSmartContract;
@@ -85,5 +91,27 @@ public class CallArguments {
 
   public long parseValue() throws JsonRpcInvalidParamsException {
     return parseQuantityValue(value);
+  }
+
+    /**
+   * Get the transaction data, supporting both 'data' and 'input' parameters
+   * for Ethereum compatibility. 'input' takes precedence if both are provided.
+   * 
+   * @return the transaction data/input
+   */
+  public String getTransactionData() {
+    // Prioritize 'input' for Ethereum compatibility
+    if (StringUtils.isNotEmpty(input)) {
+      return input;
+    }
+    return data;
+  }
+
+  /**
+   * Set transaction data, updating the appropriate field based on which was used
+   */
+  public void setTransactionData(String transactionData) {
+    // For backward compatibility, default to setting 'data'
+    this.data = transactionData;
   }
 }

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/types/CallArguments.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/types/CallArguments.java
@@ -43,10 +43,10 @@ public class CallArguments {
   private String data;
   @Getter
   @Setter
-  private String input; //Add input parameter to align with Ethereum https://github.com/ethereum/go-ethereum/pull/28078
+  private String nonce; // not used
   @Getter
   @Setter
-  private String nonce; // not used
+  private String input; //Add input parameter to align with Ethereum https://github.com/ethereum/go-ethereum/pull/28078
 
   /**
    * just support TransferContract, CreateSmartContract and TriggerSmartContract

--- a/framework/src/test/java/org/tron/core/services/jsonrpc/BuildArgumentsTest.java
+++ b/framework/src/test/java/org/tron/core/services/jsonrpc/BuildArgumentsTest.java
@@ -31,7 +31,7 @@ public class BuildArgumentsTest extends BaseTest {
         "0x0000000000000000000000000000000000000000",
         "0x0000000000000000000000000000000000000001","0x10","0.01","0x100",
         "","0",9L,10000L,"",10L,
-        2000L,"args",1,"",true);
+        2000L,"args",1,"",true,"");
   }
 
 
@@ -40,7 +40,7 @@ public class BuildArgumentsTest extends BaseTest {
     CallArguments callArguments = new CallArguments(
         "0x0000000000000000000000000000000000000000",
         "0x0000000000000000000000000000000000000001","0x10","0.01","0x100",
-        "","0");
+        "","0","");
     BuildArguments buildArguments = new BuildArguments(callArguments);
     Assert.assertEquals(buildArguments.getFrom(),
         "0x0000000000000000000000000000000000000000");

--- a/framework/src/test/java/org/tron/core/services/jsonrpc/CallArgumentsTest.java
+++ b/framework/src/test/java/org/tron/core/services/jsonrpc/CallArgumentsTest.java
@@ -28,7 +28,7 @@ public class CallArgumentsTest extends BaseTest {
   public void init() {
     callArguments = new CallArguments("0x0000000000000000000000000000000000000000",
             "0x0000000000000000000000000000000000000001","0x10","0.01","0x100",
-        "","0");
+        "","0","");
   }
 
   @Test


### PR DESCRIPTION
**What does this PR do?**
Adds "input" field for transaction input while keeping "data" for legacy and compatibility.

Impacted JSON-RPC API methods:
- eth_call
- eth_estimateGas
- buildTransaction
  

**Why are these changes required?**
- Align TRON jsonrpc with [EVM new standard](https://github.com/ethereum/go-ethereum/pull/28078) . 
- Reduce development efforts for ETH/EVM developers porting their projects to TRON.
- General EVM tooling compatibility improvements

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**
- Probably will need to check further simple improvements like this to increase TRON compatibility with eth json RPC

**Extra details**
- Additional discussions within Foundry devs community: https://github.com/alloy-rs/alloy/issues/2371 
