### PR TITLE
fix(plugins): exclude transitive leveldbjni-all from :crypto

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -54,6 +54,15 @@ jobs:
       - name: Build
         run: ./gradlew clean build --no-daemon
 
+      - name: Toolkit jar smoke test
+        run: |
+          set -e
+          JAR=plugins/build/libs/Toolkit.jar
+          java -jar "$JAR" help
+          java -jar "$JAR" db --help
+          java -jar "$JAR" db archive -h
+          java -jar "$JAR" keystore --help
+
   build-ubuntu:
     name: Build ubuntu24 (JDK 17 / aarch64)
     if: ${{ github.event_name == 'pull_request' || inputs.job == 'all' || inputs.job == 'ubuntu' }}
@@ -83,6 +92,15 @@ jobs:
 
       - name: Build
         run: ./gradlew clean build --no-daemon
+
+      - name: Toolkit jar smoke test
+        run: |
+          set -e
+          JAR=plugins/build/libs/Toolkit.jar
+          java -jar "$JAR" help
+          java -jar "$JAR" db --help
+          java -jar "$JAR" db archive -h
+          java -jar "$JAR" keystore --help
 
   docker-build-rockylinux:
     name: Build rockylinux (JDK 8 / x86_64)
@@ -126,6 +144,15 @@ jobs:
 
       - name: Build
         run: ./gradlew clean build --no-daemon
+
+      - name: Toolkit jar smoke test
+        run: |
+          set -e
+          JAR=plugins/build/libs/Toolkit.jar
+          java -jar "$JAR" help
+          java -jar "$JAR" db --help
+          java -jar "$JAR" db archive -h
+          java -jar "$JAR" keystore --help
 
       - name: Test with RocksDB engine
         run: ./gradlew :framework:testWithRocksDb --no-daemon
@@ -171,6 +198,15 @@ jobs:
 
       - name: Build
         run: ./gradlew clean build --no-daemon --no-build-cache
+
+      - name: Toolkit jar smoke test
+        run: |
+          set -e
+          JAR=plugins/build/libs/Toolkit.jar
+          java -jar "$JAR" help
+          java -jar "$JAR" db --help
+          java -jar "$JAR" db archive -h
+          java -jar "$JAR" keystore --help
 
       - name: Test with RocksDB engine
         run: ./gradlew :framework:testWithRocksDb --no-daemon --no-build-cache

--- a/plugins/build.gradle
+++ b/plugins/build.gradle
@@ -39,12 +39,17 @@ dependencies {
         exclude group: 'io.prometheus'
         exclude group: 'org.aspectj'
         exclude group: 'org.apache.httpcomponents'
-        // :crypto -> :common -> :platform transitively pulls leveldbjni-all 1.8,
-        // which conflicts with the io.github.tronprotocol leveldbjni-all 1.18.2
-        // declared below on x86. Both jars contain org/iq80/leveldb/Options.class;
-        // in the fat jar the duplicate-entry write order can leave the 1.8 copy,
-        // which lacks Options.maxBatchSize(int) and breaks `db archive` at runtime.
+        // :crypto -> :common -> :platform transitively pulls in artifacts that
+        // the direct :platform dependency below already excludes on x86. Mirror
+        // those excludes here so both paths to :platform agree, otherwise the
+        // transitive copies leak into the fat jar. In particular leveldbjni-all
+        // 1.8 conflicts with io.github.tronprotocol leveldbjni-all 1.18.2: both
+        // jars carry org/iq80/leveldb/Options.class; the duplicate-entry write
+        // order in the fat jar can leave the 1.8 copy, which lacks
+        // Options.maxBatchSize(int) and breaks `db archive` at runtime.
         exclude group: 'org.fusesource.leveldbjni', module: 'leveldbjni-all'
+        exclude group: 'io.github.tronprotocol', module: 'zksnark-java-sdk'
+        exclude group: 'commons-io', module: 'commons-io'
     }
     implementation group: 'info.picocli', name: 'picocli', version: '4.6.3'
     implementation group: 'com.typesafe', name: 'config', version: '1.3.2'

