### PR TITLE
fix(jsonrpc): correct TransactionResult.nonce per JSON-RPC spec

### DIFF
--- a/framework/src/main/java/org/tron/core/services/jsonrpc/types/TransactionResult.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/types/TransactionResult.java
@@ -98,7 +98,7 @@ public class TransactionResult {
     TransactionCapsule capsule = new TransactionCapsule(tx);
     byte[] txId = capsule.getTransactionId().getBytes();
     hash = ByteArray.toJsonHex(txId);
-    nonce = ByteArray.toJsonHex(new byte[8]); // no value
+    nonce = "0x0"; // no value, QUANTITY type per Ethereum JSON-RPC spec
     blockHash = ByteArray.toJsonHex(blockCapsule.getBlockId().getBytes());
     blockNumber = ByteArray.toJsonHex(blockCapsule.getNum());
     transactionIndex = ByteArray.toJsonHex(index);
@@ -133,7 +133,7 @@ public class TransactionResult {
     TransactionCapsule capsule = new TransactionCapsule(tx);
     byte[] txId = capsule.getTransactionId().getBytes();
     hash = ByteArray.toJsonHex(txId);
-    nonce = ByteArray.toJsonHex(new byte[8]); // no value
+    nonce = "0x0"; // no value, QUANTITY type per Ethereum JSON-RPC spec
     blockHash = "0x";
     blockNumber = "0x";
     transactionIndex = "0x";

--- a/framework/src/test/java/org/tron/core/services/jsonrpc/TransactionResultTest.java
+++ b/framework/src/test/java/org/tron/core/services/jsonrpc/TransactionResultTest.java
@@ -23,8 +23,16 @@ public class TransactionResultTest extends BaseTest {
   private static final String OWNER_ADDRESS = "41548794500882809695a8a687866e76d4271a1abc";
   private static final String CONTRACT_ADDRESS = "A0B4750E2CD76E19DCA331BF5D089B71C3C2798548";
 
+  // QUANTITY pattern from ethereum/execution-apis base-types schema (uint).
+  private static final String QUANTITY_PATTERN = "^0x(0|[1-9a-f][0-9a-f]*)$";
+
   static {
     Args.setParam(new String[] {"-d", dbPath()}, TestConstants.TEST_CONF);
+  }
+
+  private static void assertQuantity(String value) {
+    Assert.assertNotNull(value);
+    Assert.assertTrue("not a valid QUANTITY: " + value, value.matches(QUANTITY_PATTERN));
   }
 
   @Test
@@ -49,6 +57,8 @@ public class TransactionResultTest extends BaseTest {
         transactionResult.getHash());
     Assert.assertEquals(transactionResult.getGasPrice(), "0x1");
     Assert.assertEquals(transactionResult.getGas(), "0x64");
+    Assert.assertEquals("0x0", transactionResult.getNonce());
+    assertQuantity(transactionResult.getNonce());
   }
 
   @Test
@@ -65,7 +75,8 @@ public class TransactionResultTest extends BaseTest {
     Assert.assertEquals("0x5691531881bc44adbc722060d85fdf29265823db8e884b0d104fcfbba253cf11",
         transactionResult.getHash());
     Assert.assertEquals(transactionResult.getGasPrice(), "0x");
-    Assert.assertEquals(transactionResult.getNonce(), "0x0000000000000000");
+    Assert.assertEquals("0x0", transactionResult.getNonce());
+    assertQuantity(transactionResult.getNonce());
   }
 
 }


### PR DESCRIPTION
## What this PR does

Corrects the `nonce` field in `TransactionResult`, the response body shared by `eth_getTransactionByHash`, `eth_getTransactionByBlockHashAndIndex`, `eth_getTransactionByBlockNumberAndIndex`, and the full-tx mode of `eth_getBlockByHash` / `eth_getBlockByNumber`.

Closes #6547.

## Why

Per [`ethereum/execution-apis`](https://github.com/ethereum/execution-apis/tree/main/src/schemas):

- `TransactionInfo.nonce` is `uint` (QUANTITY), pattern `^0x(0|[1-9a-f][0-9a-f]*)$` - no leading zeros; zero is `0x0`.

java-tron's `TransactionResult` previously emitted `ByteArray.toJsonHex(new byte[8])` -> `"0x0000000000000000"` (16 hex chars), which violates the pattern.

## What changes

| Field | Path | Before | After |
|-------|------|--------|-------|
| `nonce` | both `TransactionResult` constructors | `0x0000000000000000` | `0x0` |

## Why `Block.nonce` is intentionally NOT changed

`Block.nonce` is `bytes8` per the spec (pattern `^0x[0-9a-f]{16}$`), so the existing `0x0000000000000000` is already compliant. Shortening it to `0x0` would break conformance with the bytes8 length requirement.

`BlockResult.nonce` is therefore left untouched and existing `JsonrpcServiceTest` assertions on it (`"0x0000000000000000"`) remain valid.

## Compatibility

This PR makes a minimal, surgical change: only the `nonce` literal value is modified. All other fields in `TransactionResult` retain their existing serialization, preserving byte-for-byte compatibility with current production responses.

The numeric semantics of `nonce` are unchanged (`Long.parseLong` of either value yields `0`); only the string representation tightens to the spec-compliant form.

## Tests

`TransactionResultTest` is updated to:

- Assert `nonce == "0x0"` in both test methods (covering both `TransactionResult` constructors).
- Validate `nonce` against the schema regex `^0x(0|[1-9a-f][0-9a-f]*)$` via a small `assertQuantity` helper, so any future regression that re-introduces a leading-zero form will fail the test.

## Pre-submit checklist

- [x] Single module (jsonrpc), single issue (#6547), 2 files changed
- [x] Code style follows Google Java Style
- [x] No debug code / temporary comments / stray TODOs
- [x] No unsafe numeric ops introduced
- [x] No log-level changes
- [x] No DB schema / consensus / config changes
- [x] No dependency upgrades
- [x] Comments explain WHY (the spec rationale), not WHAT