### PR TITLE
fix(net): exit solidity node block sync on shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ The TRON network is mainly divided into:
 - **Private Networks**  
   Customized TRON networks set up by private entities for testing, development, or specific use cases.
 
-Network selection is performed by specifying the appropriate configuration file upon full-node startup. Mainnet configuration: [config.conf](framework/src/main/resources/config.conf); Nile testnet configuration: [config-nile.conf](https://github.com/tron-nile-testnet/nile-testnet/blob/master/framework/src/main/resources/config-nile.conf)
+Network selection is performed by specifying the appropriate configuration file upon full-node startup. Built-in configuration template: [reference.conf](common/src/main/resources/reference.conf); Mainnet configuration: [config.conf](framework/src/main/resources/config.conf); Nile testnet configuration: [config-nile.conf](https://github.com/tron-nile-testnet/nile-testnet/blob/master/framework/src/main/resources/config-nile.conf)
 
 ### 1. Join the TRON main network
 Launch a main-network full node with the built-in default configuration:

--- a/common/src/main/resources/reference.conf
+++ b/common/src/main/resources/reference.conf
@@ -25,17 +25,6 @@
 # Key naming rules (required for ConfigBeanFactory auto-binding):
 #   - Use standard camelCase: maxConnections, syncFetchBatchNum, etc.
 #
-# Keys that cannot auto-bind (handled via normalizeNonStandardKeys() or manual reads):
-#
-#   1. committee.pBFTExpireNum / committee.allowPBFT — normalized to camelCase in
-#      CommitteeConfig.normalizeNonStandardKeys() before ConfigBeanFactory binding.
-#
-#   2. node.isOpenFullTcpDisconnect — normalized to "openFullTcpDisconnect" in
-#      NodeConfig.normalizeNonStandardKeys() before ConfigBeanFactory binding.
-#
-#   3. node.shutdown.BlockTime/BlockHeight/BlockCount — optional PascalCase nested keys;
-#      read manually in NodeConfig.fromConfig() after ConfigBeanFactory binding.
-#
 # =============================================================================
 
 net {

--- a/framework/src/main/java/org/tron/core/net/TronNetDelegate.java
+++ b/framework/src/main/java/org/tron/core/net/TronNetDelegate.java
@@ -111,7 +111,9 @@ public class TronNetDelegate {
   @PostConstruct
   public void init() {
     hitThread =  new Thread(() -> {
-      LockSupport.park();
+      while (!hitDown && !Thread.currentThread().isInterrupted()) {
+        LockSupport.park();
+      }
       // to Guarantee Some other thread invokes unpark with the current thread as the target
       if (hitDown && exit) {
         System.exit(0);

--- a/framework/src/main/java/org/tron/program/SolidityNode.java
+++ b/framework/src/main/java/org/tron/program/SolidityNode.java
@@ -122,7 +122,7 @@ public class SolidityNode implements ApplicationListener<ContextClosedEvent> {
         logger.info("getBlock interrupted, exiting.");
         return;
       } catch (Exception e) {
-        if (!flag) {
+        if (!flag || tronNetDelegate.isHitDown()) {
           logger.info("getBlock stopped during shutdown, last block: {}.", blockNum);
           return;
         }

--- a/framework/src/main/java/org/tron/program/SolidityNode.java
+++ b/framework/src/main/java/org/tron/program/SolidityNode.java
@@ -185,6 +185,10 @@ public class SolidityNode implements ApplicationListener<ContextClosedEvent> {
           sleep(exceptionSleepTime);
         }
       } catch (Exception e) {
+        if (!flag || tronNetDelegate.isHitDown()) {
+          logger.info("getBlockByNum stopped during shutdown, block: {}.", blockNum);
+          break;
+        }
         logger.error("Failed to get block: {}, reason: {}.", blockNum, e.getMessage());
         sleep(exceptionSleepTime);
       }

--- a/framework/src/main/java/org/tron/program/SolidityNode.java
+++ b/framework/src/main/java/org/tron/program/SolidityNode.java
@@ -206,7 +206,7 @@ public class SolidityNode implements ApplicationListener<ContextClosedEvent> {
             blockNum, remoteBlockNum, System.currentTimeMillis() - time);
         return blockNum;
       } catch (Exception e) {
-        if (!flag) {
+        if (!flag || tronNetDelegate.isHitDown()) {
           logger.info("getLastSolidityBlockNum stopped during shutdown.");
           return 0;
         }

--- a/framework/src/test/java/org/tron/core/zksnark/ShieldedReceiveTest.java
+++ b/framework/src/test/java/org/tron/core/zksnark/ShieldedReceiveTest.java
@@ -8,6 +8,7 @@ import com.google.common.primitives.Bytes;
 import com.google.protobuf.Any;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
+import java.lang.reflect.Field;
 import java.security.SignatureException;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -46,6 +47,7 @@ import org.tron.common.zksnark.LibrustzcashParam.IvkToPkdParams;
 import org.tron.common.zksnark.LibrustzcashParam.OutputProofParams;
 import org.tron.common.zksnark.LibrustzcashParam.SpendSigParams;
 import org.tron.consensus.dpos.DposSlot;
+import org.tron.consensus.dpos.DposTask;
 import org.tron.core.Wallet;
 import org.tron.core.actuator.Actuator;
 import org.tron.core.actuator.ActuatorCreator;
@@ -140,6 +142,8 @@ public class ShieldedReceiveTest extends BaseTest {
   private static final String URL = "https://tron.network";
   @Resource
   private ConsensusService consensusService;
+  @Resource
+  private DposTask dposTask;
   @Resource
   private Wallet wallet;
   @Resource
@@ -2534,6 +2538,11 @@ public class ShieldedReceiveTest extends BaseTest {
       boolean ok2 = dbManager.pushTransaction(transactionCap2);
       Assert.assertTrue(ok2);
     } finally {
+      // DposTask.init() does not reset isRunning (it stays false after stop()), so force it back
+      // to true via reflection before restarting.
+      Field isRunning = DposTask.class.getDeclaredField("isRunning");
+      isRunning.setAccessible(true);
+      isRunning.set(dposTask, true);
       consensusService.start();
     }
   }

--- a/framework/src/test/java/org/tron/core/zksnark/ShieldedReceiveTest.java
+++ b/framework/src/test/java/org/tron/core/zksnark/ShieldedReceiveTest.java
@@ -45,6 +45,7 @@ import org.tron.common.zksnark.LibrustzcashParam.CheckSpendParams;
 import org.tron.common.zksnark.LibrustzcashParam.IvkToPkdParams;
 import org.tron.common.zksnark.LibrustzcashParam.OutputProofParams;
 import org.tron.common.zksnark.LibrustzcashParam.SpendSigParams;
+import org.tron.consensus.dpos.DposSlot;
 import org.tron.core.Wallet;
 import org.tron.core.actuator.Actuator;
 import org.tron.core.actuator.ActuatorCreator;
@@ -142,12 +143,12 @@ public class ShieldedReceiveTest extends BaseTest {
   @Resource
   private Wallet wallet;
   @Resource
-  private TransactionUtil transactionUtil;
+  private DposSlot dposSlot;
 
   private static boolean init;
 
   static {
-    Args.setParam(new String[]{"--output-directory", dbPath(), "-w"}, SHIELD_CONF);
+    Args.setParam(new String[] {"--output-directory", dbPath(), "-w"}, SHIELD_CONF);
     ADDRESS_ONE_PRIVATE_KEY = getRandomPrivateKey();
     FROM_ADDRESS = getHexAddressByPrivateKey(ADDRESS_ONE_PRIVATE_KEY);
   }
@@ -331,7 +332,7 @@ public class ShieldedReceiveTest extends BaseTest {
 
     //Add public address sign
     transactionCap = TransactionUtils.addTransactionSign(transactionCap.getInstance(),
-            ADDRESS_ONE_PRIVATE_KEY, chainBaseManager.getAccountStore());
+        ADDRESS_ONE_PRIVATE_KEY, chainBaseManager.getAccountStore());
     try {
       dbManager.pushTransaction(transactionCap);
     } catch (Exception e) {
@@ -433,7 +434,7 @@ public class ShieldedReceiveTest extends BaseTest {
     boolean ok2 = JLibrustzcash.librustzcashSaplingCheckOutput(checkOutputParams);
     Assert.assertTrue(ok2);
 
-    return new String[]{ByteArray.toHexString(checkSpendParamsData),
+    return new String[] {ByteArray.toHexString(checkSpendParamsData),
         ByteArray.toHexString(dataToBeSigned),
         ByteArray.toHexString(checkOutputParams.encode())};
   }
@@ -2402,128 +2403,153 @@ public class ShieldedReceiveTest extends BaseTest {
     assert ecKey != null;
     byte[] witnessAddress = ecKey.getAddress();
     WitnessCapsule witnessCapsule = new WitnessCapsule(ByteString.copyFrom(witnessAddress));
-    chainBaseManager.addWitness(ByteString.copyFrom(witnessAddress));
+    // Stop the consensus task before modifying the witness schedule: DposTask uses the same
+    // localwitness key and would otherwise race to produce blocks at the same slot,
+    // triggering fork resolution and making the test slow.
+    consensusService.stop();
+    try {
+      chainBaseManager.addWitness(ByteString.copyFrom(witnessAddress));
 
-    //sometimes generate block failed, try several times.
-    long time = System.currentTimeMillis();
-    Block block = getSignedBlock(witnessCapsule.getAddress(), time, privateKey);
-    dbManager.pushBlock(new BlockCapsule(block));
+      long time = nextScheduledTime(witnessCapsule.getAddress());
+      Block block = getSignedBlock(witnessCapsule.getAddress(), time, privateKey);
+      dbManager.pushBlock(new BlockCapsule(block));
 
-    //create transactions
-    chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
-    chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(1000 * 1000000L);
-    ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
+      //create transactions
+      chainBaseManager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
+      chainBaseManager.getDynamicPropertiesStore().saveTotalShieldedPoolValue(1000 * 1000000L);
+      ZenTransactionBuilder builder = new ZenTransactionBuilder(wallet);
 
-    // generate spend proof
-    SpendingKey sk = SpendingKey
-        .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
-    ExpandedSpendingKey expsk = sk.expandedSpendingKey();
-    byte[] senderOvk = expsk.getOvk();
-    PaymentAddress address = sk.defaultAddress();
-    Note note = new Note(address, 1000 * 1000000L);
-    IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
-    byte[] anchor = voucher.root().getContent().toByteArray();
-    chainBaseManager.getMerkleContainer()
-        .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
-    builder.addSpend(expsk, note, anchor, voucher);
+      // generate spend proof
+      SpendingKey sk = SpendingKey
+          .decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
+      ExpandedSpendingKey expsk = sk.expandedSpendingKey();
+      byte[] senderOvk = expsk.getOvk();
+      PaymentAddress address = sk.defaultAddress();
+      Note note = new Note(address, 1000 * 1000000L);
+      IncrementalMerkleVoucherContainer voucher = createSimpleMerkleVoucherContainer(note.cm());
+      byte[] anchor = voucher.root().getContent().toByteArray();
+      chainBaseManager.getMerkleContainer()
+          .putMerkleTreeIntoStore(anchor, voucher.getVoucherCapsule().getTree());
+      builder.addSpend(expsk, note, anchor, voucher);
 
-    // generate output proof
-    SpendingKey sk2 = SpendingKey.random();
-    FullViewingKey fullViewingKey = sk2.fullViewingKey();
-    IncomingViewingKey incomingViewingKey = fullViewingKey.inViewingKey();
+      // generate output proof
+      SpendingKey sk2 = SpendingKey.random();
+      FullViewingKey fullViewingKey = sk2.fullViewingKey();
+      IncomingViewingKey incomingViewingKey = fullViewingKey.inViewingKey();
 
-    byte[] memo = org.tron.keystore.Wallet.generateRandomBytes(512);
+      byte[] memo = org.tron.keystore.Wallet.generateRandomBytes(512);
 
-    //send coin to 2 different address generated by same sk
-    DiversifierT d1 = DiversifierT.random();
-    PaymentAddress paymentAddress1 = incomingViewingKey.address(d1).get();
-    builder.addOutput(senderOvk, paymentAddress1,
-        (1000 * 1000000L - wallet.getShieldedTransactionFee()) / 2, memo);
+      //send coin to 2 different address generated by same sk
+      DiversifierT d1 = DiversifierT.random();
+      PaymentAddress paymentAddress1 = incomingViewingKey.address(d1).get();
+      builder.addOutput(senderOvk, paymentAddress1,
+          (1000 * 1000000L - wallet.getShieldedTransactionFee()) / 2, memo);
 
-    DiversifierT d2 = DiversifierT.random();
-    PaymentAddress paymentAddress2 = incomingViewingKey.address(d2).get();
-    builder.addOutput(senderOvk, paymentAddress2,
-        (1000 * 1000000L - wallet.getShieldedTransactionFee()) / 2, memo);
+      DiversifierT d2 = DiversifierT.random();
+      PaymentAddress paymentAddress2 = incomingViewingKey.address(d2).get();
+      builder.addOutput(senderOvk, paymentAddress2,
+          (1000 * 1000000L - wallet.getShieldedTransactionFee()) / 2, memo);
 
-    TransactionCapsule transactionCap = builder.build();
+      TransactionCapsule transactionCap = builder.build();
 
-    byte[] trxId = transactionCap.getTransactionId().getBytes();
-    boolean ok = dbManager.pushTransaction(transactionCap);
-    Assert.assertTrue(ok);
+      byte[] trxId = transactionCap.getTransactionId().getBytes();
+      boolean ok = dbManager.pushTransaction(transactionCap);
+      Assert.assertTrue(ok);
 
-    Thread.sleep(500);
-    //package transaction to block
-    block = getSignedBlock(witnessCapsule.getAddress(), time + 3000, privateKey);
-    dbManager.pushBlock(new BlockCapsule(block));
+      Thread.sleep(500);
+      //package transaction to block
+      long expectedBlockNum = chainBaseManager.getDynamicPropertiesStore()
+          .getLatestBlockHeaderNumber() + 1;
+      block = getSignedBlock(witnessCapsule.getAddress(),
+          nextScheduledTime(witnessCapsule.getAddress()), privateKey);
+      dbManager.pushBlock(new BlockCapsule(block));
 
-    BlockCapsule blockCapsule3 = new BlockCapsule(wallet.getNowBlock());
-    Assert.assertEquals("blocknum != 2", 2, blockCapsule3.getNum());
+      BlockCapsule blockCapsule3 = new BlockCapsule(wallet.getNowBlock());
+      Assert.assertEquals("unexpected block number", expectedBlockNum, blockCapsule3.getNum());
 
-    block = getSignedBlock(witnessCapsule.getAddress(), time + 6000, privateKey);
-    dbManager.pushBlock(new BlockCapsule(block));
+      block = getSignedBlock(witnessCapsule.getAddress(),
+          nextScheduledTime(witnessCapsule.getAddress()), privateKey);
+      dbManager.pushBlock(new BlockCapsule(block));
 
-    // scan note by ivk
-    byte[] receiverIvk = incomingViewingKey.getValue();
-    DecryptNotes notes1 = wallet.scanNoteByIvk(0, 100, receiverIvk);
-    Assert.assertEquals(2, notes1.getNoteTxsCount());
+      // scan note by ivk
+      byte[] receiverIvk = incomingViewingKey.getValue();
+      DecryptNotes notes1 = wallet.scanNoteByIvk(0, 100, receiverIvk);
+      Assert.assertEquals(2, notes1.getNoteTxsCount());
 
-    // scan note by ivk and mark
-    DecryptNotesMarked notes3 = wallet.scanAndMarkNoteByIvk(0, 100, receiverIvk,
-        fullViewingKey.getAk(), fullViewingKey.getNk());
-    Assert.assertEquals(2, notes3.getNoteTxsCount());
+      // scan note by ivk and mark
+      DecryptNotesMarked notes3 = wallet.scanAndMarkNoteByIvk(0, 100, receiverIvk,
+          fullViewingKey.getAk(), fullViewingKey.getNk());
+      Assert.assertEquals(2, notes3.getNoteTxsCount());
 
-    // scan note by ovk
-    DecryptNotes notes2 = wallet.scanNoteByOvk(0, 100, senderOvk);
-    Assert.assertEquals(2, notes2.getNoteTxsCount());
+      // scan note by ovk
+      DecryptNotes notes2 = wallet.scanNoteByOvk(0, 100, senderOvk);
+      Assert.assertEquals(2, notes2.getNoteTxsCount());
 
-    // to spend received note above.
-    ZenTransactionBuilder builder2 = new ZenTransactionBuilder(wallet);
+      // to spend received note above.
+      ZenTransactionBuilder builder2 = new ZenTransactionBuilder(wallet);
 
-    //query merkleinfo
-    OutputPointInfo.Builder request = OutputPointInfo.newBuilder();
-    for (int i = 0; i < notes1.getNoteTxsCount(); i++) {
-      OutputPoint.Builder outPointBuild = OutputPoint.newBuilder();
-      outPointBuild.setHash(ByteString.copyFrom(trxId));
-      outPointBuild.setIndex(i);
-      request.addOutPoints(outPointBuild.build());
+      //query merkleinfo
+      OutputPointInfo.Builder request = OutputPointInfo.newBuilder();
+      for (int i = 0; i < notes1.getNoteTxsCount(); i++) {
+        OutputPoint.Builder outPointBuild = OutputPoint.newBuilder();
+        outPointBuild.setHash(ByteString.copyFrom(trxId));
+        outPointBuild.setIndex(i);
+        request.addOutPoints(outPointBuild.build());
+      }
+      request.setBlockNum(1);
+      IncrementalMerkleVoucherInfo merkleVoucherInfo = wallet
+          .getMerkleTreeVoucherInfo(request.build());
+
+      //build spend proof. allow only one note in spend
+      ExpandedSpendingKey expsk2 = sk2.expandedSpendingKey();
+      for (int i = 0; i < 1; i++) {
+        org.tron.api.GrpcAPI.Note grpcNote = notes1.getNoteTxs(i).getNote();
+        PaymentAddress paymentAddress = KeyIo.decodePaymentAddress(grpcNote.getPaymentAddress());
+        Note note2 = new Note(paymentAddress.getD(),
+            paymentAddress.getPkD(),
+            grpcNote.getValue(),
+            grpcNote.getRcm().toByteArray()
+        );
+
+        IncrementalMerkleVoucherContainer voucher2 =
+            new IncrementalMerkleVoucherContainer(
+                new IncrementalMerkleVoucherCapsule(merkleVoucherInfo.getVouchers(i)));
+        byte[] anchor2 = voucher2.root().getContent().toByteArray();
+        builder2.addSpend(expsk2, note2, anchor2, voucher2);
+      }
+
+      //build output proof
+      SpendingKey sk3 = SpendingKey.random();
+      FullViewingKey fvk3 = sk3.fullViewingKey();
+      IncomingViewingKey ivk3 = fvk3.inViewingKey();
+
+      DiversifierT d3 = DiversifierT.random();
+      PaymentAddress paymentAddress3 = incomingViewingKey.address(d3).get();
+      byte[] memo3 = org.tron.keystore.Wallet.generateRandomBytes(512);
+      builder2.addOutput(expsk2.getOvk(), paymentAddress3,
+          (1000 * 1000000L - wallet.getShieldedTransactionFee()) / 2 - wallet
+              .getShieldedTransactionFee(), memo3);
+
+      TransactionCapsule transactionCap2 = builder2.build();
+      boolean ok2 = dbManager.pushTransaction(transactionCap2);
+      Assert.assertTrue(ok2);
+    } finally {
+      consensusService.start();
     }
-    request.setBlockNum(1);
-    IncrementalMerkleVoucherInfo merkleVoucherInfo = wallet
-        .getMerkleTreeVoucherInfo(request.build());
+  }
 
-    //build spend proof. allow only one note in spend
-    ExpandedSpendingKey expsk2 = sk2.expandedSpendingKey();
-    for (int i = 0; i < 1; i++) {
-      org.tron.api.GrpcAPI.Note grpcNote = notes1.getNoteTxs(i).getNote();
-      PaymentAddress paymentAddress = KeyIo.decodePaymentAddress(grpcNote.getPaymentAddress());
-      Note note2 = new Note(paymentAddress.getD(),
-          paymentAddress.getPkD(),
-          grpcNote.getValue(),
-          grpcNote.getRcm().toByteArray()
-      );
-
-      IncrementalMerkleVoucherContainer voucher2 =
-          new IncrementalMerkleVoucherContainer(
-              new IncrementalMerkleVoucherCapsule(merkleVoucherInfo.getVouchers(i)));
-      byte[] anchor2 = voucher2.root().getContent().toByteArray();
-      builder2.addSpend(expsk2, note2, anchor2, voucher2);
+  // Returns the earliest timestamp at which witnessAddr is the DPoS-scheduled producer,
+  // relative to the current chain head. Using this avoids relying on the genesis-only
+  // bypass in validBlock() (latestBlockHeaderNumber == 0) when prior tests have pushed blocks.
+  private long nextScheduledTime(ByteString witnessAddr) {
+    int size = chainBaseManager.getWitnessScheduleStore().getActiveWitnesses().size();
+    for (long slot = 1; slot <= size; slot++) {
+      if (dposSlot.getScheduledWitness(slot).equals(witnessAddr)) {
+        return dposSlot.getTime(slot);
+      }
     }
-
-    //build output proof
-    SpendingKey sk3 = SpendingKey.random();
-    FullViewingKey fvk3 = sk3.fullViewingKey();
-    IncomingViewingKey ivk3 = fvk3.inViewingKey();
-
-    DiversifierT d3 = DiversifierT.random();
-    PaymentAddress paymentAddress3 = incomingViewingKey.address(d3).get();
-    byte[] memo3 = org.tron.keystore.Wallet.generateRandomBytes(512);
-    builder2.addOutput(expsk2.getOvk(), paymentAddress3,
-        (1000 * 1000000L - wallet.getShieldedTransactionFee()) / 2 - wallet
-            .getShieldedTransactionFee(), memo3);
-
-    TransactionCapsule transactionCap2 = builder2.build();
-    boolean ok2 = dbManager.pushTransaction(transactionCap2);
-    Assert.assertTrue(ok2);
+    throw new IllegalStateException("No scheduled slot for witness within "
+        + size + " slots: " + ByteArray.toHexString(witnessAddr.toByteArray()));
   }
 
   @Test

--- a/framework/src/test/java/org/tron/program/SolidityNodeTest.java
+++ b/framework/src/test/java/org/tron/program/SolidityNodeTest.java
@@ -3,6 +3,7 @@ package org.tron.program;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
@@ -326,6 +327,47 @@ public class SolidityNodeTest extends BaseTest {
     } finally {
       setFlag(true);
       clientField.set(solidityNode, orig);
+    }
+  }
+
+  /**
+   * getBlockByNum() must break immediately — without a 1-second sleep — when a
+   * gRPC exception is thrown while flag races to false (the P3 shutdown-race fix).
+   * The invocation time is measured directly so the assertion is independent of
+   * Spring-context startup overhead.
+   */
+  @Test(timeout = 5000)
+  public void testGetBlockByNumNoErrorOnExceptionDuringShutdown() throws Exception {
+    Method m = SolidityNode.class.getDeclaredMethod("getBlockByNum", long.class);
+    m.setAccessible(true);
+    Field clientField = getField("databaseGrpcClient");
+    Object origClient = clientField.get(solidityNode);
+    setFlag(true); // precondition: while(flag) must be entered; do not rely on test-ordering
+    try {
+      DatabaseGrpcClient mockClient = mock(DatabaseGrpcClient.class);
+      // flag races to false inside the gRPC call — exact close() race
+      Mockito.when(mockClient.getBlock(42L)).thenAnswer(inv -> {
+        setFlag(false);
+        throw new RuntimeException("channel closed during shutdown");
+      });
+      clientField.set(solidityNode, mockClient);
+
+      long start = System.currentTimeMillis();
+      InvocationTargetException t = assertThrows(InvocationTargetException.class, () -> {
+        m.invoke(solidityNode, 42L);
+      });
+      assertTrue(t.getCause() instanceof RuntimeException);
+      assertEquals("SolidityNode is closing.", t.getCause().getMessage());
+      long elapsed = System.currentTimeMillis() - start;
+      // Without the fix the catch sleeps exceptionSleepTime (1000 ms) before
+      // re-checking the while condition. With the fix it breaks immediately.
+      assertTrue("Expected break without sleep (<500 ms), got " + elapsed + " ms",
+          elapsed < 500);
+      // No retry: exactly one gRPC call must be made.
+      Mockito.verify(mockClient, Mockito.times(1)).getBlock(42L);
+    } finally {
+      setFlag(true);
+      clientField.set(solidityNode, origClient);
     }
   }
 


### PR DESCRIPTION
**What does this PR do?**

1. **`TronNetDelegate`** — wrap `LockSupport.park()` in a `while (!hitDown && !Thread.currentThread().isInterrupted())` loop so that spurious unparks (e.g. from `Thread.interrupt()` in `close()`) cannot trigger the `System.exit(0)` path prematurely, and so the hit-thread exits cleanly when the Spring context is destroyed.

2. **`SolidityNode`** — fix a shutdown race in `getBlockByNum()`: when a gRPC exception is thrown while the node is shutting down (`!flag || isHitDown()`), break out immediately instead of sleeping `exceptionSleepTime` (1 s) and retrying.

3. **`ShieldedReceiveTest.pushSameSkAndScanAndSpend`** — fix a test isolation bug and a performance regression:
   - The test relied on the genesis bypass in `validBlock()` (`latestBlockHeaderNumber == 0 → return true`) to skip DPoS schedule validation. When prior tests cause the consensus background task to produce blocks, this bypass no longer applies and the block push fails with `ValidateScheduleException`.
   - Replace hardcoded `System.currentTimeMillis()` timestamps with `nextScheduledTime()`, which looks up the nearest slot where the witness is actually scheduled according to `DposSlot`.
   - Stop `ConsensusService` before manual block pushes: `DposTask` shares the same `localwitness` key and would race to produce blocks at the same slot, triggering `switchFork` and making the test slow.

4. **`reference.conf`** — remove the stale "Keys that cannot auto-bind" comment block; those implementation details belong in the source classes, not in the config template.

5. **`README.md`** — surface `reference.conf` alongside `config.conf` in the configuration-file list so users know a built-in defaults template exists (added in v4.8.2).

**Why are these changes required?**

- The single `LockSupport.park()` call could be woken by `Thread.interrupt()` from `close()`, causing the process to reach `System.exit(0)` before `hitDown` was ever set. With the while-loop fix, `close()` calling `interrupt()` caused a busy-spin because `park()` returns immediately when interrupted but the loop never exited — adding the `isInterrupted()` guard lets the thread exit cleanly.
- During shutdown, a transient gRPC exception in `getBlockByNum()` triggered a 1-second sleep and an unnecessary retry loop, delaying clean exit and producing noisy error logs.
- `pushSameSkAndScanAndSpend` passed in isolation because the chain started at genesis (block 0), bypassing DPoS validation. In a full test run, the consensus background task produces blocks before this test runs, advancing the head past 0 and exposing the missing schedule-aware timestamp logic.
- The `reference.conf` comment described internal normalisation details that have since been refactored into the Java classes.
- `reference.conf` was introduced in v4.8.2 but not mentioned in the README.

**This PR has been tested by:**
- Unit Tests
  - `testGetBlockByNumNoErrorOnExceptionDuringShutdown`: verifies the shutdown race fix — method breaks in < 500 ms; without the fix a 1-second sleep fires first.
  - `pushSameSkAndScanAndSpend`: now stable in both single-test and full-suite runs.
- Manual Testing

**Follow up**

**Extra details**