### PR TITLE
feat(net): fix TRX inv rate limit bug and add BLOCK inv rate limit

### DIFF
--- a/common/src/main/java/org/tron/common/parameter/CommonParameter.java
+++ b/common/src/main/java/org/tron/common/parameter/CommonParameter.java
@@ -119,6 +119,9 @@ public class CommonParameter {
   public int maxTps; // clearParam: 1000
   @Getter
   @Setter
+  public int maxBlockInvPerSecond = 10; // default: 10 block inv hashes/s per peer
+  @Getter
+  @Setter
   public int minParticipationRate;
   @Getter
   public P2pConfig p2pConfig;

--- a/common/src/main/java/org/tron/core/config/args/NodeConfig.java
+++ b/common/src/main/java/org/tron/core/config/args/NodeConfig.java
@@ -35,6 +35,7 @@ public class NodeConfig {
   private boolean openPrintLog = true;
   private boolean openTransactionSort = false;
   private int maxTps = 1000;
+  private int maxBlockInvPerSecond = 10;
   // Config key "isOpenFullTcpDisconnect" cannot auto-bind — read manually in fromConfig()
   @Getter(lombok.AccessLevel.NONE)
   @Setter(lombok.AccessLevel.NONE)
@@ -450,6 +451,11 @@ public class NodeConfig {
     // inactiveThreshold: minimum 1
     if (inactiveThreshold < 1) {
       inactiveThreshold = 1;
+    }
+
+    // maxBlockInvPerSecond: minimum 1
+    if (maxBlockInvPerSecond < 1) {
+      maxBlockInvPerSecond = 1;
     }
 
     // maxFastForwardNum: clamp to [1, MAX_ACTIVE_WITNESS_NUM]

--- a/common/src/main/resources/reference.conf
+++ b/common/src/main/resources/reference.conf
@@ -227,6 +227,8 @@ node {
   # Threshold for broadcast transactions received from each peer per second,
   # transactions exceeding this are discarded
   maxTps = 1000
+  # Max block inv hashes accepted per peer per second. Minimum: 1.
+  maxBlockInvPerSecond = 10
 
   isOpenFullTcpDisconnect = false
   inactiveThreshold = 600       // seconds

--- a/framework/src/main/java/org/tron/core/config/args/Args.java
+++ b/framework/src/main/java/org/tron/core/config/args/Args.java
@@ -615,6 +615,7 @@ public class Args extends CommonParameter {
     PARAMETER.minActiveConnections = nc.getMinActiveConnections();
     PARAMETER.maxConnectionsWithSameIp = nc.getMaxConnectionsWithSameIp();
     PARAMETER.maxTps = nc.getMaxTps();
+    PARAMETER.maxBlockInvPerSecond = nc.getMaxBlockInvPerSecond();
     PARAMETER.minParticipationRate = nc.getMinParticipationRate();
     PARAMETER.nodeListenPort = nc.getListenPort();
     PARAMETER.nodeEnableIpv6 = nc.isEnableIpv6();

--- a/framework/src/main/java/org/tron/core/net/P2pEventHandlerImpl.java
+++ b/framework/src/main/java/org/tron/core/net/P2pEventHandlerImpl.java
@@ -36,6 +36,7 @@ import org.tron.core.net.peer.PeerManager;
 import org.tron.core.net.service.effective.EffectiveCheckService;
 import org.tron.core.net.service.handshake.HandshakeService;
 import org.tron.core.net.service.keepalive.KeepAliveService;
+import org.tron.core.net.service.statistics.MessageStatistics;
 import org.tron.p2p.P2pEventHandler;
 import org.tron.p2p.connection.Channel;
 import org.tron.protos.Protocol;
@@ -91,6 +92,7 @@ public class P2pEventHandlerImpl extends P2pEventHandler {
   private byte MESSAGE_MAX_TYPE = 127;
 
   private int maxCountIn10s = Args.getInstance().getMaxTps() * 10;
+  private int maxBlockInvIn10s = Args.getInstance().getMaxBlockInvPerSecond() * 10;
 
   public P2pEventHandlerImpl() {
     Set<Byte> set = new HashSet<>();
@@ -149,19 +151,8 @@ public class P2pEventHandlerImpl extends P2pEventHandler {
       msg = TronMessageFactory.create(data);
       type = msg.getType();
 
-      if (INVENTORY.equals(type)) {
-        InventoryMessage message = (InventoryMessage) msg;
-        Protocol.Inventory.InventoryType inventoryType = message.getInventoryType();
-        int count = peer.getPeerStatistics().messageStatistics.tronInTrxInventoryElement
-                .getCount(10);
-        if (inventoryType.equals(Protocol.Inventory.InventoryType.TRX) && count > maxCountIn10s) {
-          logger.warn("Drop inventory from Peer {}, cur:{}, max:{}",
-                  peer.getInetAddress(), count, maxCountIn10s);
-          if (Args.getInstance().isOpenPrintLog()) {
-            logger.warn("[overload]Drop tx list is: {}", ((InventoryMessage) msg).getHashList());
-          }
-          return;
-        }
+      if (INVENTORY.equals(type) && !checkInvRateLimit(peer, (InventoryMessage) msg)) {
+        return;
       }
 
       peer.getPeerStatistics().messageStatistics.addTcpInMessage(msg);
@@ -222,6 +213,32 @@ public class P2pEventHandlerImpl extends P2pEventHandler {
         }
       }
     }
+  }
+
+  private boolean checkInvRateLimit(PeerConnection peer, InventoryMessage msg) {
+    InventoryType invType = msg.getInventoryType();
+    int currentSize = msg.getInventory().getIdsCount();
+    MessageStatistics stats = peer.getPeerStatistics().messageStatistics;
+
+    if (invType == InventoryType.TRX) {
+      int count = stats.tronInTrxInventoryElement.getCount(10);
+      if (count + currentSize > maxCountIn10s) {
+        logger.warn("Drop TRX inv from {}, window:{}, cur:{}, max:{}",
+            peer.getInetAddress(), count, currentSize, maxCountIn10s);
+        if (Args.getInstance().isOpenPrintLog()) {
+          logger.warn("[overload] Drop tx list: {}", msg.getHashList());
+        }
+        return false;
+      }
+    } else if (invType == InventoryType.BLOCK) {
+      int count = stats.tronInBlockInventoryElement.getCount(10);
+      if (count + currentSize > maxBlockInvIn10s) {
+        logger.warn("Drop BLOCK inv from {}, window:{}, cur:{}, max:{}",
+            peer.getInetAddress(), count, currentSize, maxBlockInvIn10s);
+        return false;
+      }
+    }
+    return true;
   }
 
   private void updateLastInteractiveTime(PeerConnection peer, TronMessage msg) {

--- a/framework/src/test/java/org/tron/core/net/P2pEventHandlerImplTest.java
+++ b/framework/src/test/java/org/tron/core/net/P2pEventHandlerImplTest.java
@@ -34,6 +34,7 @@ public class P2pEventHandlerImplTest extends BaseTest {
   public void testProcessInventoryMessage() throws Exception {
     CommonParameter parameter = CommonParameter.getInstance();
     parameter.setMaxTps(10);
+    parameter.setMaxBlockInvPerSecond(10);
 
     PeerStatistics peerStatistics = new PeerStatistics();
 
@@ -75,7 +76,7 @@ public class P2pEventHandlerImplTest extends BaseTest {
 
     count = peer.getPeerStatistics().messageStatistics.tronInTrxInventoryElement.getCount(10);
 
-    Assert.assertEquals(110, count);
+    Assert.assertEquals(10, count);  // 100 hashes dropped: 10+100=110 > maxCountIn10s(100)
 
     list.clear();
     for (int i = 0; i < 100; i++) {
@@ -88,7 +89,7 @@ public class P2pEventHandlerImplTest extends BaseTest {
 
     count = peer.getPeerStatistics().messageStatistics.tronInTrxInventoryElement.getCount(10);
 
-    Assert.assertEquals(110, count);
+    Assert.assertEquals(10, count);  // still dropped: window=10, 10+100=110 > 100
 
     list.clear();
     for (int i = 0; i < 200; i++) {
@@ -101,7 +102,7 @@ public class P2pEventHandlerImplTest extends BaseTest {
 
     count = peer.getPeerStatistics().messageStatistics.tronInBlockInventoryElement.getCount(10);
 
-    Assert.assertEquals(200, count);
+    Assert.assertEquals(0, count);   // 200 hashes dropped: 0+200=200 > maxBlockInvIn10s(100)
 
     list.clear();
     for (int i = 0; i < 100; i++) {
@@ -114,8 +115,98 @@ public class P2pEventHandlerImplTest extends BaseTest {
 
     count = peer.getPeerStatistics().messageStatistics.tronInBlockInventoryElement.getCount(10);
 
-    Assert.assertEquals(300, count);
+    Assert.assertEquals(100, count); // passes: window=0, 0+100=100, not > 100
 
+  }
+
+  @Test
+  public void testCheckInvRateLimitTrxBoundary() throws Exception {
+    // maxTps=10 → maxCountIn10s=100
+    CommonParameter parameter = CommonParameter.getInstance();
+    parameter.setMaxTps(10);
+    parameter.setMaxBlockInvPerSecond(10);
+
+    PeerStatistics peerStatistics = new PeerStatistics();
+    PeerConnection peer = mock(PeerConnection.class);
+    Mockito.when(peer.getPeerStatistics()).thenReturn(peerStatistics);
+
+    P2pEventHandlerImpl handler = new P2pEventHandlerImpl();
+    Method method = handler.getClass()
+        .getDeclaredMethod("processMessage", PeerConnection.class, byte[].class);
+    method.setAccessible(true);
+
+    // Fill window to 91: send 91 TRX hashes → passes (0+91=91 ≤ 100)
+    List<Sha256Hash> list91 = new ArrayList<>();
+    for (int i = 0; i < 91; i++) {
+      list91.add(new Sha256Hash(i, new byte[32]));
+    }
+    InventoryMessage msg91 = new InventoryMessage(list91, InventoryType.TRX);
+    method.invoke(handler, peer, msg91.getSendBytes());
+    Assert.assertEquals(91,
+        peer.getPeerStatistics().messageStatistics.tronInTrxInventoryElement.getCount(10));
+
+    // Send 9 more TRX hashes → passes (91+9=100, not > 100)
+    List<Sha256Hash> list9 = new ArrayList<>();
+    for (int i = 0; i < 9; i++) {
+      list9.add(new Sha256Hash(i, new byte[32]));
+    }
+    InventoryMessage msg9 = new InventoryMessage(list9, InventoryType.TRX);
+    method.invoke(handler, peer, msg9.getSendBytes());
+    Assert.assertEquals(100,
+        peer.getPeerStatistics().messageStatistics.tronInTrxInventoryElement.getCount(10));
+
+    // Send 1 more TRX hash → DROPPED (100+1=101 > 100)
+    List<Sha256Hash> list1 = new ArrayList<>();
+    list1.add(new Sha256Hash(0, new byte[32]));
+    InventoryMessage msg1 = new InventoryMessage(list1, InventoryType.TRX);
+    method.invoke(handler, peer, msg1.getSendBytes());
+    Assert.assertEquals(100,  // count unchanged: message was dropped
+        peer.getPeerStatistics().messageStatistics.tronInTrxInventoryElement.getCount(10));
+  }
+
+  @Test
+  public void testCheckInvRateLimitBlockBoundary() throws Exception {
+    // maxBlockInvPerSecond=10 → maxBlockInvIn10s=100
+    CommonParameter parameter = CommonParameter.getInstance();
+    parameter.setMaxTps(1000);
+    parameter.setMaxBlockInvPerSecond(10);
+
+    PeerStatistics peerStatistics = new PeerStatistics();
+    PeerConnection peer = mock(PeerConnection.class);
+    Mockito.when(peer.getPeerStatistics()).thenReturn(peerStatistics);
+
+    P2pEventHandlerImpl handler = new P2pEventHandlerImpl();
+    Method method = handler.getClass()
+        .getDeclaredMethod("processMessage", PeerConnection.class, byte[].class);
+    method.setAccessible(true);
+
+    // Send 101 BLOCK hashes → DROPPED (0+101=101 > 100)
+    List<Sha256Hash> list101 = new ArrayList<>();
+    for (int i = 0; i < 101; i++) {
+      list101.add(new Sha256Hash(i, new byte[32]));
+    }
+    InventoryMessage msgBlock101 = new InventoryMessage(list101, InventoryType.BLOCK);
+    method.invoke(handler, peer, msgBlock101.getSendBytes());
+    Assert.assertEquals(0,
+        peer.getPeerStatistics().messageStatistics.tronInBlockInventoryElement.getCount(10));
+
+    // Send 100 BLOCK hashes → passes (0+100=100, not > 100)
+    List<Sha256Hash> list100 = new ArrayList<>();
+    for (int i = 0; i < 100; i++) {
+      list100.add(new Sha256Hash(i, new byte[32]));
+    }
+    InventoryMessage msgBlock100 = new InventoryMessage(list100, InventoryType.BLOCK);
+    method.invoke(handler, peer, msgBlock100.getSendBytes());
+    Assert.assertEquals(100,
+        peer.getPeerStatistics().messageStatistics.tronInBlockInventoryElement.getCount(10));
+
+    // Send 1 more BLOCK hash → DROPPED (100+1=101 > 100)
+    List<Sha256Hash> list1 = new ArrayList<>();
+    list1.add(new Sha256Hash(0, new byte[32]));
+    InventoryMessage msgBlock1 = new InventoryMessage(list1, InventoryType.BLOCK);
+    method.invoke(handler, peer, msgBlock1.getSendBytes());
+    Assert.assertEquals(100,  // count unchanged: message was dropped
+        peer.getPeerStatistics().messageStatistics.tronInBlockInventoryElement.getCount(10));
   }
 
   @Test


### PR DESCRIPTION
**What does this PR do?**

Tighten and extend the inbound inventory rate limit on the P2P layer. Two fixes plus a new knob:                                                                     
   
  1. **Fix the TRX-inv counting bug** — `P2pEventHandlerImpl` previously checked `count > maxCountIn10s` against the existing 10-second window count *only*, ignoring  
  the size of the incoming `InventoryMessage`. A peer sending a single message with thousands of hashes could slip through whenever the window count alone was still
  under the limit. The check is now `count + currentSize > maxCountIn10s`, which compares the projected window against the cap.                                        
                  
  2. **Add a BLOCK-inv rate limit** — block inventories were previously unbounded. New per-peer cap on `BLOCK` inventory hashes per 10s, controlled by:                
     - `node.maxBlockInvPerSecond` (default `10`, minimum `1`)
     - Wired through `NodeConfig.maxBlockInvPerSecond` (auto-bound by `ConfigBeanFactory`, clamped in `postProcess()`)                                                 
     - Bridged to runtime via `Args.applyNodeConfig` → `CommonParameter.maxBlockInvPerSecond`                                                                          
     - Default value mirrored in `reference.conf`                                                                                                                      
                                                                                                                                                                       
  3. **Refactor for readability** — the inline TRX check inside `processMessage` was extracted into `checkInvRateLimit(PeerConnection, InventoryMessage)`, which now   
  handles both `TRX` and `BLOCK` branches uniformly.
                                                                                                                                                                       
  4. **Tests** — `P2pEventHandlerImplTest` adds `testCheckInvRateLimitTrxBoundary` and `testCheckInvRateLimitBlockBoundary` to cover the at-limit and over-limit cases 
  for both inventory types.

**Why are these changes required?**

1. **The original TRX check was a TOCTOU-style undercount.** A burst peer could legitimately stay below `count` while still pushing the system over `maxCountIn10s`  
  in a single message — the gating condition simply did not include the new payload. This let an attacker amplify by batching: one message of 10,000 inventory hashes
  was indistinguishable from one of 10. The fix restores the intended invariant: *projected* window size must stay under the cap, not the *current* window alone.      
                  
  2. **Unbounded BLOCK-inv was an unmonitored attack surface.** TRX inv had a cap; block inv did not. A misbehaving or malicious peer could flood block-inv hashes —   
  each requiring lookup work on the receiver — without any throttling, consuming I/O and CPU. Adding a bounded `maxBlockInvPerSecond` closes the gap symmetrically,
  with a default tuned for the protocol's healthy block rate (~3 s interval, so 10/s is generous headroom for retransmits and forks).                                  
                  
  3. **Surfacing the limit as a config knob (not a constant)** lets operators tune it without a release, which is important the first time a new limit ships in case   
  the default proves too tight on real networks.
                                                                                                                                                                       
  4. **Refactoring out `checkInvRateLimit`** keeps the dispatch path in `processMessage` short and makes the two inventory-type branches uniform — easier to reason    
  about, and easier to add a third inventory type later without re-introducing the old undercount bug.

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

Fixes https://github.com/tronprotocol/java-tron/issues/6659 