### PR TITLE
fix(config): optimizes config binding for node 

### DIFF
--- a/common/src/main/java/org/tron/common/parameter/CommonParameter.java
+++ b/common/src/main/java/org/tron/common/parameter/CommonParameter.java
@@ -119,13 +119,7 @@ public class CommonParameter {
   public boolean nodeEffectiveCheckEnable;
   @Getter
   @Setter
-  public int nodeConnectionTimeout = 2000; // from clearParam(), consistent with mainnet.conf
-  @Getter
-  @Setter
   public int fetchBlockTimeout;
-  @Getter
-  @Setter
-  public int nodeChannelReadTimeout;
   @Getter
   @Setter
   public int maxConnections = 30; // from clearParam(), consistent with mainnet.conf
@@ -297,13 +291,6 @@ public class CommonParameter {
   @Setter
   public long forbidTransferToContract;
 
-  // -- Netty --
-  @Getter
-  @Setter
-  public int tcpNettyWorkThreadNum;
-  @Getter
-  @Setter
-  public int udpNettyWorkThreadNum;
   @Getter
   @Setter
   public String trustNodeAddr; // clearParam: ""

--- a/common/src/main/java/org/tron/core/config/args/NodeConfig.java
+++ b/common/src/main/java/org/tron/core/config/args/NodeConfig.java
@@ -5,7 +5,6 @@ import static org.tron.core.exception.TronError.ErrCode.PARAMETER_INIT;
 
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigBeanFactory;
-import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigValueFactory;
 import java.util.ArrayList;
 import java.util.List;
@@ -49,6 +48,9 @@ public class NodeConfig {
 
   // node.discovery.* — HOCON merges into node { discovery { ... } }, auto-bound
   private DiscoveryConfig discovery = new DiscoveryConfig();
+  @Getter(lombok.AccessLevel.NONE)
+  @Setter(lombok.AccessLevel.NONE)
+  private String externalIP = "";
 
   // node.shutdown.* uses PascalCase keys (BlockTime, BlockHeight, BlockCount)
   // that don't match JavaBean naming. Excluded, read manually.
@@ -64,7 +66,7 @@ public class NodeConfig {
 
   public boolean isDiscoveryEnable() { return discovery.isEnable(); }
   public boolean isDiscoveryPersist() { return discovery.isPersist(); }
-  public String getDiscoveryExternalIp() { return discovery.getExternal().getIp(); }
+  public String getDiscoveryExternalIp() { return externalIP; }
   public String getShutdownBlockTime() { return shutdownBlockTime; }
   public long getShutdownBlockHeight() { return shutdownBlockHeight; }
   public long getShutdownBlockCount() { return shutdownBlockCount; }
@@ -76,13 +78,10 @@ public class NodeConfig {
   private boolean enableIpv6 = false;
   private boolean effectiveCheckEnable = false;
   private int maxFastForwardNum = 4;
-  private int tcpNettyWorkThreadNum = 0;
-  private int udpNettyWorkThreadNum = 1;
   private ValidContractProtoConfig validContractProto = new ValidContractProtoConfig();
   private int shieldedTransInPendingMaxCounts = 10;
   private long blockCacheTimeout = 60;
   private long receiveTcpMinDataLength = 2048;
-  private ChannelConfig channel = new ChannelConfig();
   private int maxTransactionPendingSize = 2000;
   private long pendingTransactionTimeout = 60000;
   private int maxTrxCacheSize = 50_000;
@@ -91,6 +90,8 @@ public class NodeConfig {
   private boolean unsolidifiedBlockCheck = false;
   private int maxUnsolidifiedBlocks = 54;
   private String zenTokenId = "000000";
+  @Getter(lombok.AccessLevel.NONE)
+  @Setter(lombok.AccessLevel.NONE)
   private boolean allowShieldedTransactionApi = false;
   private double activeConnectFactor = 0.1;
   private double connectFactor = 0.6;
@@ -100,17 +101,15 @@ public class NodeConfig {
 
   // ---- Sub-beans matching config's dot-notation nested structure ----
   private ListenConfig listen = new ListenConfig();
-  private ConnectionConfig connection = new ConnectionConfig();
   private FetchBlockConfig fetchBlock = new FetchBlockConfig();
   private SolidityConfig solidity = new SolidityConfig();
 
   // Convenience getters for backward compatibility with applyNodeConfig
   public int getListenPort() { return listen.getPort(); }
-  public int getConnectionTimeout() { return connection.getTimeout(); }
   public int getFetchBlockTimeout() { return fetchBlock.getTimeout(); }
   public int getSolidityThreads() { return solidity.getThreads(); }
-  public int getChannelReadTimeout() { return channel.getRead().getTimeout(); }
   public int getValidContractProtoThreads() { return validContractProto.getThreads(); }
+  public boolean isAllowShieldedTransactionApi() { return allowShieldedTransactionApi; }
 
   // ---- List fields (manually read) ----
   private List<String> active = new ArrayList<>();
@@ -139,25 +138,12 @@ public class NodeConfig {
   public static class DiscoveryConfig {
     private boolean enable = false;
     private boolean persist = false;
-    private ExternalConfig external = new ExternalConfig();
-
-    @Getter
-    @Setter
-    public static class ExternalConfig {
-      private String ip = "";
-    }
   }
 
   @Getter
   @Setter
   public static class ListenConfig {
     private int port = 18888;
-  }
-
-  @Getter
-  @Setter
-  public static class ConnectionConfig {
-    private int timeout = 2;
   }
 
   @Getter
@@ -170,18 +156,6 @@ public class NodeConfig {
   @Setter
   public static class SolidityConfig {
     private int threads = 0; // 0 = auto (availableProcessors)
-  }
-
-  @Getter
-  @Setter
-  public static class ChannelConfig {
-    private ReadConfig read = new ReadConfig();
-
-    @Getter
-    @Setter
-    public static class ReadConfig {
-      private int timeout = 0;
-    }
   }
 
   @Getter
@@ -362,7 +336,7 @@ public class NodeConfig {
   /**
    * Create NodeConfig from the "node" section of the application config.
    *
-   * <p>Dot-notation keys (listen.port, connection.timeout, fetchBlock.timeout,
+   * <p>Dot-notation keys (listen.port, fetchBlock.timeout,
    * solidity.threads) become nested HOCON objects and cannot be auto-bound to flat
    * Java fields. They are read manually after ConfigBeanFactory binding.
    *
@@ -403,14 +377,23 @@ public class NodeConfig {
       nc.maxConnectionsWithSameIp = section.getInt("maxActiveNodesWithSameIp");
     }
 
+    nc.externalIP = getString(section, "discovery.external.ip", "");
+    if ("null".equalsIgnoreCase(nc.externalIP)) {
+      nc.externalIP = "";
+    }
+
     // Legacy key fallback: node.fullNodeAllowShieldedTransaction -> allowShieldedTransactionApi.
-    // reference.conf does not ship the legacy key, so hasPath here reliably means the user
-    // set it in their config. When present, it overrides the modern key.
-    if (section.hasPath("fullNodeAllowShieldedTransaction")) {
-      nc.allowShieldedTransactionApi = section.getBoolean("fullNodeAllowShieldedTransaction");
+    if (section.hasPath("allowShieldedTransactionApi")) {
+      nc.allowShieldedTransactionApi =
+          section.getBoolean("allowShieldedTransactionApi");
+    } else if (section.hasPath("fullNodeAllowShieldedTransaction")) {
+      // for compatibility with previous configuration
+      nc.allowShieldedTransactionApi =
+          section.getBoolean("fullNodeAllowShieldedTransaction");
       logger.warn("Configuring [node.fullNodeAllowShieldedTransaction] will be deprecated. "
           + "Please use [node.allowShieldedTransactionApi] instead.");
     }
+
     // node.shutdown.* — PascalCase keys (BlockTime, BlockHeight), cannot auto-bind
     nc.shutdownBlockTime = config.hasPath("node.shutdown.BlockTime")
         ? config.getString("node.shutdown.BlockTime") : "";

--- a/common/src/main/resources/reference.conf
+++ b/common/src/main/resources/reference.conf
@@ -174,7 +174,6 @@ node {
   walletExtensionApi = false
 
   listen.port = 18888
-  connection.timeout = 2
   fetchBlock.timeout = 500
 
   # Number of blocks to fetch in one batch during sync. Range: [100, 2000].
@@ -211,15 +210,12 @@ node {
 
   isOpenFullTcpDisconnect = false
   inactiveThreshold = 600       // seconds
-  tcpNettyWorkThreadNum = 0
-  udpNettyWorkThreadNum = 1
   maxFastForwardNum = 4
   activeConnectFactor = 0.1
   connectFactor = 0.6
   # Legacy alias `maxActiveNodesWithSameIp` is still accepted from user config
   # (see NodeConfig alias-fallback) but is intentionally NOT defaulted here —
   # shipping it in reference.conf would always mask the modern `maxConnectionsWithSameIp`.
-  channel.read.timeout = 0
   metricsEnable = false
 
   p2p {

--- a/common/src/main/resources/reference.conf
+++ b/common/src/main/resources/reference.conf
@@ -193,7 +193,7 @@ node {
   minParticipationRate = 0
 
   # Whether to enable shielded transaction API
-  allowShieldedTransactionApi = false
+  # allowShieldedTransactionApi = false
 
   # Whether to print config log at startup
   openPrintLog = true

--- a/common/src/test/java/org/tron/core/config/args/NodeConfigTest.java
+++ b/common/src/test/java/org/tron/core/config/args/NodeConfigTest.java
@@ -316,7 +316,7 @@ public class NodeConfigTest {
   }
 
   @Test
-  public void testShieldedApiLegacyKeyTakesPriorityOverModern() {
+  public void testShieldedApiModernKeyTakesPriorityOverLegacy() {
     // Consistent with maxActiveNodesWithSameIp: legacy key presence wins over modern.
     NodeConfig nc = NodeConfig.fromConfig(
         withRef("node {\n"
@@ -343,4 +343,41 @@ public class NodeConfigTest {
             + "}"));
     assertFalse(nc.isAllowShieldedTransactionApi());
   }
+
+  // ----- discovery.external.ip: null / "null" sentinel handling -----
+
+  @Test
+  public void testExternalIpAbsentDefaultsToEmpty() {
+    NodeConfig nc = NodeConfig.fromConfig(withRef());
+    assertEquals("", nc.getDiscoveryExternalIp());
+  }
+
+  @Test
+  public void testExternalIpHoconNullTreatedAsEmpty() {
+    // HOCON `null` makes hasPath() return false; getString falls back to "".
+    NodeConfig nc = NodeConfig.fromConfig(
+        withRef("node.discovery.external.ip = null"));
+    assertEquals("", nc.getDiscoveryExternalIp());
+  }
+
+  @Test
+  public void testExternalIpStringNullSentinelConvertedToEmpty() {
+    // String literal "null" (case-insensitive) is an explicit sentinel that must map to "".
+    NodeConfig nc = NodeConfig.fromConfig(
+        withRef("node.discovery.external.ip = \"null\""));
+    assertEquals("", nc.getDiscoveryExternalIp());
+
+    nc = NodeConfig.fromConfig(
+        withRef("node.discovery.external.ip = \"NULL\""));
+    assertEquals("", nc.getDiscoveryExternalIp());
+  }
+
+  @Test
+  public void testExternalIpValidValuePreserved() {
+    NodeConfig nc = NodeConfig.fromConfig(
+        withRef("node.discovery.external.ip = \"1.2.3.4\""));
+    assertEquals("1.2.3.4", nc.getDiscoveryExternalIp());
+  }
+
+
 }

--- a/common/src/test/java/org/tron/core/config/args/NodeConfigTest.java
+++ b/common/src/test/java/org/tron/core/config/args/NodeConfigTest.java
@@ -295,9 +295,6 @@ public class NodeConfigTest {
 
   @Test
   public void testShieldedApiLegacyKeyRespected() {
-    // Regression guard: reference.conf ships `allowShieldedTransactionApi = false`, which
-    // used to make the legacy-key fallback dead code. A user who only set the legacy key
-    // must still have their value honored.
     NodeConfig nc = NodeConfig.fromConfig(
         withRef("node.fullNodeAllowShieldedTransaction = true"));
     assertTrue(nc.isAllowShieldedTransactionApi());
@@ -317,7 +314,8 @@ public class NodeConfigTest {
 
   @Test
   public void testShieldedApiModernKeyTakesPriorityOverLegacy() {
-    // Consistent with maxActiveNodesWithSameIp: legacy key presence wins over modern.
+    // When both keys are set, the modern key wins; the legacy key is only used as fallback
+    // when modern is absent.
     NodeConfig nc = NodeConfig.fromConfig(
         withRef("node {\n"
             + "  allowShieldedTransactionApi = true\n"

--- a/common/src/test/java/org/tron/core/config/args/NodeConfigTest.java
+++ b/common/src/test/java/org/tron/core/config/args/NodeConfigTest.java
@@ -23,7 +23,6 @@ public class NodeConfigTest {
     Config empty = withRef();
     NodeConfig nc = NodeConfig.fromConfig(empty);
     assertEquals(18888, nc.getListenPort());
-    assertEquals(2, nc.getConnectionTimeout());
     assertEquals(500, nc.getFetchBlockTimeout());
     assertEquals(30, nc.getMaxConnections());
     assertEquals(8, nc.getMinConnections());
@@ -32,7 +31,6 @@ public class NodeConfigTest {
     // reference.conf matches code default: discovery disabled when not configured
     assertFalse(nc.isDiscoveryEnable());
     assertFalse(nc.isDiscoveryPersist());
-    assertEquals(0, nc.getChannelReadTimeout());
   }
 
   @Test
@@ -42,7 +40,6 @@ public class NodeConfigTest {
             + " fetchBlock { timeout = 300 }, solidity { threads = 4 } }");
     NodeConfig nc = NodeConfig.fromConfig(config);
     assertEquals(19999, nc.getListenPort());
-    assertEquals(5, nc.getConnectionTimeout());
     assertEquals(300, nc.getFetchBlockTimeout());
     assertEquals(4, nc.getSolidityThreads());
   }

--- a/common/src/test/java/org/tron/core/config/args/NodeConfigTest.java
+++ b/common/src/test/java/org/tron/core/config/args/NodeConfigTest.java
@@ -301,6 +301,18 @@ public class NodeConfigTest {
     NodeConfig nc = NodeConfig.fromConfig(
         withRef("node.fullNodeAllowShieldedTransaction = true"));
     assertTrue(nc.isAllowShieldedTransactionApi());
+    nc = NodeConfig.fromConfig(
+        withRef("node.fullNodeAllowShieldedTransaction = false"));
+    assertFalse(nc.isAllowShieldedTransactionApi());
+    nc = NodeConfig.fromConfig(
+        withRef("node.allowShieldedTransactionApi = true"));
+    assertTrue(nc.isAllowShieldedTransactionApi());
+    nc = NodeConfig.fromConfig(
+        withRef("node.allowShieldedTransactionApi = false"));
+    assertFalse(nc.isAllowShieldedTransactionApi());
+    nc = NodeConfig.fromConfig(
+        withRef(""));
+    assertFalse(nc.isAllowShieldedTransactionApi());
   }
 
   @Test
@@ -308,9 +320,27 @@ public class NodeConfigTest {
     // Consistent with maxActiveNodesWithSameIp: legacy key presence wins over modern.
     NodeConfig nc = NodeConfig.fromConfig(
         withRef("node {\n"
-            + "  allowShieldedTransactionApi = false\n"
+            + "  allowShieldedTransactionApi = true\n"
             + "  fullNodeAllowShieldedTransaction = true\n"
             + "}"));
     assertTrue(nc.isAllowShieldedTransactionApi());
+    nc = NodeConfig.fromConfig(
+        withRef("node {\n"
+            + "  allowShieldedTransactionApi = true\n"
+            + "  fullNodeAllowShieldedTransaction = false\n"
+            + "}"));
+    assertTrue(nc.isAllowShieldedTransactionApi());
+    nc = NodeConfig.fromConfig(
+        withRef("node {\n"
+            + "  allowShieldedTransactionApi = false\n"
+            + "  fullNodeAllowShieldedTransaction = true\n"
+            + "}"));
+    assertFalse(nc.isAllowShieldedTransactionApi());
+    nc = NodeConfig.fromConfig(
+        withRef("node {\n"
+            + "  allowShieldedTransactionApi = false\n"
+            + "  fullNodeAllowShieldedTransaction = false\n"
+            + "}"));
+    assertFalse(nc.isAllowShieldedTransactionApi());
   }
 }

--- a/framework/src/main/java/org/tron/core/config/args/Args.java
+++ b/framework/src/main/java/org/tron/core/config/args/Args.java
@@ -510,7 +510,7 @@ public class Args extends CommonParameter {
    * which are applied here after copying the bean value.
    *
    * @param nc the NodeConfig bean populated from config.conf "node" section
-   *               node.discovery / node.channel.read.timeout (dot-notation paths
+   *               node.discovery /  (dot-notation paths
    *               not part of the NodeConfig bean)
    */
   @SuppressWarnings("checkstyle:MethodLength")
@@ -578,7 +578,6 @@ public class Args extends CommonParameter {
 
     // ---- Flat scalar fields ----
     PARAMETER.nodeEffectiveCheckEnable = nc.isEffectiveCheckEnable();
-    PARAMETER.nodeConnectionTimeout = nc.getConnectionTimeout() * 1000;
 
     // fetchBlock.timeout — range check [100, 1000], default 500
     int fetchTimeout = nc.getFetchBlockTimeout();
@@ -606,8 +605,6 @@ public class Args extends CommonParameter {
 
     PARAMETER.maxHttpConnectNumber = nc.getMaxHttpConnectNumber();
     PARAMETER.netMaxTrxPerSecond = nc.getNetMaxTrxPerSecond();
-    PARAMETER.tcpNettyWorkThreadNum = nc.getTcpNettyWorkThreadNum();
-    PARAMETER.udpNettyWorkThreadNum = nc.getUdpNettyWorkThreadNum();
 
     if (StringUtils.isEmpty(PARAMETER.trustNodeAddr)) {
       String trustNode = nc.getTrustNode();
@@ -654,7 +651,6 @@ public class Args extends CommonParameter {
     // discovery (dot-notation, read in NodeConfig.fromConfig)
     PARAMETER.nodeDiscoveryEnable = nc.isDiscoveryEnable();
     PARAMETER.nodeDiscoveryPersist = nc.isDiscoveryPersist();
-    PARAMETER.nodeChannelReadTimeout = nc.getChannelReadTimeout();
 
     // Legacy maxActiveNodes fallback handled in NodeConfig.fromConfig()
 

--- a/framework/src/main/resources/config.conf
+++ b/framework/src/main/resources/config.conf
@@ -150,8 +150,6 @@ node {
 
   listen.port = 18888
 
-  connection.timeout = 2
-
   fetchBlock.timeout = 200
   # syncFetchBatchNum = 2000
 

--- a/framework/src/test/java/org/tron/common/ParameterTest.java
+++ b/framework/src/test/java/org/tron/common/ParameterTest.java
@@ -76,12 +76,8 @@ public class ParameterTest {
     assertFalse(parameter.isNodeDiscoveryPersist());
     parameter.setNodeEffectiveCheckEnable(false);
     assertFalse(parameter.isNodeEffectiveCheckEnable());
-    parameter.setNodeConnectionTimeout(500);
-    assertEquals(500, parameter.getNodeConnectionTimeout());
     parameter.setFetchBlockTimeout(500);
     assertEquals(500, parameter.getFetchBlockTimeout());
-    parameter.setNodeChannelReadTimeout(500);
-    assertEquals(500, parameter.getNodeChannelReadTimeout());
     parameter.setMaxConnections(500);
     assertEquals(500, parameter.getMaxConnections());
     parameter.setMinConnections(500);
@@ -170,10 +166,6 @@ public class ParameterTest {
     assertEquals(1, parameter.getAllowTvmSolidity059());
     parameter.setForbidTransferToContract(1);
     assertEquals(1, parameter.getForbidTransferToContract());
-    parameter.setTcpNettyWorkThreadNum(5);
-    assertEquals(5, parameter.getTcpNettyWorkThreadNum());
-    parameter.setUdpNettyWorkThreadNum(5);
-    assertEquals(5, parameter.getUdpNettyWorkThreadNum());
     parameter.setTrustNodeAddr("address");
     assertEquals("address", parameter.getTrustNodeAddr());
     parameter.setWalletExtensionApi(false);

--- a/framework/src/test/java/org/tron/core/config/args/ArgsTest.java
+++ b/framework/src/test/java/org/tron/core/config/args/ArgsTest.java
@@ -94,7 +94,6 @@ public class ArgsTest {
     Assert.assertTrue(parameter.isNodeDiscoveryPersist());
     Assert.assertEquals("46.168.1.1", parameter.getNodeExternalIp());
     Assert.assertEquals(18888, parameter.getNodeListenPort());
-    Assert.assertEquals(2000, parameter.getNodeConnectionTimeout());
     Assert.assertEquals(0, parameter.getActiveNodes().size());
     Assert.assertEquals(30, parameter.getMaxConnections());
     Assert.assertEquals(43, parameter.getNodeP2pVersion());

--- a/framework/src/test/resources/args-test.conf
+++ b/framework/src/test/resources/args-test.conf
@@ -85,8 +85,6 @@ node {
 
   listen.port = 18888
 
-  connection.timeout = 2
-
   active = []
 
   maxConnections = 30

--- a/framework/src/test/resources/config-localtest.conf
+++ b/framework/src/test/resources/config-localtest.conf
@@ -77,12 +77,6 @@ node {
 
   listen.port = 6666
 
-  connection.timeout = 2
-
-  tcpNettyWorkThreadNum = 0
-
-  udpNettyWorkThreadNum = 1
-
   # Number of validate sign thread, default availableProcessors / 2
   # validateSignThreadNum = 16
 

--- a/framework/src/test/resources/config-test-index.conf
+++ b/framework/src/test/resources/config-test-index.conf
@@ -60,8 +60,6 @@ node.discovery = {
 node {
   listen.port = 18888
 
-  connection.timeout = 2
-
   active = [
     # Sample entries:
     # { url = "enode://<hex nodeID>@hostname.com:30303" }

--- a/framework/src/test/resources/config-test-mainnet.conf
+++ b/framework/src/test/resources/config-test-mainnet.conf
@@ -62,8 +62,6 @@ node {
 
   listen.port = 18888
 
-  connection.timeout = 2
-
   active = [
     # Sample entries:
     # { url = "enode://<hex nodeID>@hostname.com:30303" }

--- a/framework/src/test/resources/config-test-storagetest.conf
+++ b/framework/src/test/resources/config-test-storagetest.conf
@@ -85,8 +85,6 @@ node {
 
   listen.port = 18888
 
-  connection.timeout = 2
-
   active = [
     # Sample entries:
     # { url = "enode://<hex nodeID>@hostname.com:30303" }

--- a/framework/src/test/resources/config-test.conf
+++ b/framework/src/test/resources/config-test.conf
@@ -89,8 +89,6 @@ node {
 
   listen.port = 18888
 
-  connection.timeout = 2
-
   active = [
     # Sample entries:
     # { url = "enode://<hex nodeID>@hostname.com:30303" }


### PR DESCRIPTION
**What does this PR do?**

1. bug Fixes

  - treat "null" as unset for `discovery.external.ip`; bind via a flat externalIP.
  - fix the proprity of some config items, do not default `allowShieldedTransactionApi` in reference.conf; use it when set, else fall back to `fullNodeAllowShieldedTransaction` with a deprecation warning.

2. migration
  - remove unused node bindings: `node.connection.timeout`, `node.channel.read.timeout`, `node.tcpNettyWorkThreadNum`, `node.udpNettyWorkThreadNum`
  
**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

