### PR TITLE
feat(framework): unify request body size limits across APIs

### DIFF
--- a/common/src/main/java/org/tron/common/parameter/CommonParameter.java
+++ b/common/src/main/java/org/tron/common/parameter/CommonParameter.java
@@ -216,6 +216,12 @@ public class CommonParameter {
   public int maxMessageSize;
   @Getter
   @Setter
+  public int httpMaxMessageSize;
+  @Getter
+  @Setter
+  public int jsonRpcMaxMessageSize;
+  @Getter
+  @Setter
   public int maxHeaderListSize;
   @Getter
   @Setter

--- a/framework/src/main/java/org/tron/common/application/HttpService.java
+++ b/framework/src/main/java/org/tron/common/application/HttpService.java
@@ -30,6 +30,8 @@ public abstract class HttpService extends AbstractService {
 
   protected String contextPath;
 
+  protected int maxRequestSize;
+
   @Override
   public void innerStart() throws Exception {
     if (this.apiServer != null) {
@@ -64,8 +66,7 @@ public abstract class HttpService extends AbstractService {
   protected ServletContextHandler initContextHandler() {
     ServletContextHandler context = new ServletContextHandler(ServletContextHandler.SESSIONS);
     context.setContextPath(this.contextPath);
-    int maxMessageSize = Args.getInstance().getMaxMessageSize();
-    SizeLimitHandler sizeLimitHandler = new SizeLimitHandler(maxMessageSize, -1);
+    SizeLimitHandler sizeLimitHandler = new SizeLimitHandler(this.maxRequestSize, -1);
     sizeLimitHandler.setHandler(context);
     this.apiServer.setHandler(sizeLimitHandler);
     return context;

--- a/framework/src/main/java/org/tron/common/application/HttpService.java
+++ b/framework/src/main/java/org/tron/common/application/HttpService.java
@@ -19,6 +19,7 @@ import java.util.concurrent.CompletableFuture;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.jetty.server.ConnectionLimit;
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.SizeLimitHandler;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.tron.core.config.args.Args;
 
@@ -63,7 +64,10 @@ public abstract class HttpService extends AbstractService {
   protected ServletContextHandler initContextHandler() {
     ServletContextHandler context = new ServletContextHandler(ServletContextHandler.SESSIONS);
     context.setContextPath(this.contextPath);
-    this.apiServer.setHandler(context);
+    int maxMessageSize = Args.getInstance().getMaxMessageSize();
+    SizeLimitHandler sizeLimitHandler = new SizeLimitHandler(maxMessageSize, -1);
+    sizeLimitHandler.setHandler(context);
+    this.apiServer.setHandler(sizeLimitHandler);
     return context;
   }
 

--- a/framework/src/main/java/org/tron/core/config/args/Args.java
+++ b/framework/src/main/java/org/tron/core/config/args/Args.java
@@ -474,6 +474,20 @@ public class Args extends CommonParameter {
     PARAMETER.maxMessageSize = config.hasPath(ConfigKey.NODE_RPC_MAX_MESSAGE_SIZE)
         ? config.getInt(ConfigKey.NODE_RPC_MAX_MESSAGE_SIZE) : GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE;
 
+    int defaultHttpMaxMessageSize = 4 * GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE;
+    PARAMETER.httpMaxMessageSize = config.hasPath(ConfigKey.NODE_HTTP_MAX_MESSAGE_SIZE)
+        ? config.getInt(ConfigKey.NODE_HTTP_MAX_MESSAGE_SIZE) : defaultHttpMaxMessageSize;
+    if (PARAMETER.httpMaxMessageSize <= 0) {
+      throw new TronError("node.http.maxMessageSize must be positive, got: "
+          + PARAMETER.httpMaxMessageSize, PARAMETER_INIT);
+    }
+    PARAMETER.jsonRpcMaxMessageSize = config.hasPath(ConfigKey.NODE_JSONRPC_MAX_MESSAGE_SIZE)
+        ? config.getInt(ConfigKey.NODE_JSONRPC_MAX_MESSAGE_SIZE) : defaultHttpMaxMessageSize;
+    if (PARAMETER.jsonRpcMaxMessageSize <= 0) {
+      throw new TronError("node.jsonrpc.maxMessageSize must be positive, got: "
+          + PARAMETER.jsonRpcMaxMessageSize, PARAMETER_INIT);
+    }
+
     PARAMETER.maxHeaderListSize = config.hasPath(ConfigKey.NODE_RPC_MAX_HEADER_LIST_SIZE)
         ? config.getInt(ConfigKey.NODE_RPC_MAX_HEADER_LIST_SIZE)
         : GrpcUtil.DEFAULT_MAX_HEADER_LIST_SIZE;

--- a/framework/src/main/java/org/tron/core/config/args/ConfigKey.java
+++ b/framework/src/main/java/org/tron/core/config/args/ConfigKey.java
@@ -136,6 +136,7 @@ final class ConfigKey {
   public static final String NODE_HTTP_SOLIDITY_ENABLE = "node.http.solidityEnable";
   public static final String NODE_HTTP_PBFT_ENABLE = "node.http.PBFTEnable";
   public static final String NODE_HTTP_PBFT_PORT = "node.http.PBFTPort";
+  public static final String NODE_HTTP_MAX_MESSAGE_SIZE = "node.http.maxMessageSize";
 
   // node - jsonrpc
   public static final String NODE_JSONRPC_HTTP_FULLNODE_ENABLE =
@@ -150,6 +151,7 @@ final class ConfigKey {
   public static final String NODE_JSONRPC_MAX_SUB_TOPICS = "node.jsonrpc.maxSubTopics";
   public static final String NODE_JSONRPC_MAX_BLOCK_FILTER_NUM =
       "node.jsonrpc.maxBlockFilterNum";
+  public static final String NODE_JSONRPC_MAX_MESSAGE_SIZE = "node.jsonrpc.maxMessageSize";
 
   // node - dns
   public static final String NODE_DNS_TREE_URLS = "node.dns.treeUrls";

--- a/framework/src/main/java/org/tron/core/services/http/FullNodeHttpApiService.java
+++ b/framework/src/main/java/org/tron/core/services/http/FullNodeHttpApiService.java
@@ -297,6 +297,7 @@ public class FullNodeHttpApiService extends HttpService {
     port = Args.getInstance().getFullNodeHttpPort();
     enable = isFullNode() && Args.getInstance().isFullNodeHttpEnable();
     contextPath = "/";
+    maxRequestSize = Args.getInstance().getHttpMaxMessageSize();
   }
 
   @Override

--- a/framework/src/main/java/org/tron/core/services/http/Util.java
+++ b/framework/src/main/java/org/tron/core/services/http/Util.java
@@ -327,6 +327,7 @@ public class Util {
     }
   }
 
+  @Deprecated
   public static void checkBodySize(String body) throws Exception {
     CommonParameter parameter = Args.getInstance();
     if (body.getBytes().length > parameter.getMaxMessageSize()) {

--- a/framework/src/main/java/org/tron/core/services/http/solidity/SolidityNodeHttpApiService.java
+++ b/framework/src/main/java/org/tron/core/services/http/solidity/SolidityNodeHttpApiService.java
@@ -170,6 +170,7 @@ public class SolidityNodeHttpApiService extends HttpService {
     port = Args.getInstance().getSolidityHttpPort();
     enable = !isFullNode() && Args.getInstance().isSolidityNodeHttpEnable();
     contextPath = "/";
+    maxRequestSize = Args.getInstance().getHttpMaxMessageSize();
   }
 
   @Override

--- a/framework/src/main/java/org/tron/core/services/interfaceJsonRpcOnPBFT/JsonRpcServiceOnPBFT.java
+++ b/framework/src/main/java/org/tron/core/services/interfaceJsonRpcOnPBFT/JsonRpcServiceOnPBFT.java
@@ -19,6 +19,7 @@ public class JsonRpcServiceOnPBFT extends HttpService {
     port = Args.getInstance().getJsonRpcHttpPBFTPort();
     enable = isFullNode() && Args.getInstance().isJsonRpcHttpPBFTNodeEnable();
     contextPath = "/";
+    maxRequestSize = Args.getInstance().getJsonRpcMaxMessageSize();
   }
 
   @Override

--- a/framework/src/main/java/org/tron/core/services/interfaceJsonRpcOnSolidity/JsonRpcServiceOnSolidity.java
+++ b/framework/src/main/java/org/tron/core/services/interfaceJsonRpcOnSolidity/JsonRpcServiceOnSolidity.java
@@ -19,6 +19,7 @@ public class JsonRpcServiceOnSolidity extends HttpService {
     port = Args.getInstance().getJsonRpcHttpSolidityPort();
     enable = isFullNode() && Args.getInstance().isJsonRpcHttpSolidityNodeEnable();
     contextPath = "/";
+    maxRequestSize = Args.getInstance().getJsonRpcMaxMessageSize();
   }
 
   @Override

--- a/framework/src/main/java/org/tron/core/services/interfaceOnPBFT/http/PBFT/HttpApiOnPBFTService.java
+++ b/framework/src/main/java/org/tron/core/services/interfaceOnPBFT/http/PBFT/HttpApiOnPBFTService.java
@@ -173,6 +173,7 @@ public class HttpApiOnPBFTService extends HttpService {
     port = Args.getInstance().getPBFTHttpPort();
     enable = isFullNode() && Args.getInstance().isPBFTHttpEnable();
     contextPath = "/walletpbft";
+    maxRequestSize = Args.getInstance().getHttpMaxMessageSize();
   }
 
   @Override

--- a/framework/src/main/java/org/tron/core/services/interfaceOnSolidity/http/solidity/HttpApiOnSolidityService.java
+++ b/framework/src/main/java/org/tron/core/services/interfaceOnSolidity/http/solidity/HttpApiOnSolidityService.java
@@ -181,6 +181,7 @@ public class HttpApiOnSolidityService extends HttpService {
     port = Args.getInstance().getSolidityHttpPort();
     enable = isFullNode() && Args.getInstance().isSolidityNodeHttpEnable();
     contextPath = "/";
+    maxRequestSize = Args.getInstance().getHttpMaxMessageSize();
   }
 
   @Override

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/FullNodeJsonRpcHttpService.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/FullNodeJsonRpcHttpService.java
@@ -24,6 +24,7 @@ public class FullNodeJsonRpcHttpService extends HttpService {
     port = Args.getInstance().getJsonRpcHttpFullNodePort();
     enable = isFullNode() && Args.getInstance().isJsonRpcHttpFullNodeEnable();
     contextPath = "/";
+    maxRequestSize = Args.getInstance().getJsonRpcMaxMessageSize();
   }
 
   @Override

--- a/framework/src/test/java/org/tron/common/jetty/SizeLimitHandlerTest.java
+++ b/framework/src/test/java/org/tron/common/jetty/SizeLimitHandlerTest.java
@@ -3,7 +3,6 @@ package org.tron.common.jetty;
 import com.google.common.io.ByteStreams;
 import java.io.IOException;
 import java.net.URI;
-import java.nio.file.Files;
 import java.util.concurrent.TimeUnit;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -21,7 +20,9 @@ import org.eclipse.jetty.servlet.ServletHolder;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.tron.common.TestConstants;
 import org.tron.common.application.HttpService;
 import org.tron.common.utils.PublicMethod;
@@ -29,27 +30,30 @@ import org.tron.core.config.args.Args;
 
 /**
  * Tests the {@link org.eclipse.jetty.server.handler.SizeLimitHandler} body-size
- * enforcement configured in {@link HttpService initContextHandler()}.
+ * enforcement configured in {@link HttpService#initContextHandler()}.
  *
- * <p>Unlike a standalone Jetty micro-server, this test creates a concrete
- * {@link HttpService} subclass and calls {@link HttpService#start()}, so the
- * production code paths of {@code initServer()} and {@code initContextHandler()}
- * are exercised directly and reflected in code-coverage reports.</p>
- *
- * <p>Key behaviours proven:</p>
+ * <p>Covers:</p>
  * <ul>
  *   <li>Bodies within the limit are accepted ({@code 200}).</li>
  *   <li>Bodies exceeding the limit are rejected ({@code 413}).</li>
  *   <li>The limit counts raw UTF-8 <em>bytes</em>, not Java {@code char}s.</li>
+ *   <li>HTTP and JSON-RPC services use independent size limits.</li>
+ *   <li>Default values are 4x {@code GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE}.</li>
  * </ul>
  */
 @Slf4j
 public class SizeLimitHandlerTest {
 
-  private static final int MAX_BODY_SIZE = 1024;
+  private static final int HTTP_MAX_BODY_SIZE = 1024;
+  private static final int JSONRPC_MAX_BODY_SIZE = 512;
+
+  @ClassRule
+  public static final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
   private static TestHttpService     httpService;
-  private static URI                 serverUri;
+  private static TestJsonRpcService  jsonRpcService;
+  private static URI                 httpServerUri;
+  private static URI                 jsonRpcServerUri;
   private static CloseableHttpClient client;
 
   /** Echoes the raw request-body bytes back so tests can inspect what arrived. */
@@ -63,11 +67,12 @@ public class SizeLimitHandlerTest {
     }
   }
 
-  /** Minimal concrete {@link HttpService} that registers only an {@link EchoServlet}. */
+  /** Minimal concrete {@link HttpService} wired with a given size limit. */
   static class TestHttpService extends HttpService {
-    TestHttpService(int port) {
+    TestHttpService(int port, int maxRequestSize) {
       this.port = port;
       this.contextPath = "/";
+      this.maxRequestSize = maxRequestSize;
     }
 
     @Override
@@ -76,23 +81,37 @@ public class SizeLimitHandlerTest {
     }
   }
 
-  /**
-   * Initialises {@link Args} and starts a real {@link HttpService} whose
-   * {@code initServer()} and {@code initContextHandler()} are the production
-   * implementations — guaranteeing test coverage of the new
-   * {@code SizeLimitHandler} wiring.
-   */
+  /** Minimal concrete {@link HttpService} simulating a JSON-RPC service. */
+  static class TestJsonRpcService extends HttpService {
+    TestJsonRpcService(int port, int maxRequestSize) {
+      this.port = port;
+      this.contextPath = "/";
+      this.maxRequestSize = maxRequestSize;
+    }
+
+    @Override
+    protected void addServlet(ServletContextHandler context) {
+      context.addServlet(new ServletHolder(new EchoServlet()), "/jsonrpc");
+    }
+  }
+
   @BeforeClass
   public static void setup() throws Exception {
-    String dbPath = Files.createTempDirectory("sizelimit-test").toString();
-    Args.setParam(new String[]{"--output-directory", dbPath}, TestConstants.TEST_CONF);
-    Args.getInstance().setMaxMessageSize(MAX_BODY_SIZE);
+    Args.setParam(new String[]{"-d", temporaryFolder.newFolder().toString()},
+        TestConstants.TEST_CONF);
+    Args.getInstance().setHttpMaxMessageSize(HTTP_MAX_BODY_SIZE);
+    Args.getInstance().setJsonRpcMaxMessageSize(JSONRPC_MAX_BODY_SIZE);
 
-    int port = PublicMethod.chooseRandomPort();
-    httpService = new TestHttpService(port);
+    int httpPort = PublicMethod.chooseRandomPort();
+    httpService = new TestHttpService(httpPort, HTTP_MAX_BODY_SIZE);
     httpService.start().get(10, TimeUnit.SECONDS);
+    httpServerUri = new URI(String.format("http://localhost:%d/", httpPort));
 
-    serverUri = new URI(String.format("http://localhost:%d/", port));
+    int jsonRpcPort = PublicMethod.chooseRandomPort();
+    jsonRpcService = new TestJsonRpcService(jsonRpcPort, JSONRPC_MAX_BODY_SIZE);
+    jsonRpcService.start().get(10, TimeUnit.SECONDS);
+    jsonRpcServerUri = new URI(String.format("http://localhost:%d/jsonrpc", jsonRpcPort));
+
     client = HttpClients.createDefault();
   }
 
@@ -103,30 +122,86 @@ public class SizeLimitHandlerTest {
         client.close();
       }
     } finally {
-      if (httpService != null) {
-        httpService.stop();
+      try {
+        if (httpService != null) {
+          httpService.stop();
+        }
+      } finally {
+        if (jsonRpcService != null) {
+          jsonRpcService.stop();
+        }
       }
       Args.clearParam();
     }
   }
 
-  // -- body-size tests (covers HttpService.initContextHandler) ---------------
+  // -- HTTP service body-size tests -------------------------------------------
 
   @Test
-  public void testBodyWithinLimit() throws Exception {
-    Assert.assertEquals(200, post(new StringEntity("small body")));
+  public void testHttpBodyWithinLimit() throws Exception {
+    Assert.assertEquals(200, post(httpServerUri, new StringEntity("small body")));
   }
 
   @Test
-  public void testBodyExceedsLimit() throws Exception {
-    Assert.assertEquals(413, post(new StringEntity(repeat('a', MAX_BODY_SIZE + 1))));
+  public void testHttpBodyExceedsLimit() throws Exception {
+    Assert.assertEquals(413,
+        post(httpServerUri, new StringEntity(repeat('a', HTTP_MAX_BODY_SIZE + 1))));
   }
 
-  // -- helpers ---------------------------------------------------------------
+  @Test
+  public void testHttpBodyAtExactLimit() throws Exception {
+    Assert.assertEquals(200,
+        post(httpServerUri, new StringEntity(repeat('b', HTTP_MAX_BODY_SIZE))));
+  }
+
+  // -- JSON-RPC service body-size tests ---------------------------------------
+
+  @Test
+  public void testJsonRpcBodyWithinLimit() throws Exception {
+    Assert.assertEquals(200,
+        post(jsonRpcServerUri, new StringEntity("{\"method\":\"eth_blockNumber\"}")));
+  }
+
+  @Test
+  public void testJsonRpcBodyExceedsLimit() throws Exception {
+    Assert.assertEquals(413,
+        post(jsonRpcServerUri, new StringEntity(repeat('x', JSONRPC_MAX_BODY_SIZE + 1))));
+  }
+
+  @Test
+  public void testJsonRpcBodyAtExactLimit() throws Exception {
+    Assert.assertEquals(200,
+        post(jsonRpcServerUri, new StringEntity(repeat('c', JSONRPC_MAX_BODY_SIZE))));
+  }
+
+  // -- Independent limit tests ------------------------------------------------
+
+  @Test
+  public void testHttpAndJsonRpcHaveIndependentLimits() throws Exception {
+    // A body that exceeds JSON-RPC limit but is within HTTP limit
+    String body = repeat('d', JSONRPC_MAX_BODY_SIZE + 100);
+    Assert.assertTrue(body.length() < HTTP_MAX_BODY_SIZE);
+
+    Assert.assertEquals(200, post(httpServerUri, new StringEntity(body)));
+    Assert.assertEquals(413, post(jsonRpcServerUri, new StringEntity(body)));
+  }
+
+  // -- UTF-8 byte counting test -----------------------------------------------
+
+  @Test
+  public void testLimitIsBasedOnBytesNotCharacters() throws Exception {
+    // Each CJK character is 3 UTF-8 bytes; 342 chars x 3 = 1026 bytes > 1024
+    String cjk = repeat('\u4e00', 342);
+    Assert.assertEquals(342, cjk.length());
+    Assert.assertEquals(1026, cjk.getBytes("UTF-8").length);
+    Assert.assertEquals(413, post(httpServerUri, new StringEntity(cjk, "UTF-8")));
+  }
+
+  // -- helpers ----------------------------------------------------------------
 
   /** POSTs with the given entity and returns the HTTP status code. */
-  private int post(HttpEntity entity) throws Exception {
-    HttpPost req = new HttpPost(serverUri);
+  private int post(URI uri, HttpEntity entity) throws Exception {
+    HttpPost req = new HttpPost(uri);
     req.setEntity(entity);
     HttpResponse resp = client.execute(req);
     EntityUtils.consume(resp.getEntity());

--- a/framework/src/test/java/org/tron/common/jetty/SizeLimitHandlerTest.java
+++ b/framework/src/test/java/org/tron/common/jetty/SizeLimitHandlerTest.java
@@ -4,6 +4,7 @@ import com.google.common.io.ByteStreams;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
+import java.util.concurrent.TimeUnit;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -89,7 +90,7 @@ public class SizeLimitHandlerTest {
 
     int port = PublicMethod.chooseRandomPort();
     httpService = new TestHttpService(port);
-    httpService.start();
+    httpService.start().get(10, TimeUnit.SECONDS);
 
     serverUri = new URI(String.format("http://localhost:%d/", port));
     client = HttpClients.createDefault();

--- a/framework/src/test/java/org/tron/common/jetty/SizeLimitHandlerTest.java
+++ b/framework/src/test/java/org/tron/common/jetty/SizeLimitHandlerTest.java
@@ -1,0 +1,139 @@
+package org.tron.common.jetty;
+
+import com.google.common.io.ByteStreams;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.tron.common.TestConstants;
+import org.tron.common.application.HttpService;
+import org.tron.common.utils.PublicMethod;
+import org.tron.core.config.args.Args;
+
+/**
+ * Tests the {@link org.eclipse.jetty.server.handler.SizeLimitHandler} body-size
+ * enforcement configured in {@link HttpService initContextHandler()}.
+ *
+ * <p>Unlike a standalone Jetty micro-server, this test creates a concrete
+ * {@link HttpService} subclass and calls {@link HttpService#start()}, so the
+ * production code paths of {@code initServer()} and {@code initContextHandler()}
+ * are exercised directly and reflected in code-coverage reports.</p>
+ *
+ * <p>Key behaviours proven:</p>
+ * <ul>
+ *   <li>Bodies within the limit are accepted ({@code 200}).</li>
+ *   <li>Bodies exceeding the limit are rejected ({@code 413}).</li>
+ *   <li>The limit counts raw UTF-8 <em>bytes</em>, not Java {@code char}s.</li>
+ * </ul>
+ */
+@Slf4j
+public class SizeLimitHandlerTest {
+
+  private static final int MAX_BODY_SIZE = 1024;
+
+  private static TestHttpService     httpService;
+  private static URI                 serverUri;
+  private static CloseableHttpClient client;
+
+  /** Echoes the raw request-body bytes back so tests can inspect what arrived. */
+  public static class EchoServlet extends HttpServlet {
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+      byte[] body = ByteStreams.toByteArray(req.getInputStream());
+      resp.setStatus(HttpServletResponse.SC_OK);
+      resp.setContentType("application/octet-stream");
+      resp.getOutputStream().write(body);
+    }
+  }
+
+  /** Minimal concrete {@link HttpService} that registers only an {@link EchoServlet}. */
+  static class TestHttpService extends HttpService {
+    TestHttpService(int port) {
+      this.port = port;
+      this.contextPath = "/";
+    }
+
+    @Override
+    protected void addServlet(ServletContextHandler context) {
+      context.addServlet(new ServletHolder(new EchoServlet()), "/*");
+    }
+  }
+
+  /**
+   * Initialises {@link Args} and starts a real {@link HttpService} whose
+   * {@code initServer()} and {@code initContextHandler()} are the production
+   * implementations — guaranteeing test coverage of the new
+   * {@code SizeLimitHandler} wiring.
+   */
+  @BeforeClass
+  public static void setup() throws Exception {
+    String dbPath = Files.createTempDirectory("sizelimit-test").toString();
+    Args.setParam(new String[]{"--output-directory", dbPath}, TestConstants.TEST_CONF);
+    Args.getInstance().setMaxMessageSize(MAX_BODY_SIZE);
+
+    int port = PublicMethod.chooseRandomPort();
+    httpService = new TestHttpService(port);
+    httpService.start();
+
+    serverUri = new URI(String.format("http://localhost:%d/", port));
+    client = HttpClients.createDefault();
+  }
+
+  @AfterClass
+  public static void teardown() throws Exception {
+    try {
+      if (client != null) {
+        client.close();
+      }
+    } finally {
+      if (httpService != null) {
+        httpService.stop();
+      }
+      Args.clearParam();
+    }
+  }
+
+  // -- body-size tests (covers HttpService.initContextHandler) ---------------
+
+  @Test
+  public void testBodyWithinLimit() throws Exception {
+    Assert.assertEquals(200, post(new StringEntity("small body")));
+  }
+
+  @Test
+  public void testBodyExceedsLimit() throws Exception {
+    Assert.assertEquals(413, post(new StringEntity(repeat('a', MAX_BODY_SIZE + 1))));
+  }
+
+  // -- helpers ---------------------------------------------------------------
+
+  /** POSTs with the given entity and returns the HTTP status code. */
+  private int post(HttpEntity entity) throws Exception {
+    HttpPost req = new HttpPost(serverUri);
+    req.setEntity(entity);
+    HttpResponse resp = client.execute(req);
+    EntityUtils.consume(resp.getEntity());
+    return resp.getStatusLine().getStatusCode();
+  }
+
+  /** Returns a string of {@code n} repetitions of {@code c}. */
+  private static String repeat(char c, int n) {
+    return new String(new char[n]).replace('\0', c);
+  }
+}

--- a/framework/src/test/java/org/tron/common/jetty/SizeLimitHandlerTest.java
+++ b/framework/src/test/java/org/tron/common/jetty/SizeLimitHandlerTest.java
@@ -30,7 +30,7 @@ import org.tron.core.config.args.Args;
 
 /**
  * Tests the {@link org.eclipse.jetty.server.handler.SizeLimitHandler} body-size
- * enforcement configured in {@link HttpService#initContextHandler()}.
+ * enforcement configured in {@link HttpService initContextHandler()}.
  *
  * <p>Covers:</p>
  * <ul>
@@ -191,7 +191,7 @@ public class SizeLimitHandlerTest {
   @Test
   public void testLimitIsBasedOnBytesNotCharacters() throws Exception {
     // Each CJK character is 3 UTF-8 bytes; 342 chars x 3 = 1026 bytes > 1024
-    String cjk = repeat('\u4e00', 342);
+    String cjk = repeat('一', 342);
     Assert.assertEquals(342, cjk.length());
     Assert.assertEquals(1026, cjk.getBytes("UTF-8").length);
     Assert.assertEquals(413, post(httpServerUri, new StringEntity(cjk, "UTF-8")));

--- a/framework/src/test/java/org/tron/core/config/args/ArgsTest.java
+++ b/framework/src/test/java/org/tron/core/config/args/ArgsTest.java
@@ -120,6 +120,9 @@ public class ArgsTest {
     Assert.assertEquals(60000L, parameter.getMaxConnectionIdleInMillis());
     Assert.assertEquals(Long.MAX_VALUE, parameter.getMaxConnectionAgeInMillis());
     Assert.assertEquals(GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE, parameter.getMaxMessageSize());
+    Assert.assertEquals(4 * GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE, parameter.getHttpMaxMessageSize());
+    Assert.assertEquals(4 * GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE,
+        parameter.getJsonRpcMaxMessageSize());
     Assert.assertEquals(GrpcUtil.DEFAULT_MAX_HEADER_LIST_SIZE, parameter.getMaxHeaderListSize());
     Assert.assertEquals(1L, parameter.getAllowCreationOfContracts());
     Assert.assertEquals(0, parameter.getConsensusLogicOptimization());


### PR DESCRIPTION
**What does this PR do?**
introduce a unified request body size limit handler for inbound requests, and apply consistent limit checks across HTTP and JSON-RPC related endpoints in framework

**Why are these changes required?**
a single and consistent limit policy improves predictability, security posture, and operational clarity

**This PR has been tested by:**
- [x] Unit Tests
- [x]  Manual Testing

**Follow up**

**Extra details**

