### PR TITLE
fix(net): map BLOCK_MERKLE_INVALID to BAD_BLOCK disconnect reason

### DIFF
--- a/common/src/main/java/org/tron/core/exception/P2pException.java
+++ b/common/src/main/java/org/tron/core/exception/P2pException.java
@@ -50,8 +50,8 @@ public class P2pException extends Exception {
     TRX_EXE_FAILED(12, "trx exe failed"),
     DB_ITEM_NOT_FOUND(13, "DB item not found"),
     PROTOBUF_ERROR(14, "protobuf inconsistent"),
-    BLOCK_SIGN_ERROR(15, "block sign error"),
-    BLOCK_MERKLE_ERROR(16, "block merkle error"),
+    BLOCK_SIGN_INVALID(15, "block sign invalid"),
+    BLOCK_MERKLE_INVALID(16, "block merkle invalid"),
     RATE_LIMIT_EXCEEDED(17, "rate limit exceeded"),
 
     DEFAULT(100, "default exception");

--- a/framework/src/main/java/org/tron/core/net/P2pEventHandlerImpl.java
+++ b/framework/src/main/java/org/tron/core/net/P2pEventHandlerImpl.java
@@ -272,7 +272,8 @@ public class P2pEventHandlerImpl extends P2pEventHandler {
           code = Protocol.ReasonCode.BAD_TX;
           break;
         case BAD_BLOCK:
-        case BLOCK_SIGN_ERROR:
+        case BLOCK_SIGN_INVALID:
+        case BLOCK_MERKLE_INVALID:
           code = Protocol.ReasonCode.BAD_BLOCK;
           break;
         case NO_SUCH_MESSAGE:

--- a/framework/src/main/java/org/tron/core/net/TronNetDelegate.java
+++ b/framework/src/main/java/org/tron/core/net/TronNetDelegate.java
@@ -312,7 +312,7 @@ public class TronNetDelegate {
         logger.error("Process block failed, {}, reason: {}", blockId.getString(), e.getMessage());
         if (e instanceof BadBlockException
                 && ((BadBlockException) e).getType().equals(CALC_MERKLE_ROOT_FAILED)) {
-          throw new P2pException(TypeEnum.BLOCK_MERKLE_ERROR, e);
+          throw new P2pException(TypeEnum.BLOCK_MERKLE_INVALID, e);
         } else {
           throw new P2pException(TypeEnum.BAD_BLOCK, e);
         }
@@ -347,10 +347,10 @@ public class TronNetDelegate {
       flag = block.validateSignature(dbManager.getDynamicPropertiesStore(),
               dbManager.getAccountStore());
     } catch (Exception e) {
-      throw new P2pException(TypeEnum.BLOCK_SIGN_ERROR, e);
+      throw new P2pException(TypeEnum.BLOCK_SIGN_INVALID, e);
     }
     if (!flag) {
-      throw new P2pException(TypeEnum.BLOCK_SIGN_ERROR, "valid signature failed.");
+      throw new P2pException(TypeEnum.BLOCK_SIGN_INVALID, "valid signature failed.");
     }
   }
 
@@ -363,7 +363,7 @@ public class TronNetDelegate {
     try {
       block.validateMerkleRoot();
     } catch (BadBlockException e) {
-      throw new P2pException(TypeEnum.BLOCK_MERKLE_ERROR, e.getMessage());
+      throw new P2pException(TypeEnum.BLOCK_MERKLE_INVALID, e.getMessage());
     }
     validSignature(block);
     return witnessScheduleStore.getActiveWitnesses().contains(block.getWitnessAddress());

--- a/framework/src/main/java/org/tron/core/net/service/sync/SyncService.java
+++ b/framework/src/main/java/org/tron/core/net/service/sync/SyncService.java
@@ -342,8 +342,8 @@ public class SyncService {
     } catch (P2pException p2pException) {
       logger.error("Process sync block {} failed, type: {}",
               blockId.getString(), p2pException.getType());
-      attackFlag = p2pException.getType().equals(TypeEnum.BLOCK_SIGN_ERROR)
-              || p2pException.getType().equals(TypeEnum.BLOCK_MERKLE_ERROR);
+      attackFlag = p2pException.getType().equals(TypeEnum.BLOCK_SIGN_INVALID)
+              || p2pException.getType().equals(TypeEnum.BLOCK_MERKLE_INVALID);
       flag = false;
     } catch (Exception e) {
       logger.error("Process sync block {} failed", blockId.getString(), e);

--- a/framework/src/test/java/org/tron/core/net/P2pEventHandlerImplTest.java
+++ b/framework/src/test/java/org/tron/core/net/P2pEventHandlerImplTest.java
@@ -1,8 +1,10 @@
 package org.tron.core.net;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 import java.lang.reflect.Method;
+import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.Assert;
@@ -14,6 +16,7 @@ import org.tron.common.TestConstants;
 import org.tron.common.parameter.CommonParameter;
 import org.tron.common.utils.Sha256Hash;
 import org.tron.core.config.args.Args;
+import org.tron.core.exception.P2pException;
 import org.tron.core.net.message.TronMessage;
 import org.tron.core.net.message.adv.FetchInvDataMessage;
 import org.tron.core.net.message.adv.InventoryMessage;
@@ -222,5 +225,54 @@ public class P2pEventHandlerImplTest extends BaseTest {
     FetchInvDataMessage message = new FetchInvDataMessage(new ArrayList<>(), InventoryType.BLOCK);
     method.invoke(p2pEventHandler, peer, message);
     Assert.assertTrue(peer.getLastInteractiveTime() >= t1);
+  }
+
+  /**
+   * Regression for PR #6716: validateMerkleRoot introduced
+   * P2pException.TypeEnum.BLOCK_MERKLE_INVALID, but processException's switch
+   * did not include the new type, so the peer was disconnected with
+   * ReasonCode.UNKNOWN instead of BAD_BLOCK. This test pins that
+   * BLOCK_MERKLE_INVALID is mapped to BAD_BLOCK (and gets the bad-peer ban
+   * window via PeerConnection.processDisconnect).
+   */
+  @Test
+  public void testProcessExceptionMapsBlockMerkleErrorToBadBlock() throws Exception {
+    P2pEventHandlerImpl handler = new P2pEventHandlerImpl();
+    PeerConnection peer = mock(PeerConnection.class);
+    Mockito.when(peer.getInetSocketAddress())
+        .thenReturn(new InetSocketAddress("127.0.0.1", 18888));
+
+    P2pException ex = new P2pException(
+        P2pException.TypeEnum.BLOCK_MERKLE_INVALID, "merkle mismatch");
+
+    Method method = handler.getClass().getDeclaredMethod("processException",
+        PeerConnection.class, TronMessage.class, Exception.class);
+    method.setAccessible(true);
+    method.invoke(handler, peer, null, ex);
+
+    verify(peer).disconnect(Protocol.ReasonCode.BAD_BLOCK);
+  }
+
+  /**
+   * Companion sanity check: BLOCK_SIGN_INVALID already mapped correctly
+   * before this fix; pin it so future refactors do not silently drop it
+   * (or BLOCK_MERKLE_INVALID) back to UNKNOWN.
+   */
+  @Test
+  public void testProcessExceptionMapsBlockSignErrorToBadBlock() throws Exception {
+    P2pEventHandlerImpl handler = new P2pEventHandlerImpl();
+    PeerConnection peer = mock(PeerConnection.class);
+    Mockito.when(peer.getInetSocketAddress())
+        .thenReturn(new InetSocketAddress("127.0.0.1", 18888));
+
+    P2pException ex = new P2pException(
+        P2pException.TypeEnum.BLOCK_SIGN_INVALID, "bad signature");
+
+    Method method = handler.getClass().getDeclaredMethod("processException",
+        PeerConnection.class, TronMessage.class, Exception.class);
+    method.setAccessible(true);
+    method.invoke(handler, peer, null, ex);
+
+    verify(peer).disconnect(Protocol.ReasonCode.BAD_BLOCK);
   }
 }

--- a/framework/src/test/java/org/tron/core/net/TronNetDelegateTest.java
+++ b/framework/src/test/java/org/tron/core/net/TronNetDelegateTest.java
@@ -169,7 +169,7 @@ public class TronNetDelegateTest {
       tronNetDelegate.validBlock(tampered);
       Assert.fail("Expected P2pException for tampered merkle root");
     } catch (P2pException e) {
-      Assert.assertEquals(TypeEnum.BLOCK_MERKLE_ERROR, e.getType());
+      Assert.assertEquals(TypeEnum.BLOCK_MERKLE_INVALID, e.getType());
     }
   }
 }


### PR DESCRIPTION
**What does this PR do?**

- P2pEventHandlerImpl.processException's switch did not include the BLOCK_MERKLE_ERROR type. The new type fell through to the default branch, so peers whose blocks failed merkle root validation were disconnected with ReasonCode.UNKNOWN instead of BAD_BLOCK, missing the bad-peer ban window in PeerConnection.processDisconnect.
- Add the case alongside BAD_BLOCK and BLOCK_SIGN_ERROR so the disconnect reason is reported as BAD_BLOCK end-to-end.
- Reword BLOCK_SIGN_ERROR and BLOCK_MERKLE_ERROR descriptions in P2pException.TypeEnum from 'sign error' / 'merkle error' to 'sign failed' / 'merkle failed' to match the imperative style used by the other nearby enum entries.
 - Rename the two enum constants for naming consistency:
      BLOCK_SIGN_ERROR    -> BLOCK_SIGN_INVALID,
      BLOCK_MERKLE_ERROR  -> BLOCK_MERKLE_INVALID
- Add two regression tests in P2pEventHandlerImplTest: one pins BLOCK_MERKLE_ERROR -> BAD_BLOCK (the actual fix); the other pins BLOCK_SIGN_ERROR -> BAD_BLOCK so a future switch refactor cannot silently drop either back to UNKNOWN.

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

