### PR TITLE
fix(doc): update x86 java start params

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Make sure you operate on `Linux` or `MacOS` operating systems, other operating s
 ## Architecture
 
 ### X86_64
-Requires 64-bit version of `Oracle JDK 1.8` to be installed, other JDK versions are not supported yet.
+Requires 64-bit version of `Oracle JDK 8` to be installed, other JDK versions are not supported yet.
 
 ### ARM64
 Requires 64-bit version of `JDK 17` to be installed, other JDK versions are not supported yet.

--- a/framework/src/main/resources/config.conf
+++ b/framework/src/main/resources/config.conf
@@ -676,7 +676,7 @@ localwitness = [
 block = {
   needSyncCheck = true
   maintenanceTimeInterval = 21600000 // 6 hours: 21600000(ms)
-  proposalExpireTime = 259200000 // 3 days: 259200000(ms)
+  proposalExpireTime = 259200000 // default value: 3 days: 259200000(ms), Note: this value is controlled by committee proposal
   # checkFrozenTime = 1 // for test only
 }
 

--- a/start.sh.simple
+++ b/start.sh.simple
@@ -31,8 +31,6 @@
 
 
 # adjust JVM start
-# Set the minimum heap size to 9G, adjust as needed
-VM_XMS="9G"
 # Set the maximum heap size to 9G, adjust as needed
 VM_XMX="9G"
 # adjust JVM end
@@ -131,7 +129,7 @@ startService() {
   fi
 
   nohup "$JAVACMD" \
-    -Xms"$VM_XMS" -Xmx"$VM_XMX" \
+    -Xmx"$VM_XMX" \
     -XX:+UseZGC \
     -Xlog:gc,gc+heap:file=gc.log:time,tags,level:filecount=10,filesize=100M \
     -XX:ReservedCodeCacheSize=256m \


### PR DESCRIPTION
**What does this PR do?**         
- Provide more detailed Storage and Network specifications, and adjust the formatting.    
- Update the x86_64 FullNode running JVM Parameters

**Why are these changes required?**
- From our tests, `-Xmx 12G` is safe for a simple FullNode even when blocks fail to solidify promptly—even with a maximum wait of one maintenance window.
- Remove `-Xmx` in JDK 17 because in normal case FullNode don't need minimum 9G，as JDK 17 use RocksDB, which will take more space. 
        

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

