### PR TITLE
fix(api): Optimize memory allocation for the filter interface of JSON-RPC

### DIFF
--- a/chainbase/src/main/java/org/tron/core/db2/core/SnapshotManager.java
+++ b/chainbase/src/main/java/org/tron/core/db2/core/SnapshotManager.java
@@ -423,6 +423,7 @@ public class SnapshotManager implements RevokingDatabase {
 
   private void deleteCheckpoint() {
     if(checkTmpStore == null) {
+      // only occurs in mock test. TODO fix test
       return;
     }
     try {

--- a/common/src/main/java/org/tron/common/parameter/CommonParameter.java
+++ b/common/src/main/java/org/tron/common/parameter/CommonParameter.java
@@ -527,6 +527,9 @@ public class CommonParameter {
   @Getter
   @Setter
   public int jsonRpcMaxSubTopics = 1000;
+  @Getter
+  @Setter
+  public int jsonRpcMaxBlockFilterNum = 50000;
 
   @Getter
   @Setter

--- a/common/src/main/java/org/tron/core/Constant.java
+++ b/common/src/main/java/org/tron/core/Constant.java
@@ -154,6 +154,7 @@ public class Constant {
   public static final String NODE_JSONRPC_HTTP_PBFT_PORT = "node.jsonrpc.httpPBFTPort";
   public static final String NODE_JSONRPC_MAX_BLOCK_RANGE = "node.jsonrpc.maxBlockRange";
   public static final String NODE_JSONRPC_MAX_SUB_TOPICS = "node.jsonrpc.maxSubTopics";
+  public static final String NODE_JSONRPC_MAX_BLOCK_FILTER_NUM = "node.jsonrpc.maxBlockFilterNum";
 
   public static final String NODE_DISABLED_API_LIST = "node.disabledApi";
 

--- a/common/src/main/java/org/tron/core/exception/jsonrpc/JsonRpcExceedLimitException.java
+++ b/common/src/main/java/org/tron/core/exception/jsonrpc/JsonRpcExceedLimitException.java
@@ -1,0 +1,16 @@
+package org.tron.core.exception.jsonrpc;
+
+public class JsonRpcExceedLimitException extends JsonRpcException {
+
+  public JsonRpcExceedLimitException() {
+    super();
+  }
+
+  public JsonRpcExceedLimitException(String message) {
+    super(message);
+  }
+
+  public JsonRpcExceedLimitException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/framework/src/main/java/org/tron/common/logsfilter/EventPluginLoader.java
+++ b/framework/src/main/java/org/tron/common/logsfilter/EventPluginLoader.java
@@ -546,6 +546,7 @@ public class EventPluginLoader {
     }
     int queueSize = 0;
     if (eventListeners == null || eventListeners.isEmpty()) {
+      // only occurs in mock test. TODO fix test
       return false;
     }
     for (IPluginEventListener listener : eventListeners) {

--- a/framework/src/main/java/org/tron/core/config/args/Args.java
+++ b/framework/src/main/java/org/tron/core/config/args/Args.java
@@ -207,6 +207,7 @@ public class Args extends CommonParameter {
     PARAMETER.jsonRpcHttpPBFTNodeEnable = false;
     PARAMETER.jsonRpcMaxBlockRange = 5000;
     PARAMETER.jsonRpcMaxSubTopics = 1000;
+    PARAMETER.jsonRpcMaxBlockFilterNum = 50000;
     PARAMETER.nodeMetricsEnable = false;
     PARAMETER.metricsStorageEnable = false;
     PARAMETER.metricsPrometheusEnable = false;
@@ -489,6 +490,11 @@ public class Args extends CommonParameter {
     if (config.hasPath(Constant.NODE_JSONRPC_MAX_SUB_TOPICS)) {
       PARAMETER.jsonRpcMaxSubTopics =
           config.getInt(Constant.NODE_JSONRPC_MAX_SUB_TOPICS);
+    }
+
+    if (config.hasPath(Constant.NODE_JSONRPC_MAX_BLOCK_FILTER_NUM)) {
+      PARAMETER.jsonRpcMaxBlockFilterNum =
+          config.getInt(Constant.NODE_JSONRPC_MAX_BLOCK_FILTER_NUM);
     }
 
     if (config.hasPath(Constant.VM_MIN_TIME_RATIO)) {

--- a/framework/src/main/java/org/tron/core/net/peer/PeerStatusCheck.java
+++ b/framework/src/main/java/org/tron/core/net/peer/PeerStatusCheck.java
@@ -43,7 +43,7 @@ public class PeerStatusCheck {
     long now = System.currentTimeMillis();
 
     if (tronNetDelegate == null) {
-      //only occurs in mock test. TODO fix test
+      // only occurs in mock test. TODO fix test
       return;
     }
     tronNetDelegate.getActivePeer().forEach(peer -> {

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/TronJsonRpc.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/TronJsonRpc.java
@@ -7,6 +7,7 @@ import com.googlecode.jsonrpc4j.JsonRpcErrors;
 import com.googlecode.jsonrpc4j.JsonRpcMethod;
 import java.io.IOException;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -18,6 +19,7 @@ import org.tron.common.runtime.vm.DataWord;
 import org.tron.common.utils.ByteArray;
 import org.tron.core.exception.BadItemException;
 import org.tron.core.exception.ItemNotFoundException;
+import org.tron.core.exception.jsonrpc.JsonRpcExceedLimitException;
 import org.tron.core.exception.jsonrpc.JsonRpcInternalException;
 import org.tron.core.exception.jsonrpc.JsonRpcInvalidParamsException;
 import org.tron.core.exception.jsonrpc.JsonRpcInvalidRequestException;
@@ -29,6 +31,9 @@ import org.tron.core.services.jsonrpc.types.CallArguments;
 import org.tron.core.services.jsonrpc.types.TransactionReceipt;
 import org.tron.core.services.jsonrpc.types.TransactionResult;
 
+/**
+ * Error code refers to https://www.quicknode.com/docs/ethereum/error-references
+ */
 @Component
 public interface TronJsonRpc {
 
@@ -292,9 +297,10 @@ public interface TronJsonRpc {
 
   @JsonRpcMethod("eth_newBlockFilter")
   @JsonRpcErrors({
+      @JsonRpcError(exception = JsonRpcExceedLimitException.class, code = -32005, data = "{}"),
       @JsonRpcError(exception = JsonRpcMethodNotFoundException.class, code = -32601, data = "{}"),
   })
-  String newBlockFilter() throws JsonRpcMethodNotFoundException;
+  String newBlockFilter() throws JsonRpcExceedLimitException, JsonRpcMethodNotFoundException;
 
   @JsonRpcMethod("eth_uninstallFilter")
   @JsonRpcErrors({
@@ -472,5 +478,35 @@ public interface TronJsonRpc {
       }
       this.removed = removed;
     }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || this.getClass() != o.getClass()) {
+        return false;
+      }
+      LogFilterElement item = (LogFilterElement) o;
+      if (!Objects.equals(blockHash, item.blockHash)) {
+        return false;
+      }
+      if (!Objects.equals(transactionHash, item.transactionHash)) {
+        return false;
+      }
+      if (!Objects.equals(transactionIndex, item.transactionIndex)) {
+        return false;
+      }
+      if (!Objects.equals(logIndex, item.logIndex)) {
+        return false;
+      }
+      return removed == item.removed;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(blockHash, transactionHash, transactionIndex, logIndex, removed);
+    }
+
   }
 }

--- a/framework/src/main/resources/config-localtest.conf
+++ b/framework/src/main/resources/config-localtest.conf
@@ -163,6 +163,7 @@ node {
     # httpPBFTPort = 8565
     # maxBlockRange = 5000
     # maxSubTopics = 1000
+    # maxBlockFilterNum = 30000
   }
 
 }

--- a/framework/src/main/resources/config.conf
+++ b/framework/src/main/resources/config.conf
@@ -375,6 +375,8 @@ node {
     # The maximum number of allowed topics within a topic criteria, default value is 1000,
     # should be > 0, otherwise means no limit.
     maxSubTopics = 1000
+    # Allowed maximum number for blockFilter
+    maxBlockFilterNum = 50000
   }
 
   # Disabled api list, it will work for http, rpc and pbft, both FullNode and SolidityNode,

--- a/framework/src/test/java/org/tron/core/jsonrpc/LogMatchExactlyTest.java
+++ b/framework/src/test/java/org/tron/core/jsonrpc/LogMatchExactlyTest.java
@@ -4,6 +4,7 @@ import static org.tron.core.services.jsonrpc.filters.LogMatch.matchBlock;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import org.junit.Assert;
 import org.junit.Test;
 import org.tron.common.runtime.vm.DataWord;
@@ -220,6 +221,18 @@ public class LogMatchExactlyTest {
       List<LogFilterElement> elementList =
           matchBlock(logFilter, 100, null, transactionInfoList, false);
       Assert.assertEquals(1, elementList.size());
+
+      //test LogFilterElement
+      List<LogFilterElement> elementList2 =
+          matchBlock(logFilter, 100, null, transactionInfoList, false);
+      Assert.assertEquals(1, elementList2.size());
+
+      LogFilterElement logFilterElement1 = elementList.get(0);
+      LogFilterElement logFilterElement2 = elementList2.get(0);
+
+      Assert.assertEquals(logFilterElement1.hashCode(), logFilterElement2.hashCode());
+      Assert.assertEquals(logFilterElement1, logFilterElement2);
+
     } catch (JsonRpcInvalidParamsException e) {
       Assert.fail();
     }

--- a/framework/src/test/java/org/tron/core/net/service/nodepersist/NodePersistServiceTest.java
+++ b/framework/src/test/java/org/tron/core/net/service/nodepersist/NodePersistServiceTest.java
@@ -1,0 +1,40 @@
+package org.tron.core.net.service.nodepersist;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Resource;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.tron.common.BaseTest;
+import org.tron.common.utils.JsonUtil;
+import org.tron.core.Constant;
+import org.tron.core.capsule.BytesCapsule;
+import org.tron.core.config.args.Args;
+
+
+public class NodePersistServiceTest extends BaseTest {
+
+  @Resource
+  private NodePersistService nodePersistService;
+
+  @BeforeClass
+  public static void init() {
+    Args.setParam(new String[] {"--output-directory", dbPath(), "--debug"},
+        Constant.TEST_CONF);
+  }
+
+  @Test
+  public void testDbRead() {
+    byte[] DB_KEY_PEERS = "peers".getBytes();
+    DBNode dbNode = new DBNode("localhost", 3306);
+    List<DBNode> dbNodeList = new ArrayList<>();
+    dbNodeList.add(dbNode);
+    DBNodes dbNodes = new DBNodes();
+    dbNodes.setNodes(dbNodeList);
+    chainBaseManager.getCommonStore().put(DB_KEY_PEERS, new BytesCapsule(
+        JsonUtil.obj2Json(dbNodes).getBytes()));
+
+    Assert.assertEquals(1, nodePersistService.dbRead().size());
+  }
+}

--- a/framework/src/test/java/org/tron/core/zksnark/ShieldedReceiveTest.java
+++ b/framework/src/test/java/org/tron/core/zksnark/ShieldedReceiveTest.java
@@ -228,6 +228,11 @@ public class ShieldedReceiveTest extends BaseTest {
     chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(totalShieldedPoolValue);
   }
 
+  @Test
+  public void testIsMining() {
+    Assert.assertTrue(wallet.isMining());
+  }
+
   /*
    * test of change ShieldedTransactionFee proposal
    */

--- a/framework/src/test/resources/config-localtest.conf
+++ b/framework/src/test/resources/config-localtest.conf
@@ -167,6 +167,7 @@ node {
     # httpPBFTPort = 8565
     # maxBlockRange = 5000
     # maxSubTopics = 1000
+    # maxBlockFilterNum = 30000
   }
 
 }

--- a/framework/src/test/resources/config-test-index.conf
+++ b/framework/src/test/resources/config-test-index.conf
@@ -88,6 +88,7 @@ node {
     httpPBFTEnable = false
     # maxBlockRange = 5000
     # maxSubTopics = 1000
+    # maxBlockFilterNum = 30000
   }
 
   rpc {

--- a/framework/src/test/resources/config-test-mainnet.conf
+++ b/framework/src/test/resources/config-test-mainnet.conf
@@ -94,6 +94,7 @@ node {
     httpPBFTEnable = false
     # maxBlockRange = 5000
     # maxSubTopics = 1000
+    # maxBlockFilterNum = 50000
   }
 
   rpc {

--- a/framework/src/test/resources/config-test.conf
+++ b/framework/src/test/resources/config-test.conf
@@ -118,6 +118,7 @@ node {
     httpPBFTEnable = false
     # maxBlockRange = 5000
     # maxSubTopics = 1000
+    # maxBlockFilterNum = 30000
   }
 
   # use your ipv6 address for node discovery and tcp connection, default false


### PR DESCRIPTION
**What does this PR do?**

- Optimize memory allocation for the filter interface of JSON-RPC, `eth_newFilter`, `eth_newBlockFilter`
- add config item `node.jsonrpc.maxBlockFilterNum`

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

