### PR TITLE
feat(actuator): correct protobuf unpack types in getOwnerAddress()

### DIFF
--- a/actuator/src/main/java/org/tron/core/actuator/MarketCancelOrderActuator.java
+++ b/actuator/src/main/java/org/tron/core/actuator/MarketCancelOrderActuator.java
@@ -43,7 +43,6 @@ import org.tron.core.store.MarketPairToPriceStore;
 import org.tron.protos.Protocol.MarketOrder.State;
 import org.tron.protos.Protocol.Transaction.Contract.ContractType;
 import org.tron.protos.Protocol.Transaction.Result.code;
-import org.tron.protos.contract.AssetIssueContractOuterClass.AssetIssueContract;
 import org.tron.protos.contract.MarketContract.MarketCancelOrderContract;
 
 @Slf4j(topic = "actuator")
@@ -221,7 +220,7 @@ public class MarketCancelOrderActuator extends AbstractActuator {
 
   @Override
   public ByteString getOwnerAddress() throws InvalidProtocolBufferException {
-    return any.unpack(AssetIssueContract.class).getOwnerAddress();
+    return any.unpack(MarketCancelOrderContract.class).getOwnerAddress();
   }
 
   @Override

--- a/actuator/src/main/java/org/tron/core/actuator/MarketSellAssetActuator.java
+++ b/actuator/src/main/java/org/tron/core/actuator/MarketSellAssetActuator.java
@@ -54,7 +54,6 @@ import org.tron.protos.Protocol.MarketOrderDetail;
 import org.tron.protos.Protocol.MarketPrice;
 import org.tron.protos.Protocol.Transaction.Contract.ContractType;
 import org.tron.protos.Protocol.Transaction.Result.code;
-import org.tron.protos.contract.AssetIssueContractOuterClass.AssetIssueContract;
 import org.tron.protos.contract.MarketContract.MarketSellAssetContract;
 
 @Slf4j(topic = "actuator")
@@ -283,7 +282,7 @@ public class MarketSellAssetActuator extends AbstractActuator {
 
   @Override
   public ByteString getOwnerAddress() throws InvalidProtocolBufferException {
-    return any.unpack(AssetIssueContract.class).getOwnerAddress();
+    return any.unpack(MarketSellAssetContract.class).getOwnerAddress();
   }
 
   @Override

--- a/actuator/src/main/java/org/tron/core/actuator/UpdateAssetActuator.java
+++ b/actuator/src/main/java/org/tron/core/actuator/UpdateAssetActuator.java
@@ -17,7 +17,6 @@ import org.tron.core.store.DynamicPropertiesStore;
 import org.tron.core.utils.TransactionUtil;
 import org.tron.protos.Protocol.Transaction.Contract.ContractType;
 import org.tron.protos.Protocol.Transaction.Result.code;
-import org.tron.protos.contract.AccountContract.AccountUpdateContract;
 import org.tron.protos.contract.AssetIssueContractOuterClass.UpdateAssetContract;
 
 @Slf4j(topic = "actuator")
@@ -171,7 +170,7 @@ public class UpdateAssetActuator extends AbstractActuator {
 
   @Override
   public ByteString getOwnerAddress() throws InvalidProtocolBufferException {
-    return any.unpack(AccountUpdateContract.class).getOwnerAddress();
+    return any.unpack(UpdateAssetContract.class).getOwnerAddress();
   }
 
   @Override

--- a/framework/src/test/java/org/tron/core/actuator/MarketCancelOrderActuatorTest.java
+++ b/framework/src/test/java/org/tron/core/actuator/MarketCancelOrderActuatorTest.java
@@ -2,6 +2,7 @@ package org.tron.core.actuator;
 
 import com.google.protobuf.Any;
 import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Assert;
@@ -758,5 +759,15 @@ public class MarketCancelOrderActuatorTest extends BaseTest {
         .getUnchecked(pairPriceKey);
     Assert.assertNull(orderIdListCapsule);
 
+  }
+
+  @Test
+  public void testGetOwnerAddress() throws InvalidProtocolBufferException {
+    MarketCancelOrderActuator actuator = new MarketCancelOrderActuator();
+    actuator.setChainBaseManager(dbManager.getChainBaseManager())
+        .setAny(getContract(OWNER_ADDRESS_FIRST, ByteString.copyFromUtf8("orderId")));
+
+    Assert.assertEquals(OWNER_ADDRESS_FIRST,
+        ByteArray.toHexString(actuator.getOwnerAddress().toByteArray()));
   }
 }

--- a/framework/src/test/java/org/tron/core/actuator/MarketSellAssetActuatorTest.java
+++ b/framework/src/test/java/org/tron/core/actuator/MarketSellAssetActuatorTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.fail;
 
 import com.google.protobuf.Any;
 import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.After;
@@ -1869,6 +1870,16 @@ public class MarketSellAssetActuatorTest extends BaseTest {
     } catch (Exception e) {
       Assert.assertTrue(false);
     }
+  }
+
+  @Test
+  public void testGetOwnerAddress() throws InvalidProtocolBufferException {
+    MarketSellAssetActuator actuator = new MarketSellAssetActuator();
+    actuator.setChainBaseManager(dbManager.getChainBaseManager())
+        .setAny(getContract(OWNER_ADDRESS_FIRST, "sellToken", 100L, "buyToken", 200L));
+
+    Assert.assertEquals(OWNER_ADDRESS_FIRST,
+        ByteArray.toHexString(actuator.getOwnerAddress().toByteArray()));
   }
 
 }

--- a/framework/src/test/java/org/tron/core/actuator/UpdateAssetActuatorTest.java
+++ b/framework/src/test/java/org/tron/core/actuator/UpdateAssetActuatorTest.java
@@ -4,6 +4,7 @@ import static junit.framework.TestCase.fail;
 
 import com.google.protobuf.Any;
 import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
 import java.util.Date;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Assert;
@@ -486,6 +487,16 @@ public class UpdateAssetActuatorTest extends BaseTest {
 
     actuatorTest.setNullDBManagerMsg("No account store or dynamic store!");
     actuatorTest.nullDBManger();
+  }
+
+  @Test
+  public void testGetOwnerAddress() throws InvalidProtocolBufferException {
+    UpdateAssetActuator actuator = new UpdateAssetActuator();
+    actuator.setChainBaseManager(dbManager.getChainBaseManager())
+        .setAny(getContract(OWNER_ADDRESS, DESCRIPTION, URL, 500L, 8000L));
+
+    Assert.assertEquals(OWNER_ADDRESS,
+        ByteArray.toHexString(actuator.getOwnerAddress().toByteArray()));
   }
 
 }


### PR DESCRIPTION
Fix incorrect protobuf types used in any.unpack() within getOwnerAddress() for three actuators:
- UpdateAssetActuator: AccountUpdateContract -> UpdateAssetContract
- MarketCancelOrderActuator: AssetIssueContract -> MarketCancelOrderContract
- MarketSellAssetActuator: AssetIssueContract -> MarketSellAssetContract

 close #6670

