### PR TITLE
feat(http): replace getRequestURI() with getServletPath()

### DIFF
--- a/framework/src/main/java/org/tron/core/services/filter/HttpApiAccessFilter.java
+++ b/framework/src/main/java/org/tron/core/services/filter/HttpApiAccessFilter.java
@@ -26,7 +26,8 @@ public class HttpApiAccessFilter implements Filter {
   public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) {
     try {
       if (request instanceof HttpServletRequest) {
-        String endpoint = ((HttpServletRequest) request).getRequestURI();
+        String contextPath = ((HttpServletRequest) request).getContextPath();
+        String endpoint = contextPath + ((HttpServletRequest) request).getServletPath();
         HttpServletResponse resp = (HttpServletResponse) response;
 
         if (isDisabled(endpoint)) {

--- a/framework/src/main/java/org/tron/core/services/filter/HttpInterceptor.java
+++ b/framework/src/main/java/org/tron/core/services/filter/HttpInterceptor.java
@@ -34,7 +34,8 @@ public class HttpInterceptor implements Filter {
         chain.doFilter(request, response);
         return;
       }
-      endpoint = ((HttpServletRequest) request).getRequestURI();
+      String contextPath = ((HttpServletRequest) request).getContextPath();
+      endpoint = contextPath + ((HttpServletRequest) request).getServletPath();
       CharResponseWrapper responseWrapper = new CharResponseWrapper(
               (HttpServletResponse) response);
       chain.doFilter(request, responseWrapper);

--- a/framework/src/main/java/org/tron/core/services/filter/LiteFnQueryHttpFilter.java
+++ b/framework/src/main/java/org/tron/core/services/filter/LiteFnQueryHttpFilter.java
@@ -110,7 +110,8 @@ public class LiteFnQueryHttpFilter implements Filter {
   @Override
   public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse,
                        FilterChain filterChain) throws IOException, ServletException {
-    String requestPath = ((HttpServletRequest) servletRequest).getRequestURI();
+    String contextPath = ((HttpServletRequest) servletRequest).getContextPath();
+    String requestPath = contextPath + ((HttpServletRequest) servletRequest).getServletPath();
     if (chainBaseManager.isLiteNode()
             && !CommonParameter.getInstance().openHistoryQueryWhenLiteFN
             && filterPaths.contains(requestPath)) {

--- a/framework/src/main/java/org/tron/core/services/http/RateLimiterServlet.java
+++ b/framework/src/main/java/org/tron/core/services/http/RateLimiterServlet.java
@@ -99,8 +99,9 @@ public abstract class RateLimiterServlet extends HttpServlet {
     if (rateLimiter != null) {
       acquireResource = rateLimiter.acquire(runtimeData);
     }
-    String url = Strings.isNullOrEmpty(req.getRequestURI())
-        ? MetricLabels.UNDEFINED : req.getRequestURI();
+    String contextPath = req.getContextPath();
+    String url = Strings.isNullOrEmpty(req.getServletPath())
+        ? MetricLabels.UNDEFINED : contextPath + req.getServletPath();
     try {
       resp.setContentType("application/json; charset=utf-8");
 

--- a/framework/src/main/java/org/tron/core/services/interfaceOnPBFT/http/PBFT/HttpApiOnPBFTService.java
+++ b/framework/src/main/java/org/tron/core/services/interfaceOnPBFT/http/PBFT/HttpApiOnPBFTService.java
@@ -172,7 +172,7 @@ public class HttpApiOnPBFTService extends HttpService {
   public HttpApiOnPBFTService() {
     port = Args.getInstance().getPBFTHttpPort();
     enable = isFullNode() && Args.getInstance().isPBFTHttpEnable();
-    contextPath = "/walletpbft/";
+    contextPath = "/walletpbft";
   }
 
   @Override


### PR DESCRIPTION
**What does this PR do?**

Replaces `getRequestURI()` with `getContextPath()` + `getServletPath()` for HttpServletRequest.

**Why are these changes required?**
   Prevent bypass path traversal protections.

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**
