### PR TITLE
fix(crypto): bind burn cipher nonce to nullifier

### DIFF
--- a/framework/src/main/java/org/tron/core/Wallet.java
+++ b/framework/src/main/java/org/tron/core/Wallet.java
@@ -3909,7 +3909,9 @@ public class Wallet {
             int index = 0;
             for (TransactionInfo.Log log : logList) {
               int logType = getShieldedTRC20LogType(log, shieldedTRC20ContractAddress);
-              if (logType > 0) {
+              // Only note-producing log types (1..3) advance the note index;
+              // TokenBurn (4) and NoteSpent (5) do not emit a leaf.
+              if (logType > 0 && logType < 4) {
                 noteBuilder = DecryptNotesTRC20.NoteTx.newBuilder();
                 noteBuilder.setTxid(ByteString.copyFrom(txId));
                 noteBuilder.setIndex(index);
@@ -4307,17 +4309,45 @@ public class Wallet {
         parameterType);
     if (parametersBuilder.getShieldedTRC20ParametersType() == ShieldedTRC20ParametersType.BURN) {
       byte[] burnCiper = ByteArray.fromHexString(shieldedTRC20Parameters.getTriggerContractInput());
-      if (!ArrayUtils.isEmpty(burnCiper)
-          && burnCiper.length == NoteEncryption.Encryption.BURN_CIPHER_RECORD_SIZE) {
-        parametersBuilder.setBurnCiphertext(burnCiper);
-      } else if (!ArrayUtils.isEmpty(burnCiper) && burnCiper.length == 80) {
-        throw new ZksnarkException(
-            "legacy 80-byte burn cipher is deprecated and rejected; expected "
-                + NoteEncryption.Encryption.BURN_CIPHER_RECORD_SIZE + "-byte burn record");
-      } else {
+      if (ArrayUtils.isEmpty(burnCiper)
+          || burnCiper.length != NoteEncryption.Encryption.BURN_CIPHER_RECORD_SIZE) {
+        if (!ArrayUtils.isEmpty(burnCiper) && burnCiper.length == 80) {
+          throw new ZksnarkException(
+              "legacy 80-byte burn cipher is deprecated and rejected; expected "
+                  + NoteEncryption.Encryption.BURN_CIPHER_RECORD_SIZE + "-byte burn record");
+        }
         throw new ZksnarkException(
             "invalid shielded TRC-20 contract parameters for burn trigger input");
       }
+      // v2-only: length alone would accept a legacy all-zero suffix and bypass
+      // the nf-bound nonce. Require reserved==v2 marker and nonce==derive(nf).
+      byte[] reserved = Arrays.copyOfRange(burnCiper,
+          NoteEncryption.Encryption.BURN_RESERVED_OFFSET,
+          NoteEncryption.Encryption.BURN_RESERVED_OFFSET
+              + NoteEncryption.Encryption.BURN_RESERVED_LEN);
+      if (!Arrays.equals(reserved, NoteEncryption.Encryption.getBurnRecordV2Marker())) {
+        throw new ZksnarkException(
+            "burn trigger input must be v2 (reserved=0x00000001); legacy/unknown markers rejected");
+      }
+      if (shieldedTRC20Parameters.getSpendDescriptionList().size() != 1) {
+        throw new ZksnarkException(
+            "burn trigger input requires exactly one spendDescription for nf-bound nonce");
+      }
+      byte[] nf = shieldedTRC20Parameters.getSpendDescription(0).getNullifier().toByteArray();
+      if (nf.length != 32) {
+        throw new ZksnarkException(
+            "burn trigger input requires 32-byte spendDescription.nullifier");
+      }
+      byte[] nonceFromInput = Arrays.copyOfRange(burnCiper,
+          NoteEncryption.Encryption.BURN_NONCE_OFFSET,
+          NoteEncryption.Encryption.BURN_NONCE_OFFSET
+              + NoteEncryption.Encryption.BURN_NONCE_LEN);
+      byte[] expectedNonce = NoteEncryption.Encryption.deriveNonceFromNf(nf);
+      if (!Arrays.equals(nonceFromInput, expectedNonce)) {
+        throw new ZksnarkException(
+            "burn trigger input nonce does not match nf-bound nonce");
+      }
+      parametersBuilder.setBurnCiphertext(burnCiper);
     }
     String input = parametersBuilder
         .getTriggerContractInput(shieldedTRC20Parameters, spendAuthoritySignature, value, false,

--- a/framework/src/main/java/org/tron/core/Wallet.java
+++ b/framework/src/main/java/org/tron/core/Wallet.java
@@ -270,6 +270,8 @@ public class Wallet {
       "BurnNewLeaf(uint256,bytes32,bytes32,bytes32,bytes32[21])"));
   private static final byte[] SHIELDED_TRC20_LOG_TOPICS_BURN_TOKEN = Hash.sha3(ByteArray
       .fromString("TokenBurn(address,uint256,bytes32[3])"));
+  private static final byte[] SHIELDED_TRC20_LOG_TOPICS_NOTE_SPENT = Hash.sha3(ByteArray
+      .fromString("NoteSpent(bytes32)"));
   private static final String BROADCAST_TRANS_FAILED = "Broadcast transaction {} failed, {}.";
 
   @Getter
@@ -3672,9 +3674,7 @@ public class Wallet {
         builder.setTransparentToAddress(transparentToAddressTvm);
         builder.setTransparentToAmount(toAmount);
 
-        Optional<byte[]> cipher = NoteEncryption.Encryption
-            .encryptBurnMessageByOvk(ovk, toAmount, transparentToAddress);
-        cipher.ifPresent(builder::setBurnCiphertext);
+        builder.setOvk(ovk);
 
         ExpandedSpendingKey expsk = new ExpandedSpendingKey(ask, nsk, ovk);
         GrpcAPI.SpendNoteTRC20 spendNote = shieldedSpends.get(0);
@@ -3799,9 +3799,7 @@ public class Wallet {
         System.arraycopy(transparentToAddress, 1, transparentToAddressTvm, 0, 20);
         builder.setTransparentToAddress(transparentToAddressTvm);
         builder.setTransparentToAmount(toAmount);
-        Optional<byte[]> cipher = NoteEncryption.Encryption
-            .encryptBurnMessageByOvk(ovk, toAmount, transparentToAddress);
-        cipher.ifPresent(builder::setBurnCiphertext);
+        builder.setOvk(ovk);
         GrpcAPI.SpendNoteTRC20 spendNote = shieldedSpends.get(0);
         buildShieldedTRC20InputWithAK(builder, spendNote, ak, nsk);
         if (receiveSize == 1) {
@@ -3838,6 +3836,8 @@ public class Wallet {
         return 3;
       } else if (Arrays.equals(topicsBytes, SHIELDED_TRC20_LOG_TOPICS_BURN_TOKEN)) {
         return 4;
+      } else if (Arrays.equals(topicsBytes, SHIELDED_TRC20_LOG_TOPICS_NOTE_SPENT)) {
+        return 5;
       }
     }
     return 0;
@@ -4001,7 +4001,8 @@ public class Wallet {
 
   private Optional<DecryptNotesTRC20.NoteTx> getNoteTxFromLogListByOvk(
       DecryptNotesTRC20.NoteTx.Builder builder,
-      TransactionInfo.Log log, byte[] ovk, int logType) throws ZksnarkException {
+      TransactionInfo.Log log, byte[] ovk, int logType, byte[] pendingNf)
+      throws ZksnarkException {
     byte[] logData = log.getData().toByteArray();
     if (!ArrayUtils.isEmpty(logData)) {
       if (logType > 0 && logType < 4) {
@@ -4040,18 +4041,32 @@ public class Wallet {
           }
         }
       } else if (logType == 4) {
-        //Data = toAddress(32) + value(32) + ciphertext(80) + padding(16)
+        // Data = toAddress(32) + value(32) + cipher(80) + nonce(12) + reserved/version(4)
+        if (logData.length < 64 + NoteEncryption.Encryption.BURN_CIPHER_RECORD_SIZE) {
+          return Optional.empty();
+        }
         byte[] logToAddress = ByteArray.subArray(logData, 12, 32);
         byte[] logAmountArray = ByteArray.subArray(logData, 32, 64);
         byte[] cipher = ByteArray.subArray(logData, 64, 144);
+        byte[] nonceFromLog = ByteArray.subArray(logData, 144,
+            144 + NoteEncryption.Encryption.BURN_NONCE_LEN);
+        byte[] reservedFromLog = ByteArray.subArray(logData,
+            144 + NoteEncryption.Encryption.BURN_NONCE_LEN,
+            144 + NoteEncryption.Encryption.BURN_NONCE_LEN
+                + NoteEncryption.Encryption.BURN_RESERVED_LEN);
         BigInteger logAmount = ByteUtil.bytesToBigInteger(logAmountArray);
         byte[] plaintext;
         byte[] amountArray = new byte[32];
         byte[] decryptedAddress = new byte[20];
+
         Optional<byte[]> decryptedText = NoteEncryption.Encryption
-            .decryptBurnMessageByOvk(ovk, cipher);
+            .decryptBurnMessageByOvk(ovk, cipher, nonceFromLog, reservedFromLog, pendingNf);
+
         if (decryptedText.isPresent()) {
           plaintext = decryptedText.get();
+          if (plaintext[32] != Wallet.getAddressPreFixByte()) {
+            return Optional.empty();
+          }
           System.arraycopy(plaintext, 0, amountArray, 0, 32);
           System.arraycopy(plaintext, 33, decryptedAddress, 0, 20);
           BigInteger decryptedAmount = ByteUtil.bytesToBigInteger(amountArray);
@@ -4091,15 +4106,24 @@ public class Wallet {
           if (!Objects.isNull(logList)) {
             Optional<DecryptNotesTRC20.NoteTx> noteTx;
             int index = 0;
+            byte[] pendingNf = null;
             for (TransactionInfo.Log log : logList) {
               int logType = getShieldedTRC20LogType(log, shieldedTRC20ContractAddress);
-              if (logType > 0) {
+              if (logType == 5) {
+                byte[] logData = log.getData().toByteArray();
+                if (logData.length >= 32) {
+                  pendingNf = ByteArray.subArray(logData, 0, 32);
+                }
+              } else if (logType > 0) {
                 noteBuilder = DecryptNotesTRC20.NoteTx.newBuilder();
                 noteBuilder.setTxid(ByteString.copyFrom(txid));
                 noteBuilder.setIndex(index);
                 index += 1;
-                noteTx = getNoteTxFromLogListByOvk(noteBuilder, log, ovk, logType);
+                noteTx = getNoteTxFromLogListByOvk(noteBuilder, log, ovk, logType, pendingNf);
                 noteTx.ifPresent(builder::addNoteTxs);
+                if (logType == 4) {
+                  pendingNf = null;
+                }
               }
             }
           }
@@ -4283,8 +4307,13 @@ public class Wallet {
         parameterType);
     if (parametersBuilder.getShieldedTRC20ParametersType() == ShieldedTRC20ParametersType.BURN) {
       byte[] burnCiper = ByteArray.fromHexString(shieldedTRC20Parameters.getTriggerContractInput());
-      if (!ArrayUtils.isEmpty(burnCiper) && burnCiper.length == 80) {
+      if (!ArrayUtils.isEmpty(burnCiper)
+          && burnCiper.length == NoteEncryption.Encryption.BURN_CIPHER_RECORD_SIZE) {
         parametersBuilder.setBurnCiphertext(burnCiper);
+      } else if (!ArrayUtils.isEmpty(burnCiper) && burnCiper.length == 80) {
+        throw new ZksnarkException(
+            "legacy 80-byte burn cipher is deprecated and rejected; expected "
+                + NoteEncryption.Encryption.BURN_CIPHER_RECORD_SIZE + "-byte burn record");
       } else {
         throw new ZksnarkException(
             "invalid shielded TRC-20 contract parameters for burn trigger input");

--- a/framework/src/main/java/org/tron/core/Wallet.java
+++ b/framework/src/main/java/org/tron/core/Wallet.java
@@ -4061,8 +4061,12 @@ public class Wallet {
         byte[] amountArray = new byte[32];
         byte[] decryptedAddress = new byte[20];
 
+        byte[] addr21FromLog = new byte[21];
+        addr21FromLog[0] = Wallet.getAddressPreFixByte();
+        System.arraycopy(logToAddress, 0, addr21FromLog, 1, 20);
         Optional<byte[]> decryptedText = NoteEncryption.Encryption
-            .decryptBurnMessageByOvk(ovk, cipher, nonceFromLog, reservedFromLog, pendingNf);
+            .decryptBurnMessageByOvk(ovk, cipher, nonceFromLog, reservedFromLog, pendingNf,
+                logAmountArray, addr21FromLog);
 
         if (decryptedText.isPresent()) {
           plaintext = decryptedText.get();
@@ -4342,10 +4346,14 @@ public class Wallet {
           NoteEncryption.Encryption.BURN_NONCE_OFFSET,
           NoteEncryption.Encryption.BURN_NONCE_OFFSET
               + NoteEncryption.Encryption.BURN_NONCE_LEN);
-      byte[] expectedNonce = NoteEncryption.Encryption.deriveNonceFromNf(nf);
+      byte[] amount32 = ByteUtil.bigIntegerToBytes(value, 32);
+      byte[] addr21 = new byte[21];
+      addr21[0] = Wallet.getAddressPreFixByte();
+      System.arraycopy(transparentToAddressTvm, 0, addr21, 1, 20);
+      byte[] expectedNonce = NoteEncryption.Encryption.deriveBurnNonce(nf, amount32, addr21);
       if (!Arrays.equals(nonceFromInput, expectedNonce)) {
         throw new ZksnarkException(
-            "burn trigger input nonce does not match nf-bound nonce");
+            "burn trigger input nonce does not match nonce bound to (nf, amount, addr)");
       }
       parametersBuilder.setBurnCiphertext(burnCiper);
     }

--- a/framework/src/main/java/org/tron/core/zen/ShieldedTRC20ParametersBuilder.java
+++ b/framework/src/main/java/org/tron/core/zen/ShieldedTRC20ParametersBuilder.java
@@ -63,8 +63,16 @@ public class ShieldedTRC20ParametersBuilder {
   private BigInteger transparentToAmount;
   @Setter
   private byte[] ovk;
-  @Setter
   private byte[] burnCiphertext = new byte[Encryption.BURN_CIPHER_RECORD_SIZE];
+
+  public void setBurnCiphertext(byte[] burnCiphertext) {
+    if (burnCiphertext == null
+        || burnCiphertext.length != Encryption.BURN_CIPHER_RECORD_SIZE) {
+      throw new IllegalArgumentException(
+          "burnCiphertext must be " + Encryption.BURN_CIPHER_RECORD_SIZE + " bytes");
+    }
+    this.burnCiphertext = burnCiphertext.clone();
+  }
 
   public ShieldedTRC20ParametersBuilder() {
 

--- a/framework/src/main/java/org/tron/core/zen/ShieldedTRC20ParametersBuilder.java
+++ b/framework/src/main/java/org/tron/core/zen/ShieldedTRC20ParametersBuilder.java
@@ -30,6 +30,7 @@ import org.tron.core.zen.address.ExpandedSpendingKey;
 import org.tron.core.zen.address.PaymentAddress;
 import org.tron.core.zen.note.Note;
 import org.tron.core.zen.note.NoteEncryption;
+import org.tron.core.zen.note.NoteEncryption.Encryption;
 import org.tron.core.zen.note.OutgoingPlaintext;
 import org.tron.protos.contract.ShieldContract;
 import org.tron.protos.contract.ShieldContract.ReceiveDescription;
@@ -61,7 +62,9 @@ public class ShieldedTRC20ParametersBuilder {
   @Setter
   private BigInteger transparentToAmount;
   @Setter
-  private byte[] burnCiphertext = new byte[80];
+  private byte[] ovk;
+  @Setter
+  private byte[] burnCiphertext = new byte[Encryption.BURN_CIPHER_RECORD_SIZE];
 
   public ShieldedTRC20ParametersBuilder() {
 
@@ -207,6 +210,9 @@ public class ShieldedTRC20ParametersBuilder {
 
   private void createSpendAuth(byte[] dataToBeSigned) throws ZksnarkException {
     for (int i = 0; i < spends.size(); i++) {
+      if (spends.get(i).expsk == null) {
+        throw new ZksnarkException("missing expanded spending key for spend authorization");
+      }
       byte[] result = new byte[64];
       JLibrustzcash.librustzcashSaplingSpendSig(
           new LibrustzcashParam.SpendSigParams(spends.get(i).expsk.getAsk(),
@@ -292,6 +298,25 @@ public class ShieldedTRC20ParametersBuilder {
           SpendDescriptionInfo spend = spends.get(0);
           spendDescription = generateSpendProof(spend, ctx).getInstance();
           builder.addSpendDescription(spendDescription);
+
+          if (ovk == null && spend.expsk != null) {
+            ovk = spend.expsk.getOvk();
+          }
+          if (ovk == null) {
+            throw new ZksnarkException("missing ovk for burn encryption");
+          }
+          byte[] nf = spendDescription.getNullifier().toByteArray();
+          byte[] transparentToAddressTvm = normalizeTransparentToAddress(transparentToAddress);
+          byte[] addr21 = new byte[21];
+          addr21[0] = Wallet.getAddressPreFixByte();
+          System.arraycopy(transparentToAddressTvm, 0, addr21, 1, 20);
+          Optional<byte[]> cipherOpt = Encryption.encryptBurnMessageByOvk(
+              ovk, transparentToAmount, addr21, nf);
+          if (!cipherOpt.isPresent()) {
+            throw new ZksnarkException("encrypt burn message failed");
+          }
+          burnCiphertext = cipherOpt.get();
+
           mergedBytes = ByteUtil.merge(shieldedTRC20Address,
               encodeSpendDescriptionWithoutSpendAuthSig(spendDescription));
           if (receives.size() == 1) {
@@ -302,7 +327,7 @@ public class ShieldedTRC20ParametersBuilder {
                     encodeCencCout(receiveDescription));
           }
           mergedBytes = ByteUtil
-              .merge(mergedBytes, transparentToAddress, ByteArray.fromLong(valueBalance));
+              .merge(mergedBytes, transparentToAddressTvm, ByteArray.fromLong(valueBalance));
           value = transparentToAmount;
           builder.setParameterType("burn");
           break;
@@ -476,12 +501,10 @@ public class ShieldedTRC20ParametersBuilder {
       throw new IllegalArgumentException("the value must be positive");
     }
 
-    if (ArrayUtils.isEmpty(transparentToAddress)) {
-      throw new IllegalArgumentException("the transparent payTo address is null");
-    }
+    byte[] transparentToAddressTvm = normalizeTransparentToAddress(transparentToAddress);
 
     payTo[11] = Wallet.getAddressPreFixByte();
-    System.arraycopy(transparentToAddress, 0, payTo, 12, 20);
+    System.arraycopy(transparentToAddressTvm, 0, payTo, 12, 20);
     ShieldContract.SpendDescription spendDesc = burnParams.getSpendDescription(0);
 
     byte[] spendAuthSign;
@@ -492,7 +515,6 @@ public class ShieldedTRC20ParametersBuilder {
     }
 
     byte[] mergedBytes;
-    byte[] zeros = new byte[16];
     mergedBytes = ByteUtil.merge(
         spendDesc.getNullifier().toByteArray(),
         spendDesc.getAnchor().toByteArray(),
@@ -503,8 +525,7 @@ public class ShieldedTRC20ParametersBuilder {
         ByteUtil.bigIntegerToBytes(value, 32),
         burnParams.getBindingSignature().toByteArray(),
         payTo,
-        burnCiphertext,
-        zeros
+        burnCiphertext
     );
 
     byte[] outputOffsetBytes; // 32
@@ -524,7 +545,7 @@ public class ShieldedTRC20ParametersBuilder {
       coffsetBytes = ByteUtil.longTo32Bytes(mergedBytes.length + 32 * 3 + 32L * 9);
       countBytes = ByteUtil.longTo32Bytes(1L);
       ReceiveDescription recvDesc = burnParams.getReceiveDescription(0);
-      zeros = new byte[12];
+      byte[] zeros = new byte[12];
       mergedBytes = ByteUtil
           .merge(mergedBytes,
               outputOffsetBytes,
@@ -540,6 +561,18 @@ public class ShieldedTRC20ParametersBuilder {
               zeros);
     }
     return Hex.toHexString(mergedBytes);
+  }
+
+  private byte[] normalizeTransparentToAddress(byte[] transparentToAddress) {
+    if (transparentToAddress != null && transparentToAddress.length == 20) {
+      return transparentToAddress;
+    }
+    if (transparentToAddress != null && transparentToAddress.length == 21) {
+      byte[] transparentToAddressTvm = new byte[20];
+      System.arraycopy(transparentToAddress, 1, transparentToAddressTvm, 0, 20);
+      return transparentToAddressTvm;
+    }
+    throw new IllegalArgumentException("invalid transparentToAddress for burn encryption");
   }
 
   public void addSpend(

--- a/framework/src/main/java/org/tron/core/zen/note/NoteEncryption.java
+++ b/framework/src/main/java/org/tron/core/zen/note/NoteEncryption.java
@@ -124,6 +124,10 @@ public class NoteEncryption {
     private static final byte[] BURN_NONCE_DOMAIN =
         "Ztron_BurnNonce".getBytes(StandardCharsets.UTF_8);
 
+    public static byte[] getBurnRecordV2Marker() {
+      return BURN_RECORD_V2_MARKER.clone();
+    }
+
     /**
      * generate ock by ovk, cv, cm, epk
      */
@@ -298,7 +302,7 @@ public class NoteEncryption {
      * The nullifier is prefixed with a fixed domain tag before hashing so the
      * derivation cannot collide with any other SHA3-of-nf usage in the codebase.
      */
-    private static byte[] deriveNonceFromNf(byte[] nf) {
+    public static byte[] deriveNonceFromNf(byte[] nf) {
       byte[] tagged = new byte[BURN_NONCE_DOMAIN.length + nf.length];
       System.arraycopy(BURN_NONCE_DOMAIN, 0, tagged, 0, BURN_NONCE_DOMAIN.length);
       System.arraycopy(nf, 0, tagged, BURN_NONCE_DOMAIN.length, nf.length);
@@ -333,7 +337,7 @@ public class NoteEncryption {
         }
         effectiveNonce = nonceFromLog;
       } else if (Arrays.equals(reservedFromLog, BURN_RECORD_V2_MARKER)) {
-        if (nf == null) {
+        if (nf == null || nf.length != 32) {
           return Optional.empty();
         }
         byte[] derived = deriveNonceFromNf(nf);

--- a/framework/src/main/java/org/tron/core/zen/note/NoteEncryption.java
+++ b/framework/src/main/java/org/tron/core/zen/note/NoteEncryption.java
@@ -8,10 +8,13 @@ import static org.tron.core.utils.ZenChainParams.ZC_OUTPLAINTEXT_SIZE;
 import static org.tron.core.zen.note.NoteEncryption.Encryption.NOTEENCRYPTION_CIPHER_KEYSIZE;
 
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
+import org.tron.common.crypto.Hash;
 import org.tron.common.utils.ByteUtil;
 import org.tron.common.zksnark.JLibrustzcash;
 import org.tron.common.zksnark.JLibsodium;
@@ -111,6 +114,15 @@ public class NoteEncryption {
   public static class Encryption {
 
     public static final int NOTEENCRYPTION_CIPHER_KEYSIZE = 32;
+    public static final int BURN_CIPHER_LEN = 80;
+    public static final int BURN_NONCE_LEN = 12;
+    public static final int BURN_RESERVED_LEN = 4;
+    public static final int BURN_CIPHER_RECORD_SIZE = 96;
+    public static final int BURN_NONCE_OFFSET = BURN_CIPHER_LEN;
+    public static final int BURN_RESERVED_OFFSET = BURN_NONCE_OFFSET + BURN_NONCE_LEN;
+    private static final byte[] BURN_RECORD_V2_MARKER = new byte[]{0, 0, 0, 1};
+    private static final byte[] BURN_NONCE_DOMAIN =
+        "Ztron_BurnNonce".getBytes(StandardCharsets.UTF_8);
 
     /**
      * generate ock by ovk, cv, cm, epk
@@ -246,45 +258,113 @@ public class NoteEncryption {
     }
 
     /**
-     * encrypt the message by ovk used for scanning
+     * encrypt burn message with nf-derived nonce, returns a 96B record:
+     * cipher(80) + nonce(12) + reserved/version(4).
      */
     public static Optional<byte[]> encryptBurnMessageByOvk(byte[] ovk, BigInteger toAmount,
-        byte[] transparentToAddress)
+        byte[] transparentToAddress, byte[] nf)
         throws ZksnarkException {
+      if (ovk == null || ovk.length != NOTEENCRYPTION_CIPHER_KEYSIZE) {
+        throw new ZksnarkException("invalid ovk length");
+      }
+      if (transparentToAddress == null || transparentToAddress.length != 21) {
+        throw new ZksnarkException("invalid transparentToAddress length");
+      }
+      if (nf == null || nf.length != 32) {
+        throw new ZksnarkException("invalid nullifier length");
+      }
       byte[] plaintext = new byte[64];
       byte[] amountArray = ByteUtil.bigIntegerToBytes(toAmount, 32);
-      byte[] cipherNonce = new byte[12];
-      byte[] cipher = new byte[80];
+      byte[] nonce = deriveNonceFromNf(nf);
+      byte[] cipher = new byte[BURN_CIPHER_LEN];
       System.arraycopy(amountArray, 0, plaintext, 0, 32);
-      System.arraycopy(transparentToAddress, 0, plaintext, 32,
-          21);
+      System.arraycopy(transparentToAddress, 0, plaintext, 32, 21);
 
       if (JLibsodium.cryptoAeadChacha20Poly1305IetfEncrypt(new Chacha20Poly1305IetfEncryptParams(
           cipher, null, plaintext,
-          64, null, 0, null, cipherNonce, ovk)) != 0) {
+          64, null, 0, null, nonce, ovk)) != 0) {
         return Optional.empty();
       }
 
-      return Optional.of(cipher);
+      byte[] record = new byte[BURN_CIPHER_RECORD_SIZE];
+      System.arraycopy(cipher, 0, record, 0, BURN_CIPHER_LEN);
+      System.arraycopy(nonce, 0, record, BURN_NONCE_OFFSET, BURN_NONCE_LEN);
+      System.arraycopy(BURN_RECORD_V2_MARKER, 0, record, BURN_RESERVED_OFFSET, BURN_RESERVED_LEN);
+      return Optional.of(record);
     }
 
     /**
-     * decrypt the message by ovk used for scanning
+     * Derive a 12-byte ChaCha20-Poly1305 nonce from the spend nullifier.
+     * The nullifier is prefixed with a fixed domain tag before hashing so the
+     * derivation cannot collide with any other SHA3-of-nf usage in the codebase.
      */
-    public static Optional<byte[]> decryptBurnMessageByOvk(byte[] ovk, byte[] ciphertext)
-        throws ZksnarkException {
+    private static byte[] deriveNonceFromNf(byte[] nf) {
+      byte[] tagged = new byte[BURN_NONCE_DOMAIN.length + nf.length];
+      System.arraycopy(BURN_NONCE_DOMAIN, 0, tagged, 0, BURN_NONCE_DOMAIN.length);
+      System.arraycopy(nf, 0, tagged, BURN_NONCE_DOMAIN.length, nf.length);
+      byte[] hash = Hash.sha3(tagged);
+      byte[] nonce = new byte[BURN_NONCE_LEN];
+      System.arraycopy(hash, 0, nonce, 0, BURN_NONCE_LEN);
+      return nonce;
+    }
+
+    /**
+     * decrypt burn message. The trailing 4-byte reserved field is treated as an explicit
+     * record-version marker:
+     * - reserved = 0x00000000 and nonce = 0x000000000000000000000000 -> legacy v1 path.
+     * - reserved = 0x00000001 -> v2 path, requiring nf-bound nonce verification.
+     * - any other reserved value -> reject.
+     */
+    public static Optional<byte[]> decryptBurnMessageByOvk(byte[] ovk, byte[] ciphertext,
+        byte[] nonceFromLog, byte[] reservedFromLog, byte[] nf) throws ZksnarkException {
+      if (ovk == null || ovk.length != NOTEENCRYPTION_CIPHER_KEYSIZE) {
+        throw new ZksnarkException("invalid ovk length");
+      }
+      if (ciphertext == null || ciphertext.length != BURN_CIPHER_LEN
+          || nonceFromLog == null || nonceFromLog.length != BURN_NONCE_LEN
+          || reservedFromLog == null || reservedFromLog.length != BURN_RESERVED_LEN) {
+        return Optional.empty();
+      }
+
+      byte[] effectiveNonce;
+      if (isAllZero(reservedFromLog)) {
+        if (!isAllZero(nonceFromLog)) {
+          return Optional.empty();
+        }
+        effectiveNonce = nonceFromLog;
+      } else if (Arrays.equals(reservedFromLog, BURN_RECORD_V2_MARKER)) {
+        if (nf == null) {
+          return Optional.empty();
+        }
+        byte[] derived = deriveNonceFromNf(nf);
+        if (!Arrays.equals(nonceFromLog, derived)) {
+          return Optional.empty();
+        }
+        effectiveNonce = nonceFromLog;
+      } else {
+        return Optional.empty();
+      }
+
       byte[] outPlaintext = new byte[64];
-      byte[] cipherNonce = new byte[12];
       if (JLibsodium.cryptoAeadChacha20poly1305IetfDecrypt(new Chacha20poly1305IetfDecryptParams(
           outPlaintext, null,
           null,
-          ciphertext, 80,
+          ciphertext, BURN_CIPHER_LEN,
           null,
           0,
-          cipherNonce, ovk)) != 0) {
+          effectiveNonce, ovk)) != 0) {
         return Optional.empty();
       }
       return Optional.of(outPlaintext);
+    }
+
+    private static boolean isAllZero(byte[] data) {
+      for (byte b : data) {
+        if (b != 0) {
+          return false;
+        }
+      }
+      return true;
     }
 
     public static class EncCiphertext {

--- a/framework/src/main/java/org/tron/core/zen/note/NoteEncryption.java
+++ b/framework/src/main/java/org/tron/core/zen/note/NoteEncryption.java
@@ -262,7 +262,7 @@ public class NoteEncryption {
     }
 
     /**
-     * encrypt burn message with nf-derived nonce, returns a 96B record:
+     * encrypt burn message with nonce bound to (nf, amount, addr21), returns a 96B record:
      * cipher(80) + nonce(12) + reserved/version(4).
      */
     public static Optional<byte[]> encryptBurnMessageByOvk(byte[] ovk, BigInteger toAmount,
@@ -279,7 +279,7 @@ public class NoteEncryption {
       }
       byte[] plaintext = new byte[64];
       byte[] amountArray = ByteUtil.bigIntegerToBytes(toAmount, 32);
-      byte[] nonce = deriveNonceFromNf(nf);
+      byte[] nonce = deriveBurnNonce(nf, amountArray, transparentToAddress);
       byte[] cipher = new byte[BURN_CIPHER_LEN];
       System.arraycopy(amountArray, 0, plaintext, 0, 32);
       System.arraycopy(transparentToAddress, 0, plaintext, 32, 21);
@@ -298,14 +298,32 @@ public class NoteEncryption {
     }
 
     /**
-     * Derive a 12-byte ChaCha20-Poly1305 nonce from the spend nullifier.
-     * The nullifier is prefixed with a fixed domain tag before hashing so the
-     * derivation cannot collide with any other SHA3-of-nf usage in the codebase.
+     * Derive a 12-byte ChaCha20-Poly1305 nonce from (nf, amount, addr21).
+     * Binding the plaintext fields ensures that repeated encryption with the same nf
+     * but different amount/addr produces distinct nonces, preserving AEAD nonce
+     * uniqueness even when the same input note is used to generate multiple burn
+     * trigger inputs off-chain.
      */
-    public static byte[] deriveNonceFromNf(byte[] nf) {
-      byte[] tagged = new byte[BURN_NONCE_DOMAIN.length + nf.length];
-      System.arraycopy(BURN_NONCE_DOMAIN, 0, tagged, 0, BURN_NONCE_DOMAIN.length);
-      System.arraycopy(nf, 0, tagged, BURN_NONCE_DOMAIN.length, nf.length);
+    public static byte[] deriveBurnNonce(byte[] nf, byte[] amount32, byte[] addr21) {
+      if (nf == null || nf.length != 32) {
+        throw new IllegalArgumentException("invalid nullifier length");
+      }
+      if (amount32 == null || amount32.length != 32) {
+        throw new IllegalArgumentException("invalid amount length");
+      }
+      if (addr21 == null || addr21.length != 21) {
+        throw new IllegalArgumentException("invalid addr21 length");
+      }
+      byte[] tagged = new byte[BURN_NONCE_DOMAIN.length + nf.length + amount32.length
+          + addr21.length];
+      int off = 0;
+      System.arraycopy(BURN_NONCE_DOMAIN, 0, tagged, off, BURN_NONCE_DOMAIN.length);
+      off += BURN_NONCE_DOMAIN.length;
+      System.arraycopy(nf, 0, tagged, off, nf.length);
+      off += nf.length;
+      System.arraycopy(amount32, 0, tagged, off, amount32.length);
+      off += amount32.length;
+      System.arraycopy(addr21, 0, tagged, off, addr21.length);
       byte[] hash = Hash.sha3(tagged);
       byte[] nonce = new byte[BURN_NONCE_LEN];
       System.arraycopy(hash, 0, nonce, 0, BURN_NONCE_LEN);
@@ -316,11 +334,13 @@ public class NoteEncryption {
      * decrypt burn message. The trailing 4-byte reserved field is treated as an explicit
      * record-version marker:
      * - reserved = 0x00000000 and nonce = 0x000000000000000000000000 -> legacy v1 path.
-     * - reserved = 0x00000001 -> v2 path, requiring nf-bound nonce verification.
+     * - reserved = 0x00000001 -> v2 path; nonce must equal
+     *   deriveBurnNonce(nf, amount32, addr21) using the public log fields.
      * - any other reserved value -> reject.
      */
     public static Optional<byte[]> decryptBurnMessageByOvk(byte[] ovk, byte[] ciphertext,
-        byte[] nonceFromLog, byte[] reservedFromLog, byte[] nf) throws ZksnarkException {
+        byte[] nonceFromLog, byte[] reservedFromLog, byte[] nf, byte[] amount32, byte[] addr21)
+        throws ZksnarkException {
       if (ovk == null || ovk.length != NOTEENCRYPTION_CIPHER_KEYSIZE) {
         throw new ZksnarkException("invalid ovk length");
       }
@@ -337,10 +357,12 @@ public class NoteEncryption {
         }
         effectiveNonce = nonceFromLog;
       } else if (Arrays.equals(reservedFromLog, BURN_RECORD_V2_MARKER)) {
-        if (nf == null || nf.length != 32) {
+        if (nf == null || nf.length != 32
+            || amount32 == null || amount32.length != 32
+            || addr21 == null || addr21.length != 21) {
           return Optional.empty();
         }
-        byte[] derived = deriveNonceFromNf(nf);
+        byte[] derived = deriveBurnNonce(nf, amount32, addr21);
         if (!Arrays.equals(nonceFromLog, derived)) {
           return Optional.empty();
         }

--- a/framework/src/test/java/org/tron/common/runtime/vm/PrecompiledContractsVerifyProofTest.java
+++ b/framework/src/test/java/org/tron/common/runtime/vm/PrecompiledContractsVerifyProofTest.java
@@ -1126,6 +1126,124 @@ public class PrecompiledContractsVerifyProofTest extends BaseTest {
   }
 
   @Test
+  public void buildBurnRejectsInvalidTransparentToAddress() throws ZksnarkException {
+    long value = 100L;
+    SpendingKey senderSk = SpendingKey.random();
+    ExpandedSpendingKey senderExpsk = senderSk.expandedSpendingKey();
+    FullViewingKey senderFvk = senderSk.fullViewingKey();
+    IncomingViewingKey senderIvk = senderFvk.inViewingKey();
+    byte[] rcm = new byte[32];
+    JLibrustzcash.librustzcashSaplingGenerateR(rcm);
+    PaymentAddress senderPaymentAddress = senderIvk.address(DiversifierT.random()).orElse(null);
+    assertNotNull(senderPaymentAddress);
+
+    ShieldedTRC20ParametersBuilder builder = new ShieldedTRC20ParametersBuilder();
+    builder.setShieldedTRC20ParametersType(ShieldedTRC20ParametersType.BURN);
+    builder.setShieldedTRC20Address(SHIELDED_CONTRACT_ADDRESS);
+    builder.setTransparentToAmount(BigInteger.valueOf(value));
+    builder.setTransparentToAddress(new byte[19]);
+
+    Note senderNote = new Note(senderPaymentAddress.getD(), senderPaymentAddress.getPkD(),
+        value, rcm, new byte[512]);
+    byte[][] cm = new byte[1][32];
+    System.arraycopy(senderNote.cm(), 0, cm[0], 0, 32);
+    IncrementalMerkleTreeContainer tree = new IncrementalMerkleTreeContainer(
+        new IncrementalMerkleTreeCapsule());
+    IncrementalMerkleVoucherContainer voucher = addSimpleMerkleVoucherContainer(tree, cm);
+    byte[] path = decodePath(voucher.path().encode());
+    byte[] anchor = voucher.root().getContent().toByteArray();
+    long position = voucher.position();
+    builder.addSpend(senderExpsk, senderNote, anchor, path, position);
+
+    try {
+      builder.build(true);
+      Assert.fail("expected ZksnarkException for invalid transparentToAddress");
+    } catch (ZksnarkException e) {
+      Assert.assertTrue(e.getMessage().contains("invalid transparentToAddress"));
+    }
+  }
+
+  @Test
+  public void buildBurnRejectsMissingOvk() throws ZksnarkException {
+    long value = 100L;
+    SpendingKey senderSk = SpendingKey.random();
+    ExpandedSpendingKey senderExpsk = senderSk.expandedSpendingKey();
+    FullViewingKey senderFvk = senderSk.fullViewingKey();
+    IncomingViewingKey senderIvk = senderFvk.inViewingKey();
+    byte[] rcm = new byte[32];
+    JLibrustzcash.librustzcashSaplingGenerateR(rcm);
+    PaymentAddress senderPaymentAddress = senderIvk.address(DiversifierT.random()).orElse(null);
+    assertNotNull(senderPaymentAddress);
+
+    ShieldedTRC20ParametersBuilder builder = new ShieldedTRC20ParametersBuilder();
+    builder.setShieldedTRC20ParametersType(ShieldedTRC20ParametersType.BURN);
+    builder.setShieldedTRC20Address(SHIELDED_CONTRACT_ADDRESS);
+    builder.setTransparentToAmount(BigInteger.valueOf(value));
+    builder.setTransparentToAddress(PUBLIC_TO_ADDRESS);
+
+    Note senderNote = new Note(senderPaymentAddress.getD(), senderPaymentAddress.getPkD(),
+        value, rcm, new byte[512]);
+    byte[][] cm = new byte[1][32];
+    System.arraycopy(senderNote.cm(), 0, cm[0], 0, 32);
+    IncrementalMerkleTreeContainer tree = new IncrementalMerkleTreeContainer(
+        new IncrementalMerkleTreeCapsule());
+    IncrementalMerkleVoucherContainer voucher = addSimpleMerkleVoucherContainer(tree, cm);
+    byte[] path = decodePath(voucher.path().encode());
+    byte[] anchor = voucher.root().getContent().toByteArray();
+    long position = voucher.position();
+    builder.addSpend(senderFvk.getAk(), senderExpsk.getNsk(), senderNote,
+        Note.generateR(), anchor, path, position);
+
+    try {
+      builder.build(false);
+      Assert.fail("expected ZksnarkException for missing ovk");
+    } catch (ZksnarkException e) {
+      Assert.assertTrue(e.getMessage().contains("missing ovk for burn encryption"));
+    }
+  }
+
+  @Test
+  public void buildBurnRejectsMissingExpandedSpendingKeyForWithAsk() throws ZksnarkException {
+    long value = 100L;
+    SpendingKey senderSk = SpendingKey.random();
+    ExpandedSpendingKey senderExpsk = senderSk.expandedSpendingKey();
+    FullViewingKey senderFvk = senderSk.fullViewingKey();
+    IncomingViewingKey senderIvk = senderFvk.inViewingKey();
+    byte[] rcm = new byte[32];
+    JLibrustzcash.librustzcashSaplingGenerateR(rcm);
+    PaymentAddress senderPaymentAddress = senderIvk.address(DiversifierT.random()).orElse(null);
+    assertNotNull(senderPaymentAddress);
+
+    ShieldedTRC20ParametersBuilder builder = new ShieldedTRC20ParametersBuilder();
+    builder.setShieldedTRC20ParametersType(ShieldedTRC20ParametersType.BURN);
+    builder.setShieldedTRC20Address(SHIELDED_CONTRACT_ADDRESS);
+    builder.setTransparentToAmount(BigInteger.valueOf(value));
+    builder.setTransparentToAddress(PUBLIC_TO_ADDRESS);
+    builder.setOvk(senderFvk.getOvk());
+
+    Note senderNote = new Note(senderPaymentAddress.getD(), senderPaymentAddress.getPkD(),
+        value, rcm, new byte[512]);
+    byte[][] cm = new byte[1][32];
+    System.arraycopy(senderNote.cm(), 0, cm[0], 0, 32);
+    IncrementalMerkleTreeContainer tree = new IncrementalMerkleTreeContainer(
+        new IncrementalMerkleTreeCapsule());
+    IncrementalMerkleVoucherContainer voucher = addSimpleMerkleVoucherContainer(tree, cm);
+    byte[] path = decodePath(voucher.path().encode());
+    byte[] anchor = voucher.root().getContent().toByteArray();
+    long position = voucher.position();
+    builder.addSpend(senderFvk.getAk(), senderExpsk.getNsk(), senderNote,
+        Note.generateR(), anchor, path, position);
+
+    try {
+      builder.build(true);
+      Assert.fail("expected ZksnarkException for missing expanded spending key");
+    } catch (ZksnarkException e) {
+      Assert.assertTrue(e.getMessage().contains(
+          "missing expanded spending key for spend authorization"));
+    }
+  }
+
+  @Test
   public void verifyMintWrongLeafcount() throws ZksnarkException {
     long value = 100L;
     byte[] frontier = new byte[32 * 33];

--- a/framework/src/test/java/org/tron/core/WalletMockTest.java
+++ b/framework/src/test/java/org/tron/core/WalletMockTest.java
@@ -7,10 +7,12 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import com.google.common.cache.Cache;
@@ -24,6 +26,7 @@ import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.After;
@@ -39,6 +42,7 @@ import org.tron.common.utils.ByteArray;
 import org.tron.common.utils.ByteUtil;
 import org.tron.common.utils.Sha256Hash;
 import org.tron.common.utils.client.WalletClient;
+import org.tron.common.zksnark.JLibrustzcash;
 import org.tron.core.capsule.AccountCapsule;
 import org.tron.core.capsule.BlockCapsule;
 import org.tron.core.capsule.ContractCapsule;
@@ -76,6 +80,7 @@ import org.tron.core.zen.address.DiversifierT;
 import org.tron.core.zen.address.ExpandedSpendingKey;
 import org.tron.core.zen.address.KeyIo;
 import org.tron.core.zen.address.PaymentAddress;
+import org.tron.core.zen.note.Note;
 import org.tron.protos.Protocol;
 import org.tron.protos.contract.BalanceContract;
 import org.tron.protos.contract.ShieldContract;
@@ -1142,9 +1147,10 @@ public class WalletMockTest {
         "MintNewLeaf(uint256,bytes32,bytes32,bytes32,bytes32[21])",
         "TransferNewLeaf(uint256,bytes32,bytes32,bytes32,bytes32[21])",
         "BurnNewLeaf(uint256,bytes32,bytes32,bytes32,bytes32[21])",
-        "TokenBurn(address,uint256,bytes32[3])"
+        "TokenBurn(address,uint256,bytes32[3])",
+        "NoteSpent(bytes32)"
     };
-    int[] expectedTypes = {1, 2, 3, 4};
+    int[] expectedTypes = {1, 2, 3, 4, 5};
 
     for (int i = 0; i < eventSignatures.length; i++) {
       byte[] topicHash = Hash.sha3(ByteArray.fromString(eventSignatures[i]));
@@ -1155,6 +1161,70 @@ public class WalletMockTest {
       Object result = privateMethod.invoke(wallet, log, contractAddress);
       assertEquals("event " + eventSignatures[i] + " should map to log type "
           + expectedTypes[i], expectedTypes[i], ((Integer) result).intValue());
+    }
+  }
+
+  @Test
+  public void scanShieldedTRC20NotesByIvkSkipsNoteSpentIndex() throws Exception {
+    final String SHIELDED_CONTRACT_ADDRESS_STR = "TGAmX5AqVUoXCf8MoHxbuhQPmhGfWTnEgA";
+    byte[] contractAddress = WalletClient.decodeFromBase58Check(SHIELDED_CONTRACT_ADDRESS_STR);
+    byte[] addressWithoutPrefix = new byte[20];
+    System.arraycopy(contractAddress, 1, addressWithoutPrefix, 0, 20);
+
+    byte[] noteSpentTopic = Hash.sha3(ByteArray.fromString("NoteSpent(bytes32)"));
+    Protocol.TransactionInfo.Log noteSpentLog = Protocol.TransactionInfo.Log.newBuilder()
+        .setAddress(ByteString.copyFrom(addressWithoutPrefix))
+        .addTopics(ByteString.copyFrom(noteSpentTopic))
+        .setData(ByteString.copyFrom(new byte[32]))
+        .build();
+
+    byte[] transferTopic = Hash.sha3(ByteArray.fromString(
+        "TransferNewLeaf(uint256,bytes32,bytes32,bytes32,bytes32[21])"));
+    // getNoteTxFromLogListByIvk slices bytes 0..708; only `pos` (bytes 0..32) is read here.
+    byte[] transferData = new byte[708];
+    Protocol.TransactionInfo.Log transferLog = Protocol.TransactionInfo.Log.newBuilder()
+        .setAddress(ByteString.copyFrom(addressWithoutPrefix))
+        .addTopics(ByteString.copyFrom(transferTopic))
+        .setData(ByteString.copyFrom(transferData))
+        .build();
+
+    Protocol.TransactionInfo info = Protocol.TransactionInfo.newBuilder()
+        .addLog(noteSpentLog)
+        .addLog(transferLog)
+        .build();
+
+    Protocol.Block block = Protocol.Block.newBuilder()
+        .addTransactions(Protocol.Transaction.newBuilder().build())
+        .build();
+    GrpcAPI.BlockList blockList = GrpcAPI.BlockList.newBuilder().addBlock(block).build();
+
+    Wallet wallet = spy(new Wallet());
+    doReturn(blockList).when(wallet).getBlocksByLimitNext(anyLong(), anyLong());
+    doReturn(info).when(wallet).getTransactionInfoById(any());
+
+    // Bypass the real ZK crypto: return a valid note and a deterministic payment address
+    // so the scanner reaches the index-assignment branch.
+    Note fakeNote = new Note(new DiversifierT(), new byte[32], 100L,
+        new byte[32], new byte[512]);
+    boolean prevAllow = CommonParameter.getInstance().isAllowShieldedTransactionApi();
+    CommonParameter.getInstance().setAllowShieldedTransactionApi(true);
+    try (MockedStatic<Note> noteMock = mockStatic(Note.class);
+        MockedStatic<JLibrustzcash> rustMock = mockStatic(JLibrustzcash.class);
+        MockedStatic<KeyIo> keyIoMock = mockStatic(KeyIo.class)) {
+      noteMock.when(() -> Note.decrypt(any(byte[].class), any(byte[].class),
+          any(byte[].class), any(byte[].class))).thenReturn(Optional.of(fakeNote));
+      rustMock.when(() -> JLibrustzcash.librustzcashIvkToPkd(any())).thenReturn(true);
+      keyIoMock.when(() -> KeyIo.encodePaymentAddress(any())).thenReturn("zaddrFake");
+
+      byte[] ivk = new byte[32];
+      GrpcAPI.DecryptNotesTRC20 result = wallet.scanShieldedTRC20NotesByIvk(
+          0L, 1L, contractAddress, ivk, new byte[0], new byte[0]);
+
+      assertEquals(1, result.getNoteTxsCount());
+      assertEquals("TransferNewLeaf must get index 0; NoteSpent must not advance the counter",
+          0L, result.getNoteTxs(0).getIndex());
+    } finally {
+      CommonParameter.getInstance().setAllowShieldedTransactionApi(prevAllow);
     }
   }
 

--- a/framework/src/test/java/org/tron/core/zen/note/BurnCipherTest.java
+++ b/framework/src/test/java/org/tron/core/zen/note/BurnCipherTest.java
@@ -1,0 +1,232 @@
+package org.tron.core.zen.note;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Optional;
+import org.junit.Assert;
+import org.junit.Test;
+import org.tron.common.utils.ByteUtil;
+import org.tron.core.exception.ZksnarkException;
+import org.tron.core.zen.note.NoteEncryption.Encryption;
+
+public class BurnCipherTest {
+
+  private static final byte[] OVK = buildTestBytes(32, 1);
+  private static final byte[] NF = buildTestBytes(32, 7);
+  private static final byte[] ADDR_21 = buildAddr21((byte) 0x41);
+
+  private static byte[] buildTestBytes(int len, int seed) {
+    byte[] data = new byte[len];
+    for (int i = 0; i < len; i++) {
+      data[i] = (byte) (i * 3 + seed);
+    }
+    return data;
+  }
+
+  private static byte[] buildAddr21(byte prefix) {
+    byte[] addr = new byte[21];
+    addr[0] = prefix;
+    for (int i = 1; i < 21; i++) {
+      addr[i] = (byte) (i * 2);
+    }
+    return addr;
+  }
+
+  private static byte[] extractCipher(byte[] record) {
+    return Arrays.copyOf(record, Encryption.BURN_CIPHER_LEN);
+  }
+
+  private static byte[] extractNonce(byte[] record) {
+    return Arrays.copyOfRange(record,
+        Encryption.BURN_NONCE_OFFSET,
+        Encryption.BURN_NONCE_OFFSET + Encryption.BURN_NONCE_LEN);
+  }
+
+  private static byte[] extractReserved(byte[] record) {
+    return Arrays.copyOfRange(record,
+        Encryption.BURN_RESERVED_OFFSET,
+        Encryption.BURN_RESERVED_OFFSET + Encryption.BURN_RESERVED_LEN);
+  }
+
+  // ---------- constants ----------
+
+  @Test
+  public void testBurnCipherSize() {
+    Assert.assertEquals(80, Encryption.BURN_CIPHER_LEN);
+    Assert.assertEquals(12, Encryption.BURN_NONCE_LEN);
+    Assert.assertEquals(4, Encryption.BURN_RESERVED_LEN);
+    Assert.assertEquals(96, Encryption.BURN_CIPHER_RECORD_SIZE);
+  }
+
+  // ---------- encrypt ----------
+
+  @Test
+  public void testEncryptProduces96ByteRecord() throws ZksnarkException {
+    BigInteger amount = BigInteger.valueOf(1000000);
+    Optional<byte[]> recordOpt = Encryption.encryptBurnMessageByOvk(
+        OVK, amount, ADDR_21, NF);
+    Assert.assertTrue(recordOpt.isPresent());
+    Assert.assertEquals(Encryption.BURN_CIPHER_RECORD_SIZE, recordOpt.get().length);
+  }
+
+  @Test
+  public void testRecordReservedBytesCarryV2Marker() throws ZksnarkException {
+    BigInteger amount = BigInteger.valueOf(1000000);
+    byte[] record = Encryption.encryptBurnMessageByOvk(OVK, amount, ADDR_21, NF).get();
+    Assert.assertArrayEquals(new byte[]{0, 0, 0, 1}, extractReserved(record));
+  }
+
+  @Test
+  public void testNonceEmbeddedInRecord() throws ZksnarkException {
+    BigInteger amount = BigInteger.valueOf(1000000);
+    byte[] record = Encryption.encryptBurnMessageByOvk(OVK, amount, ADDR_21, NF).get();
+    byte[] nonce = extractNonce(record);
+    boolean allZero = true;
+    for (byte b : nonce) {
+      if (b != 0) {
+        allZero = false;
+        break;
+      }
+    }
+    Assert.assertFalse(allZero);
+  }
+
+  @Test
+  public void testNonceDeterminism() throws ZksnarkException {
+    BigInteger amount = BigInteger.valueOf(1000000);
+    byte[] record1 = Encryption.encryptBurnMessageByOvk(OVK, amount, ADDR_21, NF).get();
+    byte[] record2 = Encryption.encryptBurnMessageByOvk(OVK, amount, ADDR_21, NF).get();
+    Assert.assertArrayEquals(record1, record2);
+  }
+
+  @Test
+  public void testDifferentNfProducesDifferentRecord() throws ZksnarkException {
+    BigInteger amount = BigInteger.valueOf(1000000);
+    byte[] nf2 = new byte[32];
+    nf2[0] = (byte) 0xFF;
+
+    byte[] record1 = Encryption.encryptBurnMessageByOvk(OVK, amount, ADDR_21, NF).get();
+    byte[] record2 = Encryption.encryptBurnMessageByOvk(OVK, amount, ADDR_21, nf2).get();
+    Assert.assertFalse(Arrays.equals(record1, record2));
+  }
+
+  // ---------- encrypt input validation ----------
+
+  @Test(expected = ZksnarkException.class)
+  public void testEncryptRejectsNullNf() throws ZksnarkException {
+    Encryption.encryptBurnMessageByOvk(OVK, BigInteger.ONE, ADDR_21, null);
+  }
+
+  @Test(expected = ZksnarkException.class)
+  public void testEncryptRejectsShortOvk() throws ZksnarkException {
+    Encryption.encryptBurnMessageByOvk(new byte[16], BigInteger.ONE, ADDR_21, NF);
+  }
+
+  @Test(expected = ZksnarkException.class)
+  public void testEncryptRejectsBadAddrLength() throws ZksnarkException {
+    Encryption.encryptBurnMessageByOvk(OVK, BigInteger.ONE, new byte[20], NF);
+  }
+
+  // ---------- decrypt round-trip ----------
+
+  @Test
+  public void testEncryptDecryptRoundTrip() throws ZksnarkException {
+    BigInteger amount = BigInteger.valueOf(1000000);
+
+    byte[] record = Encryption.encryptBurnMessageByOvk(OVK, amount, ADDR_21, NF).get();
+    byte[] cipher = extractCipher(record);
+    byte[] nonce = extractNonce(record);
+
+    Optional<byte[]> plainOpt = Encryption.decryptBurnMessageByOvk(
+        OVK, cipher, nonce, extractReserved(record), NF);
+    Assert.assertTrue(plainOpt.isPresent());
+    byte[] plaintext = plainOpt.get();
+
+    byte[] decryptedAmount = new byte[32];
+    System.arraycopy(plaintext, 0, decryptedAmount, 0, 32);
+    Assert.assertEquals(amount, ByteUtil.bytesToBigInteger(decryptedAmount));
+
+    byte[] decryptedAddr = new byte[21];
+    System.arraycopy(plaintext, 32, decryptedAddr, 0, 21);
+    Assert.assertArrayEquals(ADDR_21, decryptedAddr);
+  }
+
+  @Test
+  public void testDecryptWithWrongNfFails() throws ZksnarkException {
+    BigInteger amount = BigInteger.valueOf(500000);
+    byte[] record = Encryption.encryptBurnMessageByOvk(OVK, amount, ADDR_21, NF).get();
+    byte[] cipher = extractCipher(record);
+    byte[] nonce = extractNonce(record);
+
+    byte[] wrongNf = new byte[32];
+    wrongNf[0] = (byte) 0xFF;
+    Optional<byte[]> result = Encryption.decryptBurnMessageByOvk(
+        OVK, cipher, nonce, extractReserved(record), wrongNf);
+    Assert.assertFalse(result.isPresent());
+  }
+
+  @Test
+  public void testDecryptWithNullNfFailsForV2() throws ZksnarkException {
+    BigInteger amount = BigInteger.valueOf(500000);
+    byte[] record = Encryption.encryptBurnMessageByOvk(OVK, amount, ADDR_21, NF).get();
+    byte[] cipher = extractCipher(record);
+    byte[] nonce = extractNonce(record);
+
+    Optional<byte[]> result = Encryption.decryptBurnMessageByOvk(
+        OVK, cipher, nonce, extractReserved(record), null);
+    Assert.assertFalse(result.isPresent());
+  }
+
+  @Test
+  public void testDecryptWithTamperedNonceFails() throws ZksnarkException {
+    BigInteger amount = BigInteger.valueOf(500000);
+    byte[] record = Encryption.encryptBurnMessageByOvk(OVK, amount, ADDR_21, NF).get();
+    byte[] cipher = extractCipher(record);
+
+    byte[] tamperedNonce = new byte[Encryption.BURN_NONCE_LEN];
+    tamperedNonce[0] = (byte) 0xDE;
+    Optional<byte[]> result = Encryption.decryptBurnMessageByOvk(
+        OVK, cipher, tamperedNonce, extractReserved(record), NF);
+    Assert.assertFalse(result.isPresent());
+  }
+
+  @Test
+  public void testDecryptWithUnknownReservedMarkerFails() throws ZksnarkException {
+    BigInteger amount = BigInteger.valueOf(500000);
+    byte[] record = Encryption.encryptBurnMessageByOvk(OVK, amount, ADDR_21, NF).get();
+    byte[] cipher = extractCipher(record);
+    byte[] nonce = extractNonce(record);
+    byte[] badReserved = new byte[]{0, 0, 0, 2};
+    Optional<byte[]> result = Encryption.decryptBurnMessageByOvk(
+        OVK, cipher, nonce, badReserved, NF);
+    Assert.assertFalse(result.isPresent());
+  }
+
+  // ---------- decrypt input validation ----------
+
+  @Test(expected = ZksnarkException.class)
+  public void testDecryptRejectsNullOvk() throws ZksnarkException {
+    Encryption.decryptBurnMessageByOvk(null, new byte[80], new byte[12], new byte[4], NF);
+  }
+
+  @Test
+  public void testDecryptRejectsBadCipherLength() throws ZksnarkException {
+    Optional<byte[]> result = Encryption.decryptBurnMessageByOvk(
+        OVK, new byte[64], new byte[12], new byte[4], NF);
+    Assert.assertFalse(result.isPresent());
+  }
+
+  @Test
+  public void testDecryptRejectsNullNonce() throws ZksnarkException {
+    Optional<byte[]> result = Encryption.decryptBurnMessageByOvk(
+        OVK, new byte[80], null, new byte[4], NF);
+    Assert.assertFalse(result.isPresent());
+  }
+
+  @Test
+  public void testDecryptRejectsNullReserved() throws ZksnarkException {
+    Optional<byte[]> result = Encryption.decryptBurnMessageByOvk(
+        OVK, new byte[80], new byte[12], null, NF);
+    Assert.assertFalse(result.isPresent());
+  }
+}

--- a/framework/src/test/java/org/tron/core/zen/note/BurnCipherTest.java
+++ b/framework/src/test/java/org/tron/core/zen/note/BurnCipherTest.java
@@ -32,6 +32,10 @@ public class BurnCipherTest {
     return addr;
   }
 
+  private static byte[] amount32(BigInteger amount) {
+    return ByteUtil.bigIntegerToBytes(amount, 32);
+  }
+
   private static byte[] extractCipher(byte[] record) {
     return Arrays.copyOf(record, Encryption.BURN_CIPHER_LEN);
   }
@@ -110,6 +114,25 @@ public class BurnCipherTest {
     Assert.assertFalse(Arrays.equals(record1, record2));
   }
 
+  @Test
+  public void testDifferentAmountProducesDifferentNonce() throws ZksnarkException {
+    byte[] record1 = Encryption.encryptBurnMessageByOvk(
+        OVK, BigInteger.valueOf(1000000), ADDR_21, NF).get();
+    byte[] record2 = Encryption.encryptBurnMessageByOvk(
+        OVK, BigInteger.valueOf(2000000), ADDR_21, NF).get();
+    Assert.assertFalse(Arrays.equals(extractNonce(record1), extractNonce(record2)));
+  }
+
+  @Test
+  public void testDifferentAddrProducesDifferentNonce() throws ZksnarkException {
+    byte[] addr2 = ADDR_21.clone();
+    addr2[5] ^= (byte) 0xFF;
+    BigInteger amount = BigInteger.valueOf(1000000);
+    byte[] record1 = Encryption.encryptBurnMessageByOvk(OVK, amount, ADDR_21, NF).get();
+    byte[] record2 = Encryption.encryptBurnMessageByOvk(OVK, amount, addr2, NF).get();
+    Assert.assertFalse(Arrays.equals(extractNonce(record1), extractNonce(record2)));
+  }
+
   // ---------- encrypt input validation ----------
 
   @Test(expected = ZksnarkException.class)
@@ -138,7 +161,7 @@ public class BurnCipherTest {
     byte[] nonce = extractNonce(record);
 
     Optional<byte[]> plainOpt = Encryption.decryptBurnMessageByOvk(
-        OVK, cipher, nonce, extractReserved(record), NF);
+        OVK, cipher, nonce, extractReserved(record), NF, amount32(amount), ADDR_21);
     Assert.assertTrue(plainOpt.isPresent());
     byte[] plaintext = plainOpt.get();
 
@@ -161,7 +184,34 @@ public class BurnCipherTest {
     byte[] wrongNf = new byte[32];
     wrongNf[0] = (byte) 0xFF;
     Optional<byte[]> result = Encryption.decryptBurnMessageByOvk(
-        OVK, cipher, nonce, extractReserved(record), wrongNf);
+        OVK, cipher, nonce, extractReserved(record), wrongNf, amount32(amount), ADDR_21);
+    Assert.assertFalse(result.isPresent());
+  }
+
+  @Test
+  public void testDecryptWithWrongAmountFails() throws ZksnarkException {
+    BigInteger amount = BigInteger.valueOf(500000);
+    byte[] record = Encryption.encryptBurnMessageByOvk(OVK, amount, ADDR_21, NF).get();
+    byte[] cipher = extractCipher(record);
+    byte[] nonce = extractNonce(record);
+
+    Optional<byte[]> result = Encryption.decryptBurnMessageByOvk(
+        OVK, cipher, nonce, extractReserved(record), NF,
+        amount32(BigInteger.valueOf(500001)), ADDR_21);
+    Assert.assertFalse(result.isPresent());
+  }
+
+  @Test
+  public void testDecryptWithWrongAddrFails() throws ZksnarkException {
+    BigInteger amount = BigInteger.valueOf(500000);
+    byte[] record = Encryption.encryptBurnMessageByOvk(OVK, amount, ADDR_21, NF).get();
+    byte[] cipher = extractCipher(record);
+    byte[] nonce = extractNonce(record);
+    byte[] wrongAddr = ADDR_21.clone();
+    wrongAddr[10] ^= (byte) 0xFF;
+
+    Optional<byte[]> result = Encryption.decryptBurnMessageByOvk(
+        OVK, cipher, nonce, extractReserved(record), NF, amount32(amount), wrongAddr);
     Assert.assertFalse(result.isPresent());
   }
 
@@ -173,7 +223,7 @@ public class BurnCipherTest {
     byte[] nonce = extractNonce(record);
 
     Optional<byte[]> result = Encryption.decryptBurnMessageByOvk(
-        OVK, cipher, nonce, extractReserved(record), null);
+        OVK, cipher, nonce, extractReserved(record), null, amount32(amount), ADDR_21);
     Assert.assertFalse(result.isPresent());
   }
 
@@ -184,13 +234,14 @@ public class BurnCipherTest {
     byte[] cipher = extractCipher(record);
     byte[] nonce = extractNonce(record);
     byte[] reserved = extractReserved(record);
+    byte[] amt = amount32(amount);
 
     Assert.assertFalse(Encryption.decryptBurnMessageByOvk(
-        OVK, cipher, nonce, reserved, new byte[31]).isPresent());
+        OVK, cipher, nonce, reserved, new byte[31], amt, ADDR_21).isPresent());
     Assert.assertFalse(Encryption.decryptBurnMessageByOvk(
-        OVK, cipher, nonce, reserved, new byte[33]).isPresent());
+        OVK, cipher, nonce, reserved, new byte[33], amt, ADDR_21).isPresent());
     Assert.assertFalse(Encryption.decryptBurnMessageByOvk(
-        OVK, cipher, nonce, reserved, new byte[0]).isPresent());
+        OVK, cipher, nonce, reserved, new byte[0], amt, ADDR_21).isPresent());
   }
 
   @Test
@@ -202,7 +253,7 @@ public class BurnCipherTest {
     byte[] tamperedNonce = new byte[Encryption.BURN_NONCE_LEN];
     tamperedNonce[0] = (byte) 0xDE;
     Optional<byte[]> result = Encryption.decryptBurnMessageByOvk(
-        OVK, cipher, tamperedNonce, extractReserved(record), NF);
+        OVK, cipher, tamperedNonce, extractReserved(record), NF, amount32(amount), ADDR_21);
     Assert.assertFalse(result.isPresent());
   }
 
@@ -214,7 +265,7 @@ public class BurnCipherTest {
     byte[] nonce = extractNonce(record);
     byte[] badReserved = new byte[]{0, 0, 0, 2};
     Optional<byte[]> result = Encryption.decryptBurnMessageByOvk(
-        OVK, cipher, nonce, badReserved, NF);
+        OVK, cipher, nonce, badReserved, NF, amount32(amount), ADDR_21);
     Assert.assertFalse(result.isPresent());
   }
 
@@ -222,27 +273,28 @@ public class BurnCipherTest {
 
   @Test(expected = ZksnarkException.class)
   public void testDecryptRejectsNullOvk() throws ZksnarkException {
-    Encryption.decryptBurnMessageByOvk(null, new byte[80], new byte[12], new byte[4], NF);
+    Encryption.decryptBurnMessageByOvk(null, new byte[80], new byte[12], new byte[4], NF,
+        new byte[32], ADDR_21);
   }
 
   @Test
   public void testDecryptRejectsBadCipherLength() throws ZksnarkException {
     Optional<byte[]> result = Encryption.decryptBurnMessageByOvk(
-        OVK, new byte[64], new byte[12], new byte[4], NF);
+        OVK, new byte[64], new byte[12], new byte[4], NF, new byte[32], ADDR_21);
     Assert.assertFalse(result.isPresent());
   }
 
   @Test
   public void testDecryptRejectsNullNonce() throws ZksnarkException {
     Optional<byte[]> result = Encryption.decryptBurnMessageByOvk(
-        OVK, new byte[80], null, new byte[4], NF);
+        OVK, new byte[80], null, new byte[4], NF, new byte[32], ADDR_21);
     Assert.assertFalse(result.isPresent());
   }
 
   @Test
   public void testDecryptRejectsNullReserved() throws ZksnarkException {
     Optional<byte[]> result = Encryption.decryptBurnMessageByOvk(
-        OVK, new byte[80], new byte[12], null, NF);
+        OVK, new byte[80], new byte[12], null, NF, new byte[32], ADDR_21);
     Assert.assertFalse(result.isPresent());
   }
 }

--- a/framework/src/test/java/org/tron/core/zen/note/BurnCipherTest.java
+++ b/framework/src/test/java/org/tron/core/zen/note/BurnCipherTest.java
@@ -178,6 +178,22 @@ public class BurnCipherTest {
   }
 
   @Test
+  public void testDecryptWithWrongNfLengthFailsForV2() throws ZksnarkException {
+    BigInteger amount = BigInteger.valueOf(500000);
+    byte[] record = Encryption.encryptBurnMessageByOvk(OVK, amount, ADDR_21, NF).get();
+    byte[] cipher = extractCipher(record);
+    byte[] nonce = extractNonce(record);
+    byte[] reserved = extractReserved(record);
+
+    Assert.assertFalse(Encryption.decryptBurnMessageByOvk(
+        OVK, cipher, nonce, reserved, new byte[31]).isPresent());
+    Assert.assertFalse(Encryption.decryptBurnMessageByOvk(
+        OVK, cipher, nonce, reserved, new byte[33]).isPresent());
+    Assert.assertFalse(Encryption.decryptBurnMessageByOvk(
+        OVK, cipher, nonce, reserved, new byte[0]).isPresent());
+  }
+
+  @Test
   public void testDecryptWithTamperedNonceFails() throws ZksnarkException {
     BigInteger amount = BigInteger.valueOf(500000);
     byte[] record = Encryption.encryptBurnMessageByOvk(OVK, amount, ADDR_21, NF).get();

--- a/framework/src/test/java/org/tron/core/zksnark/NoteEncDecryTest.java
+++ b/framework/src/test/java/org/tron/core/zksnark/NoteEncDecryTest.java
@@ -224,19 +224,19 @@ public class NoteEncDecryTest extends BaseTest {
     Assert.assertEquals(0, rc);
 
     Optional<byte[]> p1 = Encryption.decryptBurnMessageByOvk(
-        ovk, v1Cipher, new byte[12], new byte[4], null);
+        ovk, v1Cipher, new byte[12], new byte[4], null, null, null);
     Assert.assertTrue(p1.isPresent());
     Assert.assertArrayEquals(plaintext, p1.get());
 
     byte[] wrongNonce = new byte[12];
     wrongNonce[0] = 1;
     Assert.assertFalse(Encryption.decryptBurnMessageByOvk(
-        ovk, v1Cipher, wrongNonce, new byte[4], null).isPresent());
+        ovk, v1Cipher, wrongNonce, new byte[4], null, null, null).isPresent());
 
     Assert.assertFalse(Encryption.decryptBurnMessageByOvk(
-        ovk, v1Cipher, new byte[11], new byte[4], null).isPresent());
+        ovk, v1Cipher, new byte[11], new byte[4], null, null, null).isPresent());
     Assert.assertFalse(Encryption.decryptBurnMessageByOvk(
-        ovk, v1Cipher, null, new byte[4], null).isPresent());
+        ovk, v1Cipher, null, new byte[4], null, null, null).isPresent());
   }
 
   @Test
@@ -291,7 +291,7 @@ public class NoteEncDecryTest extends BaseTest {
     byte[] nf = new byte[32];
     nf[0] = 0x11;
     byte[] record = buildV2BurnRecord(nf);
-    // flip one nonce byte so it no longer matches deriveNonceFromNf(nf).
+    // flip one nonce byte so it no longer matches deriveBurnNonce(nf, amount, addr).
     record[Encryption.BURN_NONCE_OFFSET] ^= (byte) 0xFF;
     GrpcAPI.ShieldedTRC20Parameters trc20Params = buildBurnTrc20Params(record, nf);
     GrpcAPI.ShieldedTRC20TriggerContractParameters req = buildBurnTriggerRequest(
@@ -322,8 +322,11 @@ public class NoteEncDecryTest extends BaseTest {
   private static byte[] buildV2BurnRecord(byte[] nf) {
     byte[] record = new byte[Encryption.BURN_CIPHER_RECORD_SIZE];
     // cipher(0..80) left as zeros — getTriggerInputForShieldedTRC20Contract only
-    // checks reserved marker and nf-bound nonce, not cipher decryptability.
-    byte[] nonce = Encryption.deriveNonceFromNf(nf);
+    // checks reserved marker and nonce binding to (nf, amount, addr), not cipher decryptability.
+    byte[] amount32 = ByteUtil.bigIntegerToBytes(BigInteger.ONE, 32);
+    byte[] addr21 = new byte[21];
+    addr21[0] = Wallet.getAddressPreFixByte();
+    byte[] nonce = Encryption.deriveBurnNonce(nf, amount32, addr21);
     System.arraycopy(nonce, 0, record, Encryption.BURN_NONCE_OFFSET, Encryption.BURN_NONCE_LEN);
     byte[] marker = Encryption.getBurnRecordV2Marker();
     System.arraycopy(marker, 0, record, Encryption.BURN_RESERVED_OFFSET,
@@ -463,7 +466,7 @@ public class NoteEncDecryTest extends BaseTest {
     Assert.assertEquals(amount1.toString(10), tx1.getToAmount());
     Assert.assertEquals(amount2.toString(10), tx2.getToAmount());
 
-    // mis-paired cursor: nonce-from-log mismatches sha3(domain||nf), strict mode rejects
+    // mis-paired cursor: nonce-from-log mismatches sha3(domain||nf||amount||addr), strict rejects
     Optional<?> bad1 = (Optional<?>) m.invoke(
         w, GrpcAPI.DecryptNotesTRC20.NoteTx.newBuilder(), log1, ovk, 4, nf2);
     Optional<?> bad2 = (Optional<?>) m.invoke(

--- a/framework/src/test/java/org/tron/core/zksnark/NoteEncDecryTest.java
+++ b/framework/src/test/java/org/tron/core/zksnark/NoteEncDecryTest.java
@@ -240,9 +240,13 @@ public class NoteEncDecryTest extends BaseTest {
   }
 
   @Test
-  public void testGetTriggerInputBurn96ByteCipher() throws Exception {
-    byte[] burnCipher = new byte[Encryption.BURN_CIPHER_RECORD_SIZE];
-    GrpcAPI.ShieldedTRC20Parameters trc20Params = buildBurnTrc20Params(burnCipher);
+  public void testGetTriggerInputBurnV2Accepted() throws Exception {
+    byte[] nf = new byte[32];
+    for (int i = 0; i < nf.length; i++) {
+      nf[i] = (byte) (i + 1);
+    }
+    byte[] burnRecord = buildV2BurnRecord(nf);
+    GrpcAPI.ShieldedTRC20Parameters trc20Params = buildBurnTrc20Params(burnRecord, nf);
     GrpcAPI.ShieldedTRC20TriggerContractParameters req = buildBurnTriggerRequest(
         trc20Params, BigInteger.ONE);
     GrpcAPI.BytesMessage out = wallet.getTriggerInputForShieldedTRC20Contract(req);
@@ -250,9 +254,61 @@ public class NoteEncDecryTest extends BaseTest {
   }
 
   @Test
+  public void testGetTriggerInputBurnLegacy96ByteRecordRejected() throws Exception {
+    byte[] allZeroRecord = new byte[Encryption.BURN_CIPHER_RECORD_SIZE];
+    byte[] nf = new byte[32];
+    GrpcAPI.ShieldedTRC20Parameters trc20Params = buildBurnTrc20Params(allZeroRecord, nf);
+    GrpcAPI.ShieldedTRC20TriggerContractParameters req = buildBurnTriggerRequest(
+        trc20Params, BigInteger.ONE);
+    try {
+      wallet.getTriggerInputForShieldedTRC20Contract(req);
+      Assert.fail("expected ZksnarkException for legacy 96-byte burn record");
+    } catch (ZksnarkException e) {
+      Assert.assertTrue(e.getMessage(), e.getMessage().contains("v2"));
+    }
+  }
+
+  @Test
+  public void testGetTriggerInputBurnUnknownReservedRejected() throws Exception {
+    byte[] nf = new byte[32];
+    nf[0] = 0x5A;
+    byte[] record = buildV2BurnRecord(nf);
+    // mutate reserved to an unknown marker (0x00000002).
+    record[Encryption.BURN_RESERVED_OFFSET + Encryption.BURN_RESERVED_LEN - 1] = 2;
+    GrpcAPI.ShieldedTRC20Parameters trc20Params = buildBurnTrc20Params(record, nf);
+    GrpcAPI.ShieldedTRC20TriggerContractParameters req = buildBurnTriggerRequest(
+        trc20Params, BigInteger.ONE);
+    try {
+      wallet.getTriggerInputForShieldedTRC20Contract(req);
+      Assert.fail("expected ZksnarkException for unknown reserved marker");
+    } catch (ZksnarkException e) {
+      Assert.assertTrue(e.getMessage(), e.getMessage().contains("v2"));
+    }
+  }
+
+  @Test
+  public void testGetTriggerInputBurnNonceMismatchRejected() throws Exception {
+    byte[] nf = new byte[32];
+    nf[0] = 0x11;
+    byte[] record = buildV2BurnRecord(nf);
+    // flip one nonce byte so it no longer matches deriveNonceFromNf(nf).
+    record[Encryption.BURN_NONCE_OFFSET] ^= (byte) 0xFF;
+    GrpcAPI.ShieldedTRC20Parameters trc20Params = buildBurnTrc20Params(record, nf);
+    GrpcAPI.ShieldedTRC20TriggerContractParameters req = buildBurnTriggerRequest(
+        trc20Params, BigInteger.ONE);
+    try {
+      wallet.getTriggerInputForShieldedTRC20Contract(req);
+      Assert.fail("expected ZksnarkException for mismatched nf-bound nonce");
+    } catch (ZksnarkException e) {
+      Assert.assertTrue(e.getMessage(), e.getMessage().contains("nonce"));
+    }
+  }
+
+  @Test
   public void testGetTriggerInputBurn80ByteCipherRejected() throws Exception {
     byte[] legacyCipher = new byte[Encryption.BURN_CIPHER_LEN];
-    GrpcAPI.ShieldedTRC20Parameters trc20Params = buildBurnTrc20Params(legacyCipher);
+    byte[] nf = new byte[32];
+    GrpcAPI.ShieldedTRC20Parameters trc20Params = buildBurnTrc20Params(legacyCipher, nf);
     GrpcAPI.ShieldedTRC20TriggerContractParameters req = buildBurnTriggerRequest(
         trc20Params, BigInteger.ONE);
     try {
@@ -261,6 +317,18 @@ public class NoteEncDecryTest extends BaseTest {
     } catch (ZksnarkException e) {
       Assert.assertTrue(e.getMessage().contains("deprecated"));
     }
+  }
+
+  private static byte[] buildV2BurnRecord(byte[] nf) {
+    byte[] record = new byte[Encryption.BURN_CIPHER_RECORD_SIZE];
+    // cipher(0..80) left as zeros — getTriggerInputForShieldedTRC20Contract only
+    // checks reserved marker and nf-bound nonce, not cipher decryptability.
+    byte[] nonce = Encryption.deriveNonceFromNf(nf);
+    System.arraycopy(nonce, 0, record, Encryption.BURN_NONCE_OFFSET, Encryption.BURN_NONCE_LEN);
+    byte[] marker = Encryption.getBurnRecordV2Marker();
+    System.arraycopy(marker, 0, record, Encryption.BURN_RESERVED_OFFSET,
+        Encryption.BURN_RESERVED_LEN);
+    return record;
   }
 
   @Test
@@ -418,11 +486,14 @@ public class NoteEncDecryTest extends BaseTest {
         .setData(ByteString.copyFrom(logData)).build();
   }
 
-  private GrpcAPI.ShieldedTRC20Parameters buildBurnTrc20Params(byte[] cipher) {
+  private GrpcAPI.ShieldedTRC20Parameters buildBurnTrc20Params(byte[] cipher, byte[] nf) {
+    ShieldContract.SpendDescription spend = ShieldContract.SpendDescription.newBuilder()
+        .setNullifier(ByteString.copyFrom(nf))
+        .build();
     return GrpcAPI.ShieldedTRC20Parameters.newBuilder()
         .setParameterType("burn")
         .setTriggerContractInput(ByteArray.toHexString(cipher))
-        .addSpendDescription(ShieldContract.SpendDescription.getDefaultInstance())
+        .addSpendDescription(spend)
         .build();
   }
 

--- a/framework/src/test/java/org/tron/core/zksnark/NoteEncDecryTest.java
+++ b/framework/src/test/java/org/tron/core/zksnark/NoteEncDecryTest.java
@@ -1,14 +1,20 @@
 package org.tron.core.zksnark;
 
 import com.google.protobuf.ByteString;
+import java.lang.reflect.Method;
+import java.math.BigInteger;
 import java.util.Optional;
 import javax.annotation.Resource;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.tron.api.GrpcAPI;
 import org.tron.common.BaseTest;
 import org.tron.common.utils.ByteArray;
+import org.tron.common.utils.ByteUtil;
+import org.tron.common.zksnark.JLibsodium;
+import org.tron.common.zksnark.JLibsodiumParam.Chacha20Poly1305IetfEncryptParams;
 import org.tron.core.Wallet;
 import org.tron.core.capsule.AssetIssueCapsule;
 import org.tron.core.config.args.Args;
@@ -17,7 +23,9 @@ import org.tron.core.zen.note.Note;
 import org.tron.core.zen.note.NoteEncryption.Encryption;
 import org.tron.core.zen.note.NoteEncryption.Encryption.OutCiphertext;
 import org.tron.core.zen.note.OutgoingPlaintext;
+import org.tron.protos.Protocol.TransactionInfo;
 import org.tron.protos.contract.AssetIssueContractOuterClass.AssetIssueContract;
+import org.tron.protos.contract.ShieldContract;
 
 @Slf4j
 public class NoteEncDecryTest extends BaseTest {
@@ -192,5 +200,241 @@ public class NoteEncDecryTest extends BaseTest {
     Assert.assertArrayEquals(d, result2.getD().getData());
     Assert.assertArrayEquals(rcm, result2.getRcm());
     Assert.assertEquals(4000, result2.getValue());
+  }
+
+  @Test
+  public void testBurnMessageOvkLegacyZeroNonce() throws ZksnarkException {
+    byte[] ovk = new byte[]{
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+        17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32};
+    byte[] toAddress = new byte[21];
+    toAddress[0] = Wallet.getAddressPreFixByte();
+    toAddress[20] = 0x42;
+    BigInteger amount = BigInteger.valueOf(99L);
+
+    byte[] plaintext = new byte[64];
+    byte[] amountArr = ByteUtil.bigIntegerToBytes(amount, 32);
+    System.arraycopy(amountArr, 0, plaintext, 0, 32);
+    System.arraycopy(toAddress, 0, plaintext, 32, 21);
+    byte[] zeroNonce = new byte[12];
+    byte[] v1Cipher = new byte[Encryption.BURN_CIPHER_LEN];
+    int rc = JLibsodium.cryptoAeadChacha20Poly1305IetfEncrypt(
+        new Chacha20Poly1305IetfEncryptParams(
+            v1Cipher, null, plaintext, 64, null, 0, null, zeroNonce, ovk));
+    Assert.assertEquals(0, rc);
+
+    Optional<byte[]> p1 = Encryption.decryptBurnMessageByOvk(
+        ovk, v1Cipher, new byte[12], new byte[4], null);
+    Assert.assertTrue(p1.isPresent());
+    Assert.assertArrayEquals(plaintext, p1.get());
+
+    byte[] wrongNonce = new byte[12];
+    wrongNonce[0] = 1;
+    Assert.assertFalse(Encryption.decryptBurnMessageByOvk(
+        ovk, v1Cipher, wrongNonce, new byte[4], null).isPresent());
+
+    Assert.assertFalse(Encryption.decryptBurnMessageByOvk(
+        ovk, v1Cipher, new byte[11], new byte[4], null).isPresent());
+    Assert.assertFalse(Encryption.decryptBurnMessageByOvk(
+        ovk, v1Cipher, null, new byte[4], null).isPresent());
+  }
+
+  @Test
+  public void testGetTriggerInputBurn96ByteCipher() throws Exception {
+    byte[] burnCipher = new byte[Encryption.BURN_CIPHER_RECORD_SIZE];
+    GrpcAPI.ShieldedTRC20Parameters trc20Params = buildBurnTrc20Params(burnCipher);
+    GrpcAPI.ShieldedTRC20TriggerContractParameters req = buildBurnTriggerRequest(
+        trc20Params, BigInteger.ONE);
+    GrpcAPI.BytesMessage out = wallet.getTriggerInputForShieldedTRC20Contract(req);
+    Assert.assertNotNull(out);
+  }
+
+  @Test
+  public void testGetTriggerInputBurn80ByteCipherRejected() throws Exception {
+    byte[] legacyCipher = new byte[Encryption.BURN_CIPHER_LEN];
+    GrpcAPI.ShieldedTRC20Parameters trc20Params = buildBurnTrc20Params(legacyCipher);
+    GrpcAPI.ShieldedTRC20TriggerContractParameters req = buildBurnTriggerRequest(
+        trc20Params, BigInteger.ONE);
+    try {
+      wallet.getTriggerInputForShieldedTRC20Contract(req);
+      Assert.fail("expected ZksnarkException for 80-byte burn cipher");
+    } catch (ZksnarkException e) {
+      Assert.assertTrue(e.getMessage().contains("deprecated"));
+    }
+  }
+
+  @Test
+  public void testGetNoteTxFromLogListByOvkBurnTooShort() throws Exception {
+    Wallet w = new Wallet();
+    byte[] ovk = new byte[32];
+    byte[] logData = new byte[64 + Encryption.BURN_CIPHER_RECORD_SIZE - 1];
+    TransactionInfo.Log log = TransactionInfo.Log.newBuilder()
+        .setData(ByteString.copyFrom(logData)).build();
+    GrpcAPI.DecryptNotesTRC20.NoteTx.Builder builder =
+        GrpcAPI.DecryptNotesTRC20.NoteTx.newBuilder();
+
+    Method m = Wallet.class.getDeclaredMethod("getNoteTxFromLogListByOvk",
+        GrpcAPI.DecryptNotesTRC20.NoteTx.Builder.class,
+        TransactionInfo.Log.class, byte[].class, int.class, byte[].class);
+    m.setAccessible(true);
+    Object result = m.invoke(w, builder, log, ovk, 4, null);
+    Assert.assertFalse(((Optional<?>) result).isPresent());
+  }
+
+  @Test
+  public void testGetNoteTxFromLogListByOvkBurnRoundTrip() throws Exception {
+    Wallet w = new Wallet();
+    byte[] ovk = new byte[32];
+    for (int i = 0; i < 32; i++) {
+      ovk[i] = (byte) (i + 1);
+    }
+    BigInteger amount = BigInteger.valueOf(1000L);
+    byte[] toAddress = new byte[21];
+    toAddress[0] = Wallet.getAddressPreFixByte();
+    toAddress[20] = 0x42;
+    byte[] nf = new byte[32];
+    nf[0] = (byte) 0xAB;
+
+    Optional<byte[]> recordOpt = Encryption.encryptBurnMessageByOvk(
+        ovk, amount, toAddress, nf);
+    Assert.assertTrue(recordOpt.isPresent());
+    byte[] record = recordOpt.get();
+
+    byte[] logData = new byte[64 + Encryption.BURN_CIPHER_RECORD_SIZE];
+    System.arraycopy(toAddress, 1, logData, 12, 20);
+    byte[] valBytes = ByteUtil.bigIntegerToBytes(amount, 32);
+    System.arraycopy(valBytes, 0, logData, 32, 32);
+    System.arraycopy(record, 0, logData, 64, Encryption.BURN_CIPHER_RECORD_SIZE);
+
+    TransactionInfo.Log log = TransactionInfo.Log.newBuilder()
+        .setData(ByteString.copyFrom(logData)).build();
+    GrpcAPI.DecryptNotesTRC20.NoteTx.Builder builder =
+        GrpcAPI.DecryptNotesTRC20.NoteTx.newBuilder();
+
+    Method m = Wallet.class.getDeclaredMethod("getNoteTxFromLogListByOvk",
+        GrpcAPI.DecryptNotesTRC20.NoteTx.Builder.class,
+        TransactionInfo.Log.class, byte[].class, int.class, byte[].class);
+    m.setAccessible(true);
+    Object result = m.invoke(w, builder, log, ovk, 4, nf);
+    Assert.assertTrue(((Optional<?>) result).isPresent());
+  }
+
+  @Test
+  public void testGetNoteTxFromLogListByOvkBurnMissingNfRejected() throws Exception {
+    Wallet w = new Wallet();
+    byte[] ovk = new byte[32];
+    for (int i = 0; i < 32; i++) {
+      ovk[i] = (byte) (i + 1);
+    }
+    BigInteger amount = BigInteger.valueOf(1000L);
+    byte[] toAddress = new byte[21];
+    toAddress[0] = Wallet.getAddressPreFixByte();
+    toAddress[20] = 0x42;
+    byte[] nf = new byte[32];
+    nf[0] = (byte) 0xAB;
+
+    Optional<byte[]> recordOpt = Encryption.encryptBurnMessageByOvk(
+        ovk, amount, toAddress, nf);
+    Assert.assertTrue(recordOpt.isPresent());
+    byte[] record = recordOpt.get();
+
+    byte[] logData = new byte[64 + Encryption.BURN_CIPHER_RECORD_SIZE];
+    System.arraycopy(toAddress, 1, logData, 12, 20);
+    byte[] valBytes = ByteUtil.bigIntegerToBytes(amount, 32);
+    System.arraycopy(valBytes, 0, logData, 32, 32);
+    System.arraycopy(record, 0, logData, 64, Encryption.BURN_CIPHER_RECORD_SIZE);
+
+    TransactionInfo.Log log = TransactionInfo.Log.newBuilder()
+        .setData(ByteString.copyFrom(logData)).build();
+    GrpcAPI.DecryptNotesTRC20.NoteTx.Builder builder =
+        GrpcAPI.DecryptNotesTRC20.NoteTx.newBuilder();
+
+    Method m = Wallet.class.getDeclaredMethod("getNoteTxFromLogListByOvk",
+        GrpcAPI.DecryptNotesTRC20.NoteTx.Builder.class,
+        TransactionInfo.Log.class, byte[].class, int.class, byte[].class);
+    m.setAccessible(true);
+    Object result = m.invoke(w, builder, log, ovk, 4, null);
+    Assert.assertFalse(((Optional<?>) result).isPresent());
+  }
+
+  @Test
+  public void testGetNoteTxFromLogListByOvkTwoBurnsCursorPairing() throws Exception {
+    Wallet w = new Wallet();
+    byte[] ovk = new byte[32];
+    for (int i = 0; i < 32; i++) {
+      ovk[i] = (byte) (i + 1);
+    }
+    byte[] toAddress = new byte[21];
+    toAddress[0] = Wallet.getAddressPreFixByte();
+    toAddress[20] = 0x42;
+
+    byte[] nf1 = new byte[32];
+    nf1[0] = (byte) 0xAA;
+    byte[] nf2 = new byte[32];
+    nf2[0] = (byte) 0xBB;
+    BigInteger amount1 = BigInteger.valueOf(1000L);
+    BigInteger amount2 = BigInteger.valueOf(2000L);
+
+    TransactionInfo.Log log1 = buildBurnLog(ovk, amount1, toAddress, nf1);
+    TransactionInfo.Log log2 = buildBurnLog(ovk, amount2, toAddress, nf2);
+
+    Method m = Wallet.class.getDeclaredMethod("getNoteTxFromLogListByOvk",
+        GrpcAPI.DecryptNotesTRC20.NoteTx.Builder.class,
+        TransactionInfo.Log.class, byte[].class, int.class, byte[].class);
+    m.setAccessible(true);
+
+    // correct cursor pairing: each log decrypted with its own nf
+    Optional<?> r1 = (Optional<?>) m.invoke(
+        w, GrpcAPI.DecryptNotesTRC20.NoteTx.newBuilder(), log1, ovk, 4, nf1);
+    Optional<?> r2 = (Optional<?>) m.invoke(
+        w, GrpcAPI.DecryptNotesTRC20.NoteTx.newBuilder(), log2, ovk, 4, nf2);
+    Assert.assertTrue("burn1 should decrypt with nf1", r1.isPresent());
+    Assert.assertTrue("burn2 should decrypt with nf2", r2.isPresent());
+    GrpcAPI.DecryptNotesTRC20.NoteTx tx1 = (GrpcAPI.DecryptNotesTRC20.NoteTx) r1.get();
+    GrpcAPI.DecryptNotesTRC20.NoteTx tx2 = (GrpcAPI.DecryptNotesTRC20.NoteTx) r2.get();
+    Assert.assertEquals(amount1.toString(10), tx1.getToAmount());
+    Assert.assertEquals(amount2.toString(10), tx2.getToAmount());
+
+    // mis-paired cursor: nonce-from-log mismatches sha3(domain||nf), strict mode rejects
+    Optional<?> bad1 = (Optional<?>) m.invoke(
+        w, GrpcAPI.DecryptNotesTRC20.NoteTx.newBuilder(), log1, ovk, 4, nf2);
+    Optional<?> bad2 = (Optional<?>) m.invoke(
+        w, GrpcAPI.DecryptNotesTRC20.NoteTx.newBuilder(), log2, ovk, 4, nf1);
+    Assert.assertFalse("burn1 must not decrypt under nf2", bad1.isPresent());
+    Assert.assertFalse("burn2 must not decrypt under nf1", bad2.isPresent());
+  }
+
+  private TransactionInfo.Log buildBurnLog(byte[] ovk, BigInteger amount, byte[] toAddress,
+      byte[] nf) throws ZksnarkException {
+    Optional<byte[]> recordOpt = Encryption.encryptBurnMessageByOvk(ovk, amount, toAddress, nf);
+    Assert.assertTrue(recordOpt.isPresent());
+    byte[] record = recordOpt.get();
+    byte[] logData = new byte[64 + Encryption.BURN_CIPHER_RECORD_SIZE];
+    System.arraycopy(toAddress, 1, logData, 12, 20);
+    byte[] valBytes = ByteUtil.bigIntegerToBytes(amount, 32);
+    System.arraycopy(valBytes, 0, logData, 32, 32);
+    System.arraycopy(record, 0, logData, 64, Encryption.BURN_CIPHER_RECORD_SIZE);
+    return TransactionInfo.Log.newBuilder()
+        .setData(ByteString.copyFrom(logData)).build();
+  }
+
+  private GrpcAPI.ShieldedTRC20Parameters buildBurnTrc20Params(byte[] cipher) {
+    return GrpcAPI.ShieldedTRC20Parameters.newBuilder()
+        .setParameterType("burn")
+        .setTriggerContractInput(ByteArray.toHexString(cipher))
+        .addSpendDescription(ShieldContract.SpendDescription.getDefaultInstance())
+        .build();
+  }
+
+  private GrpcAPI.ShieldedTRC20TriggerContractParameters buildBurnTriggerRequest(
+      GrpcAPI.ShieldedTRC20Parameters trc20Params, BigInteger value) {
+    byte[] toAddress = new byte[21];
+    toAddress[0] = Wallet.getAddressPreFixByte();
+    return GrpcAPI.ShieldedTRC20TriggerContractParameters.newBuilder()
+        .setShieldedTRC20Parameters(trc20Params)
+        .addSpendAuthoritySignature(GrpcAPI.BytesMessage.getDefaultInstance())
+        .setAmount(value.toString())
+        .setTransparentToAddress(ByteString.copyFrom(toAddress))
+        .build();
   }
 }


### PR DESCRIPTION
## What does this PR do?

Hardens shielded TRC-20 burn encryption by binding the burn AEAD nonce to the spend nullifier, the burn amount, and the transparent recipient address; storing the nonce in the burn record; making the burn-record version explicit in the trailing reserved bytes; and tightening input validation on the burn-cipher setter exposed by `ShieldedTRC20ParametersBuilder`.

## Why are these changes required?

The original implementation encrypted every burn payload under the same long-lived `ovk` with a static all-zero ChaCha20-Poly1305 nonce. Reusing `(key, nonce)` pairs breaks the AEAD security assumptions and leaks keystream relationships across burns.

This PR gives each burn a nonce derived from `(nf, amount, addr)` — all three of which are public on chain — and records enough metadata on chain for scanners to distinguish legacy and upgraded burn records without relying on ambiguous zero-nonce heuristics. Binding amount and address in addition to the nullifier prevents a single off-chain `nf` from producing multiple `(amount, addr)` variants that would reuse the same AEAD nonce before one of them lands on chain.

## Design

### Nonce derivation with domain separation

```text
nonce = SHA3("Ztron_BurnNonce" || nf || amount32 || addr21)[:12]
```

- `nf` is the 32-byte spend nullifier.
- `amount32` is the 32-byte big-endian burn amount that the on-chain `TokenBurn` event logs.
- `addr21` is the 21-byte `prefix || transparent recipient (20B)` that the same event logs.

All three inputs are visible on chain in the burn log, so any scanner can recompute the nonce from public state. The fixed domain tag prevents collisions with any other SHA3-of-nullifier use. Since `nf` is unique per spend, and `(amount, addr)` further partitions any off-chain re-encryption of the same input note, the resulting `(ovk, nonce)` pair is unique per burn payload.

### 96-byte burn record

`encryptBurnMessageByOvk` returns a 96-byte record that occupies the same calldata / log slot as the previous `cipher(80) || zero-padding(16)` layout:

```text
record (96B) = cipher(80) || nonce(12) || reserved/version(4)
```

Current version marker:

```text
v2 marker = 0x00000001
```

### Explicit legacy/v2 discrimination for scanners

`decryptBurnMessageByOvk(ovk, cipher, nonceFromLog, reservedFromLog, nf, amount32, addr21)` now treats the trailing 4 reserved bytes as an explicit version marker:

- `reserved = 0x00000000` and `nonce = 0x000...000` -> legacy v1 path
- `reserved = 0x00000001` -> v2 path; the scanner must verify `nonce == SHA3(domain || nf || amount32 || addr21)[:12]`
- any other `reserved` value -> reject

This removes the previous ambiguity where an all-zero nonce could be interpreted both as a valid new record and as the legacy sentinel.

### Defensive input validation on the builder

`ShieldedTRC20ParametersBuilder.setBurnCiphertext(...)` is no longer the Lombok-generated setter. The hand-written replacement rejects `null` and any length other than `BURN_CIPHER_RECORD_SIZE = 96`, and stores a defensive copy. This closes the only external surface through which a malformed-length burn ciphertext could reach `burnParamsToHexString` and produce silently corrupted calldata.

### Encryption moved into the builder

BURN encryption now runs inside `ShieldedTRC20ParametersBuilder.build()` after `generateSpendProof(...)`, once the nullifier is available. Callers only need to provide `ovk`; if omitted, the builder falls back to `spend.expsk.getOvk()`.

## Compatibility

| Dimension | Impact |
|---|---|
| Consensus / hard fork | None — wallet / scanner / trigger-input only, no protocol-state transition |
| On-chain burn log layout | Still 160B total (`toAddress 32 + value 32 + burn record 96`) |
| New burn record semantics | `cipher(80) + nonce(12) + reserved/version(4)` replaces `cipher(80) + zero padding(16)` for newly generated burns |
| Legacy burns already on chain | Still scannable via the explicit legacy branch (`reserved=0 && nonce=0`) |
| `getTriggerInputForShieldedTRC20Contract` | **Breaking change for legacy callers**: 80-byte burn ciphers are now deprecated and rejected; callers must send the new 96-byte burn record |
| `setBurnCiphertext` | **Behavior change**: now throws `IllegalArgumentException` for null or non-96-byte input, where the previous Lombok setter accepted any byte array |
| gRPC / HTTP / JSON-RPC shape | Field names are unchanged, but acceptable burn payload semantics are narrower because legacy 80-byte burn ciphers are rejected |
| Config / DB schema | None |
| Third-party SDKs | SDKs that still build or submit 80-byte burn ciphers must be updated to emit the 96-byte burn record |
| Old java-tron / old SDK scanners | One-way compatibility: the new scanner reads both legacy and v2 records, but old scanners interpret a v2 record as `cipher(80) + zero-padding(16)` and attempt zero-nonce decryption, which fails. Scanners that need to read v2 burns must be upgraded in lockstep |

## Upgrade guidance

The deployed shielded TRC-20 contract accepts an opaque `bytes32[3]` burn payload and does not interpret its layout, so this PR cannot reject v1 calldata on-chain. The v1→v2 migration is therefore a coordinated wallet/SDK/scanner upgrade. To get the privacy guarantees of `(nf, amount, addr)`-bound nonces, all of the following must be upgraded:

1. **Node operators** — upgrade java-tron to the release that includes this PR. Old nodes still serve `getTriggerInputForShieldedTRC20Contract` with v1 semantics and old scanners cannot read v2 burn records (they interpret them as `cipher(80) + zero-padding(16)` and fail decryption).
2. **Wallet / SDK developers who hand-build burn calldata** — emit the 96-byte v2 record: `cipher(80) + nonce(12) + reserved=0x00000001(4)`, where `nonce = SHA3("Ztron_BurnNonce" || nf || amount32 || addr21)[:12]`. The on-chain contract does not validate this layout, so 80-byte calldata continues to confirm, but any burn assembled that way loses nf/amount/addr-binding and falls back to the legacy zero-nonce decryption path with the known `(ovk, nonce=0)` reuse weakness.
3. **End users** — until their wallet/SDK is upgraded, burns generated through that wallet retain the original v1 weakness (static `(ovk, nonce=0)` reused across every burn under the same `ovk`). Privacy improves only after the wallet itself emits v2 records.

Fully disallowing v1 calldata on-chain is an application-layer change: it requires redeploying the shielded TRC-20 contract with explicit layout validation (e.g. reject burn payloads whose trailing 16 bytes are all zero). That is out of scope for this PR.

## Key changes

| File | Change |
|---|---|
| `NoteEncryption.java` | Adds `BURN_CIPHER_RECORD_SIZE=96`, explicit reserved/version marker handling, nonce derivation from `(nf, amount, addr)`, and strict v1/v2 burn-record decryption rules |
| `ShieldedTRC20ParametersBuilder.java` | Moves BURN encryption into the builder after spend proof generation so the nullifier is available; emits the 96-byte burn record; replaces the Lombok `@Setter` on `burnCiphertext` with a hand-written setter that validates non-null + 96-byte length and stores a defensive copy |
| `Wallet.java` | Parses burn logs as `cipher(80)+nonce(12)+reserved/version(4)`; scanner now uses explicit version markers and verifies the v2 nonce against `(nf, amount, addr)` reconstructed from the log; 80-byte trigger-input burn ciphers throw a clear deprecation/rejection error |
| `BurnCipherTest.java` | Covers 96-byte record structure, reserved/version marker behavior, v2 `(nf, amount, addr)`-required decryption, wrong-amount / wrong-addr rejection, unknown marker rejection, and malformed input handling |
| `NoteEncDecryTest.java` | Covers legacy zero-nonce compatibility, 96-byte trigger-input acceptance, 80-byte trigger-input rejection, burn-log round trip, burn-log truncation, missing-nf rejection, and same-tx cursor pairing |

## Testing

- `./gradlew framework:test --tests "org.tron.core.zen.note.BurnCipherTest"`
- `./gradlew framework:test --tests "org.tron.core.zksnark.NoteEncDecryTest"`
- `./gradlew framework:test --tests org.tron.core.zksnark.NoteEncDecryTest.testGetTriggerInputBurn80ByteCipherRejected`
