### PR TITLE
refactor(config): remove unused storage index and json parsing config

### DIFF
--- a/common/src/main/java/org/tron/common/parameter/CommonParameter.java
+++ b/common/src/main/java/org/tron/common/parameter/CommonParameter.java
@@ -521,12 +521,7 @@ public class CommonParameter {
   @Getter
   @Setter
   public int pBFTHttpPort;
-  @Getter
-  @Setter
-  public int maxNestingDepth = 100;
-  @Getter
-  @Setter
-  public int maxTokenCount = 100_000;
+
   @Getter
   @Setter
   public long pBFTExpireNum; // clearParam: 20

--- a/common/src/main/java/org/tron/core/Constant.java
+++ b/common/src/main/java/org/tron/core/Constant.java
@@ -63,4 +63,8 @@ public class Constant {
   // Network
   public static final String LOCAL_HOST = "127.0.0.1";
 
+  // JSON parsing (DoS protection)
+  public static final int MAX_NESTING_DEPTH = 100;
+  public static final int MAX_TOKEN_COUNT = 100_000;
+
 }

--- a/common/src/main/java/org/tron/core/config/args/NodeConfig.java
+++ b/common/src/main/java/org/tron/core/config/args/NodeConfig.java
@@ -199,8 +199,6 @@ public class NodeConfig {
     private boolean solidityEnable = true;
     private int solidityPort = 8091;
     private long maxMessageSize = 4194304;
-    private int maxNestingDepth = 100;
-    private int maxTokenCount = 100_000;
     private boolean pBFTEnable = true;
     private int pBFTPort = 8092;
   }

--- a/common/src/main/java/org/tron/core/config/args/Storage.java
+++ b/common/src/main/java/org/tron/core/config/args/Storage.java
@@ -70,17 +70,6 @@ public class Storage {
   @Setter
   private int maxFlushCount;
 
-  /**
-   * Index storage directory: /path/to/{indexDirectory}
-   */
-  @Getter
-  @Setter
-  private String indexDirectory;
-
-  @Getter
-  @Setter
-  private String indexSwitch;
-
   @Getter
   @Setter
   private boolean contractParseSwitch;

--- a/common/src/main/java/org/tron/core/config/args/StorageConfig.java
+++ b/common/src/main/java/org/tron/core/config/args/StorageConfig.java
@@ -21,7 +21,6 @@ import org.tron.common.math.StrictMathWrapper;
 public class StorageConfig {
 
   private DbConfig db = new DbConfig();
-  private IndexConfig index = new IndexConfig();
   private TransHistoryConfig transHistory = new TransHistoryConfig();
   private boolean needToUpdateAsset = true;
   private DbSettingsConfig dbSettings = new DbSettingsConfig();
@@ -62,27 +61,8 @@ public class StorageConfig {
 
   @Getter
   @Setter
-  public static class IndexConfig {
-    private String directory = "index";
-    // "switch" is a Java keyword, but HOCON key is "index.switch"
-    // ConfigBeanFactory would look for setSwitch which works fine in Java
-    @Getter(lombok.AccessLevel.NONE)
-    @Setter(lombok.AccessLevel.NONE)
-    private String switchValue = "on";
-
-    public String getSwitch() {
-      return switchValue;
-    }
-
-    public void setSwitch(String v) {
-      this.switchValue = v;
-    }
-  }
-
-  @Getter
-  @Setter
   public static class TransHistoryConfig {
-    // "switch" is a Java keyword — same handling as IndexConfig
+    // "switch" is a reserved Java keyword; ConfigBeanFactory calls setSwitch() which works fine
     @Getter(lombok.AccessLevel.NONE)
     @Setter(lombok.AccessLevel.NONE)
     private String switchValue = "on";

--- a/common/src/main/java/org/tron/json/JSON.java
+++ b/common/src/main/java/org/tron/json/JSON.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import org.tron.common.parameter.CommonParameter;
+import org.tron.core.Constant;
 
 /**
  * Drop-in replacement for {@code com.alibaba.fastjson.JSON}.
@@ -22,15 +22,6 @@ import org.tron.common.parameter.CommonParameter;
 @Deprecated
 public final class JSON {
 
-  // Initialization-order invariant: this class must NOT be loaded before
-  // Args.setParam() completes. The factory's StreamReadConstraints are a
-  // one-shot snapshot of CommonParameter at class-init time. If JSON is
-  // touched too early — e.g. a stray reference in startup code or in a static
-  // initializer that runs before Args — the snapshot captures CommonParameter's
-  // hardcoded defaults (100 / 100_000) and any user override of
-  // node.http.maxNestingDepth / maxTokenCount is silently ignored.
-  // Current production startup (FullNode.main) calls Args.setParam first and
-  // no path in that call chain references this class, so the invariant holds.
   static final ObjectMapper MAPPER = JsonMapper.builder(buildFactory())
       // Fastjson Feature.AllowUnQuotedFieldNames (default ON)
       .enable(JsonReadFeature.ALLOW_UNQUOTED_FIELD_NAMES)
@@ -67,9 +58,9 @@ public final class JSON {
       .build();
 
   private static JsonFactory buildFactory() {
-    CommonParameter p = CommonParameter.getInstance();
     return JsonFactory.builder().streamReadConstraints(StreamReadConstraints.builder()
-            .maxNestingDepth(p.getMaxNestingDepth()).maxTokenCount(p.getMaxTokenCount())
+            .maxNestingDepth(Constant.MAX_NESTING_DEPTH)
+            .maxTokenCount(Constant.MAX_TOKEN_COUNT)
             .build()).build();
   }
 

--- a/common/src/main/resources/reference.conf
+++ b/common/src/main/resources/reference.conf
@@ -245,8 +245,6 @@ node {
 
     # Maximum HTTP request body size, default 4MB. Independent from rpc.maxMessageSize.
     maxMessageSize = 4M
-    maxNestingDepth = 100
-    maxTokenCount = 100000
   }
 
   rpc {

--- a/common/src/main/resources/reference.conf
+++ b/common/src/main/resources/reference.conf
@@ -49,10 +49,6 @@ storage {
   db.sync = false
   db.directory = "database"
 
-  # Index directory (legacy, not consumed by any runtime code, kept for CLI/test compatibility)
-  index.directory = "index"
-  index.switch = "on"
-
   # Whether to write transaction result in transactionRetStore
   transHistory.switch = "on"
 

--- a/common/src/test/java/org/tron/core/config/args/StorageConfigTest.java
+++ b/common/src/test/java/org/tron/core/config/args/StorageConfigTest.java
@@ -26,7 +26,6 @@ public class StorageConfigTest {
     assertEquals("LEVELDB", sc.getDb().getEngine());
     assertFalse(sc.getDb().isSync());
     assertEquals("database", sc.getDb().getDirectory());
-    assertEquals("index", sc.getIndex().getDirectory());
     assertTrue(sc.isNeedToUpdateAsset());
     assertEquals(7, sc.getDbSettings().getLevelNumber());
     assertEquals(5000, sc.getDbSettings().getMaxOpenFiles());

--- a/framework/src/main/java/org/tron/core/config/args/Args.java
+++ b/framework/src/main/java/org/tron/core/config/args/Args.java
@@ -80,8 +80,6 @@ public class Args extends CommonParameter {
     m.put("--storage-db-directory", "storage.db.directory");
     m.put("--storage-db-engine", "storage.db.engine");
     m.put("--storage-db-synchronous", "storage.db.sync");
-    m.put("--storage-index-directory", "storage.index.directory");
-    m.put("--storage-index-switch", "storage.index.switch");
     m.put("--storage-transactionHistory-switch", "storage.transHistory.switch");
     m.put("--contract-parse-enable", "event.subscribe.contractParse");
     m.put("--support-constant", "vm.supportConstant");
@@ -215,10 +213,6 @@ public class Args extends CommonParameter {
     PARAMETER.storage.setDbEngine(sc.getDb().getEngine());
     PARAMETER.storage.setDbSync(sc.getDb().isSync());
     PARAMETER.storage.setDbDirectory(sc.getDb().getDirectory());
-    PARAMETER.storage.setIndexDirectory(sc.getIndex().getDirectory());
-    String indexSwitch = sc.getIndex().getSwitch();
-    PARAMETER.storage.setIndexSwitch(
-        org.apache.commons.lang3.StringUtils.isNotEmpty(indexSwitch) ? indexSwitch : "on");
     PARAMETER.storage.setTransactionHistorySwitch(sc.getTransHistory().getSwitch());
     // contractParse is set in applyConfigParams alongside event config, not here
     PARAMETER.storage.setCheckpointVersion(sc.getCheckpoint().getVersion());
@@ -862,12 +856,6 @@ public class Args extends CommonParameter {
     }
     if (assigned.contains("--contract-parse-enable")) {
       PARAMETER.storage.setContractParseSwitch(Boolean.valueOf(cmd.contractParseEnable));
-    }
-    if (assigned.contains("--storage-index-directory")) {
-      PARAMETER.storage.setIndexDirectory(cmd.storageIndexDirectory);
-    }
-    if (assigned.contains("--storage-index-switch")) {
-      PARAMETER.storage.setIndexSwitch(cmd.storageIndexSwitch);
     }
     if (assigned.contains("--storage-transactionHistory-switch")) {
       PARAMETER.storage.setTransactionHistorySwitch(cmd.storageTransactionHistorySwitch);

--- a/framework/src/main/java/org/tron/core/config/args/Args.java
+++ b/framework/src/main/java/org/tron/core/config/args/Args.java
@@ -549,8 +549,6 @@ public class Args extends CommonParameter {
     PARAMETER.solidityHttpPort = http.getSolidityPort();
     PARAMETER.pBFTHttpPort = http.getPBFTPort();
     PARAMETER.httpMaxMessageSize = http.getMaxMessageSize();
-    PARAMETER.maxNestingDepth = http.getMaxNestingDepth();
-    PARAMETER.maxTokenCount = http.getMaxTokenCount();
 
     // ---- JSON-RPC sub-bean ----
     NodeConfig.JsonRpcConfig jsonrpc = nc.getJsonrpc();

--- a/framework/src/main/java/org/tron/core/config/args/CLIParameter.java
+++ b/framework/src/main/java/org/tron/core/config/args/CLIParameter.java
@@ -86,15 +86,6 @@ public class CLIParameter {
   public String storageDbSynchronous;
 
   @Deprecated
-  @Parameter(names = {"--storage-index-directory"}, description = "Storage index directory")
-  public String storageIndexDirectory;
-
-  @Deprecated
-  @Parameter(names = {"--storage-index-switch"},
-      description = "Storage index switch.(on or off)")
-  public String storageIndexSwitch;
-
-  @Deprecated
   @Parameter(names = {"--storage-transactionHistory-switch"},
       description = "Storage transaction history switch.(on or off)")
   public String storageTransactionHistorySwitch;

--- a/framework/src/main/java/org/tron/core/config/args/CLIParameter.java
+++ b/framework/src/main/java/org/tron/core/config/args/CLIParameter.java
@@ -86,6 +86,15 @@ public class CLIParameter {
   public String storageDbSynchronous;
 
   @Deprecated
+  @Parameter(names = {"--storage-index-directory"}, description = "Storage index directory")
+  public String storageIndexDirectory;
+
+  @Deprecated
+  @Parameter(names = {"--storage-index-switch"},
+      description = "Storage index switch.(on or off)")
+  public String storageIndexSwitch;
+
+  @Deprecated
   @Parameter(names = {"--storage-transactionHistory-switch"},
       description = "Storage transaction history switch.(on or off)")
   public String storageTransactionHistorySwitch;

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/JsonRpcServlet.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/JsonRpcServlet.java
@@ -24,6 +24,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.tron.common.parameter.CommonParameter;
+import org.tron.core.Constant;
 import org.tron.core.services.filter.BufferedResponseWrapper;
 import org.tron.core.services.filter.CachedBodyRequestWrapper;
 import org.tron.core.services.http.RateLimiterServlet;
@@ -32,15 +33,13 @@ import org.tron.core.services.http.RateLimiterServlet;
 @Slf4j(topic = "API")
 public class JsonRpcServlet extends RateLimiterServlet {
 
-  // Snapshot of node.http.maxNestingDepth / maxTokenCount at class-load time (after Args.setParam).
   private static final ObjectMapper MAPPER = buildMapper();
 
   private static ObjectMapper buildMapper() {
-    CommonParameter p = CommonParameter.getInstance();
     JsonFactory factory = JsonFactory.builder()
         .streamReadConstraints(StreamReadConstraints.builder()
-            .maxNestingDepth(p.getMaxNestingDepth())
-            .maxTokenCount(p.getMaxTokenCount())
+            .maxNestingDepth(Constant.MAX_NESTING_DEPTH)
+            .maxTokenCount(Constant.MAX_TOKEN_COUNT)
             .build())
         .build();
     return new ObjectMapper(factory);

--- a/framework/src/test/java/org/tron/common/runtime/vm/BandWidthRuntimeOutOfTimeTest.java
+++ b/framework/src/test/java/org/tron/common/runtime/vm/BandWidthRuntimeOutOfTimeTest.java
@@ -61,7 +61,6 @@ public class BandWidthRuntimeOutOfTimeTest extends BaseTest {
 
   public static final long totalBalance = 1000_0000_000_000L;
   private static final String dbDirectory = "db_BandWidthRuntimeOutOfTimeTest_test";
-  private static final String indexDirectory = "index_BandWidthRuntimeOutOfTimeTest_test";
 
   private static final String OwnerAddress = "TCWHANtDDdkZCTo2T2peyEq3Eg9c2XB7ut";
   private static final String TriggerOwnerAddress = "TCSgeWapPJhCqgWRxXCKb6jJ5AgNWSGjPA";
@@ -72,7 +71,6 @@ public class BandWidthRuntimeOutOfTimeTest extends BaseTest {
         new String[]{
             "--output-directory", dbPath(),
             "--storage-db-directory", dbDirectory,
-            "--storage-index-directory", indexDirectory,
             "--debug"
         },
         "config-test-mainnet.conf"

--- a/framework/src/test/java/org/tron/common/runtime/vm/BandWidthRuntimeOutOfTimeWithCheckTest.java
+++ b/framework/src/test/java/org/tron/common/runtime/vm/BandWidthRuntimeOutOfTimeWithCheckTest.java
@@ -63,7 +63,6 @@ public class BandWidthRuntimeOutOfTimeWithCheckTest extends BaseTest {
 
   public static final long totalBalance = 1000_0000_000_000L;
   private static final String dbDirectory = "db_BandWidthRuntimeOutOfTimeTest_test";
-  private static final String indexDirectory = "index_BandWidthRuntimeOutOfTimeTest_test";
   private static final String OwnerAddress = "TCWHANtDDdkZCTo2T2peyEq3Eg9c2XB7ut";
   private static final String TriggerOwnerAddress = "TCSgeWapPJhCqgWRxXCKb6jJ5AgNWSGjPA";
   private static boolean init;
@@ -73,7 +72,6 @@ public class BandWidthRuntimeOutOfTimeWithCheckTest extends BaseTest {
         new String[]{
             "--output-directory", dbPath(),
             "--storage-db-directory", dbDirectory,
-            "--storage-index-directory", indexDirectory,
             "--debug"
         },
         "config-test-mainnet.conf"

--- a/framework/src/test/java/org/tron/common/runtime/vm/BandWidthRuntimeTest.java
+++ b/framework/src/test/java/org/tron/common/runtime/vm/BandWidthRuntimeTest.java
@@ -57,7 +57,6 @@ public class BandWidthRuntimeTest extends BaseTest {
 
   public static final long totalBalance = 1000_0000_000_000L;
   private static final String dbDirectory = "db_BandWidthRuntimeTest_test";
-  private static final String indexDirectory = "index_BandWidthRuntimeTest_test";
   private static final String OwnerAddress = "TCWHANtDDdkZCTo2T2peyEq3Eg9c2XB7ut";
   private static final String TriggerOwnerAddress = "TCSgeWapPJhCqgWRxXCKb6jJ5AgNWSGjPA";
   private static final String TriggerOwnerTwoAddress = "TPMBUANrTwwQAPwShn7ZZjTJz1f3F8jknj";
@@ -69,7 +68,6 @@ public class BandWidthRuntimeTest extends BaseTest {
         new String[]{
             "--output-directory", dbPath(),
             "--storage-db-directory", dbDirectory,
-            "--storage-index-directory", indexDirectory,
         },
         "config-test-mainnet.conf"
     );

--- a/framework/src/test/java/org/tron/common/runtime/vm/BandWidthRuntimeWithCheckTest.java
+++ b/framework/src/test/java/org/tron/common/runtime/vm/BandWidthRuntimeWithCheckTest.java
@@ -63,7 +63,6 @@ public class BandWidthRuntimeWithCheckTest extends BaseTest {
 
   public static final long totalBalance = 1000_0000_000_000L;
   private static final String dbDirectory = "db_BandWidthRuntimeWithCheckTest_test";
-  private static final String indexDirectory = "index_BandWidthRuntimeWithCheckTest_test";
   private static final String OwnerAddress = "TCWHANtDDdkZCTo2T2peyEq3Eg9c2XB7ut";
   private static final String TriggerOwnerAddress = "TCSgeWapPJhCqgWRxXCKb6jJ5AgNWSGjPA";
   private static final String TriggerOwnerTwoAddress = "TPMBUANrTwwQAPwShn7ZZjTJz1f3F8jknj";
@@ -75,7 +74,6 @@ public class BandWidthRuntimeWithCheckTest extends BaseTest {
         new String[]{
             "--output-directory", dbPath(),
             "--storage-db-directory", dbDirectory,
-            "--storage-index-directory", indexDirectory,
         },
         "config-test-mainnet.conf"
     );

--- a/framework/src/test/java/org/tron/core/config/args/ArgsTest.java
+++ b/framework/src/test/java/org/tron/core/config/args/ArgsTest.java
@@ -414,33 +414,6 @@ public class ArgsTest {
   }
 
 
-  @Test
-  public void testHttpJsonParseConstraints() {
-    Map<String, String> override = new HashMap<>();
-    override.put("storage.db.directory", "database");
-    Config config = ConfigFactory.parseMap(override)
-        .withFallback(ConfigFactory.defaultReference());
-    Args.applyConfigParams(config);
-
-    Assert.assertEquals(100, Args.getInstance().getMaxNestingDepth());
-    Assert.assertEquals(100_000, Args.getInstance().getMaxTokenCount());
-    Args.clearParam();
-  }
-
-  @Test
-  public void testHttpJsonParseConstraintsApplied() {
-    Map<String, String> override = new HashMap<>();
-    override.put("storage.db.directory", "database");
-    override.put("node.http.maxNestingDepth", "42");
-    override.put("node.http.maxTokenCount", "12345");
-    Config config = ConfigFactory.parseMap(override)
-        .withFallback(ConfigFactory.defaultReference());
-    Args.applyConfigParams(config);
-
-    Assert.assertEquals(42, Args.getInstance().getMaxNestingDepth());
-    Assert.assertEquals(12345, Args.getInstance().getMaxTokenCount());
-    Args.clearParam();
-  }
 
   @Test
   public void testFetchBlockTimeoutInRangeUnchanged() {

--- a/framework/src/test/java/org/tron/core/config/args/ArgsTest.java
+++ b/framework/src/test/java/org/tron/core/config/args/ArgsTest.java
@@ -409,8 +409,6 @@ public class ArgsTest {
     Args.clearParam();
   }
 
-
-
   @Test
   public void testFetchBlockTimeoutInRangeUnchanged() {
     Map<String, String> override = new HashMap<>();

--- a/framework/src/test/java/org/tron/core/config/args/ArgsTest.java
+++ b/framework/src/test/java/org/tron/core/config/args/ArgsTest.java
@@ -303,8 +303,6 @@ public class ArgsTest {
         "--storage-db-directory", "cli-db-dir",
         "--storage-db-engine", "ROCKSDB",
         "--storage-db-synchronous", "true",
-        "--storage-index-directory", "cli-index-dir",
-        "--storage-index-switch", "cli-index-switch",
         "--storage-transactionHistory-switch", "off",
         "--contract-parse-enable", "false"
     }, TestConstants.TEST_CONF);
@@ -314,8 +312,6 @@ public class ArgsTest {
     Assert.assertEquals("cli-db-dir", parameter.getStorage().getDbDirectory());
     Assert.assertEquals("ROCKSDB", parameter.getStorage().getDbEngine());
     Assert.assertTrue(parameter.getStorage().isDbSync());
-    Assert.assertEquals("cli-index-dir", parameter.getStorage().getIndexDirectory());
-    Assert.assertEquals("cli-index-switch", parameter.getStorage().getIndexSwitch());
     Assert.assertEquals("off", parameter.getStorage().getTransactionHistorySwitch());
     Assert.assertFalse(parameter.getStorage().isContractParseSwitch());
 

--- a/framework/src/test/java/org/tron/core/config/args/StorageTest.java
+++ b/framework/src/test/java/org/tron/core/config/args/StorageTest.java
@@ -42,7 +42,6 @@ public class StorageTest {
   @Test
   public void getDirectory() {
     Assert.assertEquals("database", storage.getDbDirectory());
-    Assert.assertEquals("index", storage.getIndexDirectory());
   }
 
   @Test

--- a/framework/src/test/java/org/tron/core/db/AccountIndexStoreTest.java
+++ b/framework/src/test/java/org/tron/core/db/AccountIndexStoreTest.java
@@ -16,7 +16,6 @@ import org.tron.protos.Protocol.AccountType;
 public class AccountIndexStoreTest extends BaseTest {
 
   private static String dbDirectory = "db_AccountIndexStore_test";
-  private static String indexDirectory = "index_AccountIndexStore_test";
   @Resource
   private AccountIndexStore accountIndexStore;
   private static byte[] address = TransactionStoreTest.randomBytes(32);
@@ -26,8 +25,7 @@ public class AccountIndexStoreTest extends BaseTest {
     Args.setParam(
         new String[]{
             "--output-directory", dbPath(),
-            "--storage-db-directory", dbDirectory,
-            "--storage-index-directory", indexDirectory
+            "--storage-db-directory", dbDirectory
         },
         TestConstants.TEST_CONF
     );

--- a/framework/src/test/java/org/tron/core/db/AccountStoreTest.java
+++ b/framework/src/test/java/org/tron/core/db/AccountStoreTest.java
@@ -33,7 +33,6 @@ public class AccountStoreTest extends BaseTest {
 
   private static final byte[] data = TransactionStoreTest.randomBytes(32);
   private static String dbDirectory = "db_AccountStore_test";
-  private static String indexDirectory = "index_AccountStore_test";
   @Resource
   private AccountStore accountStore;
   @Resource
@@ -48,8 +47,7 @@ public class AccountStoreTest extends BaseTest {
     Args.setParam(
         new String[]{
             "--output-directory", dbPath(),
-            "--storage-db-directory", dbDirectory,
-            "--storage-index-directory", indexDirectory
+            "--storage-db-directory", dbDirectory
         },
         TestConstants.TEST_CONF
     );

--- a/framework/src/test/java/org/tron/core/db/TransactionHistoryTest.java
+++ b/framework/src/test/java/org/tron/core/db/TransactionHistoryTest.java
@@ -17,7 +17,6 @@ public class TransactionHistoryTest extends BaseTest {
 
   private static final byte[] transactionId = TransactionStoreTest.randomBytes(32);
   private static String dbDirectory = "db_TransactionHistoryStore_test";
-  private static String indexDirectory = "index_TransactionHistoryStore_test";
   @Resource
   private TransactionHistoryStore transactionHistoryStore;
 
@@ -27,8 +26,7 @@ public class TransactionHistoryTest extends BaseTest {
     Args.setParam(
         new String[]{
             "--output-directory", dbPath(),
-            "--storage-db-directory", dbDirectory,
-            "--storage-index-directory", indexDirectory
+            "--storage-db-directory", dbDirectory
         },
         TestConstants.TEST_CONF
     );

--- a/framework/src/test/java/org/tron/core/db/TransactionRetStoreTest.java
+++ b/framework/src/test/java/org/tron/core/db/TransactionRetStoreTest.java
@@ -21,7 +21,6 @@ public class TransactionRetStoreTest extends BaseTest {
   private static final byte[] transactionId = TransactionStoreTest.randomBytes(32);
   private static final byte[] blockNum = ByteArray.fromLong(1);
   private static String dbDirectory = "db_TransactionRetStore_test";
-  private static String indexDirectory = "index_TransactionRetStore_test";
   @Resource
   private TransactionRetStore transactionRetStore;
   private static Transaction transaction;
@@ -33,8 +32,7 @@ public class TransactionRetStoreTest extends BaseTest {
 
   static {
     Args.setParam(new String[]{"--output-directory", dbPath(),
-        "--storage-db-directory", dbDirectory,
-        "--storage-index-directory", indexDirectory}, TestConstants.TEST_CONF);
+        "--storage-db-directory", dbDirectory}, TestConstants.TEST_CONF);
   }
 
   @BeforeClass

--- a/framework/src/test/java/org/tron/core/db/TransactionStoreTest.java
+++ b/framework/src/test/java/org/tron/core/db/TransactionStoreTest.java
@@ -41,7 +41,6 @@ public class TransactionStoreTest extends BaseTest {
   private static final String WITNESS_ADDRESS =
       Wallet.getAddressPreFixString() + "548794500882809695a8a687866e76d4271a1abc";
   private static String dbDirectory = "db_TransactionStore_test";
-  private static String indexDirectory = "index_TransactionStore_test";
   @Resource
   private TransactionStore transactionStore;
 

--- a/framework/src/test/java/org/tron/core/db/TransactionTraceTest.java
+++ b/framework/src/test/java/org/tron/core/db/TransactionTraceTest.java
@@ -52,7 +52,6 @@ public class TransactionTraceTest extends BaseTest {
 
   public static final long totalBalance = 1000_0000_000_000L;
   private static String dbDirectory = "db_TransactionTrace_test";
-  private static String indexDirectory = "index_TransactionTrace_test";
   private static ByteString ownerAddress = ByteString.copyFrom(ByteArray.fromInt(1));
   private static ByteString contractAddress = ByteString.copyFrom(ByteArray.fromInt(2));
   private static String OwnerAddress = "TCWHANtDDdkZCTo2T2peyEq3Eg9c2XB7ut";
@@ -64,7 +63,6 @@ public class TransactionTraceTest extends BaseTest {
         new String[]{
             "--output-directory", dbPath(),
             "--storage-db-directory", dbDirectory,
-            "--storage-index-directory", indexDirectory,
             "--debug"
         },
         "config-test-mainnet.conf"

--- a/framework/src/test/java/org/tron/core/db/TxCacheDBTest.java
+++ b/framework/src/test/java/org/tron/core/db/TxCacheDBTest.java
@@ -18,9 +18,8 @@ public class TxCacheDBTest extends BaseTest {
   @BeforeClass
   public static void init() {
     String dbDirectory = "db_TransactionCache_test";
-    String indexDirectory = "index_TransactionCache_test";
     Args.setParam(new String[]{"--output-directory", dbPath(), "--storage-db-directory",
-        dbDirectory, "--storage-index-directory", indexDirectory}, TestConstants.TEST_CONF);
+        dbDirectory}, TestConstants.TEST_CONF);
   }
 
   @Test

--- a/framework/src/test/java/org/tron/core/metrics/MetricsApiServiceTest.java
+++ b/framework/src/test/java/org/tron/core/metrics/MetricsApiServiceTest.java
@@ -14,7 +14,6 @@ import org.tron.protos.Protocol;
 public class MetricsApiServiceTest extends BaseMethodTest {
 
   private static String dbDirectory = "metrics-database";
-  private static String indexDirectory = "metrics-index";
   private static int port = 10001;
   private MetricsApiService metricsApiService;
   private RpcApiService rpcApiService;
@@ -23,7 +22,6 @@ public class MetricsApiServiceTest extends BaseMethodTest {
   protected String[] extraArgs() {
     return new String[]{
         "--storage-db-directory", dbDirectory,
-        "--storage-index-directory", indexDirectory,
         "--debug"
     };
   }

--- a/framework/src/test/java/org/tron/core/services/jsonrpc/JsonRpcServletTest.java
+++ b/framework/src/test/java/org/tron/core/services/jsonrpc/JsonRpcServletTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.tron.common.parameter.CommonParameter;
+import org.tron.core.Constant;
 
 public class JsonRpcServletTest {
 
@@ -365,7 +366,7 @@ public class JsonRpcServletTest {
 
   @Test
   public void excessivelyNestedRequest_returnsParseError() throws Exception {
-    int limit = CommonParameter.getInstance().getMaxNestingDepth();
+    int limit = Constant.MAX_NESTING_DEPTH;
     StringBuilder sb = new StringBuilder();
     for (int i = 0; i <= limit; i++) {
       sb.append('[');
@@ -383,7 +384,7 @@ public class JsonRpcServletTest {
 
   @Test
   public void tooManyTokens_returnsParseError() throws Exception {
-    int limit = CommonParameter.getInstance().getMaxTokenCount();
+    int limit = Constant.MAX_TOKEN_COUNT;
     StringBuilder sb = new StringBuilder("[");
     for (int i = 0; i < limit; i++) {
       if (i > 0) {

--- a/framework/src/test/java/org/tron/core/zksnark/LibrustzcashTest.java
+++ b/framework/src/test/java/org/tron/core/zksnark/LibrustzcashTest.java
@@ -69,7 +69,6 @@ import org.tron.protos.contract.ShieldContract.PedersenHash;
 @Slf4j
 public class LibrustzcashTest extends BaseTest {
   private static final String dbDirectory = "db_Librustzcash_test";
-  private static final String indexDirectory = "index_Librustzcash_test";
   @Resource
   private Wallet wallet;
 
@@ -79,7 +78,6 @@ public class LibrustzcashTest extends BaseTest {
         new String[]{
             "--output-directory", dbPath(),
             "--storage-db-directory", dbDirectory,
-            "--storage-index-directory", indexDirectory,
             "--debug"
         },
         "config-test-mainnet.conf"

--- a/framework/src/test/java/org/tron/core/zksnark/MerkleTreeTest.java
+++ b/framework/src/test/java/org/tron/core/zksnark/MerkleTreeTest.java
@@ -27,7 +27,6 @@ public class MerkleTreeTest extends BaseTest {
 
   public static final long totalBalance = 1000_0000_000_000L;
   private static final String dbDirectory = "db_ShieldedTransaction_test";
-  private static final String indexDirectory = "index_ShieldedTransaction_test";
   private static boolean init;
 
   static {
@@ -35,7 +34,6 @@ public class MerkleTreeTest extends BaseTest {
         new String[]{
             "--output-directory", dbPath(),
             "--storage-db-directory", dbDirectory,
-            "--storage-index-directory", indexDirectory,
             "--debug"
         },
         "config-test-mainnet.conf"

--- a/framework/src/test/java/org/tron/json/JsonTest.java
+++ b/framework/src/test/java/org/tron/json/JsonTest.java
@@ -16,6 +16,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import org.junit.Test;
+import org.tron.core.Constant;
 
 /**
  * Tests for Jackson {@code JsonReadFeature} compatibility with Fastjson 1.x.
@@ -369,8 +370,8 @@ public class JsonTest {
   @Test
   public void testJsonMapperHasConfiguredConstraints() {
     StreamReadConstraints sr = JSON.MAPPER.getFactory().streamReadConstraints();
-    assertEquals(100, sr.getMaxNestingDepth());
-    assertEquals(100_000L, sr.getMaxTokenCount());
+    assertEquals(Constant.MAX_NESTING_DEPTH, sr.getMaxNestingDepth());
+    assertEquals((long) Constant.MAX_TOKEN_COUNT, sr.getMaxTokenCount());
   }
 
   @Test

--- a/framework/src/test/resources/args-test.conf
+++ b/framework/src/test/resources/args-test.conf
@@ -9,7 +9,6 @@ storage {
 
   db.engine = "LEVELDB"
   db.directory = "database",
-  index.directory = "index",
 
   # You can custom these 14 databases' configs:
 

--- a/framework/src/test/resources/config-localtest.conf
+++ b/framework/src/test/resources/config-localtest.conf
@@ -8,11 +8,6 @@ storage {
   db.engine ="LEVELDB",
   db.directory = "database",
 
-  # This configuration item is only for SolidityNode.
-  # Turn off the index is "off", else "on".
-  # Turning off the index will significantly improve the performance of the SolidityNode sync block.
-  # You can turn off the index if you don't use the two interfaces getTransactionsToThis and getTransactionsFromThis.
-
   # You can custom these 14 databases' configs:
 
   # account, account-index, asset-issue, block, block-index,

--- a/framework/src/test/resources/config-localtest.conf
+++ b/framework/src/test/resources/config-localtest.conf
@@ -7,13 +7,11 @@ storage {
   # Directory for storing persistent data
   db.engine ="LEVELDB",
   db.directory = "database",
-  index.directory = "index",
 
   # This configuration item is only for SolidityNode.
   # Turn off the index is "off", else "on".
   # Turning off the index will significantly improve the performance of the SolidityNode sync block.
   # You can turn off the index if you don't use the two interfaces getTransactionsToThis and getTransactionsFromThis.
-  index.switch = "on"
 
   # You can custom these 14 databases' configs:
 

--- a/framework/src/test/resources/config-test-index.conf
+++ b/framework/src/test/resources/config-test-index.conf
@@ -8,7 +8,6 @@ storage {
   # Directory for storing persistent data
 
   db.directory = "database",
-  index.directory = "index",
 
   # You can custom these 14 databases' configs:
 

--- a/framework/src/test/resources/config-test-mainnet.conf
+++ b/framework/src/test/resources/config-test-mainnet.conf
@@ -8,7 +8,6 @@ storage {
   # Directory for storing persistent data
 
   db.directory = "database",
-  index.directory = "index",
 
   # You can custom these 14 databases' configs:
 

--- a/framework/src/test/resources/config-test-storagetest.conf
+++ b/framework/src/test/resources/config-test-storagetest.conf
@@ -9,7 +9,6 @@ storage {
 
   db.engine = "LEVELDB"
   db.directory = "database",
-  index.directory = "index",
 
   # You can custom these 14 databases' configs:
 

--- a/framework/src/test/resources/config-test.conf
+++ b/framework/src/test/resources/config-test.conf
@@ -9,7 +9,6 @@ storage {
 
   db.engine = "LEVELDB"
   db.directory = "database",
-  index.directory = "index",
 
   # You can custom these 14 databases' configs:
 

--- a/plugins/src/test/resources/config-duplicate.conf
+++ b/plugins/src/test/resources/config-duplicate.conf
@@ -4,7 +4,6 @@ storage {
   db.engine = "LEVELDB",
   db.sync = false,
   db.directory = "database",
-  index.directory = "index",
   transHistory.switch = "on",
   properties = [
     {


### PR DESCRIPTION
**What does this PR do?**

Removes two groups of unused or over-engineered config items:

1. **`node.http.maxNestingDepth` / `node.http.maxTokenCount`** — these are JSON-parsing DoS-protection caps that were exposed as user-configurable fields in `reference.conf`, `NodeConfig.HttpConfig`, and `CommonParameter`. Because the values were baked into the `JSON` / `JsonRpcServlet` class-level `ObjectMapper` at first class-load, exposing them as runtime config created a silent initialization-order trap: if any code touched `JSON` before `Args.setParam()` completed, the user's overrides would be silently ignored. The values (100 / 100 000) are security constants, not operator-tunable settings. This PR promotes them to `Constant.MAX_NESTING_DEPTH` / `Constant.MAX_TOKEN_COUNT`, removes the config binding, and deletes the fragile init-order comment that described the footgun.

2. **`storage.index.directory` / `storage.index.switch`** — legacy config keys that have no consumers in runtime code. `Storage.indexDirectory` and `Storage.indexSwitch` were populated from config but never read. The `StorageConfig.IndexConfig` inner class and all config/field bindings are removed. The corresponding CLI flags (`--storage-index-directory`, `--storage-index-switch`) retain their `@Parameter` declarations so JCommander still recognises them — preventing a misleading startup crash for operators whose launch scripts still pass these flags — but the values are no longer applied anywhere.

**Why are these changes required?**

- Removing dead config items reduces cognitive overhead for operators reading `reference.conf` and for developers maintaining the config-binding pipeline.
- Eliminating the `CommonParameter`-backed `maxNestingDepth`/`maxTokenCount` fields removes a class-initialization ordering constraint that was documented only in a comment, making startup order more robust and the JSON utility class simpler.
- Keeping the CLI flag declarations (without bindings) avoids a hard startup break: without them, JCommander treats unknown flags as positional seed-node arguments, causing a misleading `Invalid inetSocketAddress` crash with no indication that the flag was removed.
- Aligns with the ongoing effort to trim `CommonParameter` and `reference.conf` of accumulated legacy fields (part of the `feature/reduce_482_config` series).

**This PR has been tested by:**
- Unit Tests (`StorageConfigTest`, `ArgsTest`, `JsonTest`, `JsonRpcServletTest` updated/passing)
- Verified that nodes started with `--storage-index-directory` / `--storage-index-switch` still start normally and emit a deprecation warning instead of crashing

**Follow up**

Continue auditing `CommonParameter` and `reference.conf` for additional unused or redundant config entries.

**Extra details**

No behaviour change for any running node: the JSON depth/token limits remain exactly 100 / 100 000; index storage was already a no-op. Operators passing the removed index CLI flags get a deprecation warning on startup; the flags are silently consumed and ignored.