### PR TITLE
ci: add comment coverage gate for reference.conf

### DIFF
--- a/.github/scripts/check_reference_comments.py
+++ b/.github/scripts/check_reference_comments.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Validate reference.conf comment coverage.
+
+Rules enforced:
+  1. Every user-defined key line must have a comment, except keys under
+     genesis.block.
+  2. A key is documented by either an inline comment on the same line or a
+     comment on the immediately preceding line. Blank lines do not count.
+  3. Object fields repeated across array elements are checked only on their
+     first occurrence within that array.
+
+This is deliberately line-oriented. pyhocon is not used because it discards
+comments, and this gate only needs enough structure to track braces, arrays,
+and the genesis.block exemption.
+"""
+import re
+import sys
+from pathlib import Path
+
+KEY_LINE = re.compile(r"^\s*([A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*)\s*[:={]")
+COMMENT_LINE = re.compile(r"^\s*(#|//)")
+
+
+def strip_quoted(line):
+    """Remove quoted string contents while preserving comments and delimiters."""
+    out = []
+    quote = None
+    escaped = False
+    i = 0
+    while i < len(line):
+        ch = line[i]
+        if quote:
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == quote:
+                quote = None
+                out.append(ch)
+            i += 1
+            continue
+        if ch in ('"', "'"):
+            quote = ch
+            out.append(ch)
+            i += 1
+            continue
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
+def strip_comments(line):
+    """Strip # and // comments outside quotes."""
+    text = strip_quoted(line)
+    i = 0
+    while i < len(text):
+        ch = text[i]
+        if ch == "#":
+            return text[:i]
+        if ch == "/" and i + 1 < len(text) and text[i + 1] == "/":
+            return text[:i]
+        i += 1
+    return text
+
+
+def has_inline_comment(line):
+    text = strip_quoted(line)
+    i = 0
+    while i < len(text):
+        if text[i] == "#":
+            return True
+        if text[i] == "/" and i + 1 < len(text) and text[i + 1] == "/":
+            return True
+        i += 1
+    return False
+
+
+def has_prevline_comment(lines, index):
+    if index == 0:
+        return False
+    prev = lines[index - 1]
+    return bool(prev.strip()) and bool(COMMENT_LINE.match(prev))
+
+
+def opening_after_key(code, match):
+    pos = match.end() - 1
+    ch = code[pos]
+    if ch in "{[":
+        return ch, pos
+    if ch in ":=":
+        i = pos + 1
+        while i < len(code) and code[i].isspace():
+            i += 1
+        if i < len(code) and code[i] in "{[":
+            return code[i], i
+    return None, None
+
+
+def nearest_array_frame(stack):
+    for frame in reversed(stack):
+        if frame["type"] == "array":
+            return frame
+    return None
+
+
+def in_genesis_block(stack, key=None):
+    return key == "genesis.block" or any(frame["name"] == "genesis.block" for frame in stack)
+
+
+def pop_frame(stack, opener):
+    target_type = "object" if opener == "}" else "array"
+    while stack:
+        frame = stack.pop()
+        if frame["type"] == target_type:
+            return
+
+
+def scan_structure(code, stack, key_open_pos=None):
+    i = 0
+    while i < len(code):
+        ch = code[i]
+        if key_open_pos is not None and i == key_open_pos:
+            i += 1
+            continue
+        if ch == "{":
+            stack.append({"type": "object", "name": None, "seen": set()})
+        elif ch == "[":
+            stack.append({"type": "array", "name": None, "seen": set()})
+        elif ch == "}":
+            pop_frame(stack, "}")
+        elif ch == "]":
+            pop_frame(stack, "]")
+        i += 1
+
+
+def collect_keys(path, list_all=False):
+    lines = path.read_text().splitlines()
+    stack = []
+    missing = []
+    seen_rows = []
+
+    for index, raw in enumerate(lines):
+        line_no = index + 1
+        code = strip_comments(raw)
+        stripped = raw.lstrip()
+        is_comment = stripped.startswith("#") or stripped.startswith("//")
+        match = None if is_comment else KEY_LINE.match(code)
+
+        key = None
+        status = "non-key"
+        key_open_pos = None
+        if match:
+            key = match.group(1)
+            opener, key_open_pos = opening_after_key(code, match)
+            exempt = in_genesis_block(stack, key)
+
+            deduped = False
+            array_frame = nearest_array_frame(stack)
+            if array_frame is not None:
+                if key in array_frame["seen"]:
+                    deduped = True
+                else:
+                    array_frame["seen"].add(key)
+
+            commented = has_inline_comment(raw) or has_prevline_comment(lines, index)
+            if exempt:
+                status = "exempt"
+            elif deduped:
+                status = "dedup"
+            elif commented:
+                status = "commented"
+            else:
+                status = "missing"
+                missing.append((line_no, key))
+
+            if opener:
+                stack.append({
+                    "type": "object" if opener == "{" else "array",
+                    "name": key,
+                    "seen": set(),
+                })
+
+        scan_structure(code, stack, key_open_pos)
+
+        if list_all and match:
+            seen_rows.append((line_no, key, status))
+
+    return missing, seen_rows
+
+
+def main(argv):
+    list_all = False
+    args = list(argv[1:])
+    if "--list" in args:
+        list_all = True
+        args.remove("--list")
+    if len(args) != 1:
+        print(f"usage: {argv[0]} [--list] <path/to/reference.conf>", file=sys.stderr)
+        return 2
+
+    path = Path(args[0])
+    if not path.is_file():
+        print(f"error: file not found: {path}", file=sys.stderr)
+        return 2
+
+    missing, seen_rows = collect_keys(path, list_all)
+
+    if list_all:
+        for line_no, key, status in seen_rows:
+            print(f"{line_no}: {key} [{status}]")
+        print()
+
+    if missing:
+        lines_out = [
+            f"Comment coverage violations ({len(missing)}) — each non-genesis.block key "
+            "needs an inline or immediately preceding comment:"
+        ]
+        for line_no, key in missing:
+            lines_out.append(f"  comment: line {line_no}: {key}")
+        print("\n".join(lines_out))
+        print()
+
+        entries = [f"line {line_no}: {key}" for line_no, key in missing]
+        body = (
+            f"reference.conf has {len(missing)} comment coverage violation(s):%0A"
+            + "%0A".join(entries)
+        )
+        print(f"::error file={path},title=reference.conf::{body}")
+        print(
+            f"FAIL: {len(missing)} comment coverage violation(s) in {path}",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"OK: {path} — all non-genesis.block keys have comments")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -119,6 +119,12 @@ jobs:
           python3 .github/scripts/check_reference_conf.py \
             common/src/main/resources/reference.conf
 
