### PR TITLE
feat(jsonrpc): add blockTimestamp to logs and receipts

### DIFF
--- a/framework/src/main/java/org/tron/core/services/jsonrpc/TronJsonRpc.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/TronJsonRpc.java
@@ -466,7 +466,7 @@ public interface TronJsonRpc {
 
     public LogFilterElement(String blockHash, Long blockNum, String txId, Integer txIndex,
         String contractAddress, List<DataWord> topicList, String logData, int logIdx,
-        boolean removed, long blockTimestamp) {
+        boolean removed, long blockTimestampMs) {
       logIndex = ByteArray.toJsonHex(logIdx);
       this.blockNumber = blockNum == null ? null : ByteArray.toJsonHex(blockNum);
       this.blockHash = blockHash == null ? null : ByteArray.toJsonHex(blockHash);
@@ -479,7 +479,7 @@ public interface TronJsonRpc {
         topics[i] = ByteArray.toJsonHex(topicList.get(i).getData());
       }
       this.removed = removed;
-      this.blockTimestamp = ByteArray.toJsonHex(blockTimestamp / 1000);
+      this.blockTimestamp = ByteArray.toJsonHex(blockTimestampMs / 1000);
     }
 
     @Override

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/TronJsonRpc.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/TronJsonRpc.java
@@ -466,7 +466,7 @@ public interface TronJsonRpc {
 
     public LogFilterElement(String blockHash, Long blockNum, String txId, Integer txIndex,
         String contractAddress, List<DataWord> topicList, String logData, int logIdx,
-        boolean removed, Long blockTimestamp) {
+        boolean removed, long blockTimestamp) {
       logIndex = ByteArray.toJsonHex(logIdx);
       this.blockNumber = blockNum == null ? null : ByteArray.toJsonHex(blockNum);
       this.blockHash = blockHash == null ? null : ByteArray.toJsonHex(blockHash);
@@ -479,8 +479,7 @@ public interface TronJsonRpc {
         topics[i] = ByteArray.toJsonHex(topicList.get(i).getData());
       }
       this.removed = removed;
-      this.blockTimestamp = blockTimestamp == null ? null
-          : ByteArray.toJsonHex(blockTimestamp / 1000);
+      this.blockTimestamp = ByteArray.toJsonHex(blockTimestamp / 1000);
     }
 
     @Override

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/TronJsonRpc.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/TronJsonRpc.java
@@ -461,10 +461,12 @@ public interface TronJsonRpc {
     private final String[] topics;
     @Getter
     private final boolean removed;
+    @Getter
+    private final String blockTimestamp;
 
     public LogFilterElement(String blockHash, Long blockNum, String txId, Integer txIndex,
         String contractAddress, List<DataWord> topicList, String logData, int logIdx,
-        boolean removed) {
+        boolean removed, Long blockTimestamp) {
       logIndex = ByteArray.toJsonHex(logIdx);
       this.blockNumber = blockNum == null ? null : ByteArray.toJsonHex(blockNum);
       this.blockHash = blockHash == null ? null : ByteArray.toJsonHex(blockHash);
@@ -477,6 +479,8 @@ public interface TronJsonRpc {
         topics[i] = ByteArray.toJsonHex(topicList.get(i).getData());
       }
       this.removed = removed;
+      this.blockTimestamp = blockTimestamp == null ? null
+          : ByteArray.toJsonHex(blockTimestamp / 1000);
     }
 
     @Override
@@ -500,12 +504,16 @@ public interface TronJsonRpc {
       if (!Objects.equals(logIndex, item.logIndex)) {
         return false;
       }
-      return removed == item.removed;
+      if (removed != item.removed) {
+        return false;
+      }
+      return Objects.equals(blockTimestamp, item.blockTimestamp);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(blockHash, transactionHash, transactionIndex, logIndex, removed);
+      return Objects.hash(blockHash, transactionHash, transactionIndex,
+          logIndex, removed, blockTimestamp);
     }
 
   }

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/filters/LogMatch.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/filters/LogMatch.java
@@ -66,7 +66,8 @@ public class LogMatch {
               topicList,
               ByteArray.toHexString(log.getData().toByteArray()),
               logIndexInBlock,
-              removed
+              removed,
+              transactionInfo.getBlockTimeStamp()
           );
           matchedLog.add(logFilterElement);
         }

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/types/TransactionReceipt.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/types/TransactionReceipt.java
@@ -109,7 +109,7 @@ public class TransactionReceipt {
 
     // Set logs
     List<TransactionLog> logList = new ArrayList<>();
-    String blockTimestamp = ByteArray.toJsonHex(txInfo.getBlockTimeStamp() / 1000);
+    String blockTimestamp = ByteArray.toJsonHex(blockCapsule.getTimeStamp() / 1000);
     for (int logIndex = 0; logIndex < txInfo.getLogCount(); logIndex++) {
       TransactionInfo.Log log = txInfo.getLogList().get(logIndex);
       TransactionLog transactionLog = new TransactionLog();

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/types/TransactionReceipt.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/types/TransactionReceipt.java
@@ -35,6 +35,7 @@ public class TransactionReceipt {
     private String data;
     private String[] topics;
     private boolean removed = false;
+    private String blockTimestamp;
 
     public TransactionLog() {}
   }
@@ -108,6 +109,7 @@ public class TransactionReceipt {
 
     // Set logs
     List<TransactionLog> logList = new ArrayList<>();
+    String blockTimestamp = ByteArray.toJsonHex(txInfo.getBlockTimeStamp() / 1000);
     for (int logIndex = 0; logIndex < txInfo.getLogCount(); logIndex++) {
       TransactionInfo.Log log = txInfo.getLogList().get(logIndex);
       TransactionLog transactionLog = new TransactionLog();
@@ -116,6 +118,7 @@ public class TransactionReceipt {
       transactionLog.setTransactionIndex(this.transactionIndex);
       transactionLog.setBlockHash(this.blockHash);
       transactionLog.setBlockNumber(this.blockNumber);
+      transactionLog.setBlockTimestamp(blockTimestamp);
 
       byte[] addressByte = convertToTronAddress(log.getAddress().toByteArray());
       transactionLog.setAddress(ByteArray.toJsonHexAddress(addressByte));

--- a/framework/src/test/java/org/tron/core/jsonrpc/JsonrpcServiceTest.java
+++ b/framework/src/test/java/org/tron/core/jsonrpc/JsonrpcServiceTest.java
@@ -45,6 +45,7 @@ import org.tron.core.services.interfaceJsonRpcOnPBFT.JsonRpcServiceOnPBFT;
 import org.tron.core.services.interfaceJsonRpcOnSolidity.JsonRpcServiceOnSolidity;
 import org.tron.core.services.jsonrpc.FullNodeJsonRpcHttpService;
 import org.tron.core.services.jsonrpc.TronJsonRpc.FilterRequest;
+import org.tron.core.services.jsonrpc.TronJsonRpc.LogFilterElement;
 import org.tron.core.services.jsonrpc.TronJsonRpcImpl;
 import org.tron.core.services.jsonrpc.filters.LogFilterWrapper;
 import org.tron.core.services.jsonrpc.types.BlockResult;
@@ -109,11 +110,11 @@ public class JsonrpcServiceTest extends BaseTest {
     blockCapsule0 = BlockUtil.newGenesisBlockCapsule();
     blockCapsule1 = new BlockCapsule(LATEST_BLOCK_NUM, Sha256Hash.wrap(ByteString.copyFrom(
         ByteArray.fromHexString(
-            "0304f784e4e7bae517bcab94c3e0c9214fb4ac7ff9d7d5a937d1f40031f87b81"))), 1,
+            "0304f784e4e7bae517bcab94c3e0c9214fb4ac7ff9d7d5a937d1f40031f87b81"))), 1000000,
         ByteString.copyFromUtf8("testAddress"));
     blockCapsule2 = new BlockCapsule(LATEST_SOLIDIFIED_BLOCK_NUM, Sha256Hash.wrap(
         ByteString.copyFrom(ByteArray.fromHexString(
-            "9938a342238077182498b464ac029222ae169360e540d1fd6aee7c2ae9575a06"))), 1,
+            "9938a342238077182498b464ac029222ae169360e540d1fd6aee7c2ae9575a06"))), 2000000,
         ByteString.copyFromUtf8("testAddress"));
 
     TransferContract transferContract1 = TransferContract.newBuilder().setAmount(1L)
@@ -135,13 +136,15 @@ public class JsonrpcServiceTest extends BaseTest {
 
     transactionCapsule1 = new TransactionCapsule(transferContract1, ContractType.TransferContract);
     transactionCapsule1.setBlockNum(blockCapsule1.getNum());
+    transactionCapsule1.setTimestamp(blockCapsule1.getTimeStamp());
     TransactionCapsule transactionCapsule2 = new TransactionCapsule(transferContract2,
         ContractType.TransferContract);
     transactionCapsule2.setBlockNum(blockCapsule1.getNum());
+    transactionCapsule2.setTimestamp(blockCapsule1.getTimeStamp());
     TransactionCapsule transactionCapsule3 = new TransactionCapsule(transferContract3,
         ContractType.TransferContract);
     transactionCapsule3.setBlockNum(blockCapsule2.getNum());
-
+    transactionCapsule3.setTimestamp(blockCapsule2.getTimeStamp());
     blockCapsule1.addTransaction(transactionCapsule1);
     blockCapsule1.addTransaction(transactionCapsule2);
     blockCapsule2.addTransaction(transactionCapsule3);
@@ -181,6 +184,7 @@ public class JsonrpcServiceTest extends BaseTest {
       TransactionInfoCapsule transactionInfoCapsule = new TransactionInfoCapsule();
       transactionInfoCapsule.setId(tx.getTransactionId().getBytes());
       transactionInfoCapsule.setBlockNumber(blockCapsule1.getNum());
+      transactionInfoCapsule.setBlockTimeStamp(blockCapsule1.getTimeStamp());
       transactionInfoCapsule.addAllLog(logs);
       transactionRetCapsule1.addTransactionInfo(transactionInfoCapsule.getInstance());
     });
@@ -192,6 +196,7 @@ public class JsonrpcServiceTest extends BaseTest {
       TransactionInfoCapsule transactionInfoCapsule = new TransactionInfoCapsule();
       transactionInfoCapsule.setId(tx.getTransactionId().getBytes());
       transactionInfoCapsule.setBlockNumber(blockCapsule2.getNum());
+      transactionInfoCapsule.setBlockTimeStamp(blockCapsule2.getTimeStamp());
       transactionRetCapsule2.addTransactionInfo(transactionInfoCapsule.getInstance());
     });
     dbManager.getTransactionRetStore()
