### PR TITLE
feat(json_format): add nesting depth check

### DIFF
--- a/common/src/main/java/org/tron/common/parameter/CommonParameter.java
+++ b/common/src/main/java/org/tron/common/parameter/CommonParameter.java
@@ -278,6 +278,15 @@ public class CommonParameter {
   public int maxHeaderListSize;
   @Getter
   @Setter
+  public int maxJsonRecursionDepth = 100;
+  @Getter
+  @Setter
+  public int maxJsonFieldsPerObject = 100;
+  @Getter
+  @Setter
+  public int maxJsonArrayElements = 100;
+  @Getter
+  @Setter
   public boolean isRpcReflectionServiceEnable;
   @Getter
   @Setter

--- a/common/src/main/java/org/tron/core/Constant.java
+++ b/common/src/main/java/org/tron/core/Constant.java
@@ -172,6 +172,9 @@ public class Constant {
   public static final String NODE_NET_MAX_TRX_PER_SECOND = "node.netMaxTrxPerSecond";
   public static final String NODE_RPC_MAX_CONNECTION_AGE_IN_MILLIS = "node.rpc.maxConnectionAgeInMillis";
   public static final String NODE_RPC_MAX_MESSAGE_SIZE = "node.rpc.maxMessageSize";
+  public static final String NODE_HTTP_JSON_MAX_RECURSION_DEPTH = "node.http.json.maxRecursionDepth";
+  public static final String NODE_HTTP_JSON_MAX_FIELDS_PER_OBJECT = "node.http.json.maxFieldsPerObject";
+  public static final String NODE_HTTP_JSON_MAX_ARRAY_ELEMENTS = "node.http.json.maxArrayElements";
 
   public static final String NODE_RPC_MAX_HEADER_LIST_SIZE = "node.rpc.maxHeaderListSize";
 

--- a/framework/src/main/java/org/tron/core/config/args/Args.java
+++ b/framework/src/main/java/org/tron/core/config/args/Args.java
@@ -256,6 +256,9 @@ public class Args extends CommonParameter {
     PARAMETER.allowTvmBlob = 0;
     PARAMETER.rpcMaxRstStream = 0;
     PARAMETER.rpcSecondsPerWindow = 0;
+    PARAMETER.maxJsonRecursionDepth = 100;
+    PARAMETER.maxJsonFieldsPerObject = 100;
+    PARAMETER.maxJsonArrayElements = 100;
   }
 
   /**
@@ -783,6 +786,15 @@ public class Args extends CommonParameter {
     PARAMETER.maxHeaderListSize = config.hasPath(Constant.NODE_RPC_MAX_HEADER_LIST_SIZE)
         ? config.getInt(Constant.NODE_RPC_MAX_HEADER_LIST_SIZE)
         : GrpcUtil.DEFAULT_MAX_HEADER_LIST_SIZE;
+
+    PARAMETER.maxJsonRecursionDepth = config.hasPath(Constant.NODE_HTTP_JSON_MAX_RECURSION_DEPTH)
+        ? config.getInt(Constant.NODE_HTTP_JSON_MAX_RECURSION_DEPTH) : 100;
+
+    PARAMETER.maxJsonFieldsPerObject = config.hasPath(Constant.NODE_HTTP_JSON_MAX_FIELDS_PER_OBJECT)
+        ? config.getInt(Constant.NODE_HTTP_JSON_MAX_FIELDS_PER_OBJECT) : 100;
+
+    PARAMETER.maxJsonArrayElements = config.hasPath(Constant.NODE_HTTP_JSON_MAX_ARRAY_ELEMENTS)
+        ? config.getInt(Constant.NODE_HTTP_JSON_MAX_ARRAY_ELEMENTS) : 100;
 
     PARAMETER.isRpcReflectionServiceEnable =
         config.hasPath(Constant.NODE_RPC_REFLECTION_SERVICE)

--- a/framework/src/main/java/org/tron/core/services/http/JsonFormat.java
+++ b/framework/src/main/java/org/tron/core/services/http/JsonFormat.java
@@ -58,6 +58,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.tron.common.utils.ByteArray;
 import org.tron.common.utils.Commons;
 import org.tron.common.utils.StringUtil;
+import org.tron.core.config.args.Args;
 import org.tron.protos.contract.BalanceContract;
 
 /**
@@ -73,7 +74,9 @@ import org.tron.protos.contract.BalanceContract;
  */
 public class JsonFormat {
 
-  private static final int MAX_RECURSION_DEPTH = 100;
+  private static final int MAX_RECURSION_DEPTH = Args.getInstance().getMaxJsonRecursionDepth();
+  private static final int MAX_FIELDS_PER_OBJECT = Args.getInstance().getMaxJsonFieldsPerObject();
+  private static final int MAX_ARRAY_ELEMENTS = Args.getInstance().getMaxJsonArrayElements();
   private static final int BUFFER_SIZE = 4096;
   private static final Pattern DIGITS = Pattern.compile(
       "[0-9]",
@@ -92,6 +95,13 @@ public class JsonFormat {
       BalanceContract.TransactionBalanceTrace.Operation.class,
       BalanceContract.TransactionBalanceTrace.class
   );
+
+  static void checkLimit(int count, int limit, String elementType) throws ParseException {
+    if (count > limit) {
+      throw new ParseException(
+          "Number of " + elementType + " exceeds maximum allowed (" + limit + ").");
+    }
+  }
 
   /**
    * Outputs a textual representation of the Protocol Message supplied into the parameter output.
@@ -515,13 +525,19 @@ public class JsonFormat {
   protected static void mergeField(Tokenizer tokenizer,
       ExtensionRegistry extensionRegistry, Message.Builder builder,
       boolean selfType, int depth) throws ParseException {
-    // check depth
+    // Check nesting depth limit
     if (depth > MAX_RECURSION_DEPTH) {
       throw new ParseException(RECURSION_LIMIT_EXCEEDED);
     }
 
-    // using do-while to void StackOverflow caused by flat structures
+    int fieldsInCurrentObject = 0;
+
+    // Using do-while to void StackOverflow caused by flat structures
     do {
+      // Check fields per object limit
+      fieldsInCurrentObject++;
+      checkLimit(fieldsInCurrentObject, MAX_FIELDS_PER_OBJECT, "fields in a single object");
+
       FieldDescriptor field;
       Descriptor type = builder.getDescriptorForType();
       final ExtensionRegistry.ExtensionInfo extension;
@@ -581,7 +597,12 @@ public class JsonFormat {
         boolean array = tokenizer.tryConsume("[");
 
         if (array) {
+          // Check array size limit
+          int elementCount = 0;
           while (!tokenizer.tryConsume("]")) {
+            elementCount++;
+            checkLimit(elementCount, MAX_ARRAY_ELEMENTS, "elements in an array");
+
             handleValue(tokenizer, extensionRegistry, builder, field, extension, unknown, selfType,
                 depth);
             tokenizer.tryConsume(",");
@@ -611,7 +632,12 @@ public class JsonFormat {
       // Message structure
       tokenizer.consume("{");
       if (!"}".equals(tokenizer.currentToken())) {
+        // Check fields per object limit
+        int fieldCount = 0;
         do {
+          fieldCount++;
+          checkLimit(fieldCount, MAX_FIELDS_PER_OBJECT, "fields in a single object");
+
           tokenizer.consumeIdentifier();
           handleMissingField(tokenizer, extensionRegistry, builder, depth + 1);
         } while (tokenizer.tryConsume(","));
@@ -622,7 +648,12 @@ public class JsonFormat {
       // Collection
       tokenizer.consume("[");
       if (!"]".equals(tokenizer.currentToken())) {
+        // Check array size limit
+        int elementCount = 0;
         do {
+          elementCount++;
+          checkLimit(elementCount, MAX_ARRAY_ELEMENTS, "elements in an array");
+
           handleMissingField(tokenizer, extensionRegistry, builder, depth + 1);
         } while (tokenizer.tryConsume(","));
       }

--- a/framework/src/test/java/org/tron/common/ParameterTest.java
+++ b/framework/src/test/java/org/tron/common/ParameterTest.java
@@ -147,6 +147,14 @@ public class ParameterTest {
     assertEquals(200, parameter.getMaxMessageSize());
     parameter.setMaxHeaderListSize(100);
     assertEquals(100, parameter.getMaxHeaderListSize());
+
+    parameter.setMaxJsonRecursionDepth(120);
+    assertEquals(120, parameter.getMaxJsonRecursionDepth());
+    parameter.setMaxJsonFieldsPerObject(130);
+    assertEquals(130, parameter.getMaxJsonFieldsPerObject());
+    parameter.setMaxJsonArrayElements(150);
+    assertEquals(150, parameter.getMaxJsonArrayElements());
+
     parameter.setRpcReflectionServiceEnable(false);
     assertFalse(parameter.isRpcReflectionServiceEnable);
     parameter.setValidateSignThreadNum(5);

--- a/framework/src/test/java/org/tron/core/config/args/ArgsTest.java
+++ b/framework/src/test/java/org/tron/core/config/args/ArgsTest.java
@@ -119,6 +119,9 @@ public class ArgsTest {
     Assert.assertEquals(Long.MAX_VALUE, parameter.getMaxConnectionAgeInMillis());
     Assert.assertEquals(GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE, parameter.getMaxMessageSize());
     Assert.assertEquals(GrpcUtil.DEFAULT_MAX_HEADER_LIST_SIZE, parameter.getMaxHeaderListSize());
+    Assert.assertEquals(100, parameter.getMaxJsonRecursionDepth());
+    Assert.assertEquals(100, parameter.getMaxJsonFieldsPerObject());
+    Assert.assertEquals(100, parameter.getMaxJsonArrayElements());
     Assert.assertEquals(1L, parameter.getAllowCreationOfContracts());
     Assert.assertEquals(0, parameter.getConsensusLogicOptimization());
 
@@ -178,6 +181,9 @@ public class ArgsTest {
     Assert.assertFalse(Args.getInstance().isJsonRpcHttpPBFTNodeEnable());
     Assert.assertEquals(5000, Args.getInstance().getJsonRpcMaxBlockRange());
     Assert.assertEquals(1000, Args.getInstance().getJsonRpcMaxSubTopics());
+    Assert.assertEquals(100, Args.getInstance().getMaxJsonRecursionDepth());
+    Assert.assertEquals(100, Args.getInstance().getMaxJsonFieldsPerObject());
+    Assert.assertEquals(100, Args.getInstance().getMaxJsonArrayElements());
     Args.clearParam();
     // test set all true value
     storage.put("node.rpc.enable", "true");
@@ -191,6 +197,9 @@ public class ArgsTest {
     storage.put("node.jsonrpc.httpPBFTEnable", "true");
     storage.put("node.jsonrpc.maxBlockRange", "10");
     storage.put("node.jsonrpc.maxSubTopics", "20");
+    storage.put("node.http.json.maxRecursionDepth", "50");
+    storage.put("node.http.json.maxFieldsPerObject", "60");
+    storage.put("node.http.json.maxArrayElements", "70");
     config = ConfigFactory.defaultOverrides().withFallback(ConfigFactory.parseMap(storage));
     // test value
     Args.setParam(config);
@@ -205,6 +214,9 @@ public class ArgsTest {
     Assert.assertTrue(Args.getInstance().isJsonRpcHttpPBFTNodeEnable());
     Assert.assertEquals(10, Args.getInstance().getJsonRpcMaxBlockRange());
     Assert.assertEquals(20, Args.getInstance().getJsonRpcMaxSubTopics());
+    Assert.assertEquals(50, Args.getInstance().getMaxJsonRecursionDepth());
+    Assert.assertEquals(60, Args.getInstance().getMaxJsonFieldsPerObject());
+    Assert.assertEquals(70, Args.getInstance().getMaxJsonArrayElements());
     Args.clearParam();
     // test set all false value
     storage.put("node.rpc.enable", "false");

--- a/framework/src/test/java/org/tron/core/services/http/JsonFormatTest.java
+++ b/framework/src/test/java/org/tron/core/services/http/JsonFormatTest.java
@@ -254,7 +254,7 @@ public class JsonFormatTest {
   }
 
   @Test
-  public void testDeeplyNestedUnknownFieldsThrowsException() {
+  public void testDeeplyNestedObjectsRejected() {
     StringBuilder json = new StringBuilder("{\"unknown\":");
 
     for (int i = 0; i < 150; i++) {
@@ -294,24 +294,6 @@ public class JsonFormatTest {
       JsonFormat.merge(json.toString(), builder);
     } catch (JsonFormat.ParseException e) {
       Assert.fail("Should not have thrown ParseException for reasonable nesting");
-    }
-  }
-
-  @Test
-  public void testManyFlatFieldsDoesNotStackOverflow() throws Exception {
-    StringBuilder json = new StringBuilder("{");
-
-    for (int i = 0; i < 10000; i++) {
-      if (i > 0) json.append(",");
-      json.append("\"field").append(i).append("\":").append(i);
-    }
-    json.append("}");
-
-    try {
-      Message.Builder builder = createTestBuilder();
-      JsonFormat.merge(json.toString(), builder);
-    } catch (JsonFormat.ParseException e) {
-      Assert.fail("Should not have thrown ParseException for many flat fields");
     }
   }
 
@@ -377,6 +359,85 @@ public class JsonFormatTest {
       Assert.fail("Should have thrown ParseException");
     } catch (JsonFormat.ParseException e) {
       assertTrue(e.getMessage().contains("nesting depth exceeds"));
+    }
+  }
+
+  @Test
+  public void testManyFlatFieldsDoesNotStackOverflow() throws Exception {
+    StringBuilder json = new StringBuilder("{");
+
+    for (int i = 0; i < 100; i++) {
+      if (i > 0) {
+        json.append(",");
+      }
+      json.append("\"field").append(i).append("\":").append(i);
+    }
+    json.append("}");
+
+    try {
+      Message.Builder builder = createTestBuilder();
+      JsonFormat.merge(json.toString(), builder);
+    } catch (JsonFormat.ParseException e) {
+      Assert.fail("Should not have thrown ParseException for many flat fields");
+    }
+  }
+
+  @Test
+  public void testExcessiveFlatFieldsRejected() {
+    StringBuilder json = new StringBuilder("{");
+    for (int i = 0; i < 101; i++) {
+      if (i > 0) {
+        json.append(",");
+      }
+      json.append("\"f").append(i).append("\":1");
+    }
+    json.append("}");
+
+    try {
+      JsonFormat.merge(json.toString(), createTestBuilder());
+      Assert.fail("Should reject too many fields");
+    } catch (JsonFormat.ParseException e) {
+      assertTrue("Should mention field limit",
+          e.getMessage().contains("Number of fields in a single object exceeds maximum allowed"));
+    }
+  }
+
+  @Test
+  public void testLargeArrayRejected() {
+    StringBuilder json = new StringBuilder("{\"arr\":[");
+    for (int i = 0; i < 101; i++) {
+      if (i > 0) {
+        json.append(",");
+      }
+      json.append(i);
+    }
+    json.append("]}");
+
+    try {
+      JsonFormat.merge(json.toString(), createTestBuilder());
+      Assert.fail("Should reject large array");
+    } catch (JsonFormat.ParseException e) {
+      assertTrue("Should mention array limit",
+          e.getMessage().contains("Number of elements in an array exceeds maximum allowed"));
+    }
+  }
+
+  @Test
+  public void testReasonableArraySucceeds() {
+    StringBuilder json = new StringBuilder("{\"arr\":[");
+    for (int i = 0; i < 100; i++) {
+      if (i > 0) {
+        json.append(",");
+      }
+      json.append(i);
+    }
+    json.append("]}");
+
+    try {
+      Message.Builder builder = createTestBuilder();
+      JsonFormat.merge(json.toString(), builder);
+    } catch (JsonFormat.ParseException e) {
+      Assert.fail("Should not have thrown ParseException for reasonable array size");
     }
   }
 


### PR DESCRIPTION
**What does this PR do?**
Implements recursion depth, object field count, and array size limits in JsonFormat. Refactors the field parsing logic from recursion to iteration to improve stability.

**Why are these changes required?**
Prevents StackOverflowError and excessive resource consumption when processing deeply nested or large JSON payloads.

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**
Limits are configurable via config.conf:
- node.http.json.maxRecursionDepth (default: 100)
- node.http.json.maxRecursionDepth (default: 100)
- node.http.json.maxArrayElements (default: 100)
