### PR TITLE
feat(metrics): add block transaction count histogram for empty block monitoring

### DIFF
--- a/README-INFRA-METRICS.md
+++ b/README-INFRA-METRICS.md
@@ -1,0 +1,188 @@
+# TRON Prometheus Infrastructure Metrics
+
+**PR for [java-tron Issue #6590](https://github.com/tronprotocol/java-tron/issues/6590)** |
+**Penn Blockchain Conference Hackathon 2026 — TRON Bounty 2**
+
+---
+
+## What This PR Does
+
+Adds two new Prometheus counters to java-tron's metrics system, enabling node operators to monitor chain health events that are otherwise invisible at the metrics layer.
+
+## New Metrics Reference
+
+| Metric Name | Type | Labels | Description |
+|-------------|------|--------|-------------|
+| `tron:block_empty_total` | Counter | `type="empty"` | Increments each time a block with zero transactions is applied to the chain |
+| `tron:sr_set_change_total` | Counter | `witness`, `change_type` | Increments when the Super Representative set changes during a maintenance period |
+
+### Label Values for `tron:sr_set_change_total`
+
+| Label | Value | Description |
+|-------|-------|-------------|
+| `change_type` | `added` | A new SR entered the active set |
+| `change_type` | `removed` | An existing SR left the active set |
+| `witness` | hex address | The SR address affected |
+
+## Setup Instructions
+
+### Enable Prometheus Metrics
+
+In your node's `config.conf`:
+
+```hocon
+node {
+  metricsPrometheusEnable = true
+}
+```
+
+Or via CLI flag:
+
+```bash
+java -jar FullNode.jar --metrics-prometheus-enable
+```
+
+### Prometheus Endpoint
+
+When enabled, metrics are available at:
+
+```
+http://localhost:9527/metrics
+```
+
+### Prometheus Configuration
+
+Add to your `prometheus.yml`:
+
+```yaml
+scrape_configs:
+  - job_name: 'tron-node'
+    static_configs:
+      - targets: ['localhost:9527']
+    metrics_path: '/metrics'
+```
+
+## PromQL Example Queries
+
+### Empty Block Rate (per minute)
+
+```promql
+rate(tron:block_empty_total[1m])
+```
+
+### Total Empty Blocks
+
+```promql
+tron:block_empty_total
+```
+
+### SR Set Changes Over Time
+
+```promql
+rate(tron:sr_set_change_total[5m])
+```
+
+### SRs Added vs Removed
+
+```promql
+# Added
+sum by (change_type) (tron:sr_set_change_total{change_type="added"})
+
+# Removed
+sum by (change_type) (tron:sr_set_change_total{change_type="removed"})
+```
+
+### Alert: High Empty Block Rate
+
+```promql
+rate(tron:block_empty_total[5m]) > 10
+```
+
+### Alert: SR Set Changed
+
+```promql
+increase(tron:sr_set_change_total[1h]) > 0
+```
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `common/src/main/java/org/tron/common/prometheus/MetricKeys.java` | Added `BLOCK_EMPTY` and `SR_SET_CHANGE` constants |
+| `common/src/main/java/org/tron/common/prometheus/MetricLabels.java` | Added `BLOCK_EMPTY`, `SR_ADDED`, `SR_REMOVED` label value constants |
+| `common/src/main/java/org/tron/common/prometheus/MetricsCounter.java` | Registered both counters with Prometheus |
+| `framework/src/main/java/org/tron/core/metrics/blockchain/BlockChainMetricManager.java` | Added empty block and SR set change detection in `applyBlock()` |
+| `framework/src/test/java/org/tron/core/metrics/prometheus/PrometheusApiServiceTest.java` | Added `testEmptyBlockMetric()` and `testSrSetChangeMetric()` tests |
+
+## Build & Test Commands
+
+```bash
+# Build without tests (fast)
+./gradlew clean build -x test
+
+# Compile modified source
+./gradlew :framework:compileJava :common:compileJava
+
+# Run Prometheus metric tests only
+./gradlew :framework:test --tests \
+  "org.tron.core.metrics.prometheus.PrometheusApiServiceTest"
+
+# Run all metrics tests
+./gradlew :framework:test --tests "org.tron.core.metrics.*"
+
+# Full test suite
+./gradlew test
+
+# Coverage report
+./gradlew :framework:jacocoTestReport
+# Report: framework/build/reports/jacoco/test/html/index.html
+```
+
+## Implementation Details
+
+### Empty Block Detection
+
+In `BlockChainMetricManager.applyBlock()`, after the existing TPS counter logic:
+
+```java
+if (block.getTransactions().isEmpty()) {
+  Metrics.counterInc(MetricKeys.Counter.BLOCK_EMPTY, 1,
+      MetricLabels.Counter.BLOCK_EMPTY);
+}
+```
+
+### SR Set Change Detection
+
+Compares the current active witness list against the previous set, emitting `added` and `removed` labels for each diff:
+
+```java
+List<ByteString> currentSrList =
+    chainBaseManager.getWitnessScheduleStore().getActiveWitnesses();
+Set<String> currentSrSet = currentSrList.stream()
+    .map(bs -> Hex.toHexString(bs.toByteArray()))
+    .collect(Collectors.toSet());
+
+if (!previousSrSet.isEmpty() && !currentSrSet.equals(previousSrSet)) {
+  for (String sr : Sets.difference(currentSrSet, previousSrSet)) {
+    Metrics.counterInc(MetricKeys.Counter.SR_SET_CHANGE, 1,
+        sr, MetricLabels.Counter.SR_ADDED);
+  }
+  for (String sr : Sets.difference(previousSrSet, currentSrSet)) {
+    Metrics.counterInc(MetricKeys.Counter.SR_SET_CHANGE, 1,
+        sr, MetricLabels.Counter.SR_REMOVED);
+  }
+}
+previousSrSet = currentSrSet;
+```
+
+### Code Style
+
+- Purely additive — zero protocol changes, zero API changes, zero backward compatibility issues
+- Uses existing `Metrics.counterInc()` pattern throughout
+- All constants defined in `MetricKeys.java` and `MetricLabels.java` (no hardcoded strings)
+- Java 8 compatible (no lambdas, no records)
+- No new Gradle dependencies
+
+## Related Issues
+
+- [java-tron #6590](https://github.com/tronprotocol/java-tron/issues/6590) — Prometheus metrics for empty blocks and SR changes

--- a/README-INFRA-METRICS.md
+++ b/README-INFRA-METRICS.md
@@ -7,14 +7,30 @@
 
 ## What This PR Does
 
-Adds two new Prometheus counters to java-tron's metrics system, enabling node operators to monitor chain health events that are otherwise invisible at the metrics layer.
+Implements Prometheus metrics for empty block detection and SR set change monitoring, addressing critical operational blind spots in java-tron's monitoring infrastructure.
 
 ## New Metrics Reference
 
 | Metric Name | Type | Labels | Description |
 |-------------|------|--------|-------------|
-| `tron:block_empty_total` | Counter | `type="empty"` | Increments each time a block with zero transactions is applied to the chain |
-| `tron:sr_set_change_total` | Counter | `witness`, `change_type` | Increments when the Super Representative set changes during a maintenance period |
+| `tron:block_transaction_count` | Histogram | `miner` | Distribution of transaction counts per block |
+| `tron:sr_set_change_total` | Counter | `witness`, `change_type` | SR set changes (added/removed) |
+
+### Empty Blocks via Histogram
+
+Query empty blocks using the histogram's `le="0.0"` bucket:
+
+```promql
+# Empty blocks count by miner
+tron:block_transaction_count_bucket{le="0.0"}
+
+# Empty block ratio
+rate(tron:block_transaction_count_bucket{le="0.0"}[1h]) / rate(tron:block_transaction_count_count[1h])
+```
+
+### Histogram Buckets
+
+`[0, 10, 50, 100, 200, 500, 1000, 2000, 5000, 10000]`
 
 ### Label Values for `tron:sr_set_change_total`
 
@@ -22,7 +38,7 @@ Adds two new Prometheus counters to java-tron's metrics system, enabling node op
 |-------|-------|-------------|
 | `change_type` | `added` | A new SR entered the active set |
 | `change_type` | `removed` | An existing SR left the active set |
-| `witness` | hex address | The SR address affected |
+| `witness` | base58 address | The SR address affected |
 
 ## Setup Instructions
 
@@ -67,13 +83,29 @@ scrape_configs:
 ### Empty Block Rate (per minute)
 
 ```promql
-rate(tron:block_empty_total[1m])
+rate(tron:block_transaction_count_bucket{le="0.0"}[1m])
 ```
 
-### Total Empty Blocks
+### Empty Block Ratio (last hour)
 
 ```promql
-tron:block_empty_total
+rate(tron:block_transaction_count_bucket{le="0.0"}[1h]) / rate(tron:block_transaction_count_count[1h])
+```
+
+### Total Empty Blocks by Miner
+
+```promql
+tron:block_transaction_count_bucket{le="0.0"}
+```
+
+### Transaction Count Distribution
+
+```promql
+# Blocks with 0-10 transactions
+tron:block_transaction_count_bucket{le="10"} - tron:block_transaction_count_bucket{le="0"}
+
+# Average transactions per block
+rate(tron:block_transaction_count_sum[5m]) / rate(tron:block_transaction_count_count[5m])
 ```
 
 ### SR Set Changes Over Time
@@ -95,7 +127,7 @@ sum by (change_type) (tron:sr_set_change_total{change_type="removed"})
 ### Alert: High Empty Block Rate
 
 ```promql
-rate(tron:block_empty_total[5m]) > 10
+rate(tron:block_transaction_count_bucket{le="0.0"}[5m]) > 10
 ```
 
 ### Alert: SR Set Changed
@@ -108,11 +140,11 @@ increase(tron:sr_set_change_total[1h]) > 0
 
 | File | Change |
 |------|--------|
-| `common/src/main/java/org/tron/common/prometheus/MetricKeys.java` | Added `BLOCK_EMPTY` and `SR_SET_CHANGE` constants |
-| `common/src/main/java/org/tron/common/prometheus/MetricLabels.java` | Added `BLOCK_EMPTY`, `SR_ADDED`, `SR_REMOVED` label value constants |
-| `common/src/main/java/org/tron/common/prometheus/MetricsCounter.java` | Registered both counters with Prometheus |
-| `framework/src/main/java/org/tron/core/metrics/blockchain/BlockChainMetricManager.java` | Added empty block and SR set change detection in `applyBlock()` |
-| `framework/src/test/java/org/tron/core/metrics/prometheus/PrometheusApiServiceTest.java` | Added `testEmptyBlockMetric()` and `testSrSetChangeMetric()` tests |
+| `common/src/main/java/org/tron/common/prometheus/MetricKeys.java` | Removed `BLOCK_EMPTY`, added `BLOCK_TRANSACTION_COUNT` histogram constant |
+| `common/src/main/java/org/tron/common/prometheus/MetricsCounter.java` | Removed `BLOCK_EMPTY` counter registration |
+| `common/src/main/java/org/tron/common/prometheus/MetricsHistogram.java` | Added overloaded `init()` for custom buckets, registered `BLOCK_TRANSACTION_COUNT` |
+| `framework/src/main/java/org/tron/core/metrics/blockchain/BlockChainMetricManager.java` | Replaced counter with `histogramObserve()` for all blocks, kept SR counter |
+| `framework/src/test/java/org/tron/core/metrics/prometheus/PrometheusApiServiceTest.java` | Updated tests for histogram bucket queries |
 
 ## Build & Test Commands
 
@@ -140,20 +172,22 @@ increase(tron:sr_set_change_total[1h]) > 0
 
 ## Implementation Details
 
-### Empty Block Detection
+### Block Transaction Count Histogram
 
-In `BlockChainMetricManager.applyBlock()`, after the existing TPS counter logic:
+Records transaction count for **all blocks** (including empty blocks):
 
 ```java
-if (block.getTransactions().isEmpty()) {
-  Metrics.counterInc(MetricKeys.Counter.BLOCK_EMPTY, 1,
-      MetricLabels.Counter.BLOCK_EMPTY);
-}
+int txCount = block.getTransactions().size();
+Metrics.histogramObserve(MetricKeys.Histogram.BLOCK_TRANSACTION_COUNT, txCount,
+    StringUtil.encode58Check(address));
 ```
 
-### SR Set Change Detection
+Benefits over simple counter:
+- **Rich insights**: Tracks full distribution of tx counts
+- **Flexible queries**: Percentiles, trends, specific ranges
+- **Empty block detection**: Via `le="0.0"` bucket
 
-Compares the current active witness list against the previous set, emitting `added` and `removed` labels for each diff:
+### SR Set Change Detection
 
 ```java
 List<ByteString> currentSrList =
@@ -178,10 +212,25 @@ previousSrSet = currentSrSet;
 ### Code Style
 
 - Purely additive — zero protocol changes, zero API changes, zero backward compatibility issues
-- Uses existing `Metrics.counterInc()` pattern throughout
-- All constants defined in `MetricKeys.java` and `MetricLabels.java` (no hardcoded strings)
-- Java 8 compatible (no lambdas, no records)
+- Uses existing `Metrics.histogramObserve()` pattern for histogram
+- Uses existing `Metrics.counterInc()` pattern for counter
+- All constants defined in `MetricKeys.java` (no hardcoded strings)
+- Java 8 compatible
 - No new Gradle dependencies
+
+## Why Histogram for Empty Blocks?
+
+The histogram approach (as suggested by Sunny6889) provides richer insights:
+
+| Approach | Pros |
+|----------|------|
+| Counter | Simple, single-purpose |
+| **Histogram** | Tracks distribution, enables ratio queries, supports percentiles |
+
+Example queries enabled by histogram:
+- Empty block ratio over any time window
+- Transaction distribution patterns
+- Block capacity utilization
 
 ## Related Issues
 

--- a/common/src/main/java/org/tron/common/prometheus/MetricKeys.java
+++ b/common/src/main/java/org/tron/common/prometheus/MetricKeys.java
@@ -17,7 +17,6 @@ public class MetricKeys {
     public static final String P2P_ERROR = "tron:p2p_error";
     public static final String P2P_DISCONNECT = "tron:p2p_disconnect";
     public static final String INTERNAL_SERVICE_FAIL = "tron:internal_service_fail";
-    public static final String BLOCK_EMPTY   = "tron:block_empty_total";
     public static final String SR_SET_CHANGE = "tron:sr_set_change_total";
 
     private Counter() {
@@ -64,6 +63,7 @@ public class MetricKeys {
     public static final String MESSAGE_PROCESS_LATENCY = "tron:message_process_latency_seconds";
     public static final String BLOCK_FETCH_LATENCY = "tron:block_fetch_latency_seconds";
     public static final String BLOCK_RECEIVE_DELAY = "tron:block_receive_delay_seconds";
+    public static final String BLOCK_TRANSACTION_COUNT = "tron:block_transaction_count";
 
     private Histogram() {
       throw new IllegalStateException("Histogram");

--- a/common/src/main/java/org/tron/common/prometheus/MetricKeys.java
+++ b/common/src/main/java/org/tron/common/prometheus/MetricKeys.java
@@ -17,6 +17,8 @@ public class MetricKeys {
     public static final String P2P_ERROR = "tron:p2p_error";
     public static final String P2P_DISCONNECT = "tron:p2p_disconnect";
     public static final String INTERNAL_SERVICE_FAIL = "tron:internal_service_fail";
+    public static final String BLOCK_EMPTY   = "tron:block_empty_total";
+    public static final String SR_SET_CHANGE = "tron:sr_set_change_total";
 
     private Counter() {
       throw new IllegalStateException("Counter");

--- a/common/src/main/java/org/tron/common/prometheus/MetricLabels.java
+++ b/common/src/main/java/org/tron/common/prometheus/MetricLabels.java
@@ -31,6 +31,9 @@ public class MetricLabels {
     public static final String TXS_FAIL_SIG = "sig";
     public static final String TXS_FAIL_TAPOS = "tapos";
     public static final String TXS_FAIL_DUP = "dup";
+    public static final String BLOCK_EMPTY  = "empty";
+    public static final String SR_ADDED     = "added";
+    public static final String SR_REMOVED   = "removed";
 
     private Counter() {
       throw new IllegalStateException("Counter");

--- a/common/src/main/java/org/tron/common/prometheus/MetricsCounter.java
+++ b/common/src/main/java/org/tron/common/prometheus/MetricsCounter.java
@@ -18,9 +18,6 @@ class MetricsCounter {
     init(MetricKeys.Counter.P2P_DISCONNECT, "tron p2p disconnect .", "type");
     init(MetricKeys.Counter.INTERNAL_SERVICE_FAIL, "internal Service fail.",
         "class", "method");
-    init(MetricKeys.Counter.BLOCK_EMPTY,
-        "Total number of empty blocks (no transactions).",
-        "type");
     init(MetricKeys.Counter.SR_SET_CHANGE,
         "Total SR set changes during maintenance periods.",
         "witness", "change_type");

--- a/common/src/main/java/org/tron/common/prometheus/MetricsCounter.java
+++ b/common/src/main/java/org/tron/common/prometheus/MetricsCounter.java
@@ -18,6 +18,12 @@ class MetricsCounter {
     init(MetricKeys.Counter.P2P_DISCONNECT, "tron p2p disconnect .", "type");
     init(MetricKeys.Counter.INTERNAL_SERVICE_FAIL, "internal Service fail.",
         "class", "method");
+    init(MetricKeys.Counter.BLOCK_EMPTY,
+        "Total number of empty blocks (no transactions).",
+        "type");
+    init(MetricKeys.Counter.SR_SET_CHANGE,
+        "Total SR set changes during maintenance periods.",
+        "witness", "change_type");
   }
 
   private MetricsCounter() {

--- a/common/src/main/java/org/tron/common/prometheus/MetricsHistogram.java
+++ b/common/src/main/java/org/tron/common/prometheus/MetricsHistogram.java
@@ -48,6 +48,10 @@ public class MetricsHistogram {
     init(MetricKeys.Histogram.BLOCK_FETCH_LATENCY, "fetch block latency.");
     init(MetricKeys.Histogram.BLOCK_RECEIVE_DELAY,
         "receive block delay time, receiveTime - blockTime.");
+    init(MetricKeys.Histogram.BLOCK_TRANSACTION_COUNT,
+        "Distribution of transaction counts per block.",
+        new double[]{0, 10, 50, 100, 200, 500, 1000, 2000, 5000, 10000},
+        "miner");
   }
 
   private MetricsHistogram() {
@@ -60,6 +64,17 @@ public class MetricsHistogram {
         .help(help)
         .labelNames(labels)
         .register());
+  }
+
+  private static void init(String name, String help, double[] buckets, String... labels) {
+    Histogram.Builder builder = Histogram.build()
+        .name(name)
+        .help(help)
+        .labelNames(labels);
+    if (buckets != null && buckets.length > 0) {
+      builder.buckets(buckets);
+    }
+    container.put(name, builder.register());
   }
 
   static Histogram.Timer startTimer(String key, String... labels) {

--- a/framework/src/main/java/org/tron/core/metrics/blockchain/BlockChainMetricManager.java
+++ b/framework/src/main/java/org/tron/core/metrics/blockchain/BlockChainMetricManager.java
@@ -1,9 +1,13 @@
 package org.tron.core.metrics.blockchain;
 
 import com.codahale.metrics.Counter;
+import com.google.common.collect.Sets;
 import com.google.protobuf.ByteString;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.concurrent.ConcurrentHashMap;
@@ -42,6 +46,7 @@ public class BlockChainMetricManager {
   private long failProcessBlockNum = 0;
   @Setter
   private String failProcessBlockReason = "";
+  private Set<String> previousSrSet = new HashSet<>();
 
   public BlockChainInfo getBlockChainInfo() {
     BlockChainInfo blockChainInfo = new BlockChainInfo();
@@ -169,6 +174,31 @@ public class BlockChainMetricManager {
       Metrics.counterInc(MetricKeys.Counter.TXS, block.getTransactions().size(),
           MetricLabels.Counter.TXS_SUCCESS, MetricLabels.Counter.TXS_SUCCESS);
     }
+
+    // Empty block detection
+    if (block.getTransactions().isEmpty()) {
+      Metrics.counterInc(MetricKeys.Counter.BLOCK_EMPTY, 1,
+          MetricLabels.Counter.BLOCK_EMPTY);
+    }
+
+    // SR set change detection
+    List<ByteString> currentSrList =
+        chainBaseManager.getWitnessScheduleStore().getActiveWitnesses();
+    Set<String> currentSrSet = currentSrList.stream()
+        .map(bs -> Hex.toHexString(bs.toByteArray()))
+        .collect(Collectors.toSet());
+
+    if (!previousSrSet.isEmpty() && !currentSrSet.equals(previousSrSet)) {
+      for (String sr : Sets.difference(currentSrSet, previousSrSet)) {
+        Metrics.counterInc(MetricKeys.Counter.SR_SET_CHANGE, 1,
+            sr, MetricLabels.Counter.SR_ADDED);
+      }
+      for (String sr : Sets.difference(previousSrSet, currentSrSet)) {
+        Metrics.counterInc(MetricKeys.Counter.SR_SET_CHANGE, 1,
+            sr, MetricLabels.Counter.SR_REMOVED);
+      }
+    }
+    previousSrSet = currentSrSet;
   }
 
   private List<WitnessInfo> getSrList() {

--- a/framework/src/main/java/org/tron/core/metrics/blockchain/BlockChainMetricManager.java
+++ b/framework/src/main/java/org/tron/core/metrics/blockchain/BlockChainMetricManager.java
@@ -175,11 +175,10 @@ public class BlockChainMetricManager {
           MetricLabels.Counter.TXS_SUCCESS, MetricLabels.Counter.TXS_SUCCESS);
     }
 
-    // Empty block detection
-    if (block.getTransactions().isEmpty()) {
-      Metrics.counterInc(MetricKeys.Counter.BLOCK_EMPTY, 1,
-          MetricLabels.Counter.BLOCK_EMPTY);
-    }
+    // Record transaction count distribution for all blocks (including empty blocks)
+    int txCount = block.getTransactions().size();
+    Metrics.histogramObserve(MetricKeys.Histogram.BLOCK_TRANSACTION_COUNT, txCount,
+        StringUtil.encode58Check(address));
 
     // SR set change detection
     List<ByteString> currentSrList =

--- a/framework/src/test/java/org/tron/core/metrics/prometheus/PrometheusApiServiceTest.java
+++ b/framework/src/test/java/org/tron/core/metrics/prometheus/PrometheusApiServiceTest.java
@@ -177,6 +177,7 @@ public class PrometheusApiServiceTest extends BaseTest {
   @Test
   public void testEmptyBlockMetric() throws Exception {
     ECKey ecKey = ECKey.fromPrivate(privateKey);
+    String minerBase58 = org.tron.common.utils.StringUtil.encode58Check(ecKey.getAddress());
     ByteString witnessAddress = ByteString.copyFrom(ecKey.getAddress());
 
     chainBaseManager.getWitnessScheduleStore().saveActiveWitnesses(new ArrayList<>());
@@ -192,19 +193,19 @@ public class PrometheusApiServiceTest extends BaseTest {
     block.sign(privateKey);
 
     Double beforeValue = CollectorRegistry.defaultRegistry.getSampleValue(
-        "tron:block_empty_total",
-        new String[]{"type"},
-        new String[]{"empty"});
+        "tron:block_transaction_count_bucket",
+        new String[]{"miner", "le"},
+        new String[]{minerBase58, "0.0"});
     double before = beforeValue == null ? 0.0 : beforeValue;
 
     blockChainMetricManager.applyBlock(block);
 
     Double afterValue = CollectorRegistry.defaultRegistry.getSampleValue(
-        "tron:block_empty_total",
-        new String[]{"type"},
-        new String[]{"empty"});
-    Assert.assertNotNull("tron:block_empty_total counter should exist", afterValue);
-    Assert.assertEquals("Counter should have incremented by 1",
+        "tron:block_transaction_count_bucket",
+        new String[]{"miner", "le"},
+        new String[]{minerBase58, "0.0"});
+    Assert.assertNotNull("Empty block bucket should exist for miner: " + minerBase58, afterValue);
+    Assert.assertEquals("Histogram bucket le=0.0 should have incremented by 1",
         before + 1.0, afterValue, 0.001);
   }
 

--- a/framework/src/test/java/org/tron/core/metrics/prometheus/PrometheusApiServiceTest.java
+++ b/framework/src/test/java/org/tron/core/metrics/prometheus/PrometheusApiServiceTest.java
@@ -22,12 +22,14 @@ import org.tron.common.crypto.ECKey;
 import org.tron.common.parameter.CommonParameter;
 import org.tron.common.prometheus.MetricLabels;
 import org.tron.common.prometheus.Metrics;
+import org.bouncycastle.util.encoders.Hex;
 import org.tron.common.utils.ByteArray;
 import org.tron.common.utils.PublicMethod;
 import org.tron.common.utils.Sha256Hash;
 import org.tron.common.utils.Utils;
 import org.tron.consensus.dpos.DposSlot;
 import org.tron.core.ChainBaseManager;
+import org.tron.core.metrics.blockchain.BlockChainMetricManager;
 import org.tron.core.capsule.AccountCapsule;
 import org.tron.core.capsule.BlockCapsule;
 import org.tron.core.capsule.WitnessCapsule;
@@ -53,6 +55,8 @@ public class PrometheusApiServiceTest extends BaseTest {
   private ConsensusService consensusService;
   @Resource
   private ChainBaseManager chainManager;
+  @Resource
+  private BlockChainMetricManager blockChainMetricManager;
 
   static {
     Args.setParam(new String[] {"-d", dbPath()}, TestConstants.TEST_CONF);
@@ -168,6 +172,84 @@ public class PrometheusApiServiceTest extends BaseTest {
     blockCapsule.setMerkleRoot();
     blockCapsule.sign(ByteArray.fromHexString(witnessAddressMap.get(witnessAddress)));
     return blockCapsule;
+  }
+
+  @Test
+  public void testEmptyBlockMetric() throws Exception {
+    ECKey ecKey = ECKey.fromPrivate(privateKey);
+    ByteString witnessAddress = ByteString.copyFrom(ecKey.getAddress());
+
+    chainBaseManager.getWitnessScheduleStore().saveActiveWitnesses(new ArrayList<>());
+    chainBaseManager.addWitness(witnessAddress);
+
+    BlockCapsule block = new BlockCapsule(
+        chainBaseManager.getDynamicPropertiesStore().getLatestBlockHeaderNumber() + 1,
+        Sha256Hash.wrap(chainBaseManager.getDynamicPropertiesStore().getLatestBlockHeaderHash().getByteString()),
+        System.currentTimeMillis(),
+        witnessAddress);
+    block.generatedByMyself = true;
+    block.setMerkleRoot();
+    block.sign(privateKey);
+
+    Double beforeValue = CollectorRegistry.defaultRegistry.getSampleValue(
+        "tron:block_empty_total",
+        new String[]{"type"},
+        new String[]{"empty"});
+    double before = beforeValue == null ? 0.0 : beforeValue;
+
+    blockChainMetricManager.applyBlock(block);
+
+    Double afterValue = CollectorRegistry.defaultRegistry.getSampleValue(
+        "tron:block_empty_total",
+        new String[]{"type"},
+        new String[]{"empty"});
+    Assert.assertNotNull("tron:block_empty_total counter should exist", afterValue);
+    Assert.assertEquals("Counter should have incremented by 1",
+        before + 1.0, afterValue, 0.001);
+  }
+
+  @Test
+  public void testSrSetChangeMetric() throws Exception {
+    ECKey ecKey = ECKey.fromPrivate(privateKey);
+    ByteString witnessAddress = ByteString.copyFrom(ecKey.getAddress());
+
+    chainBaseManager.getWitnessScheduleStore().saveActiveWitnesses(new ArrayList<>());
+    chainBaseManager.addWitness(witnessAddress);
+
+    BlockCapsule block1 = new BlockCapsule(
+        chainBaseManager.getDynamicPropertiesStore().getLatestBlockHeaderNumber() + 1,
+        Sha256Hash.wrap(chainBaseManager.getDynamicPropertiesStore().getLatestBlockHeaderHash().getByteString()),
+        System.currentTimeMillis(),
+        witnessAddress);
+    block1.generatedByMyself = true;
+    block1.setMerkleRoot();
+    block1.sign(privateKey);
+    blockChainMetricManager.applyBlock(block1);
+
+    ECKey newWitnessKey = new ECKey(Utils.getRandom());
+    ByteString newWitnessBs = ByteString.copyFrom(newWitnessKey.getAddress());
+    chainBaseManager.addWitness(newWitnessBs);
+
+    BlockCapsule block2 = new BlockCapsule(
+        chainBaseManager.getDynamicPropertiesStore().getLatestBlockHeaderNumber() + 1,
+        Sha256Hash.wrap(chainBaseManager.getDynamicPropertiesStore().getLatestBlockHeaderHash().getByteString()),
+        System.currentTimeMillis() + 3000,
+        witnessAddress);
+    block2.generatedByMyself = true;
+    block2.setMerkleRoot();
+    block2.sign(privateKey);
+    blockChainMetricManager.applyBlock(block2);
+
+    String newWitnessHex = Hex.toHexString(newWitnessBs.toByteArray());
+    Double addedValue = CollectorRegistry.defaultRegistry.getSampleValue(
+        "tron:sr_set_change_total",
+        new String[]{"witness", "change_type"},
+        new String[]{newWitnessHex, "added"});
+
+    Assert.assertNotNull(
+        "tron:sr_set_change_total{witness=...,change_type=added} should exist",
+        addedValue);
+    Assert.assertTrue("SR change counter should be >= 1", addedValue >= 1.0);
   }
 
 }


### PR DESCRIPTION
## Summary
Implements [Issue #6590](https://github.com/tronprotocol/java-tron/issues/6590) — adds Prometheus metrics for empty block detection and SR set change monitoring:

- `tron:block_transaction_count` — Histogram tracking distribution of transaction counts per block (enables empty block detection via bucket `le="0.0"`)
- `tron:sr_set_change_total` — Counter tracking SR set changes with `added`/`removed` labels

## Changes

### New Metrics
| Metric | Type | Labels | Description |
|--------|------|--------|-------------|
| `tron:block_transaction_count` | Histogram | `miner` | Distribution of tx counts per block (empty blocks: `le="0.0"`) |
| `tron:sr_set_change_total` | Counter | `witness`, `change_type` | SR set changes (added/removed) |

### Key Implementation Details
- **Histogram buckets**: `[0, 10, 50, 100, 200, 500, 1000, 2000, 5000, 10000]`
- **Empty block query**: `tron:block_transaction_count_bucket{le="0.0"}`
- **Empty block ratio**: `rate(tron:block_transaction_count_bucket{le="0.0"}[1h]) / rate(tron:block_transaction_count_count[1h])`

### Files Modified
1. `common/src/main/java/org/tron/common/prometheus/MetricKeys.java` — removed BLOCK_EMPTY counter, added BLOCK_TRANSACTION_COUNT histogram
2. `common/src/main/java/org/tron/common/prometheus/MetricsCounter.java` — removed BLOCK_EMPTY registration
3. `common/src/main/java/org/tron/common/prometheus/MetricsHistogram.java` — added overloaded init() for custom buckets
4. `framework/src/main/java/org/tron/core/metrics/blockchain/BlockChainMetricManager.java` — histogramObserve() for all blocks, keeps SR counter
5. `framework/src/test/java/org/tron/core/metrics/prometheus/PrometheusApiServiceTest.java` — updated tests for histogram

## Testing
- `testMetric()` — PASSED
- `testEmptyBlockMetric()` — PASSED  
- `testSrSetChangeMetric()` — PASSED

## Advantages Over Simple Counter
- **Rich insights**: Tracks full distribution of tx counts, not just empty blocks
- **Flexible queries**: Operators can query percentiles, trends, specific ranges
- **Backward compatible**: Still enables empty block monitoring via `le="0.0"` bucket

## Backward Compatibility
Fully backward compatible. Zero protocol changes, zero API changes, zero config changes.

Closes #6590