### PR TITLE
fix(crypto): remove unused topicsList from shielded TRC20 APIs

### DIFF
--- a/framework/src/main/java/org/tron/core/Wallet.java
+++ b/framework/src/main/java/org/tron/core/Wallet.java
@@ -780,7 +780,7 @@ public class Wallet {
     if (limit > WITNESS_COUNT_LIMIT_MAX) {
       limit = WITNESS_COUNT_LIMIT_MAX;
     }
-    
+
     /*
       In the maintenance period, the VoteStores will be cleared.
       To avoid the race condition of VoteStores deleted but Witness vote counts not updated,
@@ -1502,8 +1502,8 @@ public class Wallet {
     builder.addChainParameter(Protocol.ChainParameters.ChainParameter.newBuilder()
         .setKey("getAllowTvmSelfdestructRestriction")
         .setValue(dbManager.getDynamicPropertiesStore().getAllowTvmSelfdestructRestriction())
-        .build());                      
-    
+        .build());
+
     builder.addChainParameter(Protocol.ChainParameters.ChainParameter.newBuilder()
         .setKey("getProposalExpireTime")
         .setValue(dbManager.getDynamicPropertiesStore().getProposalExpireTime())
@@ -3847,8 +3847,8 @@ public class Wallet {
     return builder.build(false);
   }
 
-  private int getShieldedTRC20LogType(TransactionInfo.Log log, byte[] contractAddress,
-      ProtocolStringList topicsList) throws ZksnarkException {
+  private int getShieldedTRC20LogType(TransactionInfo.Log log, byte[] contractAddress)
+      throws ZksnarkException {
     byte[] logAddress = log.getAddress().toByteArray();
     byte[] addressWithoutPrefix = new byte[20];
     if (ArrayUtils.isEmpty(contractAddress) || contractAddress.length != 21) {
@@ -3861,33 +3861,14 @@ public class Wallet {
       for (ByteString bs : logTopicsList) {
         topicsBytes = ByteUtil.merge(topicsBytes, bs.toByteArray());
       }
-      if (Objects.isNull(topicsList) || topicsList.isEmpty()) {
-        if (Arrays.equals(topicsBytes, SHIELDED_TRC20_LOG_TOPICS_MINT)) {
-          return 1;
-        } else if (Arrays.equals(topicsBytes, SHIELDED_TRC20_LOG_TOPICS_TRANSFER)) {
-          return 2;
-        } else if (Arrays.equals(topicsBytes, SHIELDED_TRC20_LOG_TOPICS_BURN_LEAF)) {
-          return 3;
-        } else if (Arrays.equals(topicsBytes, SHIELDED_TRC20_LOG_TOPICS_BURN_TOKEN)) {
-          return 4;
-        }
-      } else {
-        for (String topic : topicsList) {
-          byte[] topicHash = Hash.sha3(ByteArray.fromString(topic));
-          if (Arrays.equals(topicsBytes, topicHash)) {
-            if (topic.toLowerCase().contains("mint")) {
-              return 1;
-            } else if (topic.toLowerCase().contains("transfer")) {
-              return 2;
-            } else if (topic.toLowerCase().contains("burn")) {
-              if (topic.toLowerCase().contains("leaf")) {
-                return 3;
-              } else if (topic.toLowerCase().contains("token")) {
-                return 4;
-              }
-            }
-          }
-        }
+      if (Arrays.equals(topicsBytes, SHIELDED_TRC20_LOG_TOPICS_MINT)) {
+        return 1;
+      } else if (Arrays.equals(topicsBytes, SHIELDED_TRC20_LOG_TOPICS_TRANSFER)) {
+        return 2;
+      } else if (Arrays.equals(topicsBytes, SHIELDED_TRC20_LOG_TOPICS_BURN_LEAF)) {
+        return 3;
+      } else if (Arrays.equals(topicsBytes, SHIELDED_TRC20_LOG_TOPICS_BURN_TOKEN)) {
+        return 4;
       }
     }
     return 0;
@@ -3937,8 +3918,7 @@ public class Wallet {
   }
 
   private DecryptNotesTRC20 queryTRC20NoteByIvk(long startNum, long endNum,
-      byte[] shieldedTRC20ContractAddress, byte[] ivk, byte[] ak, byte[] nk,
-      ProtocolStringList topicsList)
+      byte[] shieldedTRC20ContractAddress, byte[] ivk, byte[] ak, byte[] nk)
       throws BadItemException, ZksnarkException, ContractExeException {
     if (!(startNum >= 0 && endNum > startNum && endNum - startNum <= 1000)) {
       throw new BadItemException(
@@ -3959,7 +3939,7 @@ public class Wallet {
             Optional<DecryptNotesTRC20.NoteTx> noteTx;
             int index = 0;
             for (TransactionInfo.Log log : logList) {
-              int logType = getShieldedTRC20LogType(log, shieldedTRC20ContractAddress, topicsList);
+              int logType = getShieldedTRC20LogType(log, shieldedTRC20ContractAddress);
               if (logType > 0) {
                 noteBuilder = DecryptNotesTRC20.NoteTx.newBuilder();
                 noteBuilder.setTxid(ByteString.copyFrom(txId));
@@ -4043,12 +4023,11 @@ public class Wallet {
 
   public DecryptNotesTRC20 scanShieldedTRC20NotesByIvk(
       long startNum, long endNum, byte[] shieldedTRC20ContractAddress,
-      byte[] ivk, byte[] ak, byte[] nk, ProtocolStringList topicsList)
+      byte[] ivk, byte[] ak, byte[] nk)
       throws BadItemException, ZksnarkException, ContractExeException {
     checkAllowShieldedTransactionApi();
 
-    return queryTRC20NoteByIvk(startNum, endNum,
-        shieldedTRC20ContractAddress, ivk, ak, nk, topicsList);
+    return queryTRC20NoteByIvk(startNum, endNum, shieldedTRC20ContractAddress, ivk, ak, nk);
   }
 
   private Optional<DecryptNotesTRC20.NoteTx> getNoteTxFromLogListByOvk(
@@ -4122,7 +4101,7 @@ public class Wallet {
   }
 
   public DecryptNotesTRC20 scanShieldedTRC20NotesByOvk(long startNum, long endNum,
-      byte[] ovk, byte[] shieldedTRC20ContractAddress, ProtocolStringList topicsList)
+      byte[] ovk, byte[] shieldedTRC20ContractAddress)
       throws ZksnarkException, BadItemException {
     checkAllowShieldedTransactionApi();
 
@@ -4144,7 +4123,7 @@ public class Wallet {
             Optional<DecryptNotesTRC20.NoteTx> noteTx;
             int index = 0;
             for (TransactionInfo.Log log : logList) {
-              int logType = getShieldedTRC20LogType(log, shieldedTRC20ContractAddress, topicsList);
+              int logType = getShieldedTRC20LogType(log, shieldedTRC20ContractAddress);
               if (logType > 0) {
                 noteBuilder = DecryptNotesTRC20.NoteTx.newBuilder();
                 noteBuilder.setTxid(ByteString.copyFrom(txid));

--- a/framework/src/main/java/org/tron/core/services/RpcApiService.java
+++ b/framework/src/main/java/org/tron/core/services/RpcApiService.java
@@ -4,7 +4,6 @@ import com.google.common.base.Preconditions;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
-import com.google.protobuf.ProtocolStringList;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.netty.NettyServerBuilder;
@@ -722,18 +721,19 @@ public class RpcApiService extends RpcService {
     @Override
     public void scanShieldedTRC20NotesByIvk(IvkDecryptTRC20Parameters request,
         StreamObserver<DecryptNotesTRC20> responseObserver) {
+      if (!request.getEventsList().isEmpty()) {
+        logger.warn("'events' field in IvkDecryptTRC20Parameters is deprecated and ignored");
+      }
       long startNum = request.getStartBlockIndex();
       long endNum = request.getEndBlockIndex();
       byte[] contractAddress = request.getShieldedTRC20ContractAddress().toByteArray();
       byte[] ivk = request.getIvk().toByteArray();
       byte[] ak = request.getAk().toByteArray();
       byte[] nk = request.getNk().toByteArray();
-      ProtocolStringList topicsList = request.getEventsList();
 
       try {
         responseObserver.onNext(
-            wallet.scanShieldedTRC20NotesByIvk(startNum, endNum, contractAddress, ivk, ak, nk,
-                topicsList));
+            wallet.scanShieldedTRC20NotesByIvk(startNum, endNum, contractAddress, ivk, ak, nk));
 
       } catch (Exception e) {
         responseObserver.onError(getRunTimeException(e));
@@ -744,15 +744,16 @@ public class RpcApiService extends RpcService {
     @Override
     public void scanShieldedTRC20NotesByOvk(OvkDecryptTRC20Parameters request,
         StreamObserver<DecryptNotesTRC20> responseObserver) {
+      if (!request.getEventsList().isEmpty()) {
+        logger.warn("'events' field in OvkDecryptTRC20Parameters is deprecated and ignored");
+      }
       long startNum = request.getStartBlockIndex();
       long endNum = request.getEndBlockIndex();
       byte[] contractAddress = request.getShieldedTRC20ContractAddress().toByteArray();
       byte[] ovk = request.getOvk().toByteArray();
-      ProtocolStringList topicList = request.getEventsList();
       try {
         responseObserver
-            .onNext(wallet
-                .scanShieldedTRC20NotesByOvk(startNum, endNum, ovk, contractAddress, topicList));
+            .onNext(wallet.scanShieldedTRC20NotesByOvk(startNum, endNum, ovk, contractAddress));
       } catch (Exception e) {
         responseObserver.onError(getRunTimeException(e));
       }
@@ -2412,6 +2413,9 @@ public class RpcApiService extends RpcService {
     public void scanShieldedTRC20NotesByIvk(
         IvkDecryptTRC20Parameters request,
         StreamObserver<org.tron.api.GrpcAPI.DecryptNotesTRC20> responseObserver) {
+      if (!request.getEventsList().isEmpty()) {
+        logger.warn("'events' field in IvkDecryptTRC20Parameters is deprecated and ignored");
+      }
       long startNum = request.getStartBlockIndex();
       long endNum = request.getEndBlockIndex();
       try {
@@ -2419,8 +2423,7 @@ public class RpcApiService extends RpcService {
             request.getShieldedTRC20ContractAddress().toByteArray(),
             request.getIvk().toByteArray(),
             request.getAk().toByteArray(),
-            request.getNk().toByteArray(),
-            request.getEventsList());
+            request.getNk().toByteArray());
         responseObserver.onNext(decryptNotes);
       } catch (BadItemException | ZksnarkException e) {
         responseObserver.onError(getRunTimeException(e));
@@ -2438,13 +2441,15 @@ public class RpcApiService extends RpcService {
     public void scanShieldedTRC20NotesByOvk(
         OvkDecryptTRC20Parameters request,
         StreamObserver<org.tron.api.GrpcAPI.DecryptNotesTRC20> responseObserver) {
+      if (!request.getEventsList().isEmpty()) {
+        logger.warn("'events' field in OvkDecryptTRC20Parameters is deprecated and ignored");
+      }
       long startNum = request.getStartBlockIndex();
       long endNum = request.getEndBlockIndex();
       try {
         DecryptNotesTRC20 decryptNotes = wallet.scanShieldedTRC20NotesByOvk(startNum, endNum,
             request.getOvk().toByteArray(),
-            request.getShieldedTRC20ContractAddress().toByteArray(),
-            request.getEventsList());
+            request.getShieldedTRC20ContractAddress().toByteArray());
         responseObserver.onNext(decryptNotes);
       } catch (Exception e) {
         responseObserver.onError(getRunTimeException(e));

--- a/framework/src/main/java/org/tron/core/services/http/ScanShieldedTRC20NotesByIvkServlet.java
+++ b/framework/src/main/java/org/tron/core/services/http/ScanShieldedTRC20NotesByIvkServlet.java
@@ -2,7 +2,6 @@ package org.tron.core.services.http;
 
 import com.alibaba.fastjson.JSONArray;
 import com.alibaba.fastjson.JSONObject;
-import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
@@ -41,6 +40,9 @@ public class ScanShieldedTRC20NotesByIvkServlet extends RateLimiterServlet {
       IvkDecryptTRC20Parameters.Builder ivkDecryptTRC20Parameters = IvkDecryptTRC20Parameters
           .newBuilder();
       JsonFormat.merge(params.getParams(), ivkDecryptTRC20Parameters, params.isVisible());
+      if (!ivkDecryptTRC20Parameters.getEventsList().isEmpty()) {
+        logger.warn("'events' field in IvkDecryptTRC20Parameters is deprecated and ignored");
+      }
 
       GrpcAPI.DecryptNotesTRC20 notes = wallet
           .scanShieldedTRC20NotesByIvk(ivkDecryptTRC20Parameters.getStartBlockIndex(),
@@ -48,8 +50,7 @@ public class ScanShieldedTRC20NotesByIvkServlet extends RateLimiterServlet {
               ivkDecryptTRC20Parameters.getShieldedTRC20ContractAddress().toByteArray(),
               ivkDecryptTRC20Parameters.getIvk().toByteArray(),
               ivkDecryptTRC20Parameters.getAk().toByteArray(),
-              ivkDecryptTRC20Parameters.getNk().toByteArray(),
-              ivkDecryptTRC20Parameters.getEventsList());
+              ivkDecryptTRC20Parameters.getNk().toByteArray());
       response.getWriter().println(convertOutput(notes, params.isVisible()));
     } catch (Exception e) {
       Util.processError(e, response);
@@ -74,7 +75,7 @@ public class ScanShieldedTRC20NotesByIvkServlet extends RateLimiterServlet {
       GrpcAPI.DecryptNotesTRC20 notes = wallet
           .scanShieldedTRC20NotesByIvk(startNum, endNum,
               ByteArray.fromHexString(contractAddress), ByteArray.fromHexString(ivk),
-              ByteArray.fromHexString(ak), ByteArray.fromHexString(nk), null);
+              ByteArray.fromHexString(ak), ByteArray.fromHexString(nk));
       response.getWriter().println(convertOutput(notes, visible));
     } catch (Exception e) {
       Util.processError(e, response);

--- a/framework/src/main/java/org/tron/core/services/http/ScanShieldedTRC20NotesByOvkServlet.java
+++ b/framework/src/main/java/org/tron/core/services/http/ScanShieldedTRC20NotesByOvkServlet.java
@@ -1,6 +1,5 @@
 package org.tron.core.services.http;
 
-import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
@@ -24,14 +23,15 @@ public class ScanShieldedTRC20NotesByOvkServlet extends RateLimiterServlet {
       OvkDecryptTRC20Parameters.Builder ovkDecryptTRC20Parameters = OvkDecryptTRC20Parameters
           .newBuilder();
       JsonFormat.merge(params.getParams(), ovkDecryptTRC20Parameters, params.isVisible());
+      if (!ovkDecryptTRC20Parameters.getEventsList().isEmpty()) {
+        logger.warn("'events' field in OvkDecryptTRC20Parameters is deprecated and ignored");
+      }
 
       GrpcAPI.DecryptNotesTRC20 notes = wallet
           .scanShieldedTRC20NotesByOvk(ovkDecryptTRC20Parameters.getStartBlockIndex(),
               ovkDecryptTRC20Parameters.getEndBlockIndex(),
               ovkDecryptTRC20Parameters.getOvk().toByteArray(),
-              ovkDecryptTRC20Parameters.getShieldedTRC20ContractAddress().toByteArray(),
-              ovkDecryptTRC20Parameters.getEventsList()
-          );
+              ovkDecryptTRC20Parameters.getShieldedTRC20ContractAddress().toByteArray());
       response.getWriter()
           .println(ScanShieldedTRC20NotesByIvkServlet.convertOutput(notes, params.isVisible()));
     } catch (Exception e) {
@@ -51,7 +51,7 @@ public class ScanShieldedTRC20NotesByOvkServlet extends RateLimiterServlet {
       }
       GrpcAPI.DecryptNotesTRC20 notes = wallet
           .scanShieldedTRC20NotesByOvk(startBlockIndex, endBlockIndex,
-              ByteArray.fromHexString(ovk), ByteArray.fromHexString(contractAddress), null);
+              ByteArray.fromHexString(ovk), ByteArray.fromHexString(contractAddress));
 
       response.getWriter()
           .println(ScanShieldedTRC20NotesByIvkServlet.convertOutput(notes, visible));

--- a/framework/src/test/java/org/tron/core/ShieldedTRC20BuilderTest.java
+++ b/framework/src/test/java/org/tron/core/ShieldedTRC20BuilderTest.java
@@ -2243,7 +2243,7 @@ public class ShieldedTRC20BuilderTest extends BaseTest {
     byte[] ivk = fvk.inViewingKey().value;
 
     GrpcAPI.DecryptNotesTRC20 scannedNotes = wallet.scanShieldedTRC20NotesByIvk(
-        statNum, endNum, SHIELDED_CONTRACT_ADDRESS, ivk, fvk.getAk(), fvk.getNk(), null);
+        statNum, endNum, SHIELDED_CONTRACT_ADDRESS, ivk, fvk.getAk(), fvk.getNk());
 
     for (GrpcAPI.DecryptNotesTRC20.NoteTx noteTx : scannedNotes.getNoteTxsList()) {
       logger.info(noteTx.toString());
@@ -2258,7 +2258,7 @@ public class ShieldedTRC20BuilderTest extends BaseTest {
     FullViewingKey fvk = sk.fullViewingKey();
 
     GrpcAPI.DecryptNotesTRC20 scannedNotes = wallet.scanShieldedTRC20NotesByOvk(
-        statNum, endNum, fvk.getOvk(), SHIELDED_CONTRACT_ADDRESS, null);
+        statNum, endNum, fvk.getOvk(), SHIELDED_CONTRACT_ADDRESS);
 
     for (GrpcAPI.DecryptNotesTRC20.NoteTx noteTx : scannedNotes.getNoteTxsList()) {
       logger.info(noteTx.toString());
@@ -2274,7 +2274,7 @@ public class ShieldedTRC20BuilderTest extends BaseTest {
     byte[] ivk = fvk.inViewingKey().value;
 
     GrpcAPI.DecryptNotesTRC20 scannedNotes = wallet.scanShieldedTRC20NotesByIvk(
-        statNum, endNum, SHIELDED_CONTRACT_ADDRESS, ivk, fvk.getAk(), fvk.getNk(), null);
+        statNum, endNum, SHIELDED_CONTRACT_ADDRESS, ivk, fvk.getAk(), fvk.getNk());
 
     for (GrpcAPI.DecryptNotesTRC20.NoteTx noteTx : scannedNotes.getNoteTxsList()) {
       logger.info(noteTx.toString());

--- a/framework/src/test/java/org/tron/core/WalletMockTest.java
+++ b/framework/src/test/java/org/tron/core/WalletMockTest.java
@@ -17,9 +17,6 @@ import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.protobuf.Any;
 import com.google.protobuf.ByteString;
-import com.google.protobuf.LazyStringArrayList;
-import com.google.protobuf.ProtocolStringList;
-
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -1058,19 +1055,16 @@ public class WalletMockTest {
     Wallet wallet = new Wallet();
     Protocol.TransactionInfo.Log log = Protocol.TransactionInfo.Log.newBuilder().build();
     byte[] contractAddress = "contractAddress".getBytes(StandardCharsets.UTF_8);
-    LazyStringArrayList topicsList = new LazyStringArrayList();
 
     Throwable thrown = assertThrows(InvocationTargetException.class, () -> {
       Method privateMethod = Wallet.class.getDeclaredMethod(
           "getShieldedTRC20LogType",
           Protocol.TransactionInfo.Log.class,
-          byte[].class,
-          ProtocolStringList.class);
+          byte[].class);
       privateMethod.setAccessible(true);
       privateMethod.invoke(wallet,
           log,
-          contractAddress,
-          topicsList);
+          contractAddress);
     });
     Throwable cause = thrown.getCause();
     assertTrue(cause instanceof ZksnarkException);
@@ -1088,18 +1082,15 @@ public class WalletMockTest {
         .setAddress(ByteString.copyFrom(addressWithoutPrefix))
         .build();
 
-    LazyStringArrayList topicsList = new LazyStringArrayList();
     try {
       Method privateMethod = Wallet.class.getDeclaredMethod(
           "getShieldedTRC20LogType",
           Protocol.TransactionInfo.Log.class,
-          byte[].class,
-          ProtocolStringList.class);
+          byte[].class);
       privateMethod.setAccessible(true);
       privateMethod.invoke(wallet,
           log,
-          contractAddress,
-          topicsList);
+          contractAddress);
     } catch (Exception e) {
       assertTrue(false);
     }
@@ -1119,19 +1110,15 @@ public class WalletMockTest {
         .addTopics(ByteString.copyFrom("topic".getBytes()))
         .build();
 
-    LazyStringArrayList topicsList = new LazyStringArrayList();
-    topicsList.add("topic");
     try {
       Method privateMethod = Wallet.class.getDeclaredMethod(
           "getShieldedTRC20LogType",
           Protocol.TransactionInfo.Log.class,
-          byte[].class,
-          ProtocolStringList.class);
+          byte[].class);
       privateMethod.setAccessible(true);
       privateMethod.invoke(wallet,
           log,
-          contractAddress,
-          topicsList);
+          contractAddress);
     } catch (Exception e) {
       assertTrue(false);
     }

--- a/protocol/src/main/protos/api/api.proto
+++ b/protocol/src/main/protos/api/api.proto
@@ -1498,7 +1498,7 @@ message IvkDecryptTRC20Parameters {
   bytes ivk = 4;
   bytes ak = 5;
   bytes nk = 6;
-  repeated string events = 7;
+  repeated string events = 7 [deprecated = true];
 }
 
 message OvkDecryptTRC20Parameters {
@@ -1506,7 +1506,7 @@ message OvkDecryptTRC20Parameters {
   int64 end_block_index = 2;
   bytes ovk = 3;
   bytes shielded_TRC20_contract_address = 4;
-  repeated string events = 5;
+  repeated string events = 5 [deprecated = true];
 }
 
 message DecryptNotesTRC20 {


### PR DESCRIPTION
  **What does this PR do?**                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                      
  This PR removes the unused `topicsList` parameter from shielded TRC20 APIs.                                                                                                                                                                     
                                                                                                                                                                                                                                                      
  **Changes:**                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                      
  - Remove `ProtocolStringList topicsList` parameter from `getShieldedTRC20LogType()` method
  - Simplify the log type detection logic to use direct topic bytes comparison                                                                                                                                                                        
  - Mark `events` field as deprecated in `IvkDecryptTRC20Parameters` and `OvkDecryptTRC20Parameters`
  - Add warning logs when deprecated `events` field is provided                                                                                                                                                                                       
  - Update related tests and remove unused imports                                                                                                                                                                                                    
                                                                                                                                                                                                                                                      
  **Why are these changes required?**                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                      
  The `topicsList` parameter was never used in the actual logic. The method always used the topics from the log itself. This change:                                                                                                                  
  - Removes unnecessary API complexity                                                                                                                                                                                                                
  - Simplifies the code
  - Maintains backward compatibility by deprecating the field instead of removing it                                                                                                                                                                  
                  
  **This PR has been tested by:**
  - Unit Tests
    - `./gradlew framework:test --tests org.tron.core.WalletMockTest`
    - `./gradlew framework:test --tests org.tron.core.ShieldedTRC20BuilderTest`

