### PR TITLE
feat(vm): implement TIP-854 canonicalize sign-precompile calldata

### DIFF
--- a/actuator/src/main/java/org/tron/core/vm/PrecompiledContracts.java
+++ b/actuator/src/main/java/org/tron/core/vm/PrecompiledContracts.java
@@ -414,6 +414,14 @@ public class PrecompiledContracts {
     return Arrays.copyOfRange(data, offset, offset + len);
   }
 
+  private static boolean isValidAbiEncoding(byte[] data, int headerWords, int itemWords) {
+    if (data == null || data.length % WORD_SIZE != 0) {
+      return false;
+    }
+    int tail = data.length - headerWords * WORD_SIZE;
+    return tail >= 0 && tail % (itemWords * WORD_SIZE) == 0;
+  }
+
   public abstract static class PrecompiledContract {
 
     protected static final byte[] DATA_FALSE = new byte[WORD_SIZE];
@@ -938,6 +946,8 @@ public class PrecompiledContracts {
 
     private static final int ENGERYPERSIGN = 1500;
     private static final int MAX_SIZE = 5;
+    private static final int ABI_HEADER_WORDS = 5;
+    private static final int ABI_ITEM_WORDS = 5;
 
 
     @Override
@@ -949,6 +959,10 @@ public class PrecompiledContracts {
 
     @Override
     public Pair<Boolean, byte[]> execute(byte[] rawData) {
+      if (VMConfig.allowTvmOsaka()
+          && !isValidAbiEncoding(rawData, ABI_HEADER_WORDS, ABI_ITEM_WORDS)) {
+        return Pair.of(false, EMPTY_BYTE_ARRAY);
+      }
       DataWord[] words = DataWord.parseArray(rawData);
       byte[] address = words[0].toTronAddress();
       int permissionId = words[1].intValueSafe();
@@ -1021,6 +1035,8 @@ public class PrecompiledContracts {
     private static final String workersName = "validate-sign-contract";
     private static final int ENGERYPERSIGN = 1500;
     private static final int MAX_SIZE = 16;
+    private static final int ABI_HEADER_WORDS = 5;
+    private static final int ABI_ITEM_WORDS = 6;
 
     static {
       workers = ExecutorServiceManager.newFixedThreadPool(workersName,
@@ -1048,6 +1064,10 @@ public class PrecompiledContracts {
 
     private Pair<Boolean, byte[]> doExecute(byte[] data)
         throws InterruptedException, ExecutionException {
+      if (VMConfig.allowTvmOsaka()
+          && !isValidAbiEncoding(data, ABI_HEADER_WORDS, ABI_ITEM_WORDS)) {
+        return Pair.of(false, EMPTY_BYTE_ARRAY);
+      }
       DataWord[] words = DataWord.parseArray(data);
       byte[] hash = words[0].getData();
 

--- a/actuator/src/main/java/org/tron/core/vm/PrecompiledContracts.java
+++ b/actuator/src/main/java/org/tron/core/vm/PrecompiledContracts.java
@@ -3,6 +3,8 @@ package org.tron.core.vm;
 import static java.util.Arrays.copyOfRange;
 import static org.tron.common.math.Maths.max;
 import static org.tron.common.math.Maths.min;
+import static org.tron.common.math.StrictMathWrapper.multiplyExact;
+import static org.tron.common.math.StrictMathWrapper.subtractExact;
 import static org.tron.common.runtime.vm.DataWord.WORD_SIZE;
 import static org.tron.common.utils.BIUtil.addSafely;
 import static org.tron.common.utils.BIUtil.isLessThan;
@@ -418,8 +420,8 @@ public class PrecompiledContracts {
     if (data == null || data.length % WORD_SIZE != 0) {
       return false;
     }
-    int tail = data.length - headerWords * WORD_SIZE;
-    return tail >= 0 && tail % (itemWords * WORD_SIZE) == 0;
+    long tail = subtractExact(data.length, multiplyExact(headerWords, WORD_SIZE));
+    return tail > 0 && tail % multiplyExact(itemWords, WORD_SIZE) == 0;
   }
 
   public abstract static class PrecompiledContract {

--- a/framework/src/test/java/org/tron/common/runtime/vm/BatchValidateSignContractTest.java
+++ b/framework/src/test/java/org/tron/common/runtime/vm/BatchValidateSignContractTest.java
@@ -10,6 +10,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.tron.common.crypto.ECKey;
 import org.tron.common.crypto.Hash;
+import org.tron.common.utils.ByteUtil;
 import org.tron.common.utils.StringUtil;
 import org.tron.common.utils.client.utils.AbiUtil;
 import org.tron.core.db.TransactionTrace;
@@ -128,6 +129,87 @@ public class BatchValidateSignContractTest {
     ret = validateMultiSign(hash, incorrectSigns, addresses);
     Assert.assertArrayEquals(ret.getValue(), DataWord.ZERO().getData());
     System.gc(); // force triggering full gc to avoid timeout for next test
+  }
+
+  // TIP-854: after activation, batchValidateSign (H=5, I=6) must reject calldata
+  // whose byte length is incompatible with the (words - 5) / 6 shape the per-call
+  // energy formula already assumes, returning (false, empty). The guard lives in
+  // doExecute(); the outer try/catch does not mask it because the guard does not
+  // throw (pure arithmetic + a static getter).
+  @Test
+  public void testTip854RejectsMalformedCalldata() {
+    contract.setVmShouldEndInUs(System.nanoTime() / 1000 + 2_000_000);
+    VMConfig.initAllowTvmOsaka(1);
+    try {
+      // Bucket 1: 32-aligned head + sub-word trailing bytes (r=1, r=31).
+      for (int r : new int[]{1, 31}) {
+        byte[] data = new byte[(5 + 6) * 32 + r];
+        Pair<Boolean, byte[]> ret = contract.execute(data);
+        Assert.assertFalse("non-32-aligned len=" + data.length, ret.getLeft());
+        Assert.assertSame(ByteUtil.EMPTY_BYTE_ARRAY, ret.getRight());
+      }
+      // Bucket 2: fewer than the static head's 5 words.
+      for (int bytes : new int[]{0, 32, 64, 96, 128}) {
+        Pair<Boolean, byte[]> ret = contract.execute(new byte[bytes]);
+        Assert.assertFalse("len=" + bytes + " < 5 words", ret.getLeft());
+        Assert.assertSame(ByteUtil.EMPTY_BYTE_ARRAY, ret.getRight());
+      }
+      // Bucket 3: 32-aligned but tail not a multiple of I=6 words (k = 1..5).
+      for (int k = 1; k <= 5; k++) {
+        byte[] data = new byte[(5 + k) * 32];
+        Pair<Boolean, byte[]> ret = contract.execute(data);
+        Assert.assertFalse("aligned bad-tail k=" + k, ret.getLeft());
+        Assert.assertSame(ByteUtil.EMPTY_BYTE_ARRAY, ret.getRight());
+      }
+      // Null calldata: explicit spec clause.
+      Pair<Boolean, byte[]> ret = contract.execute(null);
+      Assert.assertFalse("null calldata", ret.getLeft());
+      Assert.assertSame(ByteUtil.EMPTY_BYTE_ARRAY, ret.getRight());
+    } finally {
+      VMConfig.initAllowTvmOsaka(0);
+    }
+    System.gc();
+  }
+
+  // TIP-854 Compatibility: for canonically-shaped calldata — all 65-byte real
+  // signatures so each bytes[i] encodes in exactly 4 words (1 length + 3 content)
+  // — total length equals 5*32 + 6*32*N, so pre- and post-activation must be
+  // observationally identical.
+  @Test
+  public void testTip854CanonicalInputUnchanged() {
+    contract.setConstantCall(true);
+    List<Object> signatures = new ArrayList<>();
+    List<Object> addresses = new ArrayList<>();
+    byte[] hash = Hash.sha3(longData);
+    for (int i = 0; i < 8; i++) {
+      ECKey key = new ECKey();
+      signatures.add(Hex.toHexString(key.sign(hash).toByteArray()));
+      addresses.add(StringUtil.encode58Check(key.getAddress()));
+    }
+
+    VMConfig.initAllowTvmOsaka(0);
+    Pair<Boolean, byte[]> pre = validateMultiSign(hash, signatures, addresses);
+    VMConfig.initAllowTvmOsaka(1);
+    try {
+      Pair<Boolean, byte[]> post = validateMultiSign(hash, signatures, addresses);
+      Assert.assertEquals(pre.getLeft(), post.getLeft());
+      Assert.assertArrayEquals(pre.getValue(), post.getValue());
+    } finally {
+      VMConfig.initAllowTvmOsaka(0);
+    }
+    System.gc();
+  }
+
+  // TIP-854: before activation the guard is not consulted. Malformed calldata
+  // that would raise inside doExecute gets collapsed to (true, 32-byte zero) by
+  // the outer catch — this is the legacy behaviour and must be preserved.
+  @Test
+  public void testTip854PreActivationNoOp() {
+    VMConfig.initAllowTvmOsaka(0);
+    contract.setVmShouldEndInUs(System.nanoTime() / 1000 + 2_000_000);
+    Pair<Boolean, byte[]> ret = contract.execute(new byte[(5 + 1) * 32]);
+    Assert.assertTrue("pre-activation must not take the new reject path", ret.getLeft());
+    Assert.assertEquals(32, ret.getRight().length);
   }
 
   Pair<Boolean, byte[]> validateMultiSign(byte[] hash, List<Object> signatures,

--- a/framework/src/test/java/org/tron/common/runtime/vm/OperationsTest.java
+++ b/framework/src/test/java/org/tron/common/runtime/vm/OperationsTest.java
@@ -786,6 +786,49 @@ public class OperationsTest extends BaseTest {
     VMConfig.initAllowTvmSelfdestructRestriction(0);
   }
 
+  // TIP-854 outer-frame containment: a CALL to validateMultiSign or
+  // batchValidateSign with malformed calldata must (a) push 0 onto the outer
+  // stack, (b) leave the outer frame free of any propagated exception, and
+  // (c) allow the outer frame to continue executing afterwards.
+  @Test
+  public void testTip854OuterFrameContainment() throws ContractValidateException {
+    byte prePrefixByte = DecodeUtil.addressPreFixByte;
+    DecodeUtil.addressPreFixByte = Constant.ADD_PRE_FIX_BYTE_MAINNET;
+    VMConfig.initAllowTvmOsaka(1);
+    try {
+      for (PrecompiledContracts.PrecompiledContract contract :
+          new PrecompiledContracts.PrecompiledContract[]{
+              new PrecompiledContracts.ValidateMultiSign(),
+              new PrecompiledContracts.BatchValidateSign()}) {
+        invoke = new ProgramInvokeMockImpl();
+        InternalTransaction interTrx = new InternalTransaction(
+            Protocol.Transaction.getDefaultInstance(),
+            InternalTransaction.TrxType.TRX_UNKNOWN_TYPE);
+        program = new Program(new byte[0], new byte[0], invoke, interTrx);
+        // inDataSize=0 ⇒ data=[] ⇒ fewer than H=5 head words ⇒ guard rejects.
+        MessageCall messageCall = new MessageCall(
+            Op.CALL, new DataWord(10000),
+            DataWord.ZERO(), DataWord.ZERO(),
+            DataWord.ZERO(), DataWord.ZERO(),
+            DataWord.ZERO(), DataWord.ZERO(),
+            DataWord.ZERO(), false);
+        program.callToPrecompiledAddress(messageCall, contract);
+
+        Assert.assertNull(contract.getClass().getSimpleName()
+                + ": outer frame must not inherit an exception",
+            program.getResult().getException());
+        Assert.assertEquals(contract.getClass().getSimpleName() + ": inner CALL pushes 0",
+            DataWord.ZERO(), program.getStack().pop());
+        // Outer frame continues: another stack op works without throwing.
+        program.stackPush(new DataWord(1));
+        Assert.assertEquals(new DataWord(1), program.getStack().pop());
+      }
+    } finally {
+      VMConfig.initAllowTvmOsaka(0);
+      DecodeUtil.addressPreFixByte = prePrefixByte;
+    }
+  }
+
   @Test
   public void testOtherOperations() throws ContractValidateException {
     invoke = new ProgramInvokeMockImpl();

--- a/framework/src/test/java/org/tron/common/runtime/vm/ValidateMultiSignContractTest.java
+++ b/framework/src/test/java/org/tron/common/runtime/vm/ValidateMultiSignContractTest.java
@@ -155,6 +155,110 @@ public class ValidateMultiSignContractTest extends BaseTest {
   }
 
 
+  // TIP-854: after activation, validateMultiSign (H=5, I=5) must reject calldata
+  // whose byte length is incompatible with the (words - 5) / 5 shape the per-call
+  // energy formula already assumes, returning (false, empty).
+  @Test
+  public void testTip854RejectsMalformedCalldata() {
+    VMConfig.initAllowTvmOsaka(1);
+    try {
+      // Bucket 1: 32-aligned head + sub-word trailing bytes (r=1, r=31).
+      for (int r : new int[]{1, 31}) {
+        byte[] data = new byte[(5 + 5) * 32 + r];
+        Pair<Boolean, byte[]> ret = contract.execute(data);
+        Assert.assertFalse("non-32-aligned len=" + data.length, ret.getLeft());
+        Assert.assertSame(ByteUtil.EMPTY_BYTE_ARRAY, ret.getRight());
+      }
+      // Bucket 2: fewer than the static head's 5 words.
+      for (int bytes : new int[]{0, 32, 64, 96, 128}) {
+        Pair<Boolean, byte[]> ret = contract.execute(new byte[bytes]);
+        Assert.assertFalse("len=" + bytes + " < 5 words", ret.getLeft());
+        Assert.assertSame(ByteUtil.EMPTY_BYTE_ARRAY, ret.getRight());
+      }
+      // Bucket 3: 32-aligned but tail not a multiple of I=5 words (k = 1..4).
+      for (int k = 1; k <= 4; k++) {
+        byte[] data = new byte[(5 + k) * 32];
+        Pair<Boolean, byte[]> ret = contract.execute(data);
+        Assert.assertFalse("aligned bad-tail k=" + k, ret.getLeft());
+        Assert.assertSame(ByteUtil.EMPTY_BYTE_ARRAY, ret.getRight());
+      }
+      // Null calldata: explicit spec clause.
+      Pair<Boolean, byte[]> ret = contract.execute(null);
+      Assert.assertFalse("null calldata", ret.getLeft());
+      Assert.assertSame(ByteUtil.EMPTY_BYTE_ARRAY, ret.getRight());
+    } finally {
+      VMConfig.initAllowTvmOsaka(0);
+    }
+  }
+
+  // TIP-854 Compatibility: for canonically-shaped calldata (real 65-byte sigs,
+  // total length == 5*32 + 5*32*N), behaviour must be identical pre- vs
+  // post-activation — the guard is a no-op for well-formed inputs.
+  @Test
+  public void testTip854CanonicalInputUnchanged() {
+    ECKey key = new ECKey();
+    AccountCapsule toAccount = new AccountCapsule(ByteString.copyFrom(key.getAddress()),
+        Protocol.AccountType.Normal,
+        System.currentTimeMillis(), true, dbManager.getDynamicPropertiesStore());
+    ECKey key1 = new ECKey();
+    ECKey key2 = new ECKey();
+    Protocol.Permission activePermission =
+        Protocol.Permission.newBuilder()
+            .setType(Protocol.Permission.PermissionType.Active)
+            .setId(2)
+            .setPermissionName("active")
+            .setThreshold(2)
+            .setOperations(ByteString.copyFrom(ByteArray
+                .fromHexString("0000000000000000000000000000000000000000000000000000000000000000")))
+            .addKeys(Protocol.Key.newBuilder().setAddress(ByteString.copyFrom(key1.getAddress()))
+                .setWeight(1).build())
+            .addKeys(Protocol.Key.newBuilder().setAddress(ByteString.copyFrom(key2.getAddress()))
+                .setWeight(1).build())
+            .build();
+    toAccount.updatePermissions(toAccount.getPermissionById(0), null,
+        Collections.singletonList(activePermission));
+    dbManager.getAccountStore().put(key.getAddress(), toAccount);
+
+    byte[] data = Sha256Hash.hash(CommonParameter.getInstance().isECKeyCryptoEngine(), longData);
+    byte[] merged = ByteUtil.merge(key.getAddress(), ByteArray.fromInt(2), data);
+    byte[] toSign = Sha256Hash.hash(CommonParameter.getInstance().isECKeyCryptoEngine(), merged);
+    List<Object> signs = new ArrayList<>();
+    signs.add(Hex.toHexString(key1.sign(toSign).toByteArray()));
+    signs.add(Hex.toHexString(key2.sign(toSign).toByteArray()));
+
+    VMConfig.initAllowTvmOsaka(0);
+    Pair<Boolean, byte[]> pre =
+        validateMultiSign(StringUtil.encode58Check(key.getAddress()), 2, data, signs);
+    VMConfig.initAllowTvmOsaka(1);
+    try {
+      Pair<Boolean, byte[]> post =
+          validateMultiSign(StringUtil.encode58Check(key.getAddress()), 2, data, signs);
+      Assert.assertEquals(pre.getLeft(), post.getLeft());
+      Assert.assertArrayEquals(pre.getValue(), post.getValue());
+      Assert.assertArrayEquals(DataWord.ONE().getData(), post.getValue());
+    } finally {
+      VMConfig.initAllowTvmOsaka(0);
+    }
+  }
+
+  // TIP-854: before activation, malformed calldata reaches the legacy decoder.
+  // Assert the guard is not taken — this precompile has no outer catch, so a
+  // too-short input raises inside the decoder; that is the documented
+  // pre-activation failure mode the TIP explicitly preserves.
+  @Test
+  public void testTip854PreActivationNoOp() {
+    VMConfig.initAllowTvmOsaka(0);
+    contract.setRepository(RepositoryImpl.createRoot(StoreFactory.getInstance()));
+    try {
+      Pair<Boolean, byte[]> ret = contract.execute(new byte[(5 + 1) * 32]);
+      // If the decoder happened to handle it without raising, we must not have
+      // taken the post-activation reject path (false, empty).
+      Assert.assertNotSame(ByteUtil.EMPTY_BYTE_ARRAY, ret.getRight());
+    } catch (RuntimeException expectedLegacyBehaviour) {
+      // Pre-activation: decoder may throw — this is the existing behaviour.
+    }
+  }
+
   Pair<Boolean, byte[]> validateMultiSign(String address, int permissionId, byte[] hash,
       List<Object> signatures) {
     List<Object> parameters = Arrays


### PR DESCRIPTION
**What does this PR do?**

Implements [TIP-854](https://github.com/tronprotocol/tips/issues/854) (Canonicalize calldata for signature-verification precompiles) for java-tron, gated behind the existing `ALLOW_TVM_OSAKA` hardfork.

- Adds a calldata-length guard at the top of `ValidateMultiSign.execute` and `BatchValidateSign.doExecute`. The guard rejects when, with `W = 32`, any of the following holds: `data == null`, `data.length % W != 0`, `data.length <= H*W`, or `(data.length - H*W) % (I*W) != 0`. `(H, I)` are the same constants the per-call energy formula `(words - H) / I` already bakes in: `(5, 5)` for `validateMultiSign`, `(5, 6)` for `batchValidateSign`. Header-only calldata, i.e. empty signature arrays, is intentionally rejected.
- On reject: `execute` returns `(false, empty)` without invoking the decoder and without performing any `ecrecover`. The invoking call frame — reachable through any of `CALL` / `CALLTOKEN` / `STATICCALL` / `DELEGATECALL` / `CALLCODE` — consumes its pre-allocated energy, the stack receives `0`, memory receives no return data, and the outer transaction continues with its remaining budget intact.
- For calldata satisfying the positive-tail total-length predicate (`length == H*W + I*W*N` for some `N >= 1`), the new rule is a no-op: execution proceeds into the existing decoder exactly as before. Pre-activation behaviour, including the per-call energy cost, is byte-for-byte unchanged.
- No new proposal / `committee.*` key / `CommonParameter` / `Args` plumbing — reuses the already-wired Osaka gate.

**Why are these changes required?**

The two precompiles charge energy under a fixed positive-tail total-length assumption — the pricing formula treats calldata as a static head followed by exactly `N` equally-sized tail slots — but the existing execute path does not enforce that same total-length predicate before decoding. The decoder follows whatever offsets calldata supplies and silently zero-pads any missing bytes through `Arrays.copyOfRange`. As a result, the set of byte lengths accepted by execution is a strict superset of the lengths pricing has been evaluated for: non-word-aligned trailing bytes are dropped, inputs shorter than or equal to the static head are zero-padded out or treated as empty arrays, and tails that don't decompose into an integer number of items still flow through. This makes the precompiles harder to reason about for wallets, SDKs, indexers, audits, and formal specifications. This PR closes that total-length gap by rejecting calldata whose byte length is outside the positive-tail predicate.

**This PR has been tested by:**
- [x] Unit Tests
  - `ValidateMultiSignContractTest`: rejects malformed calldata across four buckets (non-32-aligned tail, fewer than `H` words, header-only empty-array calldata, aligned-but-bad-tail) plus `null`; positive-tail total-length input behaviour identical pre- vs post-activation; pre-activation does not take the new reject path.
  - `BatchValidateSignContractTest`: same four shapes, parameterised for `(H, I) = (5, 6)`; the positive-tail case uses real 65-byte signatures so each `bytes` element encodes in exactly four words.
  - `OperationsTest.testTip854OuterFrameContainment`: drives both precompiles through `Program.callToPrecompiledAddress` with malformed calldata under `Op.CALL` and asserts (a) no exception propagates to the outer frame, (b) the inner CALL pushes `0`, (c) no return data is exposed or copied to output memory, (d) the pre-allocated call energy is consumed, and (e) the outer frame keeps executing afterwards.
- [x] Manual Testing
  - `./gradlew :actuator:compileJava :framework:compileTestJava` — OK.
  - `./gradlew :framework:test --tests "*ValidateMultiSignContractTest" --tests "*BatchValidateSignContractTest" --tests "*OperationsTest.testTip854*"` — all pass.

**Follow up**

- Validation of inner dynamic offsets, array lengths, per-element offsets, and any further decoder hardening (`abi.encode` conformance) is intentionally out of scope per the TIP and can be addressed in a follow-up if desired.
