### PR TITLE
ci: remove macOS 26 x86_64 (Intel) build from PR workflow

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -29,9 +29,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - java: '8'
-            runner: macos-26-intel
-            arch: x86_64
           - java: '17'
             runner: macos-26
             arch: aarch64
@@ -58,7 +55,6 @@ jobs:
         run: ./gradlew clean build --no-daemon
 
       - name: Test with RocksDB engine
-        if: matrix.arch == 'x86_64'
         run: ./gradlew :framework:testWithRocksDb --no-daemon
 
   build-ubuntu:


### PR DESCRIPTION
## Summary

  - Removed the macOS 26 Intel (x86_64, JDK 8) matrix entry from the `build-macos` job in `pr-build.yml`
  - Removed the `if: matrix.arch == 'x86_64'` condition on the RocksDB test step, as the matrix now only contains the aarch64 runner

  ## Motivation

  The `macos-26-intel` runner is no longer necessary given that the aarch64 (Apple Silicon) runner covers macOS CI
  sufficiently. Removing the Intel runner reduces CI time and resource usage.