### PR TITLE
fix(testcase): remove peer from PeerManager after testcase

### DIFF
--- a/framework/src/main/java/org/tron/common/backup/BackupManager.java
+++ b/framework/src/main/java/org/tron/common/backup/BackupManager.java
@@ -126,7 +126,7 @@ public class BackupManager implements EventHandler {
       logger.warn("Receive keep alive message from {} is not my member", sender.getHostString());
       return;
     }
-
+    logger.info("Receive keep alive message from {}", sender);
     lastKeepAliveTime = System.currentTimeMillis();
 
     KeepAliveMessage keepAliveMessage = (KeepAliveMessage) msg;

--- a/framework/src/main/java/org/tron/core/net/peer/PeerStatusCheck.java
+++ b/framework/src/main/java/org/tron/core/net/peer/PeerStatusCheck.java
@@ -42,6 +42,9 @@ public class PeerStatusCheck {
 
     long now = System.currentTimeMillis();
 
+    if (tronNetDelegate == null) {
+      return;
+    }
     tronNetDelegate.getActivePeer().forEach(peer -> {
 
       boolean isDisconnected = false;

--- a/framework/src/main/java/org/tron/core/net/peer/PeerStatusCheck.java
+++ b/framework/src/main/java/org/tron/core/net/peer/PeerStatusCheck.java
@@ -43,6 +43,7 @@ public class PeerStatusCheck {
     long now = System.currentTimeMillis();
 
     if (tronNetDelegate == null) {
+      //only occurs in mock test. TODO fix test
       return;
     }
     tronNetDelegate.getActivePeer().forEach(peer -> {

--- a/framework/src/test/java/org/tron/common/BaseTest.java
+++ b/framework/src/test/java/org/tron/common/BaseTest.java
@@ -25,6 +25,8 @@ import org.tron.core.config.DefaultConfig;
 import org.tron.core.config.args.Args;
 import org.tron.core.db.Manager;
 import org.tron.core.exception.BalanceInsufficientException;
+import org.tron.core.net.peer.PeerConnection;
+import org.tron.core.net.peer.PeerManager;
 import org.tron.core.store.AccountStore;
 import org.tron.protos.Protocol;
 
@@ -66,6 +68,12 @@ public abstract class BaseTest {
   public static void destroy() {
     appT1.shutdown();
     Args.clearParam();
+  }
+
+  public void closePeer() {
+    for (PeerConnection p : PeerManager.getPeers()) {
+      PeerManager.remove(p.getChannel());
+    }
   }
 
   public Protocol.Block getSignedBlock(ByteString witness, long time, byte[] privateKey) {

--- a/framework/src/test/java/org/tron/core/net/P2pEventHandlerImplTest.java
+++ b/framework/src/test/java/org/tron/core/net/P2pEventHandlerImplTest.java
@@ -6,8 +6,10 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.tron.common.BaseTest;
 import org.tron.common.parameter.CommonParameter;
 import org.tron.common.utils.Sha256Hash;
 import org.tron.core.Constant;
@@ -20,12 +22,15 @@ import org.tron.core.net.service.statistics.PeerStatistics;
 import org.tron.protos.Protocol;
 import org.tron.protos.Protocol.Inventory.InventoryType;
 
-public class P2pEventHandlerImplTest {
+public class P2pEventHandlerImplTest extends BaseTest {
+
+  @BeforeClass
+  public static void init() throws Exception {
+    Args.setParam(new String[] {"--output-directory", dbPath(), "--debug"}, Constant.TEST_CONF);
+  }
 
   @Test
   public void testProcessInventoryMessage() throws Exception {
-    String[] a = new String[0];
-    Args.setParam(a, Constant.TESTNET_CONF);
     CommonParameter parameter = CommonParameter.getInstance();
     parameter.setMaxTps(10);
 
@@ -114,9 +119,6 @@ public class P2pEventHandlerImplTest {
 
   @Test
   public void testUpdateLastInteractiveTime() throws Exception {
-    String[] a = new String[0];
-    Args.setParam(a, Constant.TESTNET_CONF);
-
     PeerConnection peer = new PeerConnection();
     P2pEventHandlerImpl p2pEventHandler = new P2pEventHandlerImpl();
 

--- a/framework/src/test/java/org/tron/core/net/messagehandler/MessageHandlerTest.java
+++ b/framework/src/test/java/org/tron/core/net/messagehandler/MessageHandlerTest.java
@@ -3,13 +3,10 @@ package org.tron.core.net.messagehandler;
 import static org.mockito.Mockito.mock;
 
 import com.google.protobuf.ByteString;
-import java.lang.reflect.Field;
 import java.net.InetSocketAddress;
-import java.util.ArrayList;
-import java.util.Collections;
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -63,14 +60,10 @@ public class MessageHandlerTest {
     context.destroy();
   }
 
-  @Before
+  @After
   public void clearPeers() {
-    try {
-      Field field = PeerManager.class.getDeclaredField("peers");
-      field.setAccessible(true);
-      field.set(PeerManager.class, Collections.synchronizedList(new ArrayList<>()));
-    } catch (NoSuchFieldException | IllegalAccessException e) {
-      //ignore
+    for (PeerConnection p : PeerManager.getPeers()) {
+      PeerManager.remove(p.getChannel());
     }
   }
 

--- a/framework/src/test/java/org/tron/core/net/messagehandler/PbftMsgHandlerTest.java
+++ b/framework/src/test/java/org/tron/core/net/messagehandler/PbftMsgHandlerTest.java
@@ -4,14 +4,11 @@ import static org.mockito.Mockito.mock;
 
 import com.google.protobuf.ByteString;
 import java.io.File;
-import java.lang.reflect.Field;
 import java.net.InetSocketAddress;
-import java.util.ArrayList;
-import java.util.Collections;
 import org.bouncycastle.util.encoders.Hex;
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -65,14 +62,10 @@ public class PbftMsgHandlerTest {
     FileUtil.deleteDir(new File(dbPath));
   }
 
-  @Before
+  @After
   public void clearPeers() {
-    try {
-      Field field = PeerManager.class.getDeclaredField("peers");
-      field.setAccessible(true);
-      field.set(PeerManager.class, Collections.synchronizedList(new ArrayList<>()));
-    } catch (NoSuchFieldException | IllegalAccessException e) {
-      //ignore
+    for (PeerConnection p : PeerManager.getPeers()) {
+      PeerManager.remove(p.getChannel());
     }
   }
 

--- a/framework/src/test/java/org/tron/core/net/messagehandler/SyncBlockChainMsgHandlerTest.java
+++ b/framework/src/test/java/org/tron/core/net/messagehandler/SyncBlockChainMsgHandlerTest.java
@@ -24,6 +24,7 @@ import org.tron.core.exception.P2pException;
 import org.tron.core.net.message.sync.BlockInventoryMessage;
 import org.tron.core.net.message.sync.SyncBlockChainMessage;
 import org.tron.core.net.peer.PeerConnection;
+import org.tron.core.net.peer.PeerManager;
 import org.tron.p2p.connection.Channel;
 
 public class SyncBlockChainMsgHandlerTest {
@@ -109,6 +110,9 @@ public class SyncBlockChainMsgHandlerTest {
 
   @AfterClass
   public static void destroy() {
+    for (PeerConnection p : PeerManager.getPeers()) {
+      PeerManager.remove(p.getChannel());
+    }
     context.destroy();
     Args.clearParam();
   }

--- a/framework/src/test/java/org/tron/core/net/peer/PeerConnectionTest.java
+++ b/framework/src/test/java/org/tron/core/net/peer/PeerConnectionTest.java
@@ -7,14 +7,18 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.tron.common.overlay.message.Message;
+import org.tron.common.parameter.CommonParameter;
 import org.tron.common.utils.Pair;
 import org.tron.common.utils.ReflectUtils;
 import org.tron.common.utils.Sha256Hash;
 import org.tron.core.capsule.BlockCapsule;
+import org.tron.core.config.args.Args;
 import org.tron.core.net.message.adv.InventoryMessage;
 import org.tron.core.net.message.handshake.HelloMessage;
 import org.tron.core.net.message.keepalive.PingMessage;
@@ -25,6 +29,18 @@ import org.tron.p2p.connection.Channel;
 import org.tron.protos.Protocol;
 
 public class PeerConnectionTest {
+
+  @BeforeClass
+  public static void initArgs() {
+    CommonParameter.getInstance().setRateLimiterSyncBlockChain(10);
+    CommonParameter.getInstance().setRateLimiterFetchInvData(10);
+    CommonParameter.getInstance().setRateLimiterDisconnect(10);
+  }
+
+  @AfterClass
+  public static void destroy() {
+    Args.clearParam();
+  }
 
   @Test
   public void testVariableDefaultValue() {

--- a/framework/src/test/java/org/tron/core/net/peer/PeerManagerTest.java
+++ b/framework/src/test/java/org/tron/core/net/peer/PeerManagerTest.java
@@ -8,15 +8,39 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.springframework.context.ApplicationContext;
+import org.tron.common.parameter.CommonParameter;
 import org.tron.common.utils.ReflectUtils;
+import org.tron.core.config.args.Args;
 import org.tron.p2p.connection.Channel;
 
 public class PeerManagerTest {
   List<InetSocketAddress> relayNodes = new ArrayList<>();
+
+  @BeforeClass
+  public static void initArgs() {
+    CommonParameter.getInstance().setRateLimiterSyncBlockChain(10);
+    CommonParameter.getInstance().setRateLimiterFetchInvData(10);
+    CommonParameter.getInstance().setRateLimiterDisconnect(10);
+  }
+
+  @AfterClass
+  public static void destroy() {
+    Args.clearParam();
+  }
+
+  @After
+  public void clearPeers() {
+    for (PeerConnection p : PeerManager.getPeers()) {
+      PeerManager.remove(p.getChannel());
+    }
+  }
 
   @Test
   public void testAdd() throws Exception {

--- a/framework/src/test/java/org/tron/core/net/services/AdvServiceTest.java
+++ b/framework/src/test/java/org/tron/core/net/services/AdvServiceTest.java
@@ -53,6 +53,9 @@ public class AdvServiceTest {
 
   @AfterClass
   public static void after() {
+    for (PeerConnection p : PeerManager.getPeers()) {
+      PeerManager.remove(p.getChannel());
+    }
     Args.clearParam();
     context.destroy();
   }

--- a/framework/src/test/java/org/tron/core/net/services/HandShakeServiceTest.java
+++ b/framework/src/test/java/org/tron/core/net/services/HandShakeServiceTest.java
@@ -4,16 +4,13 @@ import static org.mockito.Mockito.mock;
 import static org.tron.core.net.message.handshake.HelloMessage.getEndpointFromNode;
 
 import com.google.protobuf.ByteString;
-import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Random;
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -72,14 +69,10 @@ public class HandShakeServiceTest {
     context.destroy();
   }
 
-  @Before
+  @After
   public void clearPeers() {
-    try {
-      Field field = PeerManager.class.getDeclaredField("peers");
-      field.setAccessible(true);
-      field.set(PeerManager.class, Collections.synchronizedList(new ArrayList<>()));
-    } catch (NoSuchFieldException | IllegalAccessException e) {
-      //ignore
+    for (PeerConnection p : PeerManager.getPeers()) {
+      PeerManager.remove(p.getChannel());
     }
   }
 

--- a/framework/src/test/java/org/tron/core/net/services/RelayServiceTest.java
+++ b/framework/src/test/java/org/tron/core/net/services/RelayServiceTest.java
@@ -16,6 +16,7 @@ import java.util.Set;
 import javax.annotation.Resource;
 import lombok.extern.slf4j.Slf4j;
 import org.bouncycastle.util.encoders.Hex;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -67,6 +68,13 @@ public class RelayServiceTest extends BaseTest {
   public static void init() {
     Args.setParam(new String[]{"--output-directory", dbPath(), "--debug"},
             Constant.TEST_CONF);
+  }
+
+  @After
+  public void clearPeers() {
+    for (PeerConnection p : PeerManager.getPeers()) {
+      PeerManager.remove(p.getChannel());
+    }
   }
 
   @Test

--- a/framework/src/test/java/org/tron/core/net/services/RelayServiceTest.java
+++ b/framework/src/test/java/org/tron/core/net/services/RelayServiceTest.java
@@ -72,9 +72,7 @@ public class RelayServiceTest extends BaseTest {
 
   @After
   public void clearPeers() {
-    for (PeerConnection p : PeerManager.getPeers()) {
-      PeerManager.remove(p.getChannel());
-    }
+    closePeer();
   }
 
   @Test

--- a/framework/src/test/java/org/tron/core/net/services/ResilienceServiceTest.java
+++ b/framework/src/test/java/org/tron/core/net/services/ResilienceServiceTest.java
@@ -8,49 +8,52 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.HashSet;
 import java.util.Set;
+import javax.annotation.Resource;
 import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
+import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 import org.mockito.Mockito;
-import org.tron.common.application.TronApplicationContext;
+import org.springframework.context.ApplicationContext;
+import org.tron.common.BaseTest;
 import org.tron.common.utils.ReflectUtils;
-import org.tron.core.ChainBaseManager;
 import org.tron.core.Constant;
-import org.tron.core.config.DefaultConfig;
 import org.tron.core.config.args.Args;
+import org.tron.core.net.P2pEventHandlerImpl;
 import org.tron.core.net.peer.PeerConnection;
 import org.tron.core.net.peer.PeerManager;
 import org.tron.core.net.service.effective.ResilienceService;
 import org.tron.p2p.connection.Channel;
 
-public class ResilienceServiceTest {
+public class ResilienceServiceTest extends BaseTest {
 
-  protected TronApplicationContext context;
+  @Resource
   private ResilienceService service;
-  private ChainBaseManager chainBaseManager;
 
-  @Rule
-  public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @Resource
+  private P2pEventHandlerImpl p2pEventHandler;
 
-  @Before
-  public void init() throws IOException {
-    Args.setParam(new String[] {"--output-directory",
-        temporaryFolder.newFolder().toString(), "--debug"}, Constant.TEST_CONF);
-    context = new TronApplicationContext(DefaultConfig.class);
-    chainBaseManager = context.getBean(ChainBaseManager.class);
-    service = context.getBean(ResilienceService.class);
+
+  @BeforeClass
+  public static void init() throws IOException {
+    Args.setParam(new String[] {"--output-directory", dbPath(), "--debug"}, Constant.TEST_CONF);
+  }
+
+  @After
+  public void clearPeers() {
+    for (PeerConnection p : PeerManager.getPeers()) {
+      PeerManager.remove(p.getChannel());
+    }
   }
 
   @Test
   public void testDisconnectRandom() {
     int maxConnection = 30;
     Assert.assertEquals(maxConnection, Args.getInstance().getMaxConnections());
-    clearPeers();
     Assert.assertEquals(0, PeerManager.getPeers().size());
 
+    ApplicationContext ctx = (ApplicationContext) ReflectUtils.getFieldObject(p2pEventHandler,
+        "ctx");
     for (int i = 0; i < maxConnection + 1; i++) {
       InetSocketAddress inetSocketAddress = new InetSocketAddress("201.0.0." + i, 10001);
       Channel c1 = spy(Channel.class);
@@ -59,7 +62,7 @@ public class ResilienceServiceTest {
       ReflectUtils.setFieldValue(c1, "ctx", spy(ChannelHandlerContext.class));
       Mockito.doNothing().when(c1).send((byte[]) any());
 
-      PeerManager.add(context, c1);
+      PeerManager.add(ctx, c1);
     }
     for (PeerConnection peer : PeerManager.getPeers()
         .subList(0, ResilienceService.minBroadcastPeerSize)) {
@@ -99,9 +102,10 @@ public class ResilienceServiceTest {
   public void testDisconnectLan() {
     int minConnection = 8;
     Assert.assertEquals(minConnection, Args.getInstance().getMinConnections());
-    clearPeers();
     Assert.assertEquals(0, PeerManager.getPeers().size());
 
+    ApplicationContext ctx = (ApplicationContext) ReflectUtils.getFieldObject(p2pEventHandler,
+        "ctx");
     for (int i = 0; i < 9; i++) {
       InetSocketAddress inetSocketAddress = new InetSocketAddress("201.0.0." + i, 10001);
       Channel c1 = spy(Channel.class);
@@ -111,7 +115,7 @@ public class ResilienceServiceTest {
       ReflectUtils.setFieldValue(c1, "ctx", spy(ChannelHandlerContext.class));
       Mockito.doNothing().when(c1).send((byte[]) any());
 
-      PeerManager.add(context, c1);
+      PeerManager.add(ctx, c1);
     }
     for (PeerConnection peer : PeerManager.getPeers()) {
       peer.setNeedSyncFromPeer(false);
@@ -154,10 +158,11 @@ public class ResilienceServiceTest {
   public void testDisconnectIsolated2() {
     int maxConnection = 30;
     Assert.assertEquals(maxConnection, Args.getInstance().getMaxConnections());
-    clearPeers();
     Assert.assertEquals(0, PeerManager.getPeers().size());
 
     int addSize = (int) (maxConnection * ResilienceService.retentionPercent) + 2; //26
+    ApplicationContext ctx = (ApplicationContext) ReflectUtils.getFieldObject(p2pEventHandler,
+        "ctx");
     for (int i = 0; i < addSize; i++) {
       InetSocketAddress inetSocketAddress = new InetSocketAddress("201.0.0." + i, 10001);
       Channel c1 = spy(Channel.class);
@@ -168,7 +173,7 @@ public class ResilienceServiceTest {
       ReflectUtils.setFieldValue(c1, "ctx", spy(ChannelHandlerContext.class));
       Mockito.doNothing().when(c1).send((byte[]) any());
 
-      PeerManager.add(context, c1);
+      PeerManager.add(ctx, c1);
     }
     PeerManager.getPeers().get(10).setNeedSyncFromUs(false);
     PeerManager.getPeers().get(10).setNeedSyncFromPeer(false);
@@ -189,17 +194,5 @@ public class ResilienceServiceTest {
         activeNodeSize + passiveSize);
     Assert.assertEquals((int) (maxConnection * ResilienceService.retentionPercent),
         PeerManager.getPeers().size());
-  }
-
-  private void clearPeers() {
-    for (PeerConnection p : PeerManager.getPeers()) {
-      PeerManager.remove(p.getChannel());
-    }
-  }
-
-  @After
-  public void destroy() {
-    Args.clearParam();
-    context.destroy();
   }
 }

--- a/framework/src/test/java/org/tron/core/net/services/ResilienceServiceTest.java
+++ b/framework/src/test/java/org/tron/core/net/services/ResilienceServiceTest.java
@@ -41,9 +41,7 @@ public class ResilienceServiceTest extends BaseTest {
 
   @After
   public void clearPeers() {
-    for (PeerConnection p : PeerManager.getPeers()) {
-      PeerManager.remove(p.getChannel());
-    }
+    closePeer();
   }
 
   @Test

--- a/framework/src/test/java/org/tron/core/net/services/SyncServiceTest.java
+++ b/framework/src/test/java/org/tron/core/net/services/SyncServiceTest.java
@@ -65,6 +65,9 @@ public class SyncServiceTest {
    */
   @After
   public void destroy() {
+    for (PeerConnection p : PeerManager.getPeers()) {
+      PeerManager.remove(p.getChannel());
+    }
     Args.clearParam();
     context.destroy();
   }

--- a/framework/src/test/java/org/tron/core/services/NodeInfoServiceTest.java
+++ b/framework/src/test/java/org/tron/core/services/NodeInfoServiceTest.java
@@ -20,7 +20,6 @@ import org.tron.core.capsule.BlockCapsule;
 import org.tron.core.config.args.Args;
 import org.tron.core.net.P2pEventHandlerImpl;
 import org.tron.core.net.TronNetService;
-import org.tron.core.net.peer.PeerConnection;
 import org.tron.core.net.peer.PeerManager;
 import org.tron.p2p.P2pConfig;
 import org.tron.p2p.connection.Channel;
@@ -48,9 +47,7 @@ public class NodeInfoServiceTest extends BaseTest {
 
   @After
   public void clearPeers() {
-    for (PeerConnection p : PeerManager.getPeers()) {
-      PeerManager.remove(p.getChannel());
-    }
+    closePeer();
   }
 
   @Test

--- a/framework/src/test/java/org/tron/core/services/NodeInfoServiceTest.java
+++ b/framework/src/test/java/org/tron/core/services/NodeInfoServiceTest.java
@@ -2,17 +2,28 @@ package org.tron.core.services;
 
 import com.alibaba.fastjson.JSON;
 import com.google.protobuf.ByteString;
+import java.net.InetSocketAddress;
 import javax.annotation.Resource;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.springframework.context.ApplicationContext;
 import org.tron.common.BaseTest;
 import org.tron.common.entity.NodeInfo;
+import org.tron.common.utils.PublicMethod;
+import org.tron.common.utils.ReflectUtils;
 import org.tron.common.utils.Sha256Hash;
 import org.tron.core.Constant;
 import org.tron.core.capsule.BlockCapsule;
 import org.tron.core.config.args.Args;
+import org.tron.core.net.P2pEventHandlerImpl;
+import org.tron.core.net.TronNetService;
+import org.tron.core.net.peer.PeerConnection;
+import org.tron.core.net.peer.PeerManager;
+import org.tron.p2p.P2pConfig;
+import org.tron.p2p.connection.Channel;
 import org.tron.program.Version;
 
 
@@ -23,12 +34,23 @@ public class NodeInfoServiceTest extends BaseTest {
   protected NodeInfoService nodeInfoService;
   @Resource
   protected WitnessProductBlockService witnessProductBlockService;
+  @Resource
+  private P2pEventHandlerImpl p2pEventHandler;
+  @Resource
+  private TronNetService tronNetService;
 
 
   @BeforeClass
   public static void init() {
     Args.setParam(new String[] {"--output-directory", dbPath(), "--debug"},
         Constant.TEST_CONF);
+  }
+
+  @After
+  public void clearPeers() {
+    for (PeerConnection p : PeerManager.getPeers()) {
+      PeerManager.remove(p.getChannel());
+    }
   }
 
   @Test
@@ -40,6 +62,8 @@ public class NodeInfoServiceTest extends BaseTest {
     witnessProductBlockService.validWitnessProductTwoBlock(blockCapsule1);
     witnessProductBlockService.validWitnessProductTwoBlock(blockCapsule2);
 
+    addPeer();
+
     //test setConnectInfo
     NodeInfo nodeInfo = nodeInfoService.getNodeInfo();
     Assert.assertEquals(nodeInfo.getConfigNodeInfo().getCodeVersion(), Version.getVersion());
@@ -47,4 +71,22 @@ public class NodeInfoServiceTest extends BaseTest {
     logger.info("{}", JSON.toJSONString(nodeInfo));
   }
 
+  private void addPeer() {
+    int port = PublicMethod.chooseRandomPort();
+    P2pConfig p2pConfig = new P2pConfig();
+    p2pConfig.setIp("127.0.0.1");
+    p2pConfig.setPort(port);
+    ReflectUtils.setFieldValue(tronNetService, "p2pConfig", p2pConfig);
+    TronNetService.getP2pService().start(p2pConfig);
+
+    ApplicationContext ctx = (ApplicationContext) ReflectUtils.getFieldObject(p2pEventHandler,
+        "ctx");
+    InetSocketAddress inetSocketAddress1 =
+        new InetSocketAddress("127.0.0.1", 10001);
+    Channel c1 = new Channel();
+    ReflectUtils.setFieldValue(c1, "inetSocketAddress", inetSocketAddress1);
+    ReflectUtils.setFieldValue(c1, "inetAddress", inetSocketAddress1.getAddress());
+
+    PeerManager.add(ctx, c1);
+  }
 }


### PR DESCRIPTION
**What does this PR do?**

- remove peer from PeerManager after testcase, fix RpcApiServicesTest.testGetNodeInfo
- add log when receives keep alive message in `BackupManager` to help for debug
- check if `tronNetDelegate` is null in PeerStatusCheck to fix NullPointerException when use mock in several testcases, such as org.tron.core.net.peer.PeerStatusCheckMockTest. NullPointerException occurs only in mock test.

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

