### PR TITLE
feat(vm): add node-level vm.constantCallTimeoutMs for constant calls

### DIFF
--- a/actuator/src/main/java/org/tron/core/actuator/VMActuator.java
+++ b/actuator/src/main/java/org/tron/core/actuator/VMActuator.java
@@ -398,13 +398,9 @@ public class VMActuator implements Actuator2 {
       byte[] ops = newSmartContract.getBytecode().toByteArray();
       rootInternalTx = new InternalTransaction(trx, trxType);
 
-      long maxCpuTimeOfOneTx = rootRepository.getDynamicPropertiesStore()
-          .getMaxCpuTimeOfOneTx() * VMConstant.ONE_THOUSAND;
-      long thisTxCPULimitInUs = (long) (maxCpuTimeOfOneTx * getCpuLimitInUsRatio());
-      long constantCallTimeoutMs = CommonParameter.getInstance().getConstantCallTimeoutMs();
-      if (isConstantCall && constantCallTimeoutMs > 0L) {
-        thisTxCPULimitInUs = constantCallTimeoutMs * VMConstant.ONE_THOUSAND;
-      }
+      long thisTxCPULimitInUs = calculateCpuLimitInUs(isConstantCall,
+          rootRepository.getDynamicPropertiesStore().getMaxCpuTimeOfOneTx(),
+          getCpuLimitInUsRatio(), CommonParameter.getInstance().getConstantCallTimeoutMs());
       long vmStartInUs = System.nanoTime() / VMConstant.ONE_THOUSAND;
       long vmShouldEndInUs = vmStartInUs + thisTxCPULimitInUs;
       ProgramInvoke programInvoke = ProgramInvokeFactory
@@ -516,13 +512,9 @@ public class VMActuator implements Actuator2 {
         energyLimit = getTotalEnergyLimit(creator, caller, contract, feeLimit, callValue);
       }
 
-      long maxCpuTimeOfOneTx = rootRepository.getDynamicPropertiesStore()
-          .getMaxCpuTimeOfOneTx() * VMConstant.ONE_THOUSAND;
-      long thisTxCPULimitInUs = (long) (maxCpuTimeOfOneTx * getCpuLimitInUsRatio());
-      long constantCallTimeoutMs = CommonParameter.getInstance().getConstantCallTimeoutMs();
-      if (isConstantCall && constantCallTimeoutMs > 0L) {
-        thisTxCPULimitInUs = constantCallTimeoutMs * VMConstant.ONE_THOUSAND;
-      }
+      long thisTxCPULimitInUs = calculateCpuLimitInUs(isConstantCall,
+          rootRepository.getDynamicPropertiesStore().getMaxCpuTimeOfOneTx(),
+          getCpuLimitInUsRatio(), CommonParameter.getInstance().getConstantCallTimeoutMs());
       long vmStartInUs = System.nanoTime() / VMConstant.ONE_THOUSAND;
       long vmShouldEndInUs = vmStartInUs + thisTxCPULimitInUs;
       ProgramInvoke programInvoke = ProgramInvokeFactory
@@ -697,6 +689,14 @@ public class VMActuator implements Actuator2 {
     }
 
     return cpuLimitRatio;
+  }
+
+  static long calculateCpuLimitInUs(boolean isConstantCall, long maxCpuTimeOfOneTxMs,
+      double cpuLimitInUsRatio, long constantCallTimeoutMs) {
+    if (isConstantCall && constantCallTimeoutMs > 0L) {
+      return constantCallTimeoutMs * VMConstant.ONE_THOUSAND;
+    }
+    return (long) (maxCpuTimeOfOneTxMs * VMConstant.ONE_THOUSAND * cpuLimitInUsRatio);
   }
 
   public long getTotalEnergyLimitWithFixRatio(AccountCapsule creator, AccountCapsule caller,

--- a/actuator/src/main/java/org/tron/core/actuator/VMActuator.java
+++ b/actuator/src/main/java/org/tron/core/actuator/VMActuator.java
@@ -401,6 +401,10 @@ public class VMActuator implements Actuator2 {
       long maxCpuTimeOfOneTx = rootRepository.getDynamicPropertiesStore()
           .getMaxCpuTimeOfOneTx() * VMConstant.ONE_THOUSAND;
       long thisTxCPULimitInUs = (long) (maxCpuTimeOfOneTx * getCpuLimitInUsRatio());
+      long constantCallTimeoutMs = CommonParameter.getInstance().getConstantCallTimeoutMs();
+      if (isConstantCall && constantCallTimeoutMs > 0L) {
+        thisTxCPULimitInUs = constantCallTimeoutMs * VMConstant.ONE_THOUSAND;
+      }
       long vmStartInUs = System.nanoTime() / VMConstant.ONE_THOUSAND;
       long vmShouldEndInUs = vmStartInUs + thisTxCPULimitInUs;
       ProgramInvoke programInvoke = ProgramInvokeFactory
@@ -514,8 +518,11 @@ public class VMActuator implements Actuator2 {
 
       long maxCpuTimeOfOneTx = rootRepository.getDynamicPropertiesStore()
           .getMaxCpuTimeOfOneTx() * VMConstant.ONE_THOUSAND;
-      long thisTxCPULimitInUs =
-          (long) (maxCpuTimeOfOneTx * getCpuLimitInUsRatio());
+      long thisTxCPULimitInUs = (long) (maxCpuTimeOfOneTx * getCpuLimitInUsRatio());
+      long constantCallTimeoutMs = CommonParameter.getInstance().getConstantCallTimeoutMs();
+      if (isConstantCall && constantCallTimeoutMs > 0L) {
+        thisTxCPULimitInUs = constantCallTimeoutMs * VMConstant.ONE_THOUSAND;
+      }
       long vmStartInUs = System.nanoTime() / VMConstant.ONE_THOUSAND;
       long vmShouldEndInUs = vmStartInUs + thisTxCPULimitInUs;
       ProgramInvoke programInvoke = ProgramInvokeFactory

--- a/actuator/src/test/java/org/tron/core/actuator/VMActuatorTest.java
+++ b/actuator/src/test/java/org/tron/core/actuator/VMActuatorTest.java
@@ -1,0 +1,23 @@
+package org.tron.core.actuator;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class VMActuatorTest {
+
+  @Test
+  public void testConstantCallUsesConfiguredTimeoutVerbatim() {
+    assertEquals(123_000L, VMActuator.calculateCpuLimitInUs(true, 80L, 5.0, 123L));
+  }
+
+  @Test
+  public void testConstantCallWithoutConfiguredTimeoutUsesNetworkDeadline() {
+    assertEquals(400_000L, VMActuator.calculateCpuLimitInUs(true, 80L, 5.0, 0L));
+  }
+
+  @Test
+  public void testNonConstantCallIgnoresConfiguredTimeout() {
+    assertEquals(400_000L, VMActuator.calculateCpuLimitInUs(false, 80L, 5.0, 123L));
+  }
+}

--- a/common/src/main/java/org/tron/common/parameter/CommonParameter.java
+++ b/common/src/main/java/org/tron/common/parameter/CommonParameter.java
@@ -64,8 +64,8 @@ public class CommonParameter {
    * functions, estimateenergy, eth_call, eth_estimateGas, and any other
    * RPC routed through Wallet#callConstantContract. 0 = use the same
    * deadline as block processing (current behaviour). When operators set
-   * this in config the value must be positive; validated at config-load
-   * in VmConfig.
+   * this in config the value must be positive and fit VM deadline conversion;
+   * validated at config-load in VmConfig.
    */
   @Getter
   @Setter

--- a/common/src/main/java/org/tron/common/parameter/CommonParameter.java
+++ b/common/src/main/java/org/tron/common/parameter/CommonParameter.java
@@ -58,6 +58,18 @@ public class CommonParameter {
   @Getter
   @Setter
   public double maxTimeRatio = calcMaxTimeRatio();
+  /**
+   * Max TVM execution time (ms) for constant calls — covers
+   * triggerconstantcontract, triggersmartcontract dispatched to view/pure
+   * functions, estimateenergy, eth_call, eth_estimateGas, and any other
+   * RPC routed through Wallet#callConstantContract. 0 = use the same
+   * deadline as block processing (current behaviour). When operators set
+   * this in config the value must be positive; validated at config-load
+   * in VmConfig.
+   */
+  @Getter
+  @Setter
+  public long constantCallTimeoutMs = 0L;
   @Getter
   @Setter
   public boolean saveInternalTx;

--- a/common/src/main/java/org/tron/core/config/args/VmConfig.java
+++ b/common/src/main/java/org/tron/core/config/args/VmConfig.java
@@ -2,6 +2,7 @@ package org.tron.core.config.args;
 
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigBeanFactory;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -15,6 +16,8 @@ import lombok.extern.slf4j.Slf4j;
 @Setter
 public class VmConfig {
 
+  private static final String CONSTANT_CALL_TIMEOUT_MS_KEY = "constantCallTimeoutMs";
+
   private boolean supportConstant = false;
   private long maxEnergyLimitForConstant = 100_000_000L;
   private int lruCacheSize = 500;
@@ -27,6 +30,11 @@ public class VmConfig {
   private boolean saveInternalTx = false;
   private boolean saveFeaturedInternalTx = false;
   private boolean saveCancelAllUnfreezeV2Details = false;
+  // Excluded from ConfigBeanFactory binding (no setter): the property is
+  // intentionally absent from reference.conf so {@code Config#hasPath} alone
+  // signals operator opt-in. Bound manually in {@link #fromConfig}.
+  @Setter(AccessLevel.NONE)
+  private long constantCallTimeoutMs = 0L;
 
   /**
    * Create VmConfig from the "vm" section of the application config.
@@ -36,11 +44,11 @@ public class VmConfig {
   public static VmConfig fromConfig(Config config) {
     Config vmSection = config.getConfig("vm");
     VmConfig vmConfig = ConfigBeanFactory.create(vmSection, VmConfig.class);
-    vmConfig.postProcess();
+    vmConfig.postProcess(vmSection);
     return vmConfig;
   }
 
-  private void postProcess() {
+  private void postProcess(Config vmSection) {
     // clamp maxEnergyLimitForConstant
     if (maxEnergyLimitForConstant < 3_000_000L) {
       maxEnergyLimitForConstant = 3_000_000L;
@@ -59,6 +67,18 @@ public class VmConfig {
         && (!saveInternalTx || !saveFeaturedInternalTx)) {
       logger.warn("Configuring [vm.saveCancelAllUnfreezeV2Details] won't work as "
           + "vm.saveInternalTx or vm.saveFeaturedInternalTx is off.");
+    }
+
+    // constantCallTimeoutMs is excluded from ConfigBeanFactory binding (no
+    // setter) and intentionally absent from reference.conf, so hasPath alone
+    // tells us whether the operator opted in. Only positive values are valid.
+    if (vmSection.hasPath(CONSTANT_CALL_TIMEOUT_MS_KEY)) {
+      long value = vmSection.getLong(CONSTANT_CALL_TIMEOUT_MS_KEY);
+      if (value <= 0L) {
+        throw new IllegalArgumentException(
+            "vm.constantCallTimeoutMs must be > 0 when configured, got " + value);
+      }
+      constantCallTimeoutMs = value;
     }
   }
 }

--- a/common/src/main/java/org/tron/core/config/args/VmConfig.java
+++ b/common/src/main/java/org/tron/core/config/args/VmConfig.java
@@ -9,7 +9,8 @@ import lombok.extern.slf4j.Slf4j;
 
 /**
  * VM configuration bean. Field names match config.conf keys under the "vm" section.
- * Bound automatically via ConfigBeanFactory — no manual key constants needed.
+ * Most fields are bound automatically via ConfigBeanFactory; opt-in fields that
+ * must stay absent from reference.conf are bound manually after hasPath checks.
  */
 @Slf4j
 @Getter
@@ -17,6 +18,7 @@ import lombok.extern.slf4j.Slf4j;
 public class VmConfig {
 
   private static final String CONSTANT_CALL_TIMEOUT_MS_KEY = "constantCallTimeoutMs";
+  static final long MAX_CONSTANT_CALL_TIMEOUT_MS = Long.MAX_VALUE / 1_000L;
 
   private boolean supportConstant = false;
   private long maxEnergyLimitForConstant = 100_000_000L;
@@ -71,12 +73,18 @@ public class VmConfig {
 
     // constantCallTimeoutMs is excluded from ConfigBeanFactory binding (no
     // setter) and intentionally absent from reference.conf, so hasPath alone
-    // tells us whether the operator opted in. Only positive values are valid.
+    // tells us whether the operator opted in. Only positive values that can be
+    // safely converted to microseconds are valid.
     if (vmSection.hasPath(CONSTANT_CALL_TIMEOUT_MS_KEY)) {
       long value = vmSection.getLong(CONSTANT_CALL_TIMEOUT_MS_KEY);
       if (value <= 0L) {
         throw new IllegalArgumentException(
             "vm.constantCallTimeoutMs must be > 0 when configured, got " + value);
+      }
+      if (value > MAX_CONSTANT_CALL_TIMEOUT_MS) {
+        throw new IllegalArgumentException(
+            "vm.constantCallTimeoutMs must be <= " + MAX_CONSTANT_CALL_TIMEOUT_MS
+                + " to fit VM deadline conversion, got " + value);
       }
       constantCallTimeoutMs = value;
     }

--- a/common/src/test/java/org/tron/core/config/args/VmConfigTest.java
+++ b/common/src/test/java/org/tron/core/config/args/VmConfigTest.java
@@ -88,4 +88,55 @@ public class VmConfigTest {
     assertEquals(3, VmConfig.fromConfig(
         withRef("vm { estimateEnergyMaxRetry = 3 }")).getEstimateEnergyMaxRetry());
   }
+
+  // ===========================================================================
+  // Constant-call timeout (issue #6681). The validation rule: any positive
+  // value is accepted, but zero/negative is rejected ONLY when the operator
+  // explicitly set the property in their config. Absence keeps the in-Java
+  // default (0L = "share the block-processing deadline").
+  // ===========================================================================
+
+  @Test
+  public void testConstantCallTimeoutDefaultWhenAbsent() {
+    // No path in the config, no entry in reference.conf -> default 0L kept,
+    // no validation triggered.
+    VmConfig vm = VmConfig.fromConfig(withRef());
+    assertEquals(0L, vm.getConstantCallTimeoutMs());
+  }
+
+  @Test
+  public void testConstantCallTimeoutAcceptsAnyPositiveValue() {
+    assertEquals(1L, VmConfig.fromConfig(
+        withRef("vm { constantCallTimeoutMs = 1 }")).getConstantCallTimeoutMs());
+    assertEquals(50L, VmConfig.fromConfig(
+        withRef("vm { constantCallTimeoutMs = 50 }")).getConstantCallTimeoutMs());
+    assertEquals(500L, VmConfig.fromConfig(
+        withRef("vm { constantCallTimeoutMs = 500 }")).getConstantCallTimeoutMs());
+    assertEquals(5_000L, VmConfig.fromConfig(
+        withRef("vm { constantCallTimeoutMs = 5000 }")).getConstantCallTimeoutMs());
+  }
+
+  @Test
+  public void testConstantCallTimeoutZeroRejectedWhenExplicitlyConfigured() {
+    // Operator wrote `= 0` in config -> treated as a misconfiguration even
+    // though it equals the in-Java default. Forces an explicit positive value.
+    try {
+      VmConfig.fromConfig(withRef("vm { constantCallTimeoutMs = 0 }"));
+      org.junit.Assert.fail("expected IllegalArgumentException for explicit 0");
+    } catch (IllegalArgumentException ex) {
+      org.junit.Assert.assertTrue(ex.getMessage(),
+          ex.getMessage().contains("constantCallTimeoutMs"));
+    }
+  }
+
+  @Test
+  public void testConstantCallTimeoutNegativeRejected() {
+    try {
+      VmConfig.fromConfig(withRef("vm { constantCallTimeoutMs = -1 }"));
+      org.junit.Assert.fail("expected IllegalArgumentException for negative ms");
+    } catch (IllegalArgumentException ex) {
+      org.junit.Assert.assertTrue(ex.getMessage(),
+          ex.getMessage().contains("constantCallTimeoutMs"));
+    }
+  }
 }

--- a/common/src/test/java/org/tron/core/config/args/VmConfigTest.java
+++ b/common/src/test/java/org/tron/core/config/args/VmConfigTest.java
@@ -91,9 +91,10 @@ public class VmConfigTest {
 
   // ===========================================================================
   // Constant-call timeout (issue #6681). The validation rule: any positive
-  // value is accepted, but zero/negative is rejected ONLY when the operator
-  // explicitly set the property in their config. Absence keeps the in-Java
-  // default (0L = "share the block-processing deadline").
+  // value that fits VM deadline conversion is accepted, but zero/negative is
+  // rejected ONLY when the operator explicitly set the property in their
+  // config. Absence keeps the in-Java default (0L = "share the
+  // block-processing deadline").
   // ===========================================================================
 
   @Test
@@ -137,6 +138,18 @@ public class VmConfigTest {
     } catch (IllegalArgumentException ex) {
       org.junit.Assert.assertTrue(ex.getMessage(),
           ex.getMessage().contains("constantCallTimeoutMs"));
+    }
+  }
+
+  @Test
+  public void testConstantCallTimeoutOverflowRejected() {
+    long value = VmConfig.MAX_CONSTANT_CALL_TIMEOUT_MS + 1L;
+    try {
+      VmConfig.fromConfig(withRef("vm { constantCallTimeoutMs = " + value + " }"));
+      org.junit.Assert.fail("expected IllegalArgumentException for overflowing ms");
+    } catch (IllegalArgumentException ex) {
+      org.junit.Assert.assertTrue(ex.getMessage(),
+          ex.getMessage().contains("deadline conversion"));
     }
   }
 }

--- a/framework/src/main/java/org/tron/core/config/args/Args.java
+++ b/framework/src/main/java/org/tron/core/config/args/Args.java
@@ -212,6 +212,7 @@ public class Args extends CommonParameter {
     PARAMETER.saveInternalTx = vm.isSaveInternalTx();
     PARAMETER.saveFeaturedInternalTx = vm.isSaveFeaturedInternalTx();
     PARAMETER.saveCancelAllUnfreezeV2Details = vm.isSaveCancelAllUnfreezeV2Details();
+    PARAMETER.constantCallTimeoutMs = vm.getConstantCallTimeoutMs();
   }
 
   // Old applyStorageConfig removed — merged into applyStorageConfig()

--- a/framework/src/main/resources/config.conf
+++ b/framework/src/main/resources/config.conf
@@ -715,12 +715,12 @@ vm = {
   # triggerconstantcontract, triggersmartcontract dispatched to view/pure
   # functions, estimateenergy, eth_call, eth_estimateGas, and any other RPC
   # routed through the constant-call path. When set, must be a positive
-  # integer and is used verbatim as the per-call deadline (no clamp against
-  # the network's maxCpuTimeOfOneTx). Omit the property entirely to keep the
-  # default behaviour of sharing the block-processing deadline. Migration
-  # note: if previously running --debug to extend constant calls, switch to
-  # this option (--debug also extends block-processing, which is unsafe; see
-  # issue #6266).
+  # integer that fits VM deadline conversion and is used verbatim as the
+  # per-call deadline (no clamp against the network's maxCpuTimeOfOneTx).
+  # Omit the property entirely to keep the default behaviour of sharing the
+  # block-processing deadline. Migration note: if previously running --debug
+  # to extend constant calls, switch to this option (--debug also extends
+  # block-processing, which is unsafe; see issue #6266).
   # constantCallTimeoutMs = 100
 }
 

--- a/framework/src/main/resources/config.conf
+++ b/framework/src/main/resources/config.conf
@@ -710,6 +710,18 @@ vm = {
 
   # Indicates the max retry time for executing transaction in estimating energy. Default 3.
   # estimateEnergyMaxRetry = 3
+
+  # Max TVM execution time (ms) for constant calls — applies to
+  # triggerconstantcontract, triggersmartcontract dispatched to view/pure
+  # functions, estimateenergy, eth_call, eth_estimateGas, and any other RPC
+  # routed through the constant-call path. When set, must be a positive
+  # integer and is used verbatim as the per-call deadline (no clamp against
+  # the network's maxCpuTimeOfOneTx). Omit the property entirely to keep the
+  # default behaviour of sharing the block-processing deadline. Migration
+  # note: if previously running --debug to extend constant calls, switch to
+  # this option (--debug also extends block-processing, which is unsafe; see
+  # issue #6266).
+  # constantCallTimeoutMs = 100
 }
 
 # These parameters are designed for private chain testing only and cannot be freely switched on or off in production systems.


### PR DESCRIPTION
**What does this PR do?**

Adds a node-level config `vm.constantCallTimeoutMs` (any positive integer that fits VM deadline conversion; omit the property entirely to keep current behaviour) that extends the TVM execution-time window for the read-only RPC paths only — `triggerconstantcontract`, `triggersmartcontract` dispatched to view/pure functions, `estimateenergy`, `eth_call`, `eth_estimateGas`, and any other RPC routed through `Wallet.callConstantContract`. The block-processing deadline is unchanged.

When set, the configured value is used **verbatim** as the per-call deadline (no clamp against the network's `maxCpuTimeOfOneTx`, no `cpuLimitInUsRatio` scaling). When unset, constant calls fall back to the existing path that uses the network's `maxCpuTimeOfOneTx`.

Closes #6681.

**Why are these changes required?**

`triggerconstantcontract` / `eth_call` and the other constant-call RPCs are widely used for state queries and dry-runs but cap out at the same TVM deadline as block-processing (mainnet 80 ms). Operators currently have only `--debug` to extend this window, which **also** removes the block-processing timeout — unsafe for any node serving traffic, since it can desync from the network (#6266). This PR gives operators a scoped lever for the constant-call window without that side effect.

**Design**

- **Block-processing is structurally unaffected.** The new branch is gated by `isConstantCall` in `VMActuator.create()` / `call()`, so it is unreachable from block validation — guaranteed by structure, not by convention.
- **Verbatim semantics.** When the operator sets a value, it is used as the deadline as-is. No `max(configured, networkMs)` clamp, no `cpuLimitInUsRatio` scaling. Operators get exactly the budget they configured.
- **Opt-in detected by `Config#hasPath`.** `vm.constantCallTimeoutMs` is intentionally absent from `reference.conf`, and the `VmConfig` field is excluded from `ConfigBeanFactory` auto-binding (`@Setter(AccessLevel.NONE)`) so the strict schema check doesn't require the path. `vmSection.hasPath(...)` then becomes a precise signal of "operator wrote this in `config.conf`". Same pattern as `BlockConfig` rejecting the legacy `committee.proposalExpireTime` location.
- **Validation only on opt-in.** When the operator configures the value, it must be `> 0` and fit VM deadline conversion (`<= Long.MAX_VALUE / 1000` ms); explicit `0`, negative, and overflowing values are rejected at config-load with `IllegalArgumentException`. Nodes that don't configure the property keep the existing default behaviour — no validation, no behaviour change.
- **Sub-frames inherit the deadline.** Cross-contract simulation uses the existing `Program` plumbing (`getVmShouldEndInUs()` propagated to internal `ProgramInvoke` instances), so the override applies to deep call trees — the headline use case.

**This PR has been tested by:**
- Unit Tests
  - `VmConfigTest`: default `0L` when absent; positive values accepted (`1`, `50`, `500`, `5000`); explicit `= 0`, negative values, and overflowing values rejected.
  - `VMActuatorTest`: configured constant-call timeout is used verbatim; unset constant calls fall back to the network-derived deadline; non-constant/block-processing paths ignore the override.
  - Existing `VMActuator` and `Wallet` callers' tests remain green.

**Migration from `--debug`**

Operators currently running with `--debug` **purely** to extend the constant-call window should switch to `vm.constantCallTimeoutMs=<ms>` once this lands. `--debug` additionally extends the block-processing timeout, which is unsafe for any node serving traffic (see #6266). The config reference includes this migration note; release notes should carry the same pointer.