--- a/plugins/build.gradle
+++ b/plugins/build.gradle
@@ -39,6 +39,12 @@ dependencies {
         exclude group: 'io.prometheus'
         exclude group: 'org.aspectj'
         exclude group: 'org.apache.httpcomponents'
+        // :crypto -> :common -> :platform transitively pulls leveldbjni-all 1.8,
+        // which conflicts with the io.github.tronprotocol leveldbjni-all 1.18.2
+        // declared below on x86. Both jars contain org/iq80/leveldb/Options.class;
+        // in the fat jar the duplicate-entry write order can leave the 1.8 copy,
+        // which lacks Options.maxBatchSize(int) and breaks `db archive` at runtime.
+        exclude group: 'org.fusesource.leveldbjni', module: 'leveldbjni-all'
     }
     implementation group: 'info.picocli', name: 'picocli', version: '4.6.3'
     implementation group: 'com.typesafe', name: 'config', version: '1.3.2'

--- a/plugins/build.gradle
+++ b/plugins/build.gradle
@@ -141,7 +141,13 @@ def binaryRelease(taskName, jarName, mainClass) {
         from(sourceSets.main.output) {
             include "/**"
         }
-        dependsOn (project(':protocol').jar, project(':platform').jar) // explicit_dependency
+        // Fat jar zips up runtimeClasspath, which includes the jar outputs of
+        // every project dependency. Declare them all explicitly so Gradle does
+        // not warn about implicit_dependency and disable execution optimizations
+        // (and so partial / parallel builds cannot run binaryRelease before the
+        // dependency jars exist).
+        dependsOn (project(':protocol').jar, project(':platform').jar,
+                project(':crypto').jar, project(':common').jar) // explicit_dependency
         from {
             configurations.runtimeClasspath.collect { // https://docs.gradle.org/current/userguide/upgrading_version_6.html#changes_6.3
                 it.isDirectory() ? it : zipTree(it)

--- a/plugins/build.gradle
+++ b/plugins/build.gradle
@@ -39,20 +39,22 @@ dependencies {
         exclude group: 'io.prometheus'
         exclude group: 'org.aspectj'
         exclude group: 'org.apache.httpcomponents'
-        // :crypto -> :common -> :platform transitively pulls leveldbjni-all
-        // 1.8, which conflicts with the io.github.tronprotocol fork
-        // leveldbjni-all 1.18.2 declared below on x86. Both jars carry
-        // org/iq80/leveldb/Options.class; the duplicate-entry write order in
-        // the fat jar can leave the 1.8 copy, which lacks
+        // x86 declares io.github.tronprotocol:leveldbjni-all:1.18.2 below.
+        // :crypto -> :common -> :platform also transitively pulls
+        // org.fusesource.leveldbjni:leveldbjni-all:1.8; both jars carry
+        // org/iq80/leveldb/Options.class and the duplicate-entry write order
+        // in the fat jar can leave the 1.8 copy, which lacks
         // Options.maxBatchSize(int) and breaks `db archive` at runtime.
+        // Drop the 1.8 transitive on x86 only; ARM64 has a single copy via
+        // its direct :platform declaration and no conflict.
         //
-        // The direct :platform dependency below also excludes
-        // zksnark-java-sdk and commons-io, but those are *not* mirrored here:
-        // the plugins test runtime (DbLiteTest -> Spring -> ZksnarkInitService)
-        // actually loads classes from both, so :crypto must keep transitively
-        // providing them. The :platform-side excludes are deduplication, not
-        // a "kept out of plugins" intent.
-        exclude group: 'org.fusesource.leveldbjni', module: 'leveldbjni-all'
+        // zksnark-java-sdk and commons-io are deliberately NOT mirrored from
+        // the :platform-direct excludes below: the plugins test runtime
+        // (DbLiteTest -> Spring -> ZksnarkInitService) loads classes from
+        // both at runtime, so :crypto must keep transitively providing them.
+        if (!rootProject.archInfo.isArm64) {
+            exclude group: 'org.fusesource.leveldbjni', module: 'leveldbjni-all'
+        }
     }
     implementation group: 'info.picocli', name: 'picocli', version: '4.6.3'
     implementation group: 'com.typesafe', name: 'config', version: '1.3.2'

--- a/plugins/build.gradle
+++ b/plugins/build.gradle
@@ -39,17 +39,20 @@ dependencies {
         exclude group: 'io.prometheus'
         exclude group: 'org.aspectj'
         exclude group: 'org.apache.httpcomponents'
-        // :crypto -> :common -> :platform transitively pulls in artifacts that
-        // the direct :platform dependency below already excludes on x86. Mirror
-        // those excludes here so both paths to :platform agree, otherwise the
-        // transitive copies leak into the fat jar. In particular leveldbjni-all
-        // 1.8 conflicts with io.github.tronprotocol leveldbjni-all 1.18.2: both
-        // jars carry org/iq80/leveldb/Options.class; the duplicate-entry write
-        // order in the fat jar can leave the 1.8 copy, which lacks
+        // :crypto -> :common -> :platform transitively pulls leveldbjni-all
+        // 1.8, which conflicts with the io.github.tronprotocol fork
+        // leveldbjni-all 1.18.2 declared below on x86. Both jars carry
+        // org/iq80/leveldb/Options.class; the duplicate-entry write order in
+        // the fat jar can leave the 1.8 copy, which lacks
         // Options.maxBatchSize(int) and breaks `db archive` at runtime.
+        //
+        // The direct :platform dependency below also excludes
+        // zksnark-java-sdk and commons-io, but those are *not* mirrored here:
+        // the plugins test runtime (DbLiteTest -> Spring -> ZksnarkInitService)
+        // actually loads classes from both, so :crypto must keep transitively
+        // providing them. The :platform-side excludes are deduplication, not
+        // a "kept out of plugins" intent.
         exclude group: 'org.fusesource.leveldbjni', module: 'leveldbjni-all'
-        exclude group: 'io.github.tronprotocol', module: 'zksnark-java-sdk'
-        exclude group: 'commons-io', module: 'commons-io'
     }
     implementation group: 'info.picocli', name: 'picocli', version: '4.6.3'
     implementation group: 'com.typesafe', name: 'config', version: '1.3.2'

--- a/plugins/build.gradle
+++ b/plugins/build.gradle
@@ -39,19 +39,13 @@ dependencies {
         exclude group: 'io.prometheus'
         exclude group: 'org.aspectj'
         exclude group: 'org.apache.httpcomponents'
-        // x86 declares io.github.tronprotocol:leveldbjni-all:1.18.2 below.
+        // x86 declares io.github.tronprotocol:leveldbjni-all:1.18.2 below;
         // :crypto -> :common -> :platform also transitively pulls
-        // org.fusesource.leveldbjni:leveldbjni-all:1.8; both jars carry
-        // org/iq80/leveldb/Options.class and the duplicate-entry write order
-        // in the fat jar can leave the 1.8 copy, which lacks
-        // Options.maxBatchSize(int) and breaks `db archive` at runtime.
-        // Drop the 1.8 transitive on x86 only; ARM64 has a single copy via
-        // its direct :platform declaration and no conflict.
-        //
-        // zksnark-java-sdk and commons-io are deliberately NOT mirrored from
-        // the :platform-direct excludes below: the plugins test runtime
-        // (DbLiteTest -> Spring -> ZksnarkInitService) loads classes from
-        // both at runtime, so :crypto must keep transitively providing them.
+        // org.fusesource.leveldbjni:leveldbjni-all:1.8. Both jars carry
+        // org/iq80/leveldb/Options.class and the fat jar's last-write-wins
+        // merge can leave the 1.8 copy, which lacks Options.maxBatchSize(int)
+        // and breaks `db archive` at runtime. Drop the 1.8 transitive on x86
+        // only; ARM64 has a single copy via :platform direct and no conflict.
         if (!rootProject.archInfo.isArm64) {
             exclude group: 'org.fusesource.leveldbjni', module: 'leveldbjni-all'
         }
@@ -65,9 +59,12 @@ dependencies {
         implementation project(":platform")
     } else {
         implementation project(":platform"), {
+            // Only leveldbjni-all is excluded; the io.github.tronprotocol
+            // 1.18.2 fork below is the version we want on x86. zksnark-java-sdk
+            // and commons-io are intentionally kept (the plugins test runtime
+            // needs both via :crypto -> :common -> :platform and the duplicate
+            // resolution dedups to one copy).
             exclude(group: 'org.fusesource.leveldbjni', module: 'leveldbjni-all')
-            exclude(group: 'io.github.tronprotocol', module: 'zksnark-java-sdk')
-            exclude(group: 'commons-io', module: 'commons-io')
         }
         implementation 'io.github.tronprotocol:leveldbjni-all:1.18.2'
         implementation 'io.github.tronprotocol:leveldb:1.18.2'


### PR DESCRIPTION
## Summary

x86_64 builds of `Toolkit.jar` since #6637 throw `NoSuchMethodError` on `org.iq80.leveldb.Options.maxBatchSize(I)` when running commands such as `db archive` / `--rebuild-manifest`:

```
Exception in thread "main" java.lang.NoSuchMethodError:
  org.iq80.leveldb.Options.maxBatchSize(I)Lorg/iq80/leveldb/Options;
    at org.tron.plugins.DbArchive$ArchiveManifest.newDefaultLevelDbOptions(DbArchive.java:137)
    ...
```

This PR fixes the root cause and adds CI smoke tests so the same class of bug cannot reach a release artifact again.

## Why

#6637 introduced `implementation(project(":crypto"))` to the `plugins` module without excluding `org.fusesource.leveldbjni:leveldbjni-all`, which `:crypto` pulls in transitively via `:common -> :platform`. The direct `:platform` dependency in `plugins/build.gradle` already excludes `leveldbjni-all` (so the TRON-fork `io.github.tronprotocol:leveldbjni-all:1.18.2` can be used instead), but the new transitive path through `:crypto` does not. The result on x86 is two jars carrying `org/iq80/leveldb/Options.class` on the runtime classpath:

- `org.fusesource.leveldbjni:leveldbjni-all:1.8` — does NOT have `Options.maxBatchSize(int)`
- `io.github.tronprotocol:leveldbjni-all:1.18.2` — DOES have `Options.maxBatchSize(int)`

`:plugins:dependencyInsight` confirms the regression path:

```
org.fusesource.leveldbjni:leveldbjni-all:1.8
\--- project :platform
     +--- runtimeClasspath
     \--- project :common
          \--- project :crypto
               \--- runtimeClasspath
```

## Why tests didn't catch it

- `:plugins:test` keeps source jars separate; the JVM classloader returns the first match in classpath order, which is `1.18.2` (declared directly by `plugins/build.gradle`). Tests pass.
- The fat-jar `binaryRelease` task merges class entries with last-write-wins (Gradle Zip default `INCLUDE`), so the surviving `Options.class` can be the `1.8` copy. Same classpath, opposite winner.
- ARM64 declares only `:platform` directly (no `1.18.2` fork), so there is no conflict; ARM64 also excludes Archive tests.
- The CI matrix builds the fat jar but never executes it — Toolkit-specific runtime errors are not exercised.

## Fix

1. **`plugins/build.gradle`** — exclude `org.fusesource.leveldbjni:leveldbjni-all` from the `:crypto` dependency, mirroring the existing exclusion on the direct `:platform` dependency. This collapses the x86 runtimeClasspath to a single `leveldbjni-all` (`1.18.2`).
2. **`.github/workflows/pr-build.yml`** — after each platform build (macos / ubuntu-arm / rockylinux-x86 / debian11-x86), run a short smoke test against the freshly built `Toolkit.jar`:
    ```
    java -jar Toolkit.jar help
    java -jar Toolkit.jar db --help
    java -jar Toolkit.jar db archive -h     # directly exercises the failing path
    java -jar Toolkit.jar keystore --help   # exercises the :crypto path added by #6637
    ```
    Each smoke step adds ~10–15s; jobs run in parallel so PR critical path increases by at most ~15s.

## Verification

Reproduced on x86_64 + JDK 8 in `eclipse-temurin:8-jdk` (clean build):

- Before fix: `java -jar Toolkit.jar db archive -d <empty>` → `NoSuchMethodError`
- After fix: `java -jar Toolkit.jar db archive -d <empty>` → exits 0, reports "directory does not contain any database"
- `:plugins:dependencies --configuration runtimeClasspath` no longer lists `org.fusesource.leveldbjni:leveldbjni-all:1.8`
- `./gradlew checkstyleMain checkstyleTest` passes
- `./gradlew :plugins:test` passes (KeystoreUpdate, DbLite, RocksDb tests)

## Test plan

- [ ] CI passes on all four platform builds
- [ ] New "Toolkit jar smoke test" step is green on each platform
- [ ] Reviewer manually confirms `java -jar Toolkit.jar db archive -d <db>` works on x86 with this branch's artifact

## Notes

- No production Java changes; only `plugins/build.gradle` (+6 lines) and `.github/workflows/pr-build.yml` (+36 lines).
- ARM64 path is unaffected: the `:platform` direct dependency on ARM64 has no exclusion (it never had the conflict), and the new `:crypto` exclusion is a no-op there.
- The two `org/iq80/leveldb/Options.class` entries that still exist in the fat jar (from `leveldbjni-all:1.18.2` uber and `leveldb-api:1.18.2` standalone) are pre-existing and harmless because both are the same `1.18.2` version with `maxBatchSize` available.