### PR TITLE
fix(event): reject incompatible event-plugin versions below 3.0.0

### DIFF
--- a/framework/src/main/java/org/tron/common/logsfilter/EventPluginLoader.java
+++ b/framework/src/main/java/org/tron/common/logsfilter/EventPluginLoader.java
@@ -3,6 +3,7 @@ package org.tron.common.logsfilter;
 import com.beust.jcommander.internal.Sets;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Strings;
 import java.io.File;
 import java.util.HashSet;
 import java.util.List;
@@ -14,8 +15,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.bouncycastle.util.encoders.Hex;
 import org.pf4j.CompoundPluginDescriptorFinder;
 import org.pf4j.DefaultPluginManager;
+import org.pf4j.DefaultVersionManager;
 import org.pf4j.ManifestPluginDescriptorFinder;
 import org.pf4j.PluginManager;
+import org.pf4j.VersionManager;
 import org.springframework.util.StringUtils;
 import org.tron.common.logsfilter.nativequeue.NativeMessageQueue;
 import org.tron.common.logsfilter.trigger.BlockLogTrigger;
@@ -28,6 +31,16 @@ import org.tron.common.logsfilter.trigger.Trigger;
 
 @Slf4j
 public class EventPluginLoader {
+
+  /**
+   * Minimum event-plugin Plugin-Version compatible with this node. Bumped to 3.0.0 to
+   * reject pre-fastjson-removal builds whose worker threads would fail with
+   * NoClassDefFoundError on com.alibaba.fastjson at runtime. The previous event-plugin
+   * release is 2.2.0, so 3.0.0 is the first version that ships the Jackson replacement.
+   */
+  static final String MIN_PLUGIN_VERSION = "3.0.0";
+
+  private static final VersionManager VERSION_MANAGER = new DefaultVersionManager();
 
   private static EventPluginLoader instance;
 
@@ -457,6 +470,10 @@ public class EventPluginLoader {
       return false;
     }
 
+    if (!isPluginVersionSupported(pluginManager, pluginId)) {
+      return false;
+    }
+
     pluginManager.startPlugins();
 
     eventListeners = pluginManager.getExtensions(IPluginEventListener.class);
@@ -469,6 +486,21 @@ public class EventPluginLoader {
     logger.info("'{}' loaded", path);
 
     return true;
+  }
+
+  static boolean isPluginVersionSupported(PluginManager pm, String pluginId) {
+    String pluginVersion = pm.getPlugin(pluginId).getDescriptor().getVersion();
+    if (Strings.isNullOrEmpty(pluginVersion)) {
+      return false;
+    }
+    boolean isSupported = VERSION_MANAGER.compareVersions(pluginVersion, MIN_PLUGIN_VERSION) >= 0;
+
+    if (!isSupported) {
+      logger.error(
+          "event-plugin '{}' version {} is older than required {}, please upgrade event-plugin",
+          pluginId, pluginVersion, MIN_PLUGIN_VERSION);
+    }
+    return isSupported;
   }
 
   public void stopPlugin() {

--- a/framework/src/test/java/org/tron/common/logsfilter/EventLoaderTest.java
+++ b/framework/src/test/java/org/tron/common/logsfilter/EventLoaderTest.java
@@ -3,11 +3,16 @@ package org.tron.common.logsfilter;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.Assert;
 import org.junit.Test;
+import org.pf4j.PluginDescriptor;
+import org.pf4j.PluginManager;
+import org.pf4j.PluginWrapper;
 import org.tron.common.logsfilter.trigger.BlockLogTrigger;
 import org.tron.common.logsfilter.trigger.TransactionLogTrigger;
 
@@ -46,6 +51,32 @@ public class EventLoaderTest {
     assertTrue(EventPluginLoader.getInstance().start(config));
 
     EventPluginLoader.getInstance().stopPlugin();
+  }
+
+  @Test
+  public void testIsPluginVersionSupported() {
+    assertEquals("3.0.0", EventPluginLoader.MIN_PLUGIN_VERSION);
+    // last releases before fastjson removal — must be rejected
+    assertFalse(checkVersion("1.0.0"));
+    assertFalse(checkVersion("2.2.0"));
+    assertFalse(checkVersion("2.9.9"));
+    // 3.0.0 onward — must be accepted
+    assertTrue(checkVersion("3.0.0"));
+    assertTrue(checkVersion("3.1.5"));
+    assertTrue(checkVersion("10.0.0"));
+    // empty/null version — reject
+    assertFalse(checkVersion(""));
+    assertFalse(checkVersion(null));
+  }
+
+  private static boolean checkVersion(String version) {
+    PluginManager pm = mock(PluginManager.class);
+    PluginWrapper wrapper = mock(PluginWrapper.class);
+    PluginDescriptor desc = mock(PluginDescriptor.class);
+    when(pm.getPlugin("test")).thenReturn(wrapper);
+    when(wrapper.getDescriptor()).thenReturn(desc);
+    when(desc.getVersion()).thenReturn(version);
+    return EventPluginLoader.isPluginVersionSupported(pm, "test");
   }
 
   @Test


### PR DESCRIPTION
**What does this PR do?**

Enforce a minimum `Plugin-Version` at startup in `EventPluginLoader.startPlugin` using `pf4j's VersionManager` (semver). When the descriptor version is below `3.0.0`, log a clear upgrade hint and return false; the existing call chain in `Manager.startEventSubscribing` wraps it in a `TronError(EVENT_SUBSCRIBE_INIT)` and aborts node startup instead of silently degrading.

**Why are these changes required?**

Pre-3.0.0 event-plugin builds still link against `com.alibaba.fastjson`, which was removed from java-tron in #6701. When such a plugin is loaded, the `NoClassDefFoundError` surfaces inside the plugin's own worker thread and is swallowed by its catch(Throwable) handler. The node keeps running while silently dropping every trigger, leaving operators without any indication that the event subscription is broken.

**This PR has been tested by:**
- Unit Tests: Add a unit test covering accept/reject boundaries and empty/null versions.
- Manual Testing

**Follow up**
   - https://github.com/tronprotocol/event-plugin/pull/54
**Extra details**
```log
09:06:03.792 ERROR [main] [o.t.c.l.EventPluginLoader](EventPluginLoader.java:499) event-plugin 'kafka' version 1.0.0 is older than required 3.0.0, please upgrade event-plugin
09:07:41.179 ERROR [main] [o.t.c.l.EventPluginLoader](EventPluginLoader.java:499) event-plugin 'mongodb' version 1.0.0 is older than required 3.0.0, please upgrade event-plugin
```

