### PR TITLE
feat(vm): save in database the input and output of InternalTransactions

### DIFF
--- a/actuator/src/main/java/org/tron/core/vm/program/Program.java
+++ b/actuator/src/main/java/org/tron/core/vm/program/Program.java
@@ -816,6 +816,11 @@ public class Program {
     // 4. CREATE THE CONTRACT OUT OF RETURN
     byte[] code = createResult.getHReturn();
 
+    // capture output (deployed code) on internal transaction for indexing
+    if (internalTx != null) {
+      internalTx.setOutput(code);
+    }
+
     if (code.length != 0 && VMConfig.allowTvmLondon() && code[0] == (byte) 0xEF) {
       createResult.setException(Program.Exception
           .invalidCodeException());
@@ -1083,6 +1088,11 @@ public class Program {
       memorySaveLimited(offset, buffer, size);
 
       returnDataBuffer = buffer;
+
+      // capture output on internal transaction for indexing
+      if (internalTx != null) {
+        internalTx.setOutput(buffer);
+      }
     }
 
     // 5. REFUND THE REMAIN ENERGY

--- a/chainbase/src/main/java/org/tron/common/runtime/InternalTransaction.java
+++ b/chainbase/src/main/java/org/tron/common/runtime/InternalTransaction.java
@@ -71,6 +71,11 @@ public class InternalTransaction {
    */
   private String extra;
 
+  /*
+   * output/return data of the internal call
+   */
+  private byte[] output;
+
 
   /**
    * Construct a root InternalTransaction
@@ -217,6 +222,17 @@ public class InternalTransaction {
 
   public String getExtra() {
     return extra == null ? "" : extra;
+  }
+
+  public void setOutput(byte[] output) {
+    this.output = output;
+  }
+
+  public byte[] getOutput() {
+    if (output == null) {
+      return EMPTY_BYTE_ARRAY;
+    }
+    return output.clone();
   }
 
   public final byte[] getHash() {

--- a/chainbase/src/main/java/org/tron/core/capsule/utils/TransactionUtil.java
+++ b/chainbase/src/main/java/org/tron/core/capsule/utils/TransactionUtil.java
@@ -169,6 +169,8 @@ public class TransactionUtil {
     itBuilder.setNote(ByteString.copyFrom(it.getNote().getBytes()));
     itBuilder.setRejected(it.isRejected());
     itBuilder.setExtra(it.getExtra());
+    itBuilder.setData(ByteString.copyFrom(it.getData()));
+    itBuilder.setOutput(ByteString.copyFrom(it.getOutput()));
     return itBuilder.build();
   }
 

--- a/protocol/src/main/protos/core/Tron.proto
+++ b/protocol/src/main/protos/core/Tron.proto
@@ -648,6 +648,10 @@ message InternalTransaction {
   bytes note = 5;
   bool rejected = 6;
   string extra = 7;
+  // Input data of the internal transaction
+  bytes data = 8;
+  // Output/return data of the internal transaction
+  bytes output = 9;
 }
 
 message DelegatedResourceAccountIndex {


### PR DESCRIPTION
**What does this PR do?**
Add input (`data`) and output of InternalTransactions (i.e. traces in EVM)

You can learn about the attributes of a trace [here](https://www.alchemy.com/docs/reference/what-are-evm-traces)

**Why are these changes required?**
Since TRON doesn't save these specific fields in its database, indexers are unable to fetch very important actions that happen inside the network, like function calls and contract deployments via factories.

**This PR has been tested by:**
- Manual Testing

**Follow up**

**Extra details**