+      - name: Validate reference.conf comment coverage
+        shell: bash
+        run: |
+          python3 .github/scripts/check_reference_comments.py \
+            common/src/main/resources/reference.conf
+
       - name: Set up JDK 17
         uses: actions/setup-java@v5
         with:

--- a/common/src/main/resources/reference.conf
+++ b/common/src/main/resources/reference.conf
@@ -38,16 +38,18 @@
 #
 # =============================================================================
 
+# Network type placeholder; deprecated and has no effect.
 net {
   # type is deprecated and has no effect.
   # type = mainnet
 }
 
+# Storage engine and database settings.
 storage {
   # Database engine: "LEVELDB" or "ROCKSDB" (ARM only supports ROCKSDB)
   db.engine = "LEVELDB"
-  db.sync = false
-  db.directory = "database"
+  db.sync = false          # Whether to force synchronous database writes.
+  db.directory = "database" # Database directory under the node output path.
 
   # Whether to write transaction result in transactionRetStore
   transHistory.switch = "on"
@@ -91,27 +93,27 @@ storage {
   # ]
   properties = []
 
-  needToUpdateAsset = true
+  needToUpdateAsset = true # Whether to run legacy asset update logic.
 
   # RocksDB settings (only used when db.engine = "ROCKSDB")
   # Strongly recommend NOT modifying unless you know every item's meaning clearly.
   dbSettings = {
-    levelNumber = 7
+    levelNumber = 7             // Number of RocksDB levels.
     compactThreads = 0          // 0 = auto: max(availableProcessors, 1)
     blocksize = 16              // n * KB
     maxBytesForLevelBase = 256  // n * MB
-    maxBytesForLevelMultiplier = 10
-    level0FileNumCompactionTrigger = 2
+    maxBytesForLevelMultiplier = 10 // Level size multiplier.
+    level0FileNumCompactionTrigger = 2 // L0 files that trigger compaction.
     targetFileSizeBase = 64     // n * MB
-    targetFileSizeMultiplier = 1
-    maxOpenFiles = 5000
+    targetFileSizeMultiplier = 1 // Target file size multiplier.
+    maxOpenFiles = 5000         // Maximum open files for RocksDB.
   }
 
-  balance.history.lookup = false
+  balance.history.lookup = false # Whether to enable historical balance lookup.
 
   # Checkpoint version for snapshot mechanism. Version 2 enables V2 snapshot.
   checkpoint.version = 1
-  checkpoint.sync = true
+  checkpoint.sync = true # Whether to sync when write checkpoint storage.
 
   # Estimated number of block transactions (default 1000, min 100, max 10000).
   # Total cached transactions = 65536 * txCache.estimatedTransactions
@@ -128,10 +130,11 @@ storage {
   # }
 }
 
+# Node discovery settings.
 node.discovery = {
-  enable = false
-  persist = false
-  external.ip = ""
+  enable = false     # Whether to enable node discovery.
+  persist = false    # Whether to persist discovered peers.
+  external.ip = ""   # External IP advertised to peers.
 }
 
 # Custom stop condition
@@ -141,30 +144,31 @@ node.discovery = {
 #   BlockCount = 12                  # block sync count after node start
 # }
 
-node.backup {
+node.backup { # Backup node election settings.
   port = 10001             # UDP listen port; each member should have the same configuration
   priority = 0             # Node priority; each member should use a different priority
   keepAliveInterval = 3000 # Keep-alive interval (ms); each member should have the same configuration
-  members = [
+  members = [                # Backup member IP list.
     # "ip",               # Peer IP list, better to add at most one IP; must not contain this node's own IP
   ]
 }
 
 # Algorithm for generating public key from private key. Do not modify to avoid forks.
 crypto {
-  engine = "eckey"
+  engine = "eckey" # Signature engine.
 }
 
 # Energy limit block number (config key has typo "enery" preserved for backward compatibility)
 enery.limit.block.num = 4727890
 
-node.metrics = {
-  prometheus {
-    enable = false
-    port = 9527
+node.metrics = { # Node metrics settings.
+  prometheus {      # Prometheus exporter settings.
+    enable = false  # Whether to enable Prometheus metrics.
+    port = 9527     # Prometheus exporter port.
   }
 }
 
+# Node runtime, networking, and API settings.
 node {
   # Trust node for solidity node (example: "127.0.0.1:50051").
   trustNode = ""
@@ -172,8 +176,8 @@ node {
   # Expose extension api to public or not
   walletExtensionApi = false
 
-  listen.port = 18888
-  fetchBlock.timeout = 500
+  listen.port = 18888   # P2P listen port.
+  fetchBlock.timeout = 500 # Block fetch timeout (ms).
 
   # Number of blocks to fetch in one batch during sync. Range: [100, 2000].
   syncFetchBatchNum = 2000
@@ -184,12 +188,12 @@ node {
   # Number of validate sign threads, 0 = auto (availableProcessors)
   validateSignThreadNum = 0
 
-  maxConnections = 30
-  minConnections = 8
-  minActiveConnections = 3
-  maxConnectionsWithSameIp = 2
-  maxHttpConnectNumber = 50
-  minParticipationRate = 0
+  maxConnections = 30           # Maximum peer connections.
+  minConnections = 8            # Minimum peer connections to maintain.
+  minActiveConnections = 3      # Minimum active peer connections.
+  maxConnectionsWithSameIp = 2  # Maximum peer connections per IP.
+  maxHttpConnectNumber = 50     # Maximum HTTP connections.
+  minParticipationRate = 0      # Minimum SR participation rate.
 
   # WARNING: Some shielded transaction APIs require sending private keys as parameters.
   # Calling these APIs on untrusted or remote nodes may leak your private keys.
@@ -212,56 +216,57 @@ node {
   # Max block inv hashes accepted per peer per second. Minimum: 1.
   maxBlockInvPerSecond = 10
 
+  # In P2P service,whether any peer connection can be disconnected, when peers connection over maxConnections.
   isOpenFullTcpDisconnect = false
   inactiveThreshold = 600       // seconds
-  maxFastForwardNum = 4
+  maxFastForwardNum = 4          # Maximum fast-forward peers.
 
   # Legacy alias `maxActiveNodesWithSameIp` is still accepted from user config
   # (see NodeConfig alias-fallback) but is intentionally NOT defaulted here —
   # shipping it in reference.conf would always mask the modern `maxConnectionsWithSameIp`.
   metricsEnable = false
 
-  p2p {
+  p2p { # P2P protocol version settings.
     version = 11111   # Mainnet:11111; Nile:201910292; Shasta:1
   }
 
-  active = [
+  active = [ # Peers to actively connect to.
     # Active establish connection in any case
     # "ip:port",
     # "ip:port"
   ]
 
-  passive = [
+  passive = [ # Peers allowed to passively connect.
     # Passive accept connection in any case
     # "ip:port",
     # "ip:port"
   ]
 
-  fastForward = [
+  fastForward = [ # Fast-forward peer list.
     "100.27.171.62:18888",
     "15.188.6.125:18888"
   ]
 
-  http {
-    fullNodeEnable = true
-    fullNodePort = 8090
-    solidityEnable = true
-    solidityPort = 8091
-    PBFTEnable = true
-    PBFTPort = 8092
+  http { # HTTP API settings.
+    fullNodeEnable = true # Whether to enable FullNode HTTP API.
+    fullNodePort = 8090  # FullNode HTTP API port.
+    solidityEnable = true # Whether to enable Solidity HTTP API.
+    solidityPort = 8091  # Solidity HTTP API port.
+    PBFTEnable = true    # Whether to enable PBFT HTTP API.
+    PBFTPort = 8092      # PBFT HTTP API port.
 
     # Maximum HTTP request body size (default 4M). Setting to 0 rejects all non-empty request bodies.
     # Independent from rpc.maxMessageSize.
     maxMessageSize = 4194304
   }
 
-  rpc {
-    enable = true
-    port = 50051
-    solidityEnable = true
-    solidityPort = 50061
-    PBFTEnable = true
-    PBFTPort = 50071
+  rpc { # gRPC API settings.
+    enable = true        # Whether to enable FullNode gRPC API.
+    port = 50051         # FullNode gRPC API port.
+    solidityEnable = true # Whether to enable Solidity gRPC API.
+    solidityPort = 50061 # Solidity gRPC API port.
+    PBFTEnable = true    # Whether to enable PBFT gRPC API.
+    PBFTPort = 50071     # PBFT gRPC API port.
 
     # Number of gRPC threads, 0 = auto (availableProcessors / 2)
     thread = 0
@@ -297,7 +302,7 @@ node {
 
     # Reflection service switch for grpcurl tool
     reflectionService = false
-    trxCacheEnable = false
+    trxCacheEnable = false # Whether to enable transaction cache in broadcast transaction API(rpc and http).
   }
 
   # Number of solidity threads in FullNode.
@@ -323,18 +328,18 @@ node {
 
   # Dynamic loading configuration function
   dynamicConfig = {
-    enable = false
-    checkInterval = 600
+    enable = false       # Whether to enable dynamic config loading.
+    checkInterval = 600  # Dynamic config check interval (s).
   }
 
   # Block solidification check
   unsolidifiedBlockCheck = false
-  maxUnsolidifiedBlocks = 54
-  blockCacheTimeout = 60
+  maxUnsolidifiedBlocks = 54 # Maximum unsolidified blocks allowed,when accept transaction
+  blockCacheTimeout = 60     # Block cache timeout (s) in P2P service
 
   # TCP and transaction limits
   maxTransactionPendingSize = 2000
-  pendingTransactionTimeout = 60000
+  pendingTransactionTimeout = 60000 # Pending transaction timeout (ms).
   # total cached trx across handler queues + pending + rePush
   maxTrxCacheSize = 50000
 
@@ -343,12 +348,12 @@ node {
 
   # Shielded transaction (ZK)
   zenTokenId = "000000"
-  shieldedTransInPendingMaxCounts = 10
+  shieldedTransInPendingMaxCounts = 10 # Max shielded transactions in pending pool.
 
   # Contract proto validation thread pool (0 = auto: availableProcessors)
   validContractProto.threads = 0
 
-  dns {
+  dns { # DNS discovery and publish settings.
     # DNS URLs to discover peers, format: tree://{pubkey}@{domain}. Default: empty.
     treeUrls = [
       # "tree://AKMQMNAJJBL73LXWPXDI4I5ZWWIZ4AWO34DWQ636QOBBXNFXH3LQS@main.trondisco.net",
@@ -388,17 +393,17 @@ node {
   # Deprecated: these fields were used by the old connection-factor algorithm.
   # They are still accepted from user config for backward compatibility but have no effect.
   activeConnectFactor = 0.1
-  connectFactor = 0.6
+  connectFactor = 0.6 # Deprecated connection factor.
 
-  jsonrpc {
+  jsonrpc { # JSON-RPC API settings.
     # Note: Before release_4.8.1, if you turn on jsonrpc and run it for a while and then turn it off,
     # you will not be able to get the data from eth_getLogs for that period of time. Default: false
     httpFullNodeEnable = false
-    httpFullNodePort = 8545
-    httpSolidityEnable = false
-    httpSolidityPort = 8555
-    httpPBFTEnable = false
-    httpPBFTPort = 8565
+    httpFullNodePort = 8545     # FullNode JSON-RPC HTTP port.
+    httpSolidityEnable = false  # Whether to enable Solidity JSON-RPC HTTP API.
+    httpSolidityPort = 8555     # Solidity JSON-RPC HTTP port.
+    httpPBFTEnable = false      # Whether to enable PBFT JSON-RPC HTTP API.
+    httpPBFTPort = 8565         # PBFT JSON-RPC HTTP port.
 
     # The maximum blocks range to retrieve logs for eth_getLogs, default: 5000, <=0 means no limit
     maxBlockRange = 5000
@@ -476,7 +481,7 @@ rate.limiter = {
     # }
   ]
 
-  p2p = {
+  p2p = { # P2P message rate limits.
     # QPS ceiling for individual P2P message types received from peers.
     # Values are doubles; fractional QPS is allowed (e.g. 0.5 = one per 2 s).
     syncBlockChain = 3.0  # SyncBlockChain handshake messages
@@ -494,8 +499,8 @@ rate.limiter = {
   apiNonBlocking = false
 }
 
-seed.node = {
-  ip.list = [
+seed.node = { # Bootstrap seed node settings.
+  ip.list = [ # Seed node addresses.
     "3.225.171.164:18888",
     "52.8.46.215:18888",
     "3.79.71.167:18888",
@@ -727,15 +732,15 @@ genesis.block = {
 # When it is empty,the localwitness is configured with the private key of the witness account.
 # localWitnessAccountAddress =
 
-localwitness = [
+localwitness = [ # Local witness private keys.
 ]
 
 # localwitnesskeystore = [
 #   "localwitnesskeystore.json"
 # ]
 
-block = {
-  needSyncCheck = false
+block = { # Block processing settings.
+  needSyncCheck = false                   // Whether to check sync before producing blocks.
   maintenanceTimeInterval = 21600000   // 6 hours (ms)
   proposalExpireTime = 259200000       // 3 days (ms), controlled by committee proposal
   checkFrozenTime = 1                  // maintenance periods to check frozen balance (test only)
@@ -747,14 +752,14 @@ trx.reference.block = "solid"
 # Transaction expiration time in milliseconds.
 trx.expiration.timeInMilliseconds = 60000
 
-vm = {
-  supportConstant = false
-  maxEnergyLimitForConstant = 100000000
-  minTimeRatio = 0.0
-  maxTimeRatio = 5.0
-  saveInternalTx = false
-  lruCacheSize = 500
-  vmTrace = false
+vm = { # TVM execution settings.
+  supportConstant = false                 # Whether to support constant contract calls.
+  maxEnergyLimitForConstant = 100000000   # Max energy for constant calls.
+  minTimeRatio = 0.0                      # Minimum VM time ratio.
+  maxTimeRatio = 5.0                      # Maximum VM time ratio.
+  saveInternalTx = false                  # Whether to save internal transactions.
+  lruCacheSize = 500                      # VM LRU cache size.
+  vmTrace = false                         # Whether to enable VM trace output.
 
   # Whether to store featured internal transactions (freeze, vote, etc.)
   saveFeaturedInternalTx = false
@@ -784,67 +789,69 @@ vm = {
   constantCallTimeoutMs = 0
 }
 
-# Governance proposal toggle parameters. All default to 0 (disabled).
+# Governance parameters exposed by /wallet/getchainparameters.
+# Comments list the API chainParameter key and ProposalType ID where applicable.
+# All default to 0 (disabled) unless noted.
 # Controlled by on-chain committee proposals, not manual configuration.
 # Setting them in config is only for private chain testing.
 committee = {
-  allowCreationOfContracts = 0
-  allowMultiSign = 0
-  allowAdaptiveEnergy = 0
-  allowDelegateResource = 0
-  allowSameTokenName = 0
-  allowTvmTransferTrc10 = 0
-  allowTvmConstantinople = 0
-  allowTvmSolidity059 = 0
-  forbidTransferToContract = 0
-  allowShieldedTRC20Transaction = 0
-  allowTvmIstanbul = 0
-  allowMarketTransaction = 0
-  allowProtoFilterNum = 0
-  allowAccountStateRoot = 0
-  changedDelegation = 0
-  allowPBFT = 0
-  pBFTExpireNum = 20
-  allowTransactionFeePool = 0
-  allowBlackHoleOptimization = 0
-  allowNewResourceModel = 0
-  allowReceiptsMerkleRoot = 0
-  allowTvmFreeze = 0
-  allowTvmVote = 0
-  unfreezeDelayDays = 0
-  allowTvmLondon = 0
-  allowTvmCompatibleEvm = 0
-  allowHigherLimitForMaxCpuTimeOfOneTx = 0
-  allowNewRewardAlgorithm = 0
-  allowOptimizedReturnValueOfChainId = 0
-  allowTvmShangHai = 0
-  allowOldRewardOpt = 0
-  allowEnergyAdjustment = 0
-  allowStrictMath = 0
-  consensusLogicOptimization = 0
-  allowTvmCancun = 0
-  allowTvmBlob = 0
-  allowAccountAssetOptimization = 0
-  allowAssetOptimization = 0
-  allowNewReward = 0
-  memoFee = 0
-  allowDelegateOptimization = 0
-  allowDynamicEnergy = 0
-  dynamicEnergyThreshold = 0
-  dynamicEnergyIncreaseFactor = 0
-  dynamicEnergyMaxFactor = 0
+  allowCreationOfContracts = 0        # getAllowCreationOfContracts, #9: enable smart contract creation
+  allowMultiSign = 0                  # getAllowMultiSign, #20: enable account permission multi-signature
+  allowAdaptiveEnergy = 0             # getAllowAdaptiveEnergy, #21: enable adaptive energy limits
+  allowDelegateResource = 0           # getAllowDelegateResource, #16: enable delegated resource operations
+  allowSameTokenName = 0              # getAllowSameTokenName, #15: allow duplicate TRC10 token names
+  allowTvmTransferTrc10 = 0           # getAllowTvmTransferTrc10, #18: allow TRC10 transfer in TVM
+  allowTvmConstantinople = 0          # getAllowTvmConstantinople, #26: enable Constantinople TVM rules
+  allowTvmSolidity059 = 0             # getAllowTvmSolidity059, #32: enable Solidity 0.5.9 TVM rules
+  forbidTransferToContract = 0        # getForbidTransferToContract, #35: forbid direct transfers to contracts
+  allowShieldedTRC20Transaction = 0   # getAllowShieldedTRC20Transaction, #39: enable shielded TRC20 transfers
+  allowTvmIstanbul = 0                # getAllowTvmIstanbul, #41: enable Istanbul TVM rules
+  allowMarketTransaction = 0          # getAllowMarketTransaction, #44: enable market transactions
+  allowProtoFilterNum = 0             # getAllowProtoFilterNum, #24: enable protobuf field-number filtering
+  allowAccountStateRoot = 0           # getAllowAccountStateRoot, #25: enable account state root
+  changedDelegation = 0               # getChangeDelegation, #30: enable delegation changes
+  allowPBFT = 0                       # getAllowPBFT, #40: enable PBFT chain parameter
+  pBFTExpireNum = 20                  # PBFT message expiration, in maintenance rounds
+  allowTransactionFeePool = 0         # getAllowTransactionFeePool, #48: enable transaction fee pool
+  allowBlackHoleOptimization = 0      # getAllowOptimizeBlackHole, #49: enable blackhole account optimization
+  allowNewResourceModel = 0           # getAllowNewResourceModel, #51: enable new resource model
+  allowReceiptsMerkleRoot = 0         # receiptsMerkleRoot: enable receipts Merkle root for private chains
+  allowTvmFreeze = 0                  # getAllowTvmFreeze, #52: enable freeze operations in TVM
+  allowTvmVote = 0                    # getAllowTvmVote, #59: enable vote operations in TVM
+  unfreezeDelayDays = 0               # getUnfreezeDelayDays, #70: resource unfreeze delay days [1, 365]
+  allowTvmLondon = 0                  # getAllowTvmLondon, #63: enable London TVM rules
+  allowTvmCompatibleEvm = 0           # getAllowTvmCompatibleEvm, #60: enable EVM-compatible TVM behavior
+  allowHigherLimitForMaxCpuTimeOfOneTx = 0 # getAllowHigherLimitForMaxCpuTimeOfOneTx, #65: allow higher tx CPU limit
+  allowNewRewardAlgorithm = 0         # newRewardAlgorithm: enable new reward algorithm for private chains
+  allowOptimizedReturnValueOfChainId = 0 # getAllowOptimizedReturnValueOfChainId, #71: optimize CHAINID return value
+  allowTvmShangHai = 0                # getAllowTvmShangHai, #76: enable Shanghai TVM rules
+  allowOldRewardOpt = 0               # getAllowOldRewardOpt, #79: enable old reward optimization
+  allowEnergyAdjustment = 0           # getAllowEnergyAdjustment, #81: enable energy adjustment
+  allowStrictMath = 0                 # getAllowStrictMath, #87: enable strict arithmetic checks
+  consensusLogicOptimization = 0      # getConsensusLogicOptimization, #88: enable consensus logic optimization
+  allowTvmCancun = 0                  # getAllowTvmCancun, #83: enable Cancun TVM rules
+  allowTvmBlob = 0                    # getAllowTvmBlob, #89: enable blob transaction support in TVM
+  allowAccountAssetOptimization = 0   # getAllowAccountAssetOptimization, #53: enable account asset optimization
+  allowAssetOptimization = 0          # getAllowAssetOptimization, #66: enable asset optimization
+  allowNewReward = 0                  # getAllowNewReward, #67: enable new reward logic
+  memoFee = 0                         # getMemoFee, #68: memo fee in SUN [0, 1000000000]
+  allowDelegateOptimization = 0       # getAllowDelegateOptimization, #69: enable delegate optimization
+  allowDynamicEnergy = 0              # getAllowDynamicEnergy, #72: enable contract dynamic energy model
+  dynamicEnergyThreshold = 0          # getDynamicEnergyThreshold, #73: usage threshold for dynamic energy
+  dynamicEnergyIncreaseFactor = 0     # getDynamicEnergyIncreaseFactor, #74: dynamic energy increase factor
+  dynamicEnergyMaxFactor = 0          # getDynamicEnergyMaxFactor, #75: maximum dynamic energy factor
 }
 
-event.subscribe = {
-  enable = false
+event.subscribe = { # Event subscription settings.
+  enable = false # Whether to enable event subscription.
 
-  native = {
+  native = { # Native event queue settings.
     useNativeQueue = false // if true, use native message queue, else use event plugin.
     bindport = 5555        // bind port
     sendqueuelength = 1000 // max length of send queue
   }
 
-  version = 0
+  version = 0 # Event subscription version.
   # Specify the starting block number to sync historical events. Only applicable when version = 1.
   # After performing a full event sync, set this value to 0 or a negative number.
   startSyncBlockNum = 0
@@ -853,12 +860,12 @@ event.subscribe = {
   # dbname|username|password. To auto-create indexes on missing collections, append |2:
   # dbname|username|password|2 (if collection exists, indexes must be created manually).
   dbconfig = ""
-  contractParse = true
+  contractParse = true # Whether to parse contract event data.
 
-  topics = [
+  topics = [ # Event trigger topics.
     {
       triggerName = "block" // block trigger, the value can't be modified
-      enable = false
+      enable = false        // Whether to enable this trigger.
       topic = "block"       // plugin topic, the value could be modified
       solidified = false    // if set true, just need solidified block. Default: false
     },
@@ -867,7 +874,9 @@ event.subscribe = {
       enable = false
       topic = "transaction"
       solidified = false
-      ethCompatible = false // if set true, add transactionIndex, cumulativeEnergyUsed, preCumulativeLogCount, logList, energyUnitPrice. Default: false
+      // if set true, add transactionIndex, cumulativeEnergyUsed, preCumulativeLogCount, logList, energyUnitPrice.
+      // Default: false
+      ethCompatible = false
     },
     {
       triggerName = "contractevent" // contractevent represents contractlog data decoded by the ABI.
@@ -898,13 +907,13 @@ event.subscribe = {
     }
   ]
 
-  filter = {
+  filter = { # Event filter settings.
     fromblock = "" // "", "earliest", or a specific block number as the beginning of the queried range
     toblock = ""   // "", "latest", or a specific block number as end of the queried range
-    contractAddress = [
+    contractAddress = [ // Contract addresses to subscribe; "" means any contract address.
       "" // contract address to subscribe; "" means any contract address
     ]
-    contractTopic = [
+    contractTopic = [ // Contract topics to subscribe; "" means any contract topic.
       "" // contract topic to subscribe; "" means any contract topic
     ]
   }


### PR DESCRIPTION
**What does this PR do?**

Adds a CI comment-coverage gate for `reference.conf` and documents all previously undocumented configuration keys.

1. **New script** `.github/scripts/check_reference_comments.py` — a zero-dependency, line-oriented Python 3 script that enforces every non-`genesis.block` key in `reference.conf` carries either an inline (`#` / `//`) comment or a comment on the immediately preceding line. Array-element keys are deduplicated (only the first occurrence is checked). Fails with `::error` GHA annotations listing every offending `line N: key`.

2. **CI step** in `.github/workflows/pr-check.yml` — runs the new gate directly after the existing `check_reference_conf.py` (key-format / port-uniqueness) step, so future PRs that add undocumented keys are blocked automatically.

3. **reference.conf annotations** — all previously undocumented keys now carry inline comments. The `committee` block includes the `/wallet/getchainparameters` API key name and `ProposalType` ID (verified against both the live mainnet API and `ProposalUtil.ProposalType` enum) for every governance parameter.

**Why are these changes required?**

`reference.conf` is the primary configuration reference for node operators. Before this change, the majority of keys had no explanation, forcing operators to read source code to understand parameters. There was also no CI enforcement, so new keys could be merged without documentation.

**This PR has been tested by:**
- Manual Testing: `python3 .github/scripts/check_reference_comments.py common/src/main/resources/reference.conf` returns `OK` (exit 0)
- Manual Testing: existing `check_reference_conf.py` (pyhocon-based key-format gate) still passes after the `reference.conf` changes
- Committee block comments verified against live mainnet `/wallet/getchainparameters` API and `ProposalUtil.ProposalType` enum

**Follow up**

- The two scripts share utility functions (`strip_quoted`, `strip_comments`, stack-frame tracking). A follow-up PR could extract a shared `hocon_scan.py` helper to avoid drift.

**Extra details**

- `genesis.block` keys are exempt from the comment requirement (private-chain operators customise these freely).
- Three keys — `pBFTExpireNum`, `allowReceiptsMerkleRoot`, `allowNewRewardAlgorithm` — have no `ProposalType` entry (private-chain / deprecated governance); their comments reflect this without a `#N` ID.
- HOCON comments are fully transparent to both Typesafe Config and pyhocon; no runtime behaviour is affected.