### PR TITLE
ci: make build job depend on PR lint check

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -68,6 +68,7 @@ jobs:
 
   build:
     name: Build (JDK ${{ matrix.java }} / ${{ matrix.arch }})
+    needs: pr-lint
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary
- Add `needs: pr-lint` to the `build` job in pr-check workflow
- Ensures builds only run after PR title and description checks pass, avoiding wasted CI resources

## Test plan
- [ ] Open a PR with an invalid title and verify build job is skipped
- [ ] Open a PR with a valid title and verify build job runs normally