### PR TITLE
fix(vm): write TIP-2935 parent hash after witness permission check

### DIFF
--- a/framework/src/main/java/org/tron/core/db/Manager.java
+++ b/framework/src/main/java/org/tron/core/db/Manager.java
@@ -1625,7 +1625,6 @@ public class Manager {
     session.reset();
     session.setValue(revokingStore.buildSession());
 
-    HistoryBlockHashUtil.write(this, blockCapsule);
     accountStateCallBack.preExecute(blockCapsule);
 
     if (getDynamicPropertiesStore().getAllowMultiSign() == 1) {
@@ -1637,6 +1636,8 @@ public class Manager {
         return null;
       }
     }
+
+    HistoryBlockHashUtil.write(this, blockCapsule);
 
     Set<String> accountSet = new HashSet<>();
     AtomicInteger shieldedTransCounts = new AtomicInteger(0);

--- a/framework/src/test/java/org/tron/core/db/HistoryBlockHashIntegrationTest.java
+++ b/framework/src/test/java/org/tron/core/db/HistoryBlockHashIntegrationTest.java
@@ -256,14 +256,18 @@ public class HistoryBlockHashIntegrationTest extends BaseTest {
    * SR / validator parity: the producer's {@code generateBlock} simulation
    * loop and the validator's {@code processBlock} apply loop must see the
    * same storage state when transactions hit {@code HISTORY_STORAGE_ADDRESS}.
-   * That requires {@link HistoryBlockHashUtil#write} to run before the tx
-   * loop on both paths. {@code processBlock} writes at line 1858; this test
-   * pins the matching write inside {@code generateBlock}.
+   * Both paths run {@link HistoryBlockHashUtil#write} before their tx loop:
+   * {@code processBlock} after its {@code validBlock} guard, and
+   * {@code generateBlock} after the witness-permission guard, so a failed
+   * permission check never writes the parent hash.
    *
-   * <p>Spy {@code accountStateCallBack.preExecute} — called between the
-   * write and the tx loop on both paths — and snapshot the slot from inside
-   * the revoking session. Pre-fix the slot is empty (write never ran);
-   * post-fix it holds the parent block hash.
+   * <p>In {@code generateBlock} {@code preExecute} runs ahead of the write
+   * (it precedes the guard), so this spies
+   * {@code accountStateCallBack.executeGenerateFinish} — the last callback
+   * before {@code session.reset()} — and snapshots the slot from inside the
+   * revoking session. With no pending transactions the tx loop is a no-op, so
+   * reaching this callback means the write already ran: if it were dropped the
+   * slot would be empty; instead it holds the parent block hash.
    */
   @Test
   public void generateBlockWritesParentHashBeforeTxLoop() throws Exception {
@@ -286,7 +290,7 @@ public class HistoryBlockHashIntegrationTest extends BaseTest {
           chainBaseManager.getStorageRowStore());
       captured.set(st.getValue(new DataWord(expectedSlot)));
       return inv.callRealMethod();
-    }).when(spy).preExecute(Mockito.any(BlockCapsule.class));
+    }).when(spy).executeGenerateFinish();
     cbField.set(dbManager, spy);
 
     try {
@@ -303,10 +307,11 @@ public class HistoryBlockHashIntegrationTest extends BaseTest {
     }
 
     assertNotNull(
-        "preExecute fired with an empty slot — write() must run before preExecute",
+        "executeGenerateFinish fired with an empty slot — "
+            + "write() must run during block generation",
         captured.get());
     assertArrayEquals(
-        "slot must hold the parent block hash before the tx loop runs",
+        "slot must hold the parent block hash by the time generation finishes",
         expectedParentHash, captured.get().getData());
   }
 


### PR DESCRIPTION
**What does this PR do?**

Move the TIP-2935 parent-hash write (`HistoryBlockHashUtil.write`) in `Manager#generateBlock` to after the witness-permission check, so a failed permission check (which returns `null`) never writes the parent hash. `accountStateCallBack.preExecute` keeps its original position before the guard; only the write moves.

**Why are these changes required?**

`generateBlock` can `return null` from the witness-permission check (when `ALLOW_MULTI_SIGN` is on and the producing key does not match the witness permission address). The TIP-2935 write previously ran before that guard, so on a permission failure the parent hash was still written into the current revoking session. The failure path returns without `session.reset()`, so the stale write survives into the session reused by the next `pushTransaction` (the `!session.valid()` branch is skipped), polluting the pending-transaction preview until the next reset. It never reaches disk, but it is an avoidable dirty write. Moving the write below the guard removes it from the abort path; the write still runs before the tx loop, so SR/validator parity is unchanged. `processBlock`'s write is unaffected — it already runs after `consensus.validBlock(...)`.

**This PR has been tested by:**
- Unit Tests — `HistoryBlockHashIntegrationTest` (16 cases, all passing). `generateBlockWritesParentHashBeforeTxLoop` now snapshots the slot at `executeGenerateFinish` (the last callback before `session.reset()`), since `preExecute` now precedes the write.

**Follow up**

N/A

**Extra details**

Follow-up to #6686 (TIP-2935). One-statement reorder.