### PR TITLE
fix: use random port on each startApp to avoid port binding conflict in DbLiteTest

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -68,6 +68,7 @@ jobs:
 
   build:
     name: Build (JDK ${{ matrix.java }} / ${{ matrix.arch }})
+    needs: pr-lint
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false

--- a/plugins/src/test/java/org/tron/plugins/DbLiteTest.java
+++ b/plugins/src/test/java/org/tron/plugins/DbLiteTest.java
@@ -44,6 +44,7 @@ public class DbLiteTest {
    * init logic.
    */
   public void startApp() {
+    Args.getInstance().setRpcPort(PublicMethod.chooseRandomPort());
     context = new TronApplicationContext(DefaultConfig.class);
     appTest = ApplicationFactory.create(context);
     appTest.startup();


### PR DESCRIPTION
## Summary
- Fix flaky test `DbLiteRocksDbTest.testToolsWithRocksDB` caused by TCP port binding conflict
- `DbLiteTest.testTools()` calls `startApp()` 4 times in a single test, but the RPC port was only set once in `init()`. After `shutdown()`, the port may remain in TCP TIME_WAIT state, causing the next `startApp()` to fail with `Failed to bind to address 0.0.0.0:xxxx`
- Fix: call `PublicMethod.chooseRandomPort()` at the beginning of each `startApp()` to ensure a fresh port every time

## Test plan
- [x] `DbLiteRocksDbTest.testToolsWithRocksDB` passed 3/3 runs locally
- [x] `DbLiteLevelDbTest.testToolsWithLevelDB` passed 3/3 runs locally
- [x] `DbLiteRocksDbV2Test.testToolsWithRocksDB` passed 3/3 runs locally