### PR TITLE
fix(jsonrpc): make the JSON-RPC output more compliant with specification

### DIFF
--- a/framework/src/main/java/org/tron/core/services/jsonrpc/JsonRpcServlet.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/JsonRpcServlet.java
@@ -247,6 +247,7 @@ public class JsonRpcServlet extends RateLimiterServlet {
 
     // JSON-RPC 2.0 §6: MUST NOT return an empty Array when there are no response objects.
     if (batchResult.isEmpty()) {
+      resp.setContentType("application/json-rpc");
       resp.setStatus(HttpServletResponse.SC_OK);
       resp.setContentLength(0);
       return;

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/JsonRpcServlet.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/JsonRpcServlet.java
@@ -177,18 +177,28 @@ public class JsonRpcServlet extends RateLimiterServlet {
     for (int i = 0; i < rootNode.size(); i++) {
       JsonNode subRequest = rootNode.get(i);
 
-      if (!subRequest.isObject()) {
-        batchResult.add(buildErrorNode(JsonRpcError.INVALID_REQUEST, "Invalid Request", null));
-        continue;
-      }
-
       if (overflow) {
-        // Notifications (no "id") do not get a response even on overflow.
-        if (subRequest.has("id")) {
+        if (!subRequest.isObject()) {
+          batchResult.add(buildErrorNode(JsonRpcError.INVALID_REQUEST, "Invalid Request", null));
+        } else if (subRequest.has("id")) {
+          // Notifications (no "id") do not get a response even on overflow.
           batchResult.add(buildErrorNode(JsonRpcError.RESPONSE_TOO_LARGE,
               "Response exceeds the limit of " + maxResponseSize + " bytes",
               subRequest.get("id")));
         }
+        continue;
+      }
+
+      if (!subRequest.isObject()) {
+        ObjectNode errNode = buildErrorNode(JsonRpcError.INVALID_REQUEST, "Invalid Request", null);
+        byte[] errBytes = MAPPER.writeValueAsBytes(errNode);
+        int addition = errBytes.length + (!batchResult.isEmpty() ? 1 : 0);
+        if (maxResponseSize > 0 && accumulatedSize + addition > maxResponseSize) {
+          overflow = true;
+        } else {
+          accumulatedSize += addition;
+        }
+        batchResult.add(errNode);
         continue;
       }
 

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/JsonRpcServlet.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/JsonRpcServlet.java
@@ -111,11 +111,11 @@ public class JsonRpcServlet extends RateLimiterServlet {
     try {
       rootNode = MAPPER.readTree(body);
       if (rootNode == null || rootNode.isMissingNode()) {
-        writeJsonRpcError(resp, JsonRpcError.PARSE_ERROR, "Parse error", null, false);
+        writeJsonRpcError(resp, JsonRpcError.PARSE_ERROR, "JSON parse error", null, false);
         return;
       }
     } catch (JsonProcessingException e) {
-      writeJsonRpcError(resp, JsonRpcError.PARSE_ERROR, "Parse error", null, false);
+      writeJsonRpcError(resp, JsonRpcError.PARSE_ERROR, "JSON parse error", null, false);
       return;
     }
 

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/JsonRpcServlet.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/JsonRpcServlet.java
@@ -1,6 +1,8 @@
 package org.tron.core.services.jsonrpc;
 
+import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.StreamReadConstraints;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -30,7 +32,19 @@ import org.tron.core.services.http.RateLimiterServlet;
 @Slf4j(topic = "API")
 public class JsonRpcServlet extends RateLimiterServlet {
 
-  private static final ObjectMapper MAPPER = new ObjectMapper();
+  // Snapshot of node.http.maxNestingDepth / maxTokenCount at class-load time (after Args.setParam).
+  private static final ObjectMapper MAPPER = buildMapper();
+
+  private static ObjectMapper buildMapper() {
+    CommonParameter p = CommonParameter.getInstance();
+    JsonFactory factory = JsonFactory.builder()
+        .streamReadConstraints(StreamReadConstraints.builder()
+            .maxNestingDepth(p.getMaxNestingDepth())
+            .maxTokenCount(p.getMaxTokenCount())
+            .build())
+        .build();
+    return new ObjectMapper(factory);
+  }
 
   private enum JsonRpcError {
     PARSE_ERROR(-32700),
@@ -105,6 +119,11 @@ public class JsonRpcServlet extends RateLimiterServlet {
       return;
     }
 
+    if (!rootNode.isObject() && !rootNode.isArray()) {
+      writeJsonRpcError(resp, JsonRpcError.INVALID_REQUEST, "Invalid Request", null, false);
+      return;
+    }
+
     boolean isBatch = rootNode.isArray();
     if (isBatch && rootNode.isEmpty()) {
       writeJsonRpcError(resp, JsonRpcError.INVALID_REQUEST, "Invalid Request", null, false);
@@ -157,6 +176,11 @@ public class JsonRpcServlet extends RateLimiterServlet {
 
     for (int i = 0; i < rootNode.size(); i++) {
       JsonNode subRequest = rootNode.get(i);
+
+      if (!subRequest.isObject()) {
+        batchResult.add(buildErrorNode(JsonRpcError.INVALID_REQUEST, "Invalid Request", null));
+        continue;
+      }
 
       if (overflow) {
         // Notifications (no "id") do not get a response even on overflow.
@@ -219,7 +243,7 @@ public class JsonRpcServlet extends RateLimiterServlet {
     }
 
     byte[] finalBytes = MAPPER.writeValueAsBytes(batchResult);
-    resp.setContentType("application/json-rpc; charset=utf-8");
+    resp.setContentType("application/json-rpc");
     resp.setStatus(HttpServletResponse.SC_OK);
     resp.setContentLength(finalBytes.length);
     resp.getOutputStream().write(finalBytes);
@@ -261,7 +285,7 @@ public class JsonRpcServlet extends RateLimiterServlet {
     } else {
       bytes = MAPPER.writeValueAsBytes(errorObj);
     }
-    resp.setContentType("application/json-rpc; charset=utf-8");
+    resp.setContentType("application/json-rpc");
     resp.setStatus(HttpServletResponse.SC_OK);
     resp.setContentLength(bytes.length);
     resp.getOutputStream().write(bytes);

--- a/framework/src/test/java/org/tron/core/services/jsonrpc/JsonRpcServletTest.java
+++ b/framework/src/test/java/org/tron/core/services/jsonrpc/JsonRpcServletTest.java
@@ -245,6 +245,143 @@ public class JsonRpcServletTest {
     assertArrayEquals(rpcResp, resp.getContentAsByteArray());
   }
 
+  // --- Content-Type header: must be application/json-rpc (no charset suffix) ---
+
+  @Test
+  public void errorResponse_contentTypeIsApplicationJsonRpc() throws Exception {
+    MockHttpServletResponse resp = doPost("not valid json");
+    assertEquals("application/json-rpc", resp.getContentType());
+  }
+
+  @Test
+  public void batchResponse_contentTypeIsApplicationJsonRpc() throws Exception {
+    byte[] singleResp = "{\"jsonrpc\":\"2.0\",\"result\":\"ok\",\"id\":1}"
+        .getBytes(StandardCharsets.UTF_8);
+    doAnswer(inv -> {
+      OutputStream out = inv.getArgument(1);
+      out.write(singleResp);
+      return 0;
+    }).when(mockRpcServer).handleRequest(any(InputStream.class), any(OutputStream.class));
+
+    MockHttpServletResponse resp = doPost("[{\"id\":1}]");
+    assertEquals("application/json-rpc", resp.getContentType());
+  }
+
+  // --- Primitive root node → Invalid Request (-32600), id must be JSON null ---
+
+  @Test
+  public void primitiveRootNull_returnsInvalidRequestWithJsonNullId() throws Exception {
+    MockHttpServletResponse resp = doPost("null");
+    assertEquals(200, resp.getStatus());
+    JsonNode body = MAPPER.readTree(resp.getContentAsString());
+    assertFalse(body.isArray());
+    assertEquals("2.0", body.get("jsonrpc").asText());
+    assertEquals(-32600, body.get("error").get("code").asInt());
+    assertTrue("id must be JSON null, not the string \"null\"", body.get("id").isNull());
+    assertFalse("id must not be a string", body.get("id").isTextual());
+  }
+
+  @Test
+  public void primitiveRootBoolean_returnsInvalidRequest() throws Exception {
+    MockHttpServletResponse resp = doPost("true");
+    assertEquals(200, resp.getStatus());
+    assertEquals(-32600, MAPPER.readTree(resp.getContentAsString()).get("error").get("code").asInt());
+  }
+
+  @Test
+  public void primitiveRootNumber_returnsInvalidRequest() throws Exception {
+    MockHttpServletResponse resp = doPost("123");
+    assertEquals(200, resp.getStatus());
+    assertEquals(-32600, MAPPER.readTree(resp.getContentAsString()).get("error").get("code").asInt());
+  }
+
+  @Test
+  public void primitiveRootString_returnsInvalidRequest() throws Exception {
+    MockHttpServletResponse resp = doPost("\"hello\"");
+    assertEquals(200, resp.getStatus());
+    assertEquals(-32600, MAPPER.readTree(resp.getContentAsString()).get("error").get("code").asInt());
+  }
+
+  // --- Non-object element inside a batch → Invalid Request per element ---
+
+  @Test
+  public void batchWithNestedArray_returnsInvalidRequestArray() throws Exception {
+    MockHttpServletResponse resp = doPost("[[]]");
+    assertEquals(200, resp.getStatus());
+    JsonNode body = MAPPER.readTree(resp.getContentAsString());
+    assertTrue("response must be a JSON array", body.isArray());
+    assertEquals(1, body.size());
+    assertEquals(-32600, body.get(0).get("error").get("code").asInt());
+    assertTrue("id in batch error must be JSON null", body.get(0).get("id").isNull());
+  }
+
+  @Test
+  public void batchWithMixedObjectAndArray_objectProcessedArrayRejected() throws Exception {
+    byte[] singleResp = "{\"jsonrpc\":\"2.0\",\"result\":\"ok\",\"id\":1}"
+        .getBytes(StandardCharsets.UTF_8);
+    doAnswer(inv -> {
+      OutputStream out = inv.getArgument(1);
+      out.write(singleResp);
+      return 0;
+    }).when(mockRpcServer).handleRequest(any(InputStream.class), any(OutputStream.class));
+
+    MockHttpServletResponse resp = doPost("[{\"id\":1}, []]");
+    assertEquals(200, resp.getStatus());
+    JsonNode body = MAPPER.readTree(resp.getContentAsString());
+    assertTrue("response must be a JSON array", body.isArray());
+    assertEquals(2, body.size());
+    assertEquals("ok", body.get(0).get("result").asText());
+    assertEquals(-32600, body.get(1).get("error").get("code").asInt());
+  }
+
+  @Test
+  public void batchWithNumericAndStringElements_allGetInvalidRequest() throws Exception {
+    MockHttpServletResponse resp = doPost("[42, \"foo\", true]");
+    assertEquals(200, resp.getStatus());
+    JsonNode body = MAPPER.readTree(resp.getContentAsString());
+    assertTrue("response must be a JSON array", body.isArray());
+    assertEquals(3, body.size());
+    for (int i = 0; i < 3; i++) {
+      assertEquals(-32600, body.get(i).get("error").get("code").asInt());
+    }
+  }
+
+  // --- StreamReadConstraints: maxNestingDepth and maxTokenCount must be enforced ---
+
+  @Test
+  public void excessivelyNestedRequest_returnsParseError() throws Exception {
+    int limit = CommonParameter.getInstance().getMaxNestingDepth();
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i <= limit; i++) {
+      sb.append('[');
+    }
+    sb.append('0');
+    for (int i = 0; i <= limit; i++) {
+      sb.append(']');
+    }
+
+    MockHttpServletResponse resp = doPost(sb.toString());
+    assertEquals(200, resp.getStatus());
+    assertEquals(-32700, MAPPER.readTree(resp.getContentAsString()).get("error").get("code").asInt());
+  }
+
+  @Test
+  public void tooManyTokens_returnsParseError() throws Exception {
+    int limit = CommonParameter.getInstance().getMaxTokenCount();
+    StringBuilder sb = new StringBuilder("[");
+    for (int i = 0; i < limit; i++) {
+      if (i > 0) {
+        sb.append(',');
+      }
+      sb.append('0');
+    }
+    sb.append(']');
+
+    MockHttpServletResponse resp = doPost(sb.toString());
+    assertEquals(200, resp.getStatus());
+    assertEquals(-32700, MAPPER.readTree(resp.getContentAsString()).get("error").get("code").asInt());
+  }
+
   // --- helpers ---
 
   private MockHttpServletResponse doPost(String body) throws Exception {

--- a/framework/src/test/java/org/tron/core/services/jsonrpc/JsonRpcServletTest.java
+++ b/framework/src/test/java/org/tron/core/services/jsonrpc/JsonRpcServletTest.java
@@ -267,6 +267,18 @@ public class JsonRpcServletTest {
     assertEquals("application/json-rpc", resp.getContentType());
   }
 
+  @Test
+  public void allNotificationBatch_contentTypeIsApplicationJsonRpc() throws Exception {
+    // notification: rpcServer returns 0 bytes → empty batchResult → early return path
+    doAnswer(inv -> 0).when(mockRpcServer)
+        .handleRequest(any(InputStream.class), any(OutputStream.class));
+
+    MockHttpServletResponse resp = doPost("[{\"method\":\"eth_blockNumber\"}]");
+    assertEquals(200, resp.getStatus());
+    assertEquals(0, resp.getContentLength());
+    assertEquals("application/json-rpc", resp.getContentType());
+  }
+
   // --- Primitive root node → Invalid Request (-32600), id must be JSON null ---
 
   @Test

--- a/framework/src/test/java/org/tron/core/services/jsonrpc/JsonRpcServletTest.java
+++ b/framework/src/test/java/org/tron/core/services/jsonrpc/JsonRpcServletTest.java
@@ -285,21 +285,24 @@ public class JsonRpcServletTest {
   public void primitiveRootBoolean_returnsInvalidRequest() throws Exception {
     MockHttpServletResponse resp = doPost("true");
     assertEquals(200, resp.getStatus());
-    assertEquals(-32600, MAPPER.readTree(resp.getContentAsString()).get("error").get("code").asInt());
+    assertEquals(-32600,
+        MAPPER.readTree(resp.getContentAsString()).get("error").get("code").asInt());
   }
 
   @Test
   public void primitiveRootNumber_returnsInvalidRequest() throws Exception {
     MockHttpServletResponse resp = doPost("123");
     assertEquals(200, resp.getStatus());
-    assertEquals(-32600, MAPPER.readTree(resp.getContentAsString()).get("error").get("code").asInt());
+    assertEquals(-32600,
+        MAPPER.readTree(resp.getContentAsString()).get("error").get("code").asInt());
   }
 
   @Test
   public void primitiveRootString_returnsInvalidRequest() throws Exception {
     MockHttpServletResponse resp = doPost("\"hello\"");
     assertEquals(200, resp.getStatus());
-    assertEquals(-32600, MAPPER.readTree(resp.getContentAsString()).get("error").get("code").asInt());
+    assertEquals(-32600,
+        MAPPER.readTree(resp.getContentAsString()).get("error").get("code").asInt());
   }
 
   // --- Non-object element inside a batch → Invalid Request per element ---
@@ -362,7 +365,8 @@ public class JsonRpcServletTest {
 
     MockHttpServletResponse resp = doPost(sb.toString());
     assertEquals(200, resp.getStatus());
-    assertEquals(-32700, MAPPER.readTree(resp.getContentAsString()).get("error").get("code").asInt());
+    assertEquals(-32700,
+        MAPPER.readTree(resp.getContentAsString()).get("error").get("code").asInt());
   }
 
   @Test
@@ -379,7 +383,8 @@ public class JsonRpcServletTest {
 
     MockHttpServletResponse resp = doPost(sb.toString());
     assertEquals(200, resp.getStatus());
-    assertEquals(-32700, MAPPER.readTree(resp.getContentAsString()).get("error").get("code").asInt());
+    assertEquals(-32700,
+        MAPPER.readTree(resp.getContentAsString()).get("error").get("code").asInt());
   }
 
   // --- helpers ---


### PR DESCRIPTION
## What does this PR do?

Fixes three JSON-RPC spec-compliance issues and one parser-hardening gap in `JsonRpcServlet`:

### 1. `Content-Type` response header — remove spurious `; charset=utf-8`

The JSON-RPC 1.0/2.0 spec and Ethereum JSON-RPC both use `application/json` or `application/json-rpc` without a charset suffix. The extra `; charset=utf-8` suffix was non-standard and has been removed.

### 2. Non-object/non-array root node → `Invalid Request`

Sending a JSON primitive as the request body (e.g. `null`, `true`, `123`) was silently forwarded to `jsonrpc4j`, which produced a malformed response with `"id":"null"` (string) instead of `"id":null` (JSON null). Now these cases are caught before dispatch and return a proper `-32600 Invalid Request` response with `"id":null`.

**Before:**
```
POST /jsonrpc  body: null
→ {"jsonrpc":"2.0","id":"null","error":{"code":-32600,"message":"invalid request"}}
```

**After:**
```
POST /jsonrpc  body: null
→ {"jsonrpc":"2.0","id":null,"error":{"code":-32600,"message":"Invalid Request"}}
```

### 3. Non-object element inside a batch → `Invalid Request`

A batch containing a non-object element (e.g. `[[]]`) was forwarded per-element to `jsonrpc4j`, which echoed the inner array back unchanged, producing `[[]]` instead of an error. Non-object sub-requests are now rejected with `-32600 Invalid Request` before dispatch.

**Before:**
```
POST /jsonrpc  body: [[]]
→ [[]]
```

**After (Ethereum-compatible):**
```
POST /jsonrpc  body: [[]]
→ [{"jsonrpc":"2.0","error":{"code":-32600,"message":"Invalid Request"},"id":null}]
```

### 4. Apply `StreamReadConstraints` to the JSON-RPC parser

`JsonRpcServlet` used a bare `new ObjectMapper()`, so the `node.http.maxNestingDepth` and `node.http.maxTokenCount` settings introduced in #6701 had no effect on JSON-RPC requests. The mapper is now built with a `JsonFactory` that reads those two limits from `CommonParameter`, consistent with how `JSON.java` constructs its mapper.

Without this fix, a ~4 MB request body such as `[0,0,...,0]` (~2 M tokens) could bypass the configured `maxTokenCount` (default 100,000) and force Jackson to allocate ~2 M `JsonNode` objects, causing GC pressure (Eden/Survivor saturation → premature promotion → Full GC). With the fix, the parser throws after the configured token limit is reached, well before the 4 MB body-size cap.

## Why are these changes required?

- Issues 1–3: bring responses in line with the JSON-RPC 2.0 specification and Ethereum JSON-RPC behaviour.
- Issue 4: make the `node.http.maxNestingDepth` / `node.http.maxTokenCount` config knobs actually effective for the JSON-RPC endpoint, closing a token-density amplification vector.

## This PR has been tested by

- Unit Tests
- Manual Testing

## Extra details

Issue 4 shares the same root cause identified in the review comment on this PR: the `MAPPER` in `JsonRpcServlet` was not wired to the `StreamReadConstraints` configured via `node.http.*`.