### PR TITLE
fix(log): restore logger context after test to prevent pollution

### DIFF
--- a/common/src/main/java/org/tron/common/log/LogService.java
+++ b/common/src/main/java/org/tron/common/log/LogService.java
@@ -2,6 +2,7 @@ package org.tron.common.log;
 
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.joran.JoranConfigurator;
+import ch.qos.logback.core.util.StatusPrinter;
 import java.io.File;
 import org.slf4j.LoggerFactory;
 import org.tron.core.exception.TronError;
@@ -9,18 +10,20 @@ import org.tron.core.exception.TronError;
 public class LogService {
 
   public static void load(String path) {
+    LoggerContext lc = (LoggerContext) LoggerFactory.getILoggerFactory();
     try {
       File file = new File(path);
       if (!file.exists() || !file.isFile() || !file.canRead()) {
         return;
       }
-      LoggerContext lc = (LoggerContext) LoggerFactory.getILoggerFactory();
       JoranConfigurator configurator = new JoranConfigurator();
       configurator.setContext(lc);
       lc.reset();
       configurator.doConfigure(file);
     } catch (Exception e) {
       throw new TronError(e, TronError.ErrCode.LOG_LOAD);
+    } finally {
+      StatusPrinter.printInCaseOfErrorsOrWarnings(lc);
     }
   }
 }

--- a/framework/src/test/java/org/tron/core/exception/TronErrorTest.java
+++ b/framework/src/test/java/org/tron/core/exception/TronErrorTest.java
@@ -8,6 +8,9 @@ import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.util.ContextInitializer;
+import ch.qos.logback.core.joran.spi.JoranException;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigObject;
@@ -27,6 +30,7 @@ import org.junit.runner.RunWith;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.slf4j.LoggerFactory;
 import org.tron.common.arch.Arch;
 import org.tron.common.log.LogService;
 import org.tron.common.parameter.RateLimiterInitialization;
@@ -37,6 +41,7 @@ import org.tron.core.config.args.Args;
 import org.tron.core.services.http.GetBlockServlet;
 import org.tron.core.services.http.RateLimiterServlet;
 import org.tron.core.zen.ZksnarkInitService;
+
 
 @RunWith(MockitoJUnitRunner.class)
 public class TronErrorTest {
@@ -85,10 +90,22 @@ public class TronErrorTest {
 
   @Test
   public void LogLoadTest() throws IOException {
-    LogService.load("non-existent.xml");
-    Path path = temporaryFolder.newFile("logback.xml").toPath();
-    TronError thrown = assertThrows(TronError.class, () -> LogService.load(path.toString()));
-    assertEquals(TronError.ErrCode.LOG_LOAD, thrown.getErrCode());
+    LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
+
+    try {
+      LogService.load("non-existent.xml");
+      Path path = temporaryFolder.newFile("logback.xml").toPath();
+      TronError thrown = assertThrows(TronError.class, () -> LogService.load(path.toString()));
+      assertEquals(TronError.ErrCode.LOG_LOAD, thrown.getErrCode());
+    } finally {
+      try {
+        context.reset();
+        ContextInitializer ci = new ContextInitializer(context);
+        ci.autoConfig();
+      } catch (JoranException e) {
+        Assert.fail(e.getMessage());
+      }
+    }
   }
 
   @Test


### PR DESCRIPTION
**What does this PR do?**
  - Add StatusPrinter for Warning or Error details in LogService.load()
  - Restore default logger config in TronErrorTest

**Why are these changes required?**
     Restore logger context after test to prevent pollution.
**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

