### PR TITLE
fix(ci): fix reviewer assignment permissions for fork PRs

### DIFF
--- a/.github/workflows/pr-reviewer.yml
+++ b/.github/workflows/pr-reviewer.yml
@@ -1,15 +1,17 @@
 name: Auto Assign Reviewers
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [ 'develop', 'release_**' ]
     types: [ opened, edited, reopened ]
 
 jobs:
   assign-reviewers:
     name: Assign Reviewers by Scope
-    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
 
     steps:
       - name: Assign reviewers based on PR title scope


### PR DESCRIPTION
## Summary
- Switch `pull_request` trigger to `pull_request_target` so the workflow has write access when triggered by fork PRs
- Add explicit `permissions` block (`contents: read`, `pull-requests: write`) for least-privilege access
- Remove redundant `if: github.event_name == 'pull_request'` condition

## Why
Fork PRs running under `pull_request` trigger only get read-only `GITHUB_TOKEN`, causing the reviewer assignment step to fail silently. `pull_request_target` runs in the context of the base repo, granting the necessary write permissions.

## Test plan
- [x] Verify workflow syntax with `actionlint`
- [ ] Open a test PR from a fork to confirm reviewers are assigned automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)