### PR TITLE
fix(net): restrict admission signature length

### DIFF
--- a/common/src/main/java/org/tron/core/Constant.java
+++ b/common/src/main/java/org/tron/core/Constant.java
@@ -19,7 +19,8 @@ public class Constant {
   public static final long MAXIMUM_TIME_UNTIL_EXPIRATION = 24 * 60 * 60 * 1_000L; //one day
   public static final long TRANSACTION_DEFAULT_EXPIRATION_TIME = 60 * 1_000L; //60 seconds
   public static final long TRANSACTION_FEE_POOL_PERIOD = 1; //1 blocks
-  public static final long PER_SIGN_LENGTH = 65L;
+  public static final int PER_SIGN_LENGTH = 65;
+  public static final int MAX_PER_SIGN_LENGTH = 68;
   public static final long MAX_CONTRACT_RESULT_SIZE = 2L;
 
   // Smart contract / Energy

--- a/crypto/src/main/java/org/tron/common/crypto/SignUtils.java
+++ b/crypto/src/main/java/org/tron/common/crypto/SignUtils.java
@@ -1,5 +1,8 @@
 package org.tron.common.crypto;
 
+import static org.tron.core.Constant.MAX_PER_SIGN_LENGTH;
+import static org.tron.core.Constant.PER_SIGN_LENGTH;
+
 import java.security.SecureRandom;
 import java.security.SignatureException;
 import org.tron.common.crypto.ECKey.ECDSASignature;
@@ -7,6 +10,21 @@ import org.tron.common.crypto.sm2.SM2;
 import org.tron.common.crypto.sm2.SM2.SM2Signature;
 
 public class SignUtils {
+
+  /**
+   * Strict signature-length check for admission entry-points (RPC broadcast,
+   * P2P transaction ingress, peer hello handshake). Accepts only sizes in
+   * [{@link org.tron.core.Constant#PER_SIGN_LENGTH PER_SIGN_LENGTH},
+   * {@link org.tron.core.Constant#MAX_PER_SIGN_LENGTH MAX_PER_SIGN_LENGTH}].
+   *
+   * <p>Consensus paths (e.g. {@code TransactionCapsule.checkWeight}) intentionally
+   * keep the looser {@code size < 65} check to remain compatible with historical
+   * on-chain signatures that carry trailing padding bytes; do not call this
+   * helper from those paths.
+   */
+  public static boolean isValidLength(int size) {
+    return size >= PER_SIGN_LENGTH && size <= MAX_PER_SIGN_LENGTH;
+  }
 
   public static SignInterface getGeneratedRandomSign(
       SecureRandom secureRandom, boolean isECKeyCryptoEngine) {

--- a/framework/src/main/java/org/tron/core/Wallet.java
+++ b/framework/src/main/java/org/tron/core/Wallet.java
@@ -24,7 +24,6 @@ import static org.tron.common.math.Maths.max;
 import static org.tron.common.utils.Commons.getAssetIssueStoreFinal;
 import static org.tron.common.utils.Commons.getExchangeStoreFinal;
 import static org.tron.common.utils.WalletUtil.isConstant;
-import static org.tron.core.Constant.PER_SIGN_LENGTH;
 import static org.tron.core.capsule.utils.TransactionUtil.buildInternalTransaction;
 import static org.tron.core.config.Parameter.ChainConstant.BLOCK_PRODUCED_INTERVAL;
 import static org.tron.core.config.Parameter.ChainConstant.TRX_PRECISION;
@@ -507,7 +506,7 @@ public class Wallet {
     Sha256Hash txID = trx.getTransactionId();
     try {
       for (ByteString sig : signedTransaction.getSignatureList()) {
-        if (sig.size() != PER_SIGN_LENGTH) {
+        if (!SignUtils.isValidLength(sig.size())) {
           String info = "Signature size is " + sig.size();
           logger.warn("Broadcast transaction {} has failed, {}.", txID, info);
           return builder.setResult(false).setCode(response_code.SIGERROR)

--- a/framework/src/main/java/org/tron/core/Wallet.java
+++ b/framework/src/main/java/org/tron/core/Wallet.java
@@ -24,6 +24,7 @@ import static org.tron.common.math.Maths.max;
 import static org.tron.common.utils.Commons.getAssetIssueStoreFinal;
 import static org.tron.common.utils.Commons.getExchangeStoreFinal;
 import static org.tron.common.utils.WalletUtil.isConstant;
+import static org.tron.core.Constant.PER_SIGN_LENGTH;
 import static org.tron.core.capsule.utils.TransactionUtil.buildInternalTransaction;
 import static org.tron.core.config.Parameter.ChainConstant.BLOCK_PRODUCED_INTERVAL;
 import static org.tron.core.config.Parameter.ChainConstant.TRX_PRECISION;
@@ -505,6 +506,16 @@ public class Wallet {
     trx.setTime(System.currentTimeMillis());
     Sha256Hash txID = trx.getTransactionId();
     try {
+      for (ByteString sig : signedTransaction.getSignatureList()) {
+        if (sig.size() != PER_SIGN_LENGTH) {
+          String info = "Signature size is " + sig.size();
+          logger.warn("Broadcast transaction {} has failed, {}.", txID, info);
+          return builder.setResult(false).setCode(response_code.SIGERROR)
+              .setMessage(ByteString.copyFromUtf8("Validate signature error: " + info))
+              .build();
+        }
+      }
+
       if (tronNetDelegate.isBlockUnsolidified()) {
         logger.warn("Broadcast transaction {} has failed, block unsolidified.", txID);
         return builder.setResult(false).setCode(response_code.BLOCK_UNSOLIDIFIED)

--- a/framework/src/main/java/org/tron/core/net/messagehandler/TransactionsMsgHandler.java
+++ b/framework/src/main/java/org/tron/core/net/messagehandler/TransactionsMsgHandler.java
@@ -1,5 +1,8 @@
 package org.tron.core.net.messagehandler;
 
+import static org.tron.core.Constant.PER_SIGN_LENGTH;
+
+import com.google.protobuf.ByteString;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -141,6 +144,12 @@ public class TransactionsMsgHandler implements TronMsgHandler {
       if (trx.getRawData().getContractCount() < 1) {
         throw new P2pException(TypeEnum.BAD_TRX,
             "tx " + item.getHash() + " contract size should be greater than 0");
+      }
+      for (ByteString sig : trx.getSignatureList()) {
+        if (sig.size() != PER_SIGN_LENGTH) {
+          throw new P2pException(TypeEnum.BAD_TRX,
+              "tx " + item.getHash() + " signature size is " + sig.size());
+        }
       }
     }
   }

--- a/framework/src/main/java/org/tron/core/net/messagehandler/TransactionsMsgHandler.java
+++ b/framework/src/main/java/org/tron/core/net/messagehandler/TransactionsMsgHandler.java
@@ -1,7 +1,5 @@
 package org.tron.core.net.messagehandler;
 
-import static org.tron.core.Constant.PER_SIGN_LENGTH;
-
 import com.google.protobuf.ByteString;
 import java.util.HashSet;
 import java.util.List;
@@ -16,6 +14,7 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.tron.common.crypto.SignUtils;
 import org.tron.common.es.ExecutorServiceManager;
 import org.tron.common.utils.Sha256Hash;
 import org.tron.core.ChainBaseManager;
@@ -146,7 +145,7 @@ public class TransactionsMsgHandler implements TronMsgHandler {
             "tx " + item.getHash() + " contract size should be greater than 0");
       }
       for (ByteString sig : trx.getSignatureList()) {
-        if (sig.size() != PER_SIGN_LENGTH) {
+        if (!SignUtils.isValidLength(sig.size())) {
           throw new P2pException(TypeEnum.BAD_TRX,
               "tx " + item.getHash() + " signature size is " + sig.size());
         }

--- a/framework/src/main/java/org/tron/core/net/service/relay/RelayService.java
+++ b/framework/src/main/java/org/tron/core/net/service/relay/RelayService.java
@@ -1,5 +1,7 @@
 package org.tron.core.net.service.relay;
 
+import static org.tron.core.Constant.PER_SIGN_LENGTH;
+
 import com.google.protobuf.ByteString;
 import java.net.InetSocketAddress;
 import java.util.Arrays;
@@ -147,6 +149,12 @@ public class RelayService {
           channel.getInetAddress(),
           ByteArray.toHexString(msg.getAddress().toByteArray()),
           MAX_PEER_COUNT_PER_ADDRESS);
+      return false;
+    }
+
+    if (msg.getSignature().size() != PER_SIGN_LENGTH) {
+      logger.warn("HelloMessage from {}, signature size is {}.",
+          channel.getInetAddress(), msg.getSignature().size());
       return false;
     }
 

--- a/framework/src/main/java/org/tron/core/net/service/relay/RelayService.java
+++ b/framework/src/main/java/org/tron/core/net/service/relay/RelayService.java
@@ -1,7 +1,5 @@
 package org.tron.core.net.service.relay;
 
-import static org.tron.core.Constant.PER_SIGN_LENGTH;
-
 import com.google.protobuf.ByteString;
 import java.net.InetSocketAddress;
 import java.util.Arrays;
@@ -152,7 +150,7 @@ public class RelayService {
       return false;
     }
 
-    if (msg.getSignature().size() != PER_SIGN_LENGTH) {
+    if (!SignUtils.isValidLength(msg.getSignature().size())) {
       logger.warn("HelloMessage from {}, signature size is {}.",
           channel.getInetAddress(), msg.getSignature().size());
       return false;

--- a/framework/src/test/java/org/tron/core/WalletMockTest.java
+++ b/framework/src/test/java/org/tron/core/WalletMockTest.java
@@ -165,6 +165,47 @@ public class WalletMockTest {
 
 
   @Test
+  public void testBroadcastTxInvalidSigLength() throws Exception {
+    Wallet wallet = new Wallet();
+    TronNetDelegate tronNetDelegateMock = mock(TronNetDelegate.class);
+    Field field = wallet.getClass().getDeclaredField("tronNetDelegate");
+    field.setAccessible(true);
+    field.set(wallet, tronNetDelegateMock);
+
+    // signature shorter than 65 bytes → SIGERROR
+    Protocol.Transaction shortSig = Protocol.Transaction.newBuilder()
+        .addSignature(ByteString.copyFrom(new byte[64]))
+        .build();
+    GrpcAPI.Return ret = wallet.broadcastTransaction(shortSig);
+    assertEquals(GrpcAPI.Return.response_code.SIGERROR, ret.getCode());
+
+    // signature longer than 65 bytes → SIGERROR
+    Protocol.Transaction longSig = Protocol.Transaction.newBuilder()
+        .addSignature(ByteString.copyFrom(new byte[66]))
+        .build();
+    ret = wallet.broadcastTransaction(longSig);
+    assertEquals(GrpcAPI.Return.response_code.SIGERROR, ret.getCode());
+
+    // empty signature → SIGERROR
+    Protocol.Transaction emptySig = Protocol.Transaction.newBuilder()
+        .addSignature(ByteString.EMPTY)
+        .build();
+    ret = wallet.broadcastTransaction(emptySig);
+    assertEquals(GrpcAPI.Return.response_code.SIGERROR, ret.getCode());
+
+    // tronNetDelegate must not be consulted because the request is rejected up front
+    Mockito.verify(tronNetDelegateMock, Mockito.never()).isBlockUnsolidified();
+
+    // 65-byte signature passes the length check and proceeds to downstream logic
+    when(tronNetDelegateMock.isBlockUnsolidified()).thenReturn(true);
+    Protocol.Transaction validSig = Protocol.Transaction.newBuilder()
+        .addSignature(ByteString.copyFrom(new byte[65]))
+        .build();
+    ret = wallet.broadcastTransaction(validSig);
+    assertEquals(GrpcAPI.Return.response_code.BLOCK_UNSOLIDIFIED, ret.getCode());
+  }
+
+  @Test
   public void testBroadcastTransactionBlockUnsolidified() throws Exception {
     Wallet wallet = new Wallet();
     Protocol.Transaction transaction = Protocol.Transaction.newBuilder().build();

--- a/framework/src/test/java/org/tron/core/WalletMockTest.java
+++ b/framework/src/test/java/org/tron/core/WalletMockTest.java
@@ -179,9 +179,9 @@ public class WalletMockTest {
     GrpcAPI.Return ret = wallet.broadcastTransaction(shortSig);
     assertEquals(GrpcAPI.Return.response_code.SIGERROR, ret.getCode());
 
-    // signature longer than 65 bytes → SIGERROR
+    // signature longer than 68 bytes → SIGERROR
     Protocol.Transaction longSig = Protocol.Transaction.newBuilder()
-        .addSignature(ByteString.copyFrom(new byte[66]))
+        .addSignature(ByteString.copyFrom(new byte[69]))
         .build();
     ret = wallet.broadcastTransaction(longSig);
     assertEquals(GrpcAPI.Return.response_code.SIGERROR, ret.getCode());
@@ -202,6 +202,13 @@ public class WalletMockTest {
         .addSignature(ByteString.copyFrom(new byte[65]))
         .build();
     ret = wallet.broadcastTransaction(validSig);
+    assertEquals(GrpcAPI.Return.response_code.BLOCK_UNSOLIDIFIED, ret.getCode());
+
+    // 68-byte signature (upper bound) also passes the length check
+    Protocol.Transaction paddedSig = Protocol.Transaction.newBuilder()
+        .addSignature(ByteString.copyFrom(new byte[68]))
+        .build();
+    ret = wallet.broadcastTransaction(paddedSig);
     assertEquals(GrpcAPI.Return.response_code.BLOCK_UNSOLIDIFIED, ret.getCode());
   }
 

--- a/framework/src/test/java/org/tron/core/net/messagehandler/TransactionsMsgHandlerTest.java
+++ b/framework/src/test/java/org/tron/core/net/messagehandler/TransactionsMsgHandlerTest.java
@@ -368,7 +368,7 @@ public class TransactionsMsgHandlerTest extends BaseTest {
           () -> handler.processMessage(peer, new TransactionsMessage(shortList)));
       Assert.assertEquals(TypeEnum.BAD_TRX, shortEx.getType());
 
-      // signature longer than 65 bytes → BAD_TRX
+      // signature longer than 68 bytes → BAD_TRX
       Protocol.Transaction longSigTrx = Protocol.Transaction.newBuilder()
           .setRawData(Protocol.Transaction.raw.newBuilder()
               .setRefBlockNum(1)
@@ -376,7 +376,7 @@ public class TransactionsMsgHandlerTest extends BaseTest {
                   .setType(Protocol.Transaction.Contract.ContractType.TransferContract)
                   .setParameter(Any.pack(transferContract)).build())
               .build())
-          .addSignature(ByteString.copyFrom(new byte[66]))
+          .addSignature(ByteString.copyFrom(new byte[69]))
           .build();
 
       List<Protocol.Transaction> longList = new ArrayList<>();
@@ -401,6 +401,22 @@ public class TransactionsMsgHandlerTest extends BaseTest {
       validList.add(validSigTrx);
       stubAdvInvRequest(peer, new TransactionsMessage(validList));
       handler.processMessage(peer, new TransactionsMessage(validList));
+
+      // 68 bytes (upper bound) also passes the length check
+      Protocol.Transaction paddedSigTrx = Protocol.Transaction.newBuilder()
+          .setRawData(Protocol.Transaction.raw.newBuilder()
+              .setRefBlockNum(3)
+              .addContract(Protocol.Transaction.Contract.newBuilder()
+                  .setType(Protocol.Transaction.Contract.ContractType.TransferContract)
+                  .setParameter(Any.pack(transferContract)).build())
+              .build())
+          .addSignature(ByteString.copyFrom(new byte[68]))
+          .build();
+
+      List<Protocol.Transaction> paddedList = new ArrayList<>();
+      paddedList.add(paddedSigTrx);
+      stubAdvInvRequest(peer, new TransactionsMessage(paddedList));
+      handler.processMessage(peer, new TransactionsMessage(paddedList));
     } finally {
       handler.close();
     }

--- a/framework/src/test/java/org/tron/core/net/messagehandler/TransactionsMsgHandlerTest.java
+++ b/framework/src/test/java/org/tron/core/net/messagehandler/TransactionsMsgHandlerTest.java
@@ -338,6 +338,75 @@ public class TransactionsMsgHandlerTest extends BaseTest {
   }
 
   @Test
+  public void testInvalidSigLength() throws Exception {
+    TransactionsMsgHandler handler = new TransactionsMsgHandler();
+    handler.init();
+    try {
+      PeerConnection peer = Mockito.mock(PeerConnection.class);
+
+      BalanceContract.TransferContract transferContract = BalanceContract.TransferContract
+          .newBuilder()
+          .setAmount(10)
+          .setOwnerAddress(ByteString.copyFrom(ByteArray.fromHexString("121212a9cf")))
+          .setToAddress(ByteString.copyFrom(ByteArray.fromHexString("232323a9cf")))
+          .build();
+
+      // signature shorter than 65 bytes → BAD_TRX
+      Protocol.Transaction shortSigTrx = Protocol.Transaction.newBuilder()
+          .setRawData(Protocol.Transaction.raw.newBuilder()
+              .addContract(Protocol.Transaction.Contract.newBuilder()
+                  .setType(Protocol.Transaction.Contract.ContractType.TransferContract)
+                  .setParameter(Any.pack(transferContract)).build())
+              .build())
+          .addSignature(ByteString.copyFrom(new byte[64]))
+          .build();
+
+      List<Protocol.Transaction> shortList = new ArrayList<>();
+      shortList.add(shortSigTrx);
+      stubAdvInvRequest(peer, new TransactionsMessage(shortList));
+      P2pException shortEx = Assert.assertThrows(P2pException.class,
+          () -> handler.processMessage(peer, new TransactionsMessage(shortList)));
+      Assert.assertEquals(TypeEnum.BAD_TRX, shortEx.getType());
+
+      // signature longer than 65 bytes → BAD_TRX
+      Protocol.Transaction longSigTrx = Protocol.Transaction.newBuilder()
+          .setRawData(Protocol.Transaction.raw.newBuilder()
+              .setRefBlockNum(1)
+              .addContract(Protocol.Transaction.Contract.newBuilder()
+                  .setType(Protocol.Transaction.Contract.ContractType.TransferContract)
+                  .setParameter(Any.pack(transferContract)).build())
+              .build())
+          .addSignature(ByteString.copyFrom(new byte[66]))
+          .build();
+
+      List<Protocol.Transaction> longList = new ArrayList<>();
+      longList.add(longSigTrx);
+      stubAdvInvRequest(peer, new TransactionsMessage(longList));
+      P2pException longEx = Assert.assertThrows(P2pException.class,
+          () -> handler.processMessage(peer, new TransactionsMessage(longList)));
+      Assert.assertEquals(TypeEnum.BAD_TRX, longEx.getType());
+
+      // exactly 65 bytes → passes the length check (no P2pException from check)
+      Protocol.Transaction validSigTrx = Protocol.Transaction.newBuilder()
+          .setRawData(Protocol.Transaction.raw.newBuilder()
+              .setRefBlockNum(2)
+              .addContract(Protocol.Transaction.Contract.newBuilder()
+                  .setType(Protocol.Transaction.Contract.ContractType.TransferContract)
+                  .setParameter(Any.pack(transferContract)).build())
+              .build())
+          .addSignature(ByteString.copyFrom(new byte[65]))
+          .build();
+
+      List<Protocol.Transaction> validList = new ArrayList<>();
+      validList.add(validSigTrx);
+      stubAdvInvRequest(peer, new TransactionsMessage(validList));
+      handler.processMessage(peer, new TransactionsMessage(validList));
+    } finally {
+      handler.close();
+    }
+  }
+
+  @Test
   public void testIsBusyWithCachedTransactions() throws Exception {
     TransactionsMsgHandler handler = new TransactionsMsgHandler();
 

--- a/framework/src/test/java/org/tron/core/net/services/RelayServiceTest.java
+++ b/framework/src/test/java/org/tron/core/net/services/RelayServiceTest.java
@@ -220,6 +220,30 @@ public class RelayServiceTest extends BaseTest {
 
       boolean res = service.checkHelloMessage(helloMessage, c1);
       Assert.assertTrue(res);
+
+      HelloMessage shortSigMsg = new HelloMessage(node, System.currentTimeMillis(),
+          ChainBaseManager.getChainBaseManager());
+      shortSigMsg.setHelloMessage(shortSigMsg.getHelloMessage().toBuilder()
+          .setAddress(address)
+          .setSignature(ByteString.copyFrom(new byte[64]))
+          .build());
+      Assert.assertFalse(service.checkHelloMessage(shortSigMsg, c1));
+
+      HelloMessage longSigMsg = new HelloMessage(node, System.currentTimeMillis(),
+          ChainBaseManager.getChainBaseManager());
+      longSigMsg.setHelloMessage(longSigMsg.getHelloMessage().toBuilder()
+          .setAddress(address)
+          .setSignature(ByteString.copyFrom(new byte[66]))
+          .build());
+      Assert.assertFalse(service.checkHelloMessage(longSigMsg, c1));
+
+      HelloMessage emptySigMsg = new HelloMessage(node, System.currentTimeMillis(),
+          ChainBaseManager.getChainBaseManager());
+      emptySigMsg.setHelloMessage(emptySigMsg.getHelloMessage().toBuilder()
+          .setAddress(address)
+          .setSignature(ByteString.EMPTY)
+          .build());
+      Assert.assertFalse(service.checkHelloMessage(emptySigMsg, c1));
     } catch (Exception e) {
       logger.info("", e);
       assert false;

--- a/framework/src/test/java/org/tron/core/net/services/RelayServiceTest.java
+++ b/framework/src/test/java/org/tron/core/net/services/RelayServiceTest.java
@@ -233,7 +233,7 @@ public class RelayServiceTest extends BaseTest {
           ChainBaseManager.getChainBaseManager());
       longSigMsg.setHelloMessage(longSigMsg.getHelloMessage().toBuilder()
           .setAddress(address)
-          .setSignature(ByteString.copyFrom(new byte[66]))
+          .setSignature(ByteString.copyFrom(new byte[69]))
           .build());
       Assert.assertFalse(service.checkHelloMessage(longSigMsg, c1));
 


### PR DESCRIPTION
**What does this PR do?**

Adds a signature-length range check at broadcast / P2P admission entrypoints, before any signature recovery work is done. Accepted sizes are `[PER_SIGN_LENGTH, MAX_PER_SIGN_LENGTH]` = `[65, 68]`:

- `Wallet.broadcastTransaction` rejects the transaction with `SIGERROR` when any signature in the list falls outside `[65, 68]`.
- `TransactionsMsgHandler.check` throws `P2pException(BAD_TRX)` when any signature in a `TransactionsMessage` falls outside `[65, 68]`, causing the peer to be disconnected with `BAD_TX`.
- `RelayService.checkHelloMessage` returns `false` when the `HelloMessage` signature from a fast-forward peer falls outside `[65, 68]`.

The predicate is centralized in `SignUtils.isValidLength(int size)`; all three call sites now share that helper. The bounds live in `Constant.PER_SIGN_LENGTH` (= 65) and `Constant.MAX_PER_SIGN_LENGTH` (= 68).

**Why are these changes required?**

A canonical TRON ECDSA signature is encoded as 65 bytes (`r` 32 + `s` 32 + `v` 1). The affected entrypoints currently pass malformed admission payloads into `SignUtils.signatureToAddress` / signature recovery first, which wastes CPU before the request is rejected or fails later.

This PR adds a cheap length check at the network and broadcast boundaries so invalid admission payloads fail before crypto recovery is attempted. This is intentionally scoped to admission handling only.

**Why `[65, 68]` instead of strict `== 65`?**

A canonical signature is 65 bytes. Historical on-chain data, however, contains transactions with a small amount of trailing padding (up to 3 bytes) that ECDSA recovery silently ignores. Using `MAX_PER_SIGN_LENGTH = 68` closes the previously unbounded encoding window at admission while remaining tolerant of clients that may still produce the legacy padded form.

The long-term goal is to tighten the rule once the compatibility window is no longer needed. Because the bounds are centralized in `Constant` and the predicate is centralized in `SignUtils.isValidLength`, that tightening is a one-line change.

**Consensus compatibility**

This PR does not change transaction validation for blocks or any shared consensus validation path.

In particular, `TransactionCapsule.checkWeight` keeps the looser `sig.size() < 65` check so historical signatures with trailing padding remain valid; longer signatures continue to be parsed by the existing `Rsv.fromSignature` behavior using the first 65 bytes. Tightening that shared validation path would be a consensus-impacting behavior change and is intentionally not part of this PR.

To keep this rule visible to future readers, `SignUtils.isValidLength` carries a javadoc that names the admission-vs-consensus split and points at `TransactionCapsule.checkWeight` so the next reviewer who greps either operator lands on the explanation.

The observable behavior change is limited to local broadcast / P2P admission:

- Clients broadcasting transactions with signatures outside `[65, 68]` now receive `SIGERROR` before downstream checks.
- Peers sending transaction messages with signatures outside `[65, 68]` are rejected at message admission with `BAD_TX`.
- Fast-forward hello messages with signatures outside `[65, 68]` are rejected before signature recovery.

**This PR has been tested by:**

- Unit Tests
  - `WalletMockTest#testBroadcastTxInvalidSigLength`: 64 / 69 / empty signatures return `SIGERROR`; 65-byte and 68-byte (upper bound) signatures fall through.
  - `TransactionsMsgHandlerTest#testInvalidSigLength`: 64 / 69 signatures raise `P2pException(BAD_TRX)` via `assertThrows`; 65-byte and 68-byte signatures pass the new length check.
  - `RelayServiceTest#testCheckHelloMessage`: extended to assert that 64 / 69 / empty `HelloMessage` signatures return `false`; the existing 65-byte case still returns `true`.
- Manual Testing
  - `./gradlew :framework:checkstyleMain :framework:checkstyleTest`
  - `./gradlew :framework:test --tests "org.tron.core.WalletMockTest.testBroadcastTxInvalidSigLength" --tests "org.tron.core.net.messagehandler.TransactionsMsgHandlerTest.testInvalidSigLength" --tests "org.tron.core.net.services.RelayServiceTest.testCheckHelloMessage"`

**Follow up**

None.
