### PR TITLE
fix(config): remove the clearParam 

### DIFF
--- a/framework/src/main/java/org/tron/core/config/args/Args.java
+++ b/framework/src/main/java/org/tron/core/config/args/Args.java
@@ -388,7 +388,6 @@ public class Args extends CommonParameter {
       AnsiConsole.systemUninstall();
       throw new TronError(e, TronError.ErrCode.JDK_VERSION);
     }
-    clearParam(); // reset all parameters to avoid the influence in test
     JCommander.newBuilder().addObject(PARAMETER).build().parse(args);
     if (PARAMETER.version) {
       printVersion();

--- a/framework/src/test/java/org/tron/core/config/args/LocalWitnessTest.java
+++ b/framework/src/test/java/org/tron/core/config/args/LocalWitnessTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.fail;
 import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.security.SecureRandom;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -50,6 +51,11 @@ public class LocalWitnessTest {
         .setPrivateKeys(
             Lists.newArrayList(
                 PRIVATE_KEY));
+  }
+
+  @AfterClass
+  public static void clear() {
+    Args.clearParam();
   }
 
   @Test


### PR DESCRIPTION
**What does this PR do?**
Revert [6367](https://github.com/tronprotocol/java-tron/pull/6367).   Adding `clearParam()` in the `setParam()` function changes the default value of some parameters, for example, changing `nodeExternalIp` from `null` to `""`, which will lead to unexpected behavior.

  

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