@@ -970,6 +975,30 @@ public class JsonrpcServiceTest extends BaseTest {
   }
 
   @Test
+  public void testGetLogs() {
+    try {
+      LogFilterElement[] logs = tronJsonRpc.getLogs(
+          new FilterRequest("0x2710", "0x2710", null, null, null));
+      Assert.assertTrue(logs.length > 0);
+      LogFilterElement log = logs[0];
+      Assert.assertEquals(ByteArray.toJsonHex(blockCapsule1.getNum()), log.getBlockNumber());
+      Assert.assertEquals(ByteArray.toJsonHex(blockCapsule1.getBlockId().toString()),
+          log.getBlockHash());
+      Assert.assertEquals("0x0", log.getLogIndex());
+      Assert.assertFalse(log.isRemoved());
+      Assert.assertEquals(1, log.getTopics().length);
+      Assert.assertEquals(
+          "0x0000000000000000000000000000000000000000000000000000746f70696331",
+          log.getTopics()[0]);
+      Assert.assertEquals(ByteArray.toJsonHex("data1".getBytes()), log.getData());
+      Assert.assertEquals(ByteArray.toJsonHex(blockCapsule1.getTimeStamp() / 1000),
+          log.getBlockTimestamp());
+    } catch (Exception e) {
+      Assert.fail();
+    }
+  }
+
+  @Test
   public void testNewFilterFinalizedBlock() {
 
     try {
@@ -1026,6 +1055,10 @@ public class JsonrpcServiceTest extends BaseTest {
 
         Assert.assertEquals(
             JSON.toJSONString(transactionReceipt), JSON.toJSONString(transactionReceipt1));
+
+        Assert.assertTrue(transactionReceipt1.getLogs().length > 0);
+        Assert.assertEquals(ByteArray.toJsonHex(blockCapsule1.getTimeStamp() / 1000),
+            transactionReceipt1.getLogs()[0].getBlockTimestamp());
       }
     } catch (JsonRpcInvalidParamsException | JsonRpcInternalException e) {
       throw new RuntimeException(e);

--- a/framework/src/test/java/org/tron/core/jsonrpc/LogMatchExactlyTest.java
+++ b/framework/src/test/java/org/tron/core/jsonrpc/LogMatchExactlyTest.java
@@ -37,6 +37,7 @@ public class LogMatchExactlyTest {
     LogInfo logInfo = new LogInfo(address, topics, data);
     logList.add(LogInfo.buildLog(logInfo));
     builder.addAllLog(logList);
+    builder.setBlockTimeStamp(1000000L);
 
     return builder.build();
   }
@@ -230,6 +231,8 @@ public class LogMatchExactlyTest {
       LogFilterElement logFilterElement1 = elementList.get(0);
       LogFilterElement logFilterElement2 = elementList2.get(0);
 
+      Assert.assertEquals("0x3e8", logFilterElement1.getBlockTimestamp());
+      Assert.assertEquals("0x3e8", logFilterElement2.getBlockTimestamp());
       Assert.assertEquals(logFilterElement1.hashCode(), logFilterElement2.hashCode());
       Assert.assertEquals(logFilterElement1, logFilterElement2);
 

--- a/framework/src/test/java/org/tron/core/services/jsonrpc/TransactionReceiptTest.java
+++ b/framework/src/test/java/org/tron/core/services/jsonrpc/TransactionReceiptTest.java
@@ -54,8 +54,11 @@ public class TransactionReceiptTest extends BaseTest {
 
     Protocol.Block block = Protocol.Block.newBuilder().setBlockHeader(
         Protocol.BlockHeader.newBuilder().setRawData(
-            Protocol.BlockHeader.raw.newBuilder().setNumber(1))).addTransactions(
-        transaction).build();
+            Protocol.BlockHeader.raw.newBuilder()
+                .setNumber(1)
+                .setTimestamp(1000000L)))
+        .addTransactions(transaction)
+        .build();
 
     BlockCapsule blockCapsule = new BlockCapsule(block);
     long energyFee = wallet.getEnergyFee(blockCapsule.getTimeStamp());
@@ -66,36 +69,35 @@ public class TransactionReceiptTest extends BaseTest {
         new TransactionReceipt(blockCapsule, transactionInfo, context, energyFee);
 
     Assert.assertNotNull(transactionReceipt);
-    String blockHash = "0x0000000000000001464f071c8a336fd22eb5145dff1b245bda013ec89add8497";
+    String blockHash = "0x0000000000000001ba51f50f562758a449ff4a98df4febef89e122c1bb7e1a0c";
 
     // assert basic fields
-    Assert.assertEquals(transactionReceipt.getBlockHash(), blockHash);
-    Assert.assertEquals(transactionReceipt.getBlockNumber(), "0x1");
-    Assert.assertEquals(transactionReceipt.getTransactionHash(), "0x31");
-    Assert.assertEquals(transactionReceipt.getTransactionIndex(), "0x0");
-    Assert.assertEquals(transactionReceipt.getCumulativeGasUsed(), ByteArray.toJsonHex(102));
-    Assert.assertEquals(transactionReceipt.getGasUsed(), ByteArray.toJsonHex(100));
-    Assert.assertEquals(transactionReceipt.getEffectiveGasPrice(), ByteArray.toJsonHex(energyFee));
-    Assert.assertEquals(transactionReceipt.getStatus(), "0x1");
+    Assert.assertEquals(blockHash, transactionReceipt.getBlockHash());
+    Assert.assertEquals("0x1", transactionReceipt.getBlockNumber());
+    Assert.assertEquals("0x31", transactionReceipt.getTransactionHash());
+    Assert.assertEquals("0x0", transactionReceipt.getTransactionIndex());
+    Assert.assertEquals(ByteArray.toJsonHex(102), transactionReceipt.getCumulativeGasUsed());
+    Assert.assertEquals(ByteArray.toJsonHex(100), transactionReceipt.getGasUsed());
+    Assert.assertEquals(ByteArray.toJsonHex(energyFee), transactionReceipt.getEffectiveGasPrice());
+    Assert.assertEquals("0x1", transactionReceipt.getStatus());
 
     // assert contract fields
-    Assert.assertEquals(transactionReceipt.getFrom(), ByteArray.toJsonHexAddress(new byte[0]));
-    Assert.assertEquals(transactionReceipt.getTo(), ByteArray.toJsonHexAddress(new byte[0]));
+    Assert.assertEquals(ByteArray.toJsonHexAddress(new byte[0]), transactionReceipt.getFrom());
+    Assert.assertEquals(ByteArray.toJsonHexAddress(new byte[0]), transactionReceipt.getTo());
     Assert.assertNull(transactionReceipt.getContractAddress());
 
     // assert logs fields
-    Assert.assertEquals(transactionReceipt.getLogs().length, 1);
-    Assert.assertEquals(transactionReceipt.getLogs()[0].getLogIndex(), "0x3");
-    Assert.assertEquals(
-        transactionReceipt.getLogs()[0].getBlockHash(), blockHash);
-    Assert.assertEquals(transactionReceipt.getLogs()[0].getBlockNumber(), "0x1");
-    Assert.assertEquals(transactionReceipt.getLogs()[0].getTransactionHash(), "0x31");
-    Assert.assertEquals(transactionReceipt.getLogs()[0].getTransactionIndex(), "0x0");
-    Assert.assertEquals(transactionReceipt.getLogs()[0].getBlockTimestamp(), "0x3e8");
+    Assert.assertEquals(1, transactionReceipt.getLogs().length);
+    Assert.assertEquals("0x3", transactionReceipt.getLogs()[0].getLogIndex());
+    Assert.assertEquals(blockHash, transactionReceipt.getLogs()[0].getBlockHash());
+    Assert.assertEquals("0x1", transactionReceipt.getLogs()[0].getBlockNumber());
+    Assert.assertEquals("0x31", transactionReceipt.getLogs()[0].getTransactionHash());
+    Assert.assertEquals("0x0", transactionReceipt.getLogs()[0].getTransactionIndex());
+    Assert.assertEquals("0x3e8", transactionReceipt.getLogs()[0].getBlockTimestamp());
 
     // assert default fields
     Assert.assertNull(transactionReceipt.getRoot());
-    Assert.assertEquals(transactionReceipt.getType(), "0x0");
-    Assert.assertEquals(transactionReceipt.getLogsBloom(), ByteArray.toJsonHex(new byte[256]));
+    Assert.assertEquals("0x0", transactionReceipt.getType());
+    Assert.assertEquals(ByteArray.toJsonHex(new byte[256]), transactionReceipt.getLogsBloom());
   }
 }

--- a/framework/src/test/java/org/tron/core/services/jsonrpc/TransactionReceiptTest.java
+++ b/framework/src/test/java/org/tron/core/services/jsonrpc/TransactionReceiptTest.java
@@ -32,6 +32,7 @@ public class TransactionReceiptTest extends BaseTest {
     Protocol.TransactionInfo transactionInfo = Protocol.TransactionInfo.newBuilder()
         .setId(ByteString.copyFrom("1".getBytes()))
         .setContractAddress(ByteString.copyFrom("address1".getBytes()))
+        .setBlockTimeStamp(1000000L)
         .setReceipt(Protocol.ResourceReceipt.newBuilder()
             .setEnergyUsageTotal(100L)
             .setResult(Protocol.Transaction.Result.contractResult.DEFAULT)
@@ -90,6 +91,7 @@ public class TransactionReceiptTest extends BaseTest {
     Assert.assertEquals(transactionReceipt.getLogs()[0].getBlockNumber(), "0x1");
     Assert.assertEquals(transactionReceipt.getLogs()[0].getTransactionHash(), "0x31");
     Assert.assertEquals(transactionReceipt.getLogs()[0].getTransactionIndex(), "0x0");
+    Assert.assertEquals(transactionReceipt.getLogs()[0].getBlockTimestamp(), "0x3e8");
 
     // assert default fields
     Assert.assertNull(transactionReceipt.getRoot());


### PR DESCRIPTION
**What does this PR do?**
Adds the `blockTimestamp` field to the log objects returned by JSON-RPC event and receipt query interfaces, aligning the TRON JSON-RPC implementation with the Ethereum execution-apis specification. close https://github.com/tronprotocol/java-tron/issues/6617

Specifically, it updates:
1. `LogFilterElement` (used in `eth_getLogs`, `eth_getFilterLogs`, `eth_getFilterChanges(about log/event filter)`) to include `blockTimestamp`.
2. `TransactionLog` within `TransactionReceipt` (used in `eth_getTransactionReceipt`, `eth_getBlockReceipts`) to include `blockTimestamp`.

The timestamp is extracted from the corresponding `TransactionInfo`'s `blockTimeStamp`, divided by 1000 to convert to seconds, and returned as a hexadecimal string (e.g., `"0x3e8"`).

**Why are these changes required?**
To maintain compatibility with the evolving Ethereum JSON-RPC API standards. Adding the block generation timestamp directly to the log objects enables developers and dApps to process event streams with precise time context without needing to perform secondary `eth_getBlockByHash/Number` queries, significantly reducing network overhead and improving client efficiency.

**This PR has been tested by:**
- Unit Tests:
  - Added assertions in `LogMatchExactlyTest.java` to verify `blockTimestamp` in `LogFilterElement`.
  - Added assertions in `TransactionReceiptTest.java` to verify `blockTimestamp` in `TransactionReceipt.TransactionLog`.
- Manual Testing: N/A

**Follow up**

**Extra details**