### PR TITLE
feat(net): normalize inbound messages

### DIFF
--- a/chainbase/src/main/java/org/tron/core/capsule/BlockCapsule.java
+++ b/chainbase/src/main/java/org/tron/core/capsule/BlockCapsule.java
@@ -329,11 +329,11 @@ public class BlockCapsule implements ProtoCapsule<Block> {
     return !getInstance().getBlockHeader().getWitnessSignature().isEmpty();
   }
 
-  public void sanitize() {
+  public boolean sanitize() {
     boolean blockHasUnknown = !this.block.getUnknownFields().asMap().isEmpty();
     boolean headerHasUnknown = !this.block.getBlockHeader().getUnknownFields().asMap().isEmpty();
     if (!blockHasUnknown && !headerHasUnknown) {
-      return;
+      return false;
     }
     UnknownFieldSet empty = UnknownFieldSet.getDefaultInstance();
     Block.Builder builder = this.block.toBuilder();
@@ -346,6 +346,7 @@ public class BlockCapsule implements ProtoCapsule<Block> {
           .build());
     }
     this.block = builder.build();
+    return true;
   }
 
   @Override

--- a/chainbase/src/main/java/org/tron/core/capsule/BlockCapsule.java
+++ b/chainbase/src/main/java/org/tron/core/capsule/BlockCapsule.java
@@ -21,6 +21,7 @@ import com.google.common.primitives.Longs;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.CodedInputStream;
 import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.UnknownFieldSet;
 import java.security.SignatureException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -326,6 +327,25 @@ public class BlockCapsule implements ProtoCapsule<Block> {
 
   public boolean hasWitnessSignature() {
     return !getInstance().getBlockHeader().getWitnessSignature().isEmpty();
+  }
+
+  public void sanitize() {
+    boolean blockHasUnknown = !this.block.getUnknownFields().asMap().isEmpty();
+    boolean headerHasUnknown = !this.block.getBlockHeader().getUnknownFields().asMap().isEmpty();
+    if (!blockHasUnknown && !headerHasUnknown) {
+      return;
+    }
+    UnknownFieldSet empty = UnknownFieldSet.getDefaultInstance();
+    Block.Builder builder = this.block.toBuilder();
+    if (blockHasUnknown) {
+      builder.setUnknownFields(empty);
+    }
+    if (headerHasUnknown) {
+      builder.setBlockHeader(this.block.getBlockHeader().toBuilder()
+          .setUnknownFields(empty)
+          .build());
+    }
+    this.block = builder.build();
   }
 
   @Override

--- a/chainbase/src/main/java/org/tron/core/capsule/TransactionCapsule.java
+++ b/chainbase/src/main/java/org/tron/core/capsule/TransactionCapsule.java
@@ -28,6 +28,7 @@ import com.google.protobuf.CodedOutputStream;
 import com.google.protobuf.GeneratedMessageV3;
 import com.google.protobuf.Internal;
 import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.UnknownFieldSet;
 import java.io.IOException;
 import java.security.SignatureException;
 import java.util.ArrayList;
@@ -492,6 +493,14 @@ public class TransactionCapsule implements ProtoCapsule<Transaction> {
       return true;
     }
     return false;
+  }
+
+  public void sanitize() {
+    if (!this.transaction.getUnknownFields().asMap().isEmpty()) {
+      this.transaction = transaction.toBuilder()
+          .setUnknownFields(UnknownFieldSet.getDefaultInstance())
+          .build();
+    }
   }
 
   public void resetResult() {

--- a/chainbase/src/main/java/org/tron/core/capsule/TransactionCapsule.java
+++ b/chainbase/src/main/java/org/tron/core/capsule/TransactionCapsule.java
@@ -495,12 +495,14 @@ public class TransactionCapsule implements ProtoCapsule<Transaction> {
     return false;
   }
 
-  public void sanitize() {
-    if (!this.transaction.getUnknownFields().asMap().isEmpty()) {
-      this.transaction = transaction.toBuilder()
-          .setUnknownFields(UnknownFieldSet.getDefaultInstance())
-          .build();
+  public boolean sanitize() {
+    if (this.transaction.getUnknownFields().asMap().isEmpty()) {
+      return false;
     }
+    this.transaction = this.transaction.toBuilder()
+        .setUnknownFields(UnknownFieldSet.getDefaultInstance())
+        .build();
+    return true;
   }
 
   public void resetResult() {

--- a/framework/src/main/java/org/tron/core/Wallet.java
+++ b/framework/src/main/java/org/tron/core/Wallet.java
@@ -556,9 +556,9 @@ public class Wallet {
       if (trx.getInstance().getRawData().getContractCount() == 0) {
         throw new ContractValidateException(ActuatorConstant.CONTRACT_NOT_EXIST);
       }
-      TransactionMessage message = new TransactionMessage(trx.getInstance().toByteArray());
       trx.checkExpiration(chainBaseManager.getNextBlockSlotTime());
       dbManager.pushTransaction(trx);
+      TransactionMessage message = new TransactionMessage(trx.getInstance().toByteArray());
       int num = tronNetService.fastBroadcastTransaction(message);
       if (num == 0 && minEffectiveConnection != 0) {
         return builder.setResult(false).setCode(response_code.NOT_ENOUGH_EFFECTIVE_CONNECTION)

--- a/framework/src/main/java/org/tron/core/db/Manager.java
+++ b/framework/src/main/java/org/tron/core/db/Manager.java
@@ -1534,6 +1534,9 @@ public class Manager {
           String.format(" %s transaction signature validate failed", txId));
     }
 
+    if (!trxCap.isInBlock()) {
+      trxCap.sanitize();
+    }
     TransactionTrace trace = new TransactionTrace(trxCap, StoreFactory.getInstance(),
         new RuntimeImpl());
     trxCap.setTrxTrace(trace);

--- a/framework/src/main/java/org/tron/core/net/message/adv/BlockMessage.java
+++ b/framework/src/main/java/org/tron/core/net/message/adv/BlockMessage.java
@@ -29,8 +29,9 @@ public class BlockMessage extends TronMessage {
   }
 
   public void sanitize() {
-    this.block.sanitize();
-    this.data = this.block.getData();
+    if (this.block.sanitize()) {
+      this.data = this.block.getData();
+    }
   }
 
   public BlockId getBlockId() {

--- a/framework/src/main/java/org/tron/core/net/message/adv/BlockMessage.java
+++ b/framework/src/main/java/org/tron/core/net/message/adv/BlockMessage.java
@@ -28,6 +28,11 @@ public class BlockMessage extends TronMessage {
     this.block = block;
   }
 
+  public void sanitize() {
+    this.block.sanitize();
+    this.data = this.block.getData();
+  }
+
   public BlockId getBlockId() {
     return getBlockCapsule().getBlockId();
   }

--- a/framework/src/main/java/org/tron/core/net/messagehandler/BlockMsgHandler.java
+++ b/framework/src/main/java/org/tron/core/net/messagehandler/BlockMsgHandler.java
@@ -77,6 +77,8 @@ public class BlockMsgHandler implements TronMsgHandler {
       check(peer, blockMessage);
     }
 
+    blockMessage.sanitize();
+
     if (peer.getSyncBlockRequested().containsKey(blockId)) {
       peer.getSyncBlockRequested().remove(blockId);
       peer.getSyncBlockInProcess().add(blockId);

--- a/framework/src/test/java/org/tron/core/net/message/adv/SanitizeUnknownFieldsTest.java
+++ b/framework/src/test/java/org/tron/core/net/message/adv/SanitizeUnknownFieldsTest.java
@@ -2,7 +2,9 @@ package org.tron.core.net.message.adv;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import com.google.protobuf.ByteString;
@@ -67,7 +69,7 @@ public class SanitizeUnknownFieldsTest {
     BlockCapsule capsule = new BlockCapsule(padded);
     long originalSize = capsule.getData().length;
 
-    capsule.sanitize();
+    assertTrue("sanitize() should report it mutated the capsule", capsule.sanitize());
 
     assertTrue("Block-level unknown fields should be stripped",
         capsule.getInstance().getUnknownFields().asMap().isEmpty());
@@ -85,7 +87,7 @@ public class SanitizeUnknownFieldsTest {
     BlockCapsule capsule = new BlockCapsule(padded);
     long originalSize = capsule.getData().length;
 
-    capsule.sanitize();
+    assertTrue("sanitize() should report it mutated the capsule", capsule.sanitize());
 
     assertTrue("BlockHeader outer unknown fields should be stripped",
         capsule.getInstance().getBlockHeader().getUnknownFields().asMap().isEmpty());
@@ -109,11 +111,14 @@ public class SanitizeUnknownFieldsTest {
   public void blockCapsuleSanitizeIsNoOpOnCleanBlock() {
     Block clean = sampleBlock();
     BlockCapsule capsule = new BlockCapsule(clean);
-    byte[] before = capsule.getData();
+    Block beforeInstance = capsule.getInstance();
+    byte[] beforeData = capsule.getData();
 
-    capsule.sanitize();
+    assertFalse("sanitize() should report no-op on a clean block", capsule.sanitize());
 
-    assertArrayEquals("Clean block should pass through unchanged", before, capsule.getData());
+    assertSame("Underlying Block reference should not be rebuilt",
+        beforeInstance, capsule.getInstance());
+    assertArrayEquals("Clean block should pass through unchanged", beforeData, capsule.getData());
   }
 
   // ---- TransactionCapsule.sanitize ----
@@ -124,7 +129,7 @@ public class SanitizeUnknownFieldsTest {
     TransactionCapsule capsule = new TransactionCapsule(padded);
     long originalSize = capsule.getData().length;
 
-    capsule.sanitize();
+    assertTrue("sanitize() should report it mutated the capsule", capsule.sanitize());
 
     assertTrue("Transaction-level unknown fields should be stripped",
         capsule.getInstance().getUnknownFields().asMap().isEmpty());
@@ -149,11 +154,14 @@ public class SanitizeUnknownFieldsTest {
   public void transactionCapsuleSanitizeIsNoOpOnCleanTransaction() {
     Transaction clean = sampleTransaction();
     TransactionCapsule capsule = new TransactionCapsule(clean);
-    byte[] before = capsule.getData();
+    Transaction beforeInstance = capsule.getInstance();
+    byte[] beforeData = capsule.getData();
 
-    capsule.sanitize();
+    assertFalse("sanitize() should report no-op on a clean transaction", capsule.sanitize());
 
-    assertArrayEquals(before, capsule.getData());
+    assertSame("Underlying Transaction reference should not be rebuilt",
+        beforeInstance, capsule.getInstance());
+    assertArrayEquals(beforeData, capsule.getData());
   }
 
   // ---- BlockMessage.sanitize ----
@@ -176,5 +184,17 @@ public class SanitizeUnknownFieldsTest {
         msg.getBlockCapsule().getData(), msg.getData());
     assertNotEquals("msg.data should no longer match the padded wire bytes",
         paddedBytes.length, msg.getData().length);
+  }
+
+  @Test
+  public void blockMessageSanitizeSkipsDataRewriteOnCleanBlock() throws Exception {
+    byte[] cleanBytes = sampleBlock().toByteArray();
+    BlockMessage msg = new BlockMessage(cleanBytes);
+    byte[] before = msg.getData();
+
+    msg.sanitize();
+
+    assertSame("msg.data should not be rewritten on the no-op path",
+        before, msg.getData());
   }
 }

--- a/framework/src/test/java/org/tron/core/net/message/adv/SanitizeUnknownFieldsTest.java
+++ b/framework/src/test/java/org/tron/core/net/message/adv/SanitizeUnknownFieldsTest.java
@@ -1,0 +1,180 @@
+package org.tron.core.net.message.adv;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.UnknownFieldSet;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.tron.common.overlay.message.Message;
+import org.tron.core.capsule.BlockCapsule;
+import org.tron.core.capsule.TransactionCapsule;
+import org.tron.core.store.DynamicPropertiesStore;
+import org.tron.protos.Protocol.Block;
+import org.tron.protos.Protocol.BlockHeader;
+import org.tron.protos.Protocol.Transaction;
+
+/**
+ * Verifies the {@code sanitize()} helpers on {@link BlockCapsule},
+ * {@link TransactionCapsule} and {@link BlockMessage}: they strip outer
+ * unknown protobuf fields while leaving every consensus-hashed / signed
+ * region byte-identical.
+ */
+public class SanitizeUnknownFieldsTest {
+
+  private static final UnknownFieldSet PADDING = UnknownFieldSet.newBuilder()
+      .addField(99999, UnknownFieldSet.Field.newBuilder()
+          .addLengthDelimited(ByteString.copyFrom(new byte[1024]))
+          .build())
+      .build();
+
+  @BeforeClass
+  public static void setUp() {
+    // BlockMessage(byte[]) calls Message.isFilter() which dereferences the
+    // static DynamicPropertiesStore. The mock's primitive-long getter returns
+    // 0L by default, so isFilter() returns false.
+    Message.setDynamicPropertiesStore(Mockito.mock(DynamicPropertiesStore.class));
+  }
+
+  private static BlockHeader.raw sampleRawHeader() {
+    return BlockHeader.raw.newBuilder()
+        .setNumber(100)
+        .setTimestamp(123456789L)
+        .build();
+  }
+
+  private static Block sampleBlock() {
+    return Block.newBuilder()
+        .setBlockHeader(BlockHeader.newBuilder().setRawData(sampleRawHeader()).build())
+        .build();
+  }
+
+  private static Transaction sampleTransaction() {
+    return Transaction.newBuilder()
+        .setRawData(Transaction.raw.newBuilder().setTimestamp(123456789L).build())
+        .build();
+  }
+
+  // ---- BlockCapsule.sanitize ----
+
+  @Test
+  public void blockCapsuleSanitizeStripsBlockLevelUnknownFields() {
+    Block padded = sampleBlock().toBuilder().setUnknownFields(PADDING).build();
+    BlockCapsule capsule = new BlockCapsule(padded);
+    long originalSize = capsule.getData().length;
+
+    capsule.sanitize();
+
+    assertTrue("Block-level unknown fields should be stripped",
+        capsule.getInstance().getUnknownFields().asMap().isEmpty());
+    assertTrue("Sanitized capsule bytes should shrink",
+        capsule.getData().length < originalSize);
+  }
+
+  @Test
+  public void blockCapsuleSanitizeStripsBlockHeaderOuterUnknownFields() {
+    BlockHeader paddedHeader = BlockHeader.newBuilder()
+        .setRawData(sampleRawHeader())
+        .setUnknownFields(PADDING)
+        .build();
+    Block padded = Block.newBuilder().setBlockHeader(paddedHeader).build();
+    BlockCapsule capsule = new BlockCapsule(padded);
+    long originalSize = capsule.getData().length;
+
+    capsule.sanitize();
+
+    assertTrue("BlockHeader outer unknown fields should be stripped",
+        capsule.getInstance().getBlockHeader().getUnknownFields().asMap().isEmpty());
+    assertTrue(capsule.getData().length < originalSize);
+  }
+
+  @Test
+  public void blockCapsuleSanitizePreservesBlockHeaderRawData() {
+    Block clean = sampleBlock();
+    Block padded = clean.toBuilder().setUnknownFields(PADDING).build();
+    BlockCapsule capsule = new BlockCapsule(padded);
+
+    capsule.sanitize();
+
+    assertEquals("BlockHeader.raw_data must be byte-identical so block hash matches",
+        clean.getBlockHeader().getRawData(),
+        capsule.getInstance().getBlockHeader().getRawData());
+  }
+
+  @Test
+  public void blockCapsuleSanitizeIsNoOpOnCleanBlock() {
+    Block clean = sampleBlock();
+    BlockCapsule capsule = new BlockCapsule(clean);
+    byte[] before = capsule.getData();
+
+    capsule.sanitize();
+
+    assertArrayEquals("Clean block should pass through unchanged", before, capsule.getData());
+  }
+
+  // ---- TransactionCapsule.sanitize ----
+
+  @Test
+  public void transactionCapsuleSanitizeStripsTopLevelUnknownFields() {
+    Transaction padded = sampleTransaction().toBuilder().setUnknownFields(PADDING).build();
+    TransactionCapsule capsule = new TransactionCapsule(padded);
+    long originalSize = capsule.getData().length;
+
+    capsule.sanitize();
+
+    assertTrue("Transaction-level unknown fields should be stripped",
+        capsule.getInstance().getUnknownFields().asMap().isEmpty());
+    assertTrue(capsule.getData().length < originalSize);
+  }
+
+  @Test
+  public void transactionCapsuleSanitizePreservesTransactionId() {
+    Transaction clean = sampleTransaction();
+    Transaction padded = clean.toBuilder().setUnknownFields(PADDING).build();
+    TransactionCapsule cleanCapsule = new TransactionCapsule(clean);
+    TransactionCapsule paddedCapsule = new TransactionCapsule(padded);
+
+    paddedCapsule.sanitize();
+
+    assertEquals("Padding outside raw_data must not change the transaction id",
+        cleanCapsule.getTransactionId(),
+        paddedCapsule.getTransactionId());
+  }
+
+  @Test
+  public void transactionCapsuleSanitizeIsNoOpOnCleanTransaction() {
+    Transaction clean = sampleTransaction();
+    TransactionCapsule capsule = new TransactionCapsule(clean);
+    byte[] before = capsule.getData();
+
+    capsule.sanitize();
+
+    assertArrayEquals(before, capsule.getData());
+  }
+
+  // ---- BlockMessage.sanitize ----
+
+  @Test
+  public void blockMessageSanitizeUpdatesBothCapsuleAndWireBytes() throws Exception {
+    Block padded = sampleBlock().toBuilder().setUnknownFields(PADDING).build();
+    byte[] paddedBytes = padded.toByteArray();
+    BlockMessage msg = new BlockMessage(paddedBytes);
+    assertArrayEquals("Constructor should not sanitize on its own",
+        paddedBytes, msg.getData());
+
+    msg.sanitize();
+
+    assertTrue("BlockCapsule should be sanitized",
+        msg.getBlockCapsule().getInstance().getUnknownFields().asMap().isEmpty());
+    assertTrue("msg.data should also be rewritten to canonical bytes",
+        msg.getData().length < paddedBytes.length);
+    assertArrayEquals("msg.data should equal capsule.getData() after sanitize",
+        msg.getBlockCapsule().getData(), msg.getData());
+    assertNotEquals("msg.data should no longer match the padded wire bytes",
+        paddedBytes.length, msg.getData().length);
+  }
+}


### PR DESCRIPTION
### Summary

Add `sanitize()` to `BlockCapsule` and `TransactionCapsule` that normalizes the protobuf representation by stripping outer unknown fields, leaving all consensus-hashed and signed regions byte-identical.

Invocation:
- `BlockMsgHandler.processMessage` calls `blockMessage.sanitize()` after the existing size/time checks and before sync/adv dispatch. `BlockMessage.sanitize()` updates both the capsule and the message's wire `data` field (if it contains unknown fields).
- `Manager.processTransaction` calls `trxCap.sanitize()` after signature validation, only for mempool transactions (`!trxCap.isInBlock()`).
- `Wallet.broadcastTransaction` constructs the outbound `TransactionMessage` after `pushTransaction` so it reflects the post-sanitize state.

Each `sanitize()` short-circuits when there are no unknown fields, so the common path is allocation-free.

### Compatibility

- Consensus state is unchanged.
- Existing size checks, error paths, response codes, and log lines are untouched.
- No consensus impact.
