### PR TITLE
fix(jsonrpc): accept "input" as alias for "data" in call args

### DIFF
--- a/framework/src/main/java/org/tron/core/services/jsonrpc/JsonRpcApiUtil.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/JsonRpcApiUtil.java
@@ -442,6 +442,50 @@ public class JsonRpcApiUtil {
     return StringUtils.isEmpty(quantity) || quantity.equals("0x0");
   }
 
+  /**
+   * Validation mode for {@link #requireValidHex}.
+   */
+  public enum HexMode {
+    /**
+     * Execution-apis BYTES schema: requires {@code 0x} prefix and
+     * even total length; {@code ""} is accepted as empty bytes per
+     * geth's {@code hexutil.Bytes.UnmarshalText}.
+     */
+    STRICT,
+    /**
+     * {@link ByteArray#fromHexString}'s lenient parsing: accepts bare
+     * hex and odd-length input. Kept for backward compatibility.
+     */
+    LENIENT
+  }
+
+  /**
+   * Throws if {@code value} is not parseable hex under the given
+   * {@code mode}. {@code null} is treated as absent and returns
+   * silently. {@code fieldName} is used only in error messages.
+   */
+  public static void requireValidHex(String fieldName, String value, HexMode mode)
+      throws JsonRpcInvalidParamsException {
+    if (value == null) {
+      return;
+    }
+    if (mode == HexMode.STRICT) {
+      if (value.isEmpty()) {
+        return;
+      }
+      if (!value.startsWith("0x") || value.length() % 2 != 0) {
+        throw new JsonRpcInvalidParamsException(
+            "invalid hex string for \"" + fieldName + "\"");
+      }
+    }
+    try {
+      ByteArray.fromHexString(value);
+    } catch (Exception e) {
+      throw new JsonRpcInvalidParamsException(
+          "invalid hex string for \"" + fieldName + "\"");
+    }
+  }
+
   public static long parseQuantityValue(String value) throws JsonRpcInvalidParamsException {
     long callValue = 0L;
 

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/TronJsonRpcImpl.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/TronJsonRpcImpl.java
@@ -645,7 +645,7 @@ public class TronJsonRpcImpl implements TronJsonRpc, Closeable {
         estimateEnergy(ownerAddress,
             contractAddress,
             args.parseValue(),
-            ByteArray.fromHexString(args.getData()),
+            ByteArray.fromHexString(args.resolveData()),
             trxExtBuilder,
             retBuilder,
             estimateBuilder);
@@ -653,7 +653,7 @@ public class TronJsonRpcImpl implements TronJsonRpc, Closeable {
         callTriggerConstantContract(ownerAddress,
             contractAddress,
             args.parseValue(),
-            ByteArray.fromHexString(args.getData()),
+            ByteArray.fromHexString(args.resolveData()),
             trxExtBuilder,
             retBuilder);
       }
@@ -1007,7 +1007,7 @@ public class TronJsonRpcImpl implements TronJsonRpc, Closeable {
     byte[] contractAddressData = addressCompatibleToByteArray(transactionCall.getTo());
 
     return call(addressData, contractAddressData, transactionCall.parseValue(),
-        ByteArray.fromHexString(transactionCall.getData()));
+        ByteArray.fromHexString(transactionCall.resolveData()));
   }
 
   @Override
@@ -1114,7 +1114,8 @@ public class TronJsonRpcImpl implements TronJsonRpc, Closeable {
       smartBuilder.setOriginAddress(ByteString.copyFrom(ownerAddress));
 
       // bytecode + parameter
-      smartBuilder.setBytecode(ByteString.copyFrom(ByteArray.fromHexString(args.getData())));
+      smartBuilder.setBytecode(
+          ByteString.copyFrom(ByteArray.fromHexString(args.resolveData())));
 
       if (StringUtils.isNotEmpty(args.getName())) {
         smartBuilder.setName(args.getName());
@@ -1159,8 +1160,9 @@ public class TronJsonRpcImpl implements TronJsonRpc, Closeable {
       build.setOwnerAddress(ByteString.copyFrom(ownerAddress))
           .setContractAddress(ByteString.copyFrom(contractAddress));
 
-      if (StringUtils.isNotEmpty(args.getData())) {
-        build.setData(ByteString.copyFrom(ByteArray.fromHexString(args.getData())));
+      String callData = args.resolveData();
+      if (StringUtils.isNotEmpty(callData)) {
+        build.setData(ByteString.copyFrom(ByteArray.fromHexString(callData)));
       } else {
         build.setData(ByteString.copyFrom(new byte[0]));
       }

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/types/BuildArguments.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/types/BuildArguments.java
@@ -4,8 +4,10 @@ import static org.tron.core.services.jsonrpc.JsonRpcApiUtil.addressCompatibleToB
 import static org.tron.core.services.jsonrpc.JsonRpcApiUtil.paramQuantityIsNull;
 import static org.tron.core.services.jsonrpc.JsonRpcApiUtil.paramStringIsNull;
 import static org.tron.core.services.jsonrpc.JsonRpcApiUtil.parseQuantityValue;
+import static org.tron.core.services.jsonrpc.JsonRpcApiUtil.requireValidHex;
 
 import com.google.protobuf.ByteString;
+import java.util.Arrays;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,9 +15,11 @@ import lombok.Setter;
 import lombok.ToString;
 import org.apache.commons.lang3.StringUtils;
 import org.tron.api.GrpcAPI.BytesMessage;
+import org.tron.common.utils.ByteArray;
 import org.tron.core.Wallet;
 import org.tron.core.exception.jsonrpc.JsonRpcInvalidParamsException;
 import org.tron.core.exception.jsonrpc.JsonRpcInvalidRequestException;
+import org.tron.core.services.jsonrpc.JsonRpcApiUtil.HexMode;
 import org.tron.protos.Protocol.Transaction.Contract.ContractType;
 import org.tron.protos.contract.SmartContractOuterClass.SmartContract;
 
@@ -42,6 +46,9 @@ public class BuildArguments {
   @Getter
   @Setter
   private String data;
+  @Getter
+  @Setter
+  private String input;
   @Getter
   @Setter
   private String nonce = ""; //not used
@@ -83,16 +90,50 @@ public class BuildArguments {
     gasPrice = args.getGasPrice();
     value = args.getValue();
     data = args.getData();
+    input = args.getInput();
+  }
+
+  /**
+   * Returns {@code input} if non-null, else {@code data}. Pure
+   * precedence resolution, mirroring go-ethereum's
+   * {@code TransactionArgs.data()}.
+   *
+   * <p>Both fields are first validated by
+   * {@link org.tron.core.services.jsonrpc.JsonRpcApiUtil#requireValidHex}
+   * — strict for {@code input}, lenient for {@code data} (see that
+   * method for the rules).
+   *
+   * <p>Conflict between {@code input} and {@code data} is not checked
+   * here. Build-path callers must route through
+   * {@link #getContractType(Wallet)} for the geth-equivalent
+   * {@code setDefaults} enforcement.
+   *
+   * <p>Java callers using positional constructors should pass
+   * {@code null} (not {@code ""}) for unset {@code input}.
+   *
+   * <p>Verb-prefix name (not {@code getXxx}) keeps Jackson and
+   * FastJSON's JavaBean introspection from invoking it during
+   * serialisation; two regression tests per DTO pin this invariant.
+   */
+  public String resolveData() throws JsonRpcInvalidParamsException {
+    requireValidHex("input", input, HexMode.STRICT);
+    requireValidHex("data", data, HexMode.LENIENT);
+    return input != null ? input : data;
   }
 
   public ContractType getContractType(Wallet wallet) throws JsonRpcInvalidRequestException,
       JsonRpcInvalidParamsException {
+    // Fail fast on bad hex / conflict before the state lookup;
+    // calldataEquals relies on resolveData() having validated hex first.
+    String resolvedData = resolveData();
+    validateCallDataConflict();
+
     ContractType contractType;
 
     // to is null
     if (paramStringIsNull(to)) {
       // data is null
-      if (paramStringIsNull(data)) {
+      if (paramStringIsNull(resolvedData)) {
         throw new JsonRpcInvalidRequestException("invalid json request");
       }
 
@@ -134,6 +175,26 @@ public class BuildArguments {
 
   private boolean availableTransferAsset() {
     return tokenId > 0 && tokenValue > 0 && paramQuantityIsNull(value);
+  }
+
+  /**
+   * Throws when both fields decode to non-equal bytes. Wording matches
+   * geth's setDefaults so existing tooling can detect the error string.
+   */
+  private void validateCallDataConflict() throws JsonRpcInvalidParamsException {
+    if (input != null && data != null && !calldataEquals(input, data)) {
+      throw new JsonRpcInvalidParamsException(
+          "both \"data\" and \"input\" are set and not equal. "
+              + "Please use \"input\" to pass transaction call data");
+    }
+  }
+
+  /**
+   * Byte-level equality, so {@code "0xDEAD"} equals {@code "0xdead"}. Both
+   * args must have passed {@code requireValidHex} first.
+   */
+  private static boolean calldataEquals(String a, String b) {
+    return Arrays.equals(ByteArray.fromHexString(a), ByteArray.fromHexString(b));
   }
 
 }

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/types/BuildArguments.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/types/BuildArguments.java
@@ -28,6 +28,16 @@ import org.tron.protos.contract.SmartContractOuterClass.SmartContract;
 @ToString
 public class BuildArguments {
 
+  /**
+   * Conflict error message wording. Mirrors go-ethereum's
+   * {@code setDefaults} verbatim — external EVM tooling may
+   * pattern-match this string. Do not change the wording without
+   * coordinating with downstream consumers.
+   */
+  private static final String CONFLICT_ERR_MSG =
+      "both \"data\" and \"input\" are set and not equal. "
+          + "Please use \"input\" to pass transaction call data";
+
   @Getter
   @Setter
   private String from;
@@ -183,9 +193,7 @@ public class BuildArguments {
    */
   private void validateCallDataConflict() throws JsonRpcInvalidParamsException {
     if (input != null && data != null && !calldataEquals(input, data)) {
-      throw new JsonRpcInvalidParamsException(
-          "both \"data\" and \"input\" are set and not equal. "
-              + "Please use \"input\" to pass transaction call data");
+      throw new JsonRpcInvalidParamsException(CONFLICT_ERR_MSG);
     }
   }
 

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/types/CallArguments.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/types/CallArguments.java
@@ -3,6 +3,7 @@ package org.tron.core.services.jsonrpc.types;
 import static org.tron.core.services.jsonrpc.JsonRpcApiUtil.addressCompatibleToByteArray;
 import static org.tron.core.services.jsonrpc.JsonRpcApiUtil.paramStringIsNull;
 import static org.tron.core.services.jsonrpc.JsonRpcApiUtil.parseQuantityValue;
+import static org.tron.core.services.jsonrpc.JsonRpcApiUtil.requireValidHex;
 
 import com.google.protobuf.ByteString;
 import lombok.AllArgsConstructor;
@@ -15,6 +16,7 @@ import org.tron.api.GrpcAPI.BytesMessage;
 import org.tron.core.Wallet;
 import org.tron.core.exception.jsonrpc.JsonRpcInvalidParamsException;
 import org.tron.core.exception.jsonrpc.JsonRpcInvalidRequestException;
+import org.tron.core.services.jsonrpc.JsonRpcApiUtil.HexMode;
 import org.tron.protos.Protocol.Transaction.Contract.ContractType;
 import org.tron.protos.contract.SmartContractOuterClass.SmartContract;
 
@@ -43,21 +45,41 @@ public class CallArguments {
   private String data;
   @Getter
   @Setter
+  private String input;
+  @Getter
+  @Setter
   private String nonce; // not used
+
+  /**
+   * Returns {@code input} if non-null, else {@code data}. Pure
+   * precedence resolution, mirroring go-ethereum's
+   * {@code TransactionArgs.data()}; no conflict check on the query
+   * path (matches geth's {@code ToMessage}). See
+   * {@link BuildArguments#resolveData()} for the rationale on
+   * naming, validation split, and serialiser interaction.
+   */
+  public String resolveData() throws JsonRpcInvalidParamsException {
+    requireValidHex("input", input, HexMode.STRICT);
+    requireValidHex("data", data, HexMode.LENIENT);
+    return input != null ? input : data;
+  }
 
   /**
    * just support TransferContract, CreateSmartContract and TriggerSmartContract
    * */
   public ContractType getContractType(Wallet wallet) throws JsonRpcInvalidRequestException,
       JsonRpcInvalidParamsException {
-    ContractType contractType;
-
     // from or to is null
     if (paramStringIsNull(from)) {
       throw new JsonRpcInvalidRequestException("invalid json request");
-    } else if (paramStringIsNull(to)) {
+    }
+    // Fail fast on bad hex before the state lookup.
+    String resolvedData = resolveData();
+
+    ContractType contractType;
+    if (paramStringIsNull(to)) {
       // data is null
-      if (paramStringIsNull(data)) {
+      if (paramStringIsNull(resolvedData)) {
         throw new JsonRpcInvalidRequestException("invalid json request");
       }
 

--- a/framework/src/test/java/org/tron/core/services/jsonrpc/BuildArgumentsTest.java
+++ b/framework/src/test/java/org/tron/core/services/jsonrpc/BuildArgumentsTest.java
@@ -1,5 +1,6 @@
 package org.tron.core.services.jsonrpc;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import javax.annotation.Resource;
 import org.junit.Assert;
 import org.junit.Before;
@@ -29,9 +30,9 @@ public class BuildArgumentsTest extends BaseTest {
   public void initBuildArgs() {
     buildArguments = new BuildArguments(
         "0x0000000000000000000000000000000000000000",
-        "0x0000000000000000000000000000000000000001","0x10","0.01","0x100",
-        "","0",9L,10000L,"",10L,
-        2000L,"args",1,"",true);
+        "0x0000000000000000000000000000000000000001", "0x10", "0.01", "0x100",
+        "", "", "0", 9L, 10000L, "", 10L,
+        2000L, "args", 1, "", true);
   }
 
 
@@ -39,15 +40,13 @@ public class BuildArgumentsTest extends BaseTest {
   public void testBuildArgument() {
     CallArguments callArguments = new CallArguments(
         "0x0000000000000000000000000000000000000000",
-        "0x0000000000000000000000000000000000000001","0x10","0.01","0x100",
-        "","0");
-    BuildArguments buildArguments = new BuildArguments(callArguments);
-    Assert.assertEquals(buildArguments.getFrom(),
-        "0x0000000000000000000000000000000000000000");
-    Assert.assertEquals(buildArguments.getTo(),
-        "0x0000000000000000000000000000000000000001");
-    Assert.assertEquals(buildArguments.getGas(), "0x10");
-    Assert.assertEquals(buildArguments.getGasPrice(), "0.01");
+        "0x0000000000000000000000000000000000000001", "0x10", "0.01", "0x100",
+        "", "", "0");
+    BuildArguments args = new BuildArguments(callArguments);
+    Assert.assertEquals("0x0000000000000000000000000000000000000000", args.getFrom());
+    Assert.assertEquals("0x0000000000000000000000000000000000000001", args.getTo());
+    Assert.assertEquals("0x10", args.getGas());
+    Assert.assertEquals("0.01", args.getGasPrice());
   }
 
   @Test
@@ -55,19 +54,275 @@ public class BuildArgumentsTest extends BaseTest {
       throws JsonRpcInvalidRequestException, JsonRpcInvalidParamsException {
     Protocol.Transaction.Contract.ContractType contractType =
         buildArguments.getContractType(wallet);
-    Assert.assertEquals(contractType, Protocol.Transaction.Contract.ContractType.TransferContract);
+    Assert.assertEquals(Protocol.Transaction.Contract.ContractType.TransferContract, contractType);
   }
 
   @Test
   public void testParseValue() throws JsonRpcInvalidParamsException {
     long value = buildArguments.parseValue();
-    Assert.assertEquals(value, 256L);
+    Assert.assertEquals(256L, value);
   }
 
   @Test
   public void testParseGas() throws JsonRpcInvalidParamsException {
     long gas = buildArguments.parseGas();
-    Assert.assertEquals(gas, 16L);
+    Assert.assertEquals(16L, gas);
+  }
+
+  @Test
+  public void resolveData_inputOnly_returnsInput() throws JsonRpcInvalidParamsException {
+    BuildArguments args = new BuildArguments();
+    args.setInput("0xdeadbeef");
+    Assert.assertEquals("0xdeadbeef", args.resolveData());
+  }
+
+  @Test
+  public void resolveData_dataOnly_returnsData() throws JsonRpcInvalidParamsException {
+    BuildArguments args = new BuildArguments();
+    args.setData("0xcafebabe");
+    Assert.assertEquals("0xcafebabe", args.resolveData());
+  }
+
+  @Test
+  public void resolveData_bothPresentSame_returnsValue() throws JsonRpcInvalidParamsException {
+    BuildArguments args = new BuildArguments();
+    args.setData("0xfeedface");
+    args.setInput("0xfeedface");
+    Assert.assertEquals("0xfeedface", args.resolveData());
+  }
+
+  /** Pins that "0x" on both sides decodes to []==[] and is not a conflict. */
+  @Test
+  public void resolveData_bothZeroX_returnsZeroX() throws JsonRpcInvalidParamsException {
+    BuildArguments args = new BuildArguments();
+    args.setInput("0x");
+    args.setData("0x");
+    Assert.assertEquals("0x", args.resolveData());
+  }
+
+  @Test
+  public void resolveData_inputZeroXOnly_returnsZeroX() throws JsonRpcInvalidParamsException {
+    BuildArguments args = new BuildArguments();
+    args.setInput("0x");
+    Assert.assertEquals("0x", args.resolveData());
+  }
+
+  @Test
+  public void resolveData_dataZeroXOnly_returnsZeroX() throws JsonRpcInvalidParamsException {
+    BuildArguments args = new BuildArguments();
+    args.setData("0x");
+    Assert.assertEquals("0x", args.resolveData());
+  }
+
+  @Test
+  public void resolveData_caseDifference_returnsInput()
+      throws JsonRpcInvalidParamsException {
+    BuildArguments args = new BuildArguments();
+    args.setInput("0xDEADbeef");
+    args.setData("0xdeadbeef");
+    Assert.assertEquals("0xDEADbeef", args.resolveData());
+  }
+
+  /**
+   * Pins geth-equivalent semantics: empty string is presence with
+   * empty bytes, so paired with non-empty data the byte values differ
+   * and the build path raises the geth setDefaults conflict at the
+   * {@code getContractType()} entry point.
+   */
+  @Test
+  public void getContractType_inputEmptyDataNonEmpty_throwsConflict() {
+    BuildArguments args = new BuildArguments();
+    args.setFrom("0x0000000000000000000000000000000000000001");
+    args.setInput("");
+    args.setData("0xdeadbeef");
+    Assert.assertThrows(JsonRpcInvalidParamsException.class,
+        () -> args.getContractType(wallet));
+  }
+
+  /**
+   * Wording matches go-ethereum's setDefaults so existing tooling can
+   * detect the error string.
+   */
+  @Test
+  public void getContractType_inputAndDataConflict_throwsInvalidParams() {
+    BuildArguments args = new BuildArguments();
+    args.setFrom("0x0000000000000000000000000000000000000001");
+    args.setInput("0xdeadbeef");
+    args.setData("0xcafebabe");
+
+    JsonRpcInvalidParamsException ex = Assert.assertThrows(
+        JsonRpcInvalidParamsException.class,
+        () -> args.getContractType(wallet));
+    Assert.assertTrue(
+        "error message should match go-ethereum's wording: " + ex.getMessage(),
+        ex.getMessage().contains("both \"data\" and \"input\" are set and not equal"));
+  }
+
+  @Test
+  public void getContractType_inputZeroXDataNonEmpty_throwsConflict() {
+    BuildArguments args = new BuildArguments();
+    args.setFrom("0x0000000000000000000000000000000000000001");
+    args.setInput("0x");
+    args.setData("0xdeadbeef");
+
+    Assert.assertThrows(
+        JsonRpcInvalidParamsException.class,
+        () -> args.getContractType(wallet));
+  }
+
+  @Test
+  public void getContractType_inputAndDataEqual_succeeds()
+      throws JsonRpcInvalidRequestException, JsonRpcInvalidParamsException {
+    BuildArguments args = new BuildArguments();
+    args.setFrom("0x0000000000000000000000000000000000000001");
+    args.setInput("0xdeadbeef");
+    args.setData("0xdeadbeef");
+    Assert.assertEquals(
+        Protocol.Transaction.Contract.ContractType.CreateSmartContract,
+        args.getContractType(wallet));
+  }
+
+  /** Reproduces issue #6517 contract-creation symptom on the build path. */
+  @Test
+  public void getContractType_createSmartContractViaInput_succeeds()
+      throws JsonRpcInvalidRequestException, JsonRpcInvalidParamsException {
+    BuildArguments args = new BuildArguments();
+    args.setFrom("0x0000000000000000000000000000000000000001");
+    args.setInput("0xdeadbeef");
+    Assert.assertEquals(
+        Protocol.Transaction.Contract.ContractType.CreateSmartContract,
+        args.getContractType(wallet));
+  }
+
+  @Test
+  public void copyConstructor_preservesBothInputAndData() {
+    CallArguments src = new CallArguments();
+    src.setFrom("0x0000000000000000000000000000000000000001");
+    src.setData("0xcafebabe");
+    src.setInput("0xdeadbeef");
+
+    BuildArguments copy = new BuildArguments(src);
+    Assert.assertEquals("0xcafebabe", copy.getData());
+    Assert.assertEquals("0xdeadbeef", copy.getInput());
+  }
+
+  @Test
+  public void copyConstructor_propagatesConflictToBuildPath() {
+    CallArguments src = new CallArguments();
+    src.setData("0xcafebabe");
+    src.setInput("0xdeadbeef");
+
+    BuildArguments copy = new BuildArguments(src);
+    Assert.assertThrows(JsonRpcInvalidParamsException.class,
+        () -> copy.getContractType(wallet));
+  }
+
+  @Test
+  public void deserializeWithInputField_succeedsAndResolvesToInput() throws Exception {
+    String json = "{\"from\":\"0x0000000000000000000000000000000000000001\","
+        + "\"to\":\"0x0000000000000000000000000000000000000002\","
+        + "\"input\":\"0xdeadbeef\"}";
+    BuildArguments args = new ObjectMapper().readValue(json, BuildArguments.class);
+    Assert.assertEquals("0xdeadbeef", args.resolveData());
+    Assert.assertEquals("0xdeadbeef", args.getInput());
+    Assert.assertNull(args.getData());
+  }
+
+  /**
+   * Regression guard: a future {@code getXxx} rename would expose
+   * {@code resolveData} as a wire property and risk throwing during
+   * serialisation.
+   */
+  @Test
+  public void jacksonSerialize_doesNotExposeResolveDataOrThrowOnConflict()
+      throws Exception {
+    BuildArguments args = new BuildArguments();
+    args.setInput("0xdeadbeef");
+    args.setData("0xcafebabe");   // conflicting bytes, would throw if resolveData() were invoked
+    String json = new ObjectMapper().writeValueAsString(args);
+    Assert.assertFalse("should not leak resolveData: " + json,
+        json.contains("resolveData"));
+  }
+
+  /** Same guarantee for FastJSON, which also discovers bean getters. */
+  @Test
+  public void fastjsonSerialize_doesNotExposeResolveDataOrThrowOnConflict() {
+    BuildArguments args = new BuildArguments();
+    args.setInput("0xdeadbeef");
+    args.setData("0xcafebabe");
+    String json = com.alibaba.fastjson.JSON.toJSONString(args);
+    Assert.assertFalse("should not leak resolveData: " + json,
+        json.contains("resolveData"));
+  }
+
+  /** Validates the loser field too, not only the precedence winner. */
+  @Test
+  public void resolveData_inputValidDataMalformed_throwsInvalidParams() {
+    BuildArguments args = new BuildArguments();
+    args.setInput("0xdeadbeef");
+    args.setData("0xzz");
+    Assert.assertThrows(JsonRpcInvalidParamsException.class, args::resolveData);
+  }
+
+  @Test
+  public void resolveData_inputMalformedDataValid_throwsInvalidParams() {
+    BuildArguments args = new BuildArguments();
+    args.setInput("0xzz");
+    args.setData("0xdeadbeef");
+    Assert.assertThrows(JsonRpcInvalidParamsException.class, args::resolveData);
+  }
+
+  @Test
+  public void resolveData_inputMalformedDataAbsent_throwsInvalidParams() {
+    BuildArguments args = new BuildArguments();
+    args.setInput("0xzz");
+    Assert.assertThrows(JsonRpcInvalidParamsException.class, args::resolveData);
+  }
+
+  @Test
+  public void resolveData_dataMalformedInputAbsent_throwsInvalidParams() {
+    BuildArguments args = new BuildArguments();
+    args.setData("0xzz");
+    Assert.assertThrows(JsonRpcInvalidParamsException.class, args::resolveData);
+  }
+
+  /**
+   * {@code input} is the new spec-aligned field: missing {@code 0x} prefix
+   * is rejected per the execution-apis BYTES schema.
+   */
+  @Test
+  public void resolveData_inputNoPrefix_throwsInvalidParams() {
+    BuildArguments args = new BuildArguments();
+    args.setInput("deadbeef");
+    Assert.assertThrows(JsonRpcInvalidParamsException.class, args::resolveData);
+  }
+
+  @Test
+  public void resolveData_inputOddLength_throwsInvalidParams() {
+    BuildArguments args = new BuildArguments();
+    args.setInput("0x123");
+    Assert.assertThrows(JsonRpcInvalidParamsException.class, args::resolveData);
+  }
+
+  /**
+   * {@code data} is the legacy field: bare hex (no {@code 0x} prefix)
+   * stays accepted for backward compatibility with existing callers
+   * (e.g. BuildTransactionTest.testCreateSmartContract).
+   */
+  @Test
+  public void resolveData_dataNoPrefix_acceptedForBackwardCompat()
+      throws JsonRpcInvalidParamsException {
+    BuildArguments args = new BuildArguments();
+    args.setData("deadbeef");
+    Assert.assertEquals("deadbeef", args.resolveData());
+  }
+
+  @Test
+  public void resolveData_dataOddLength_acceptedForBackwardCompat()
+      throws JsonRpcInvalidParamsException {
+    BuildArguments args = new BuildArguments();
+    args.setData("0x123");
+    Assert.assertEquals("0x123", args.resolveData());
   }
 
 }

--- a/framework/src/test/java/org/tron/core/services/jsonrpc/CallArgumentsTest.java
+++ b/framework/src/test/java/org/tron/core/services/jsonrpc/CallArgumentsTest.java
@@ -1,5 +1,6 @@
 package org.tron.core.services.jsonrpc;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import javax.annotation.Resource;
 import org.junit.Assert;
 import org.junit.Before;
@@ -26,9 +27,11 @@ public class CallArgumentsTest extends BaseTest {
 
   @Before
   public void init() {
-    callArguments = new CallArguments("0x0000000000000000000000000000000000000000",
-            "0x0000000000000000000000000000000000000001","0x10","0.01","0x100",
-        "","0");
+    callArguments = new CallArguments(
+        "0x0000000000000000000000000000000000000000",
+        "0x0000000000000000000000000000000000000001",
+        "0x10", "0.01", "0x100",
+        "", "", "0");
   }
 
   @Test
@@ -42,6 +45,202 @@ public class CallArgumentsTest extends BaseTest {
   public void testParseValue() throws JsonRpcInvalidParamsException {
     long value = callArguments.parseValue();
     Assert.assertEquals(256L, value);
+  }
+
+  @Test
+  public void resolveData_inputOnly_returnsInput() throws JsonRpcInvalidParamsException {
+    CallArguments args = new CallArguments();
+    args.setInput("0xdeadbeef");
+    Assert.assertEquals("0xdeadbeef", args.resolveData());
+  }
+
+  @Test
+  public void resolveData_dataOnly_returnsData() throws JsonRpcInvalidParamsException {
+    CallArguments args = new CallArguments();
+    args.setData("0xcafebabe");
+    Assert.assertEquals("0xcafebabe", args.resolveData());
+  }
+
+  @Test
+  public void resolveData_bothPresentSame_returnsValue() throws JsonRpcInvalidParamsException {
+    CallArguments args = new CallArguments();
+    args.setData("0xfeedface");
+    args.setInput("0xfeedface");
+    Assert.assertEquals("0xfeedface", args.resolveData());
+  }
+
+  @Test
+  public void resolveData_bothPresentDifferent_inputWinsNoError()
+      throws JsonRpcInvalidParamsException {
+    CallArguments args = new CallArguments();
+    args.setData("0xcafebabe");
+    args.setInput("0xdeadbeef");
+    Assert.assertEquals("0xdeadbeef", args.resolveData());
+  }
+
+  @Test
+  public void resolveData_inputIsZeroX_dataNonEmpty_returnsInput()
+      throws JsonRpcInvalidParamsException {
+    CallArguments args = new CallArguments();
+    args.setInput("0x");
+    args.setData("0xdeadbeef");
+    Assert.assertEquals("0x", args.resolveData());
+  }
+
+  @Test
+  public void resolveData_dataIsZeroX_inputNonEmpty_returnsInput()
+      throws JsonRpcInvalidParamsException {
+    CallArguments args = new CallArguments();
+    args.setInput("0xdeadbeef");
+    args.setData("0x");
+    Assert.assertEquals("0xdeadbeef", args.resolveData());
+  }
+
+  @Test
+  public void resolveData_caseDifference_returnsInput()
+      throws JsonRpcInvalidParamsException {
+    CallArguments args = new CallArguments();
+    args.setInput("0xDEADbeef");
+    args.setData("0xdeadbeef");
+    Assert.assertEquals("0xDEADbeef", args.resolveData());
+  }
+
+  /** Pins geth-equivalent semantics: "" is presence, wins over data by precedence. */
+  @Test
+  public void resolveData_inputEmpty_dataNonEmpty_inputWinsAsEmpty()
+      throws JsonRpcInvalidParamsException {
+    CallArguments args = new CallArguments();
+    args.setInput("");
+    args.setData("0xdeadbeef");
+    Assert.assertEquals("", args.resolveData());
+  }
+
+  @Test
+  public void resolveData_neitherPresent_returnsNull()
+      throws JsonRpcInvalidParamsException {
+    CallArguments args = new CallArguments();
+    Assert.assertNull(args.resolveData());
+  }
+
+  /** Validates the loser field too, not only the precedence winner. */
+  @Test
+  public void resolveData_inputValidDataMalformed_throwsInvalidParams() {
+    CallArguments args = new CallArguments();
+    args.setInput("0xdeadbeef");
+    args.setData("0xzz");
+    Assert.assertThrows(JsonRpcInvalidParamsException.class, args::resolveData);
+  }
+
+  @Test
+  public void resolveData_inputMalformedDataValid_throwsInvalidParams() {
+    CallArguments args = new CallArguments();
+    args.setInput("0xzz");
+    args.setData("0xdeadbeef");
+    Assert.assertThrows(JsonRpcInvalidParamsException.class, args::resolveData);
+  }
+
+  @Test
+  public void resolveData_inputMalformedDataAbsent_throwsInvalidParams() {
+    CallArguments args = new CallArguments();
+    args.setInput("0xzz");
+    Assert.assertThrows(JsonRpcInvalidParamsException.class, args::resolveData);
+  }
+
+  @Test
+  public void resolveData_dataMalformedInputAbsent_throwsInvalidParams() {
+    CallArguments args = new CallArguments();
+    args.setData("0xzz");
+    Assert.assertThrows(JsonRpcInvalidParamsException.class, args::resolveData);
+  }
+
+  /**
+   * {@code input} is the new spec-aligned field: missing {@code 0x} prefix
+   * is rejected per the execution-apis BYTES schema.
+   */
+  @Test
+  public void resolveData_inputNoPrefix_throwsInvalidParams() {
+    CallArguments args = new CallArguments();
+    args.setInput("deadbeef");
+    Assert.assertThrows(JsonRpcInvalidParamsException.class, args::resolveData);
+  }
+
+  @Test
+  public void resolveData_inputOddLength_throwsInvalidParams() {
+    CallArguments args = new CallArguments();
+    args.setInput("0x123");
+    Assert.assertThrows(JsonRpcInvalidParamsException.class, args::resolveData);
+  }
+
+  /**
+   * {@code data} is the legacy field: bare hex (no {@code 0x} prefix)
+   * stays accepted for backward compatibility with existing callers
+   * (e.g. BuildTransactionTest.testCreateSmartContract).
+   */
+  @Test
+  public void resolveData_dataNoPrefix_acceptedForBackwardCompat()
+      throws JsonRpcInvalidParamsException {
+    CallArguments args = new CallArguments();
+    args.setData("deadbeef");
+    Assert.assertEquals("deadbeef", args.resolveData());
+  }
+
+  @Test
+  public void resolveData_dataOddLength_acceptedForBackwardCompat()
+      throws JsonRpcInvalidParamsException {
+    CallArguments args = new CallArguments();
+    args.setData("0x123");
+    Assert.assertEquals("0x123", args.resolveData());
+  }
+
+  /** Reproduces issue #6517 contract-creation symptom. */
+  @Test
+  public void getContractType_createSmartContractViaInput_succeeds()
+      throws JsonRpcInvalidRequestException, JsonRpcInvalidParamsException {
+    CallArguments args = new CallArguments();
+    args.setFrom("0x0000000000000000000000000000000000000001");
+    args.setInput("0xdeadbeef");
+    Assert.assertEquals(
+        Protocol.Transaction.Contract.ContractType.CreateSmartContract,
+        args.getContractType(wallet));
+  }
+
+  /** Reproduces issue #6517 Jackson parse-error symptom. */
+  @Test
+  public void deserializeWithInputField_succeedsAndResolvesToInput() throws Exception {
+    String json = "{\"from\":\"0x0000000000000000000000000000000000000001\","
+        + "\"to\":\"0x0000000000000000000000000000000000000002\","
+        + "\"input\":\"0xdeadbeef\"}";
+    CallArguments args = new ObjectMapper().readValue(json, CallArguments.class);
+    Assert.assertEquals("0xdeadbeef", args.resolveData());
+    Assert.assertEquals("0xdeadbeef", args.getInput());
+    Assert.assertNull(args.getData());
+  }
+
+  /**
+   * Regression guard: a future {@code getXxx} rename would expose
+   * {@code resolveData} as a wire property and risk throwing during
+   * serialisation.
+   */
+  @Test
+  public void jacksonSerialize_doesNotExposeResolveDataOrThrowOnConflict()
+      throws Exception {
+    CallArguments args = new CallArguments();
+    args.setInput("0xdeadbeef");
+    args.setData("0xcafebabe");   // would throw conflict in build path
+    String json = new ObjectMapper().writeValueAsString(args);
+    Assert.assertFalse("should not leak resolveData: " + json,
+        json.contains("resolveData"));
+  }
+
+  /** Same guarantee for FastJSON, which also discovers bean getters. */
+  @Test
+  public void fastjsonSerialize_doesNotExposeResolveDataOrThrowOnConflict() {
+    CallArguments args = new CallArguments();
+    args.setInput("0xdeadbeef");
+    args.setData("0xcafebabe");
+    String json = com.alibaba.fastjson.JSON.toJSONString(args);
+    Assert.assertFalse("should not leak resolveData: " + json,
+        json.contains("resolveData"));
   }
 
 }


### PR DESCRIPTION
### What does this PR do?

Accept `input` alongside `data` on `eth_call`, `eth_estimateGas`, and `buildTransaction` call arguments, matching the Ethereum execution-apis spec and resolving #6517.

- Add `input` (raw field) to `CallArguments` and `BuildArguments`.
- Resolve calldata via `resolveData()` - pure precedence resolution with `input` winning over `data`, mirroring go-ethereum's `TransactionArgs.data()`.
- On the build path, conflicts between `input` and `data` (both set, not equal) are detected at `BuildArguments.getContractType()` - mirroring geth's `data()` / `setDefaults` split. The error message uses go-ethereum's wording verbatim. The query path stays lenient (`input` wins silently).
- Switch five production read sites in `TronJsonRpcImpl` from `getData()` to `resolveData()`.
- Hex validation is mode-driven via `JsonRpcApiUtil.requireValidHex` (`HexMode.STRICT` / `HexMode.LENIENT`):
  - `input` is STRICT: follows the execution-apis BYTES schema (`^0x[0-9a-f]*$`, even length; `""` is accepted as empty bytes per geth's `hexutil.Bytes.UnmarshalText`).
  - `data` keeps LENIENT parsing via `ByteArray.fromHexString` (accepts bare hex and odd length) for backward compatibility with existing callers - notably `BuildTransactionTest.testCreateSmartContract`, which submits bare-hex bytecode.
- The resolver is named `resolveData()` - verb prefix, not `getXxx` - so Jackson's and FastJSON's JavaBean introspection skips it with no per-serializer annotations needed.
- The Lombok-generated positional constructors widen by one slot (`CallArguments` 7->8 args, `BuildArguments` 16->17 args). The named-JSON deserialisation path is unaffected.

### Why are these changes required?

The Ethereum execution-apis spec uses `input` as the canonical calldata field; `data` is the legacy alias. go-ethereum accepts both, with `input` winning when equal and erroring when not. Notably, go-ethereum's `ethclient` has emitted only `input` since [ethereum/go-ethereum#28078](https://github.com/ethereum/go-ethereum/pull/28078), so any tron RPC user upgrading their geth client side hits this.

Before this PR, java-tron only read `data`. A spec-compliant client carrying only `input` failed two ways:

1. Jackson rejected the unknown property (`FAIL_ON_UNKNOWN_PROPERTIES=true`), returning `-32603` instead of executing the call.
2. Even when the field was tolerated, contract-creation paths (no `to`) tripped `invalid json request` because calldata appeared absent.

Both symptoms are captured in #6517.

### This PR has been tested by:

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests

`CallArgumentsTest` (23 tests) + `BuildArgumentsTest` (29 tests) = 52 total. Coverage:

- Single-field cases: `input` only, `data` only, neither.
- Both fields equal — precedence resolves cleanly.
- Both fields not equal: `CallArguments` returns `input` silently; `BuildArguments.getContractType()` throws with geth-equivalent wording.
- Empty-string `""` is presence (matches geth).
- `0x` (zero-length payload) is presence and never collapses to absent.
- Case-insensitive byte equality (`0xDEAD == 0xdead`).
- Strict `input` validation rejects bare hex, odd length, non-hex chars.
- Lenient `data` validation still accepts bare hex and odd length; `BuildTransactionTest.testCreateSmartContract` still passes.
- Loser-field validation: malformed `data` is rejected even when `input` is the precedence winner, and vice versa.
- Jackson + FastJSON serialisation: `resolveData` never appears as a wire property and serialisation never throws even with conflicting `input` / `data` (regression guard for the verb-prefix naming).
- #6517 reproductions: Jackson deserialisation of `{"input": "0xdeadbeef"}` succeeds; contract-creation via `input` (no `to`) resolves to `CreateSmartContract`.

### Compatibility notes

Requests sending only `data` with valid hex are byte-for-byte unchanged. Two error paths shift, both improvements:

- **Issue #6517 itself** - any request carrying `input`. Pre-PR Jackson rejects the unknown property; jsonrpc4j surfaces this as `-32700 "JSON parse error"` with `id: "null"`. Post-PR the request parses cleanly and either succeeds or returns a specific `-32602` (on malformed hex or build-path conflict).

- **Invalid hex in `data`** (e.g. `data: "0xzz"`) - pre-PR BouncyCastle's `DecoderException` falls through to jsonrpc4j's default resolver:
```
code -32001
message "exception decoding Hex string: invalid characters encountered in Hex string"
data "org.bouncycastle.util.encoders.DecoderException"
```


Post-PR `requireValidHex` catches and rethrows as `JsonRpcInvalidParamsException`, mapped via `@JsonRpcError` to standard `-32602`:
```
code -32602
message "invalid hex string for "data""
data "{}"
```

Standard JSON-RPC code, deterministic message, no internal class leak. Clients hardcoded against `-32700` (#6517 symptom) or `-32001` (the BC leak) will see different behaviour.


### Follow up

- Add a JsonRpcServer-level integration test exercising the full Jackson -> handler -> response path for both `input` and `data` payloads. Useful but not blocking - the unit-level path is fully covered.
- Tighten `ByteArray.fromHexString` to the execution-apis BYTES schema, then drop the asymmetric branch in `requireValidHex`. Behaviour-changing for non-RPC callers, so deferred to a separate change.

