### PR TITLE
opt(api): optimize block JSON serialization 

### DIFF
--- a/framework/src/main/java/org/tron/core/services/http/Util.java
+++ b/framework/src/main/java/org/tron/core/services/http/Util.java
@@ -95,7 +95,7 @@ public class Util {
 
   public static String printBlockList(BlockList list, boolean selfType) {
     List<Block> blocks = list.getBlockList();
-    JSONObject jsonObject = JSONObject.parseObject(JsonFormat.printToString(list, selfType));
+    JSONObject jsonObject = new JSONObject();
     JSONArray jsonArray = new JSONArray();
     blocks.stream().forEach(block -> jsonArray.add(printBlockToJSON(block, selfType)));
     jsonObject.put("block", jsonArray);
@@ -110,8 +110,10 @@ public class Util {
   public static JSONObject printBlockToJSON(Block block, boolean selfType) {
     BlockCapsule blockCapsule = new BlockCapsule(block);
     String blockID = ByteArray.toHexString(blockCapsule.getBlockId().getBytes());
-    JSONObject jsonObject = JSONObject.parseObject(JsonFormat.printToString(block, selfType));
+    JSONObject jsonObject = new JSONObject();
     jsonObject.put("blockID", blockID);
+    jsonObject.put("block_header",
+        JSONObject.parseObject(JsonFormat.printToString(block.getBlockHeader(), selfType)));
     if (!blockCapsule.getTransactions().isEmpty()) {
       jsonObject.put("transactions",
           printTransactionListToJSON(blockCapsule.getTransactions(), selfType));

--- a/framework/src/test/java/org/tron/core/services/http/UtilMockTest.java
+++ b/framework/src/test/java/org/tron/core/services/http/UtilMockTest.java
@@ -1,5 +1,6 @@
 package org.tron.core.services.http;
 
+import com.alibaba.fastjson.JSONArray;
 import com.alibaba.fastjson.JSONObject;
 import com.google.protobuf.ByteString;
 
@@ -44,7 +45,7 @@ public class UtilMockTest  {
   public void testPrintBlockList() {
     BlockCapsule blockCapsule1 = new BlockCapsule(1, Sha256Hash.ZERO_HASH,
         System.currentTimeMillis(), Sha256Hash.ZERO_HASH.getByteString());
-    BlockCapsule blockCapsule2 = new BlockCapsule(1, Sha256Hash.ZERO_HASH,
+    BlockCapsule blockCapsule2 = new BlockCapsule(2, Sha256Hash.ZERO_HASH,
         System.currentTimeMillis(), Sha256Hash.ZERO_HASH.getByteString());
     GrpcAPI.BlockList list = GrpcAPI.BlockList.newBuilder()
         .addBlock(blockCapsule1.getInstance())
@@ -52,6 +53,20 @@ public class UtilMockTest  {
         .build();
     String out = Util.printBlockList(list, true);
     Assert.assertNotNull(out);
+
+    JSONObject json = JSONObject.parseObject(out);
+    Assert.assertTrue(json.containsKey("block"));
+    JSONArray blockArray = json.getJSONArray("block");
+    Assert.assertEquals(2, blockArray.size());
+
+    // verify each block has correct structure
+    for (int i = 0; i < blockArray.size(); i++) {
+      JSONObject blockJson = blockArray.getJSONObject(i);
+      Assert.assertTrue(blockJson.containsKey("blockID"));
+      Assert.assertTrue(blockJson.containsKey("block_header"));
+      Assert.assertFalse(blockJson.getString("blockID").isEmpty());
+      Assert.assertNotNull(blockJson.getJSONObject("block_header"));
+    }
   }
 
   @Test


### PR DESCRIPTION
**What does this PR do?**

1. remove redundant full BlockList serialization in printBlockList
2. serialize only block_header instead of entire block in printBlockToJSON
3. enhance testPrintBlockList to verify JSON structure after refactoring

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

