### PR TITLE
fix(db): fix storage config properties

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -66,7 +66,7 @@ jobs:
   build-ubuntu:
     name: Build ubuntu24 (JDK 17 / aarch64)
     if: ${{ github.event_name == 'pull_request' || inputs.job == 'all' || inputs.job == 'ubuntu' }}
-    runs-on: ubuntu-22.04-arm
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 60
 
     steps:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -66,7 +66,7 @@ jobs:
   build-ubuntu:
     name: Build ubuntu24 (JDK 17 / aarch64)
     if: ${{ github.event_name == 'pull_request' || inputs.job == 'all' || inputs.job == 'ubuntu' }}
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-22.04-arm
     timeout-minutes: 60
 
     steps:

--- a/common/src/main/java/org/tron/core/config/README.md
+++ b/common/src/main/java/org/tron/core/config/README.md
@@ -28,10 +28,7 @@ storage {
     {
       name = "account",
       path = "/path/to/accout",   // relative or absolute path
-      createIfMissing = true,
-      paranoidChecks = true,
-      verifyChecksums = true,
-      compressionType = 1,        // 0 - no compression,  1 - compressed with snappy
+      # following are only used for LevelDB
       blockSize = 4096,           // 4  KB =         4 * 1024 B
       writeBufferSize = 10485760, // 10 MB = 10 * 1024 * 1024 B
       cacheSize = 10485760,       // 10 MB = 10 * 1024 * 1024 B

--- a/common/src/main/java/org/tron/core/config/README.md
+++ b/common/src/main/java/org/tron/core/config/README.md
@@ -40,7 +40,7 @@ storage {
 
 ```
 
-As shown in the example above, the `accout` database will be stored in the path of `/path/to/accout/database` while the index be stored in `/path/to/accout/index`. And, the example also shows our default value of LevelDB options(Start from `createIfMissing` and end at `maxOpenFiles`). Please refer to the docs of [LevelDB](https://github.com/google/leveldb/blob/master/doc/index.md#performance) to figure out the details of these options.
+As shown in the example above, the `accout` database will be stored in the path of `/path/to/accout/database` while the index be stored in `/path/to/accout/index`. And, the example also shows our default value of LevelDB options(Start from `blockSize` and end at `maxOpenFiles`). Please refer to the docs of [LevelDB](https://github.com/google/leveldb/blob/master/doc/index.md#performance) to figure out the details of these options.
 
 ## gRPC
 

--- a/common/src/main/java/org/tron/core/config/args/Storage.java
+++ b/common/src/main/java/org/tron/core/config/args/Storage.java
@@ -25,7 +25,6 @@ import java.util.stream.Collectors;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
-import org.iq80.leveldb.CompressionType;
 import org.iq80.leveldb.Options;
 import org.tron.common.cache.CacheStrategies;
 import org.tron.common.cache.CacheType;
@@ -179,11 +178,6 @@ public class Storage {
    * Apply LevelDB options from PropertyConfig bean values.
    */
   private static void applyPropertyOptions(StorageConfig.PropertyConfig pc, Options dbOptions) {
-    dbOptions.createIfMissing(pc.isCreateIfMissing());
-    dbOptions.paranoidChecks(pc.isParanoidChecks());
-    dbOptions.verifyChecksums(pc.isVerifyChecksums());
-    dbOptions.compressionType(
-        CompressionType.getCompressionTypeByPersistentId(pc.getCompressionType()));
     dbOptions.blockSize(pc.getBlockSize());
     dbOptions.writeBufferSize(pc.getWriteBufferSize());
     dbOptions.cacheSize(pc.getCacheSize());
@@ -247,19 +241,6 @@ public class Storage {
   // Apply only user-specified overrides (non-null fields) to LevelDB Options.
   private static void applyDbOptionOverride(
       StorageConfig.DbOptionOverride o, Options dbOptions) {
-    if (o.getCreateIfMissing() != null) {
-      dbOptions.createIfMissing(o.getCreateIfMissing());
-    }
-    if (o.getParanoidChecks() != null) {
-      dbOptions.paranoidChecks(o.getParanoidChecks());
-    }
-    if (o.getVerifyChecksums() != null) {
-      dbOptions.verifyChecksums(o.getVerifyChecksums());
-    }
-    if (o.getCompressionType() != null) {
-      dbOptions.compressionType(
-          CompressionType.getCompressionTypeByPersistentId(o.getCompressionType()));
-    }
     if (o.getBlockSize() != null) {
       dbOptions.blockSize(o.getBlockSize());
     }

--- a/common/src/main/java/org/tron/core/config/args/Storage.java
+++ b/common/src/main/java/org/tron/core/config/args/Storage.java
@@ -169,19 +169,11 @@ public class Storage {
     }
 
     Options dbOptions = newDefaultDbOptions(property.getName());
-    applyPropertyOptions(pc, dbOptions);
+    // PropertyConfig is-a DbOptionOverride: apply only user-specified (non-null) overrides
+    // so unset fields keep the per-tier defaults already applied by newDefaultDbOptions.
+    applyDbOptionOverride(pc, dbOptions);
     property.setDbOptions(dbOptions);
     return property;
-  }
-
-  /**
-   * Apply LevelDB options from PropertyConfig bean values.
-   */
-  private static void applyPropertyOptions(StorageConfig.PropertyConfig pc, Options dbOptions) {
-    dbOptions.blockSize(pc.getBlockSize());
-    dbOptions.writeBufferSize(pc.getWriteBufferSize());
-    dbOptions.cacheSize(pc.getCacheSize());
-    dbOptions.maxOpenFiles(pc.getMaxOpenFiles());
   }
 
   /**

--- a/common/src/main/java/org/tron/core/config/args/StorageConfig.java
+++ b/common/src/main/java/org/tron/core/config/args/StorageConfig.java
@@ -28,6 +28,8 @@ public class StorageConfig {
   private CheckpointConfig checkpoint = new CheckpointConfig();
   private SnapshotConfig snapshot = new SnapshotConfig();
   private TxCacheConfig txCache = new TxCacheConfig();
+  // ConfigBeanFactory requires all bean fields present per item, so we parse manually.
+  @Setter(lombok.AccessLevel.NONE)
   private List<PropertyConfig> properties = new ArrayList<>();
 
   // merkleRoot is a nested object (e.g. { reward-vi = "hash..." }) not a string.
@@ -54,6 +56,7 @@ public class StorageConfig {
   @Getter
   @Setter
   public static class DbConfig {
+
     private String engine = "LEVELDB";
     private boolean sync = false;
     private String directory = "database";
@@ -62,6 +65,7 @@ public class StorageConfig {
   @Getter
   @Setter
   public static class TransHistoryConfig {
+
     // "switch" is a reserved Java keyword; ConfigBeanFactory calls setSwitch() which works fine
     @Getter(lombok.AccessLevel.NONE)
     @Setter(lombok.AccessLevel.NONE)
@@ -79,6 +83,7 @@ public class StorageConfig {
   @Getter
   @Setter
   public static class DbSettingsConfig {
+
     private int levelNumber = 7;
     private int compactThreads = 0; // 0 = auto: max(availableProcessors, 1)
     private int blocksize = 16;
@@ -100,11 +105,13 @@ public class StorageConfig {
   @Getter
   @Setter
   public static class BalanceConfig {
+
     private HistoryConfig history = new HistoryConfig();
 
     @Getter
     @Setter
     public static class HistoryConfig {
+
       private boolean lookup = false;
     }
   }
@@ -112,6 +119,7 @@ public class StorageConfig {
   @Getter
   @Setter
   public static class CheckpointConfig {
+
     private int version = 1;
     private boolean sync = true;
   }
@@ -119,6 +127,7 @@ public class StorageConfig {
   @Getter
   @Setter
   public static class SnapshotConfig {
+
     private int maxFlushCount = 1;
 
     // Reject out-of-range values. Mirrors develop Storage.getSnapshotMaxFlushCountFromConfig.
@@ -135,6 +144,7 @@ public class StorageConfig {
   @Getter
   @Setter
   public static class TxCacheConfig {
+
     private int estimatedTransactions = 1000;
     private boolean initOptimization = false;
 
@@ -151,6 +161,7 @@ public class StorageConfig {
   @Getter
   @Setter
   public static class PropertyConfig {
+
     private String name = "";
     private String path = "";
     private boolean createIfMissing = true;
@@ -170,6 +181,7 @@ public class StorageConfig {
 
     StorageConfig sc = ConfigBeanFactory.create(section, StorageConfig.class);
     sc.rawStorageConfig = section;
+    sc.properties = readProperties(section);
 
     // Read optional LevelDB option overrides (default, defaultM, defaultL).
     sc.defaultDbOption = readDbOption(section, "default");
@@ -187,6 +199,7 @@ public class StorageConfig {
   @Getter
   @Setter
   public static class DbOptionOverride {
+
     private Boolean createIfMissing;
     private Boolean paranoidChecks;
     private Boolean verifyChecksums;
@@ -197,14 +210,9 @@ public class StorageConfig {
     private Integer maxOpenFiles;
   }
 
-  // Read optional LevelDB option override (default/defaultM/defaultL).
-  // Not bean-bound: users may only set a subset of keys (e.g. just maxOpenFiles),
-  // ConfigBeanFactory requires all fields present so partial overrides would fail.
-  private static DbOptionOverride readDbOption(Config section, String key) {
-    if (!section.hasPath(key)) {
-      return null;
-    }
-    ConfigObject conf = section.getObject(key);
+  // Shared LevelDB option parser used by both readDbOption and readProperties.
+  // DbOptionOverride uses boxed types so null means "not specified by user".
+  private static DbOptionOverride readLevelDbOptions(ConfigObject conf) {
     DbOptionOverride o = new DbOptionOverride();
     if (conf.containsKey("createIfMissing")) {
       o.setCreateIfMissing(
@@ -259,6 +267,63 @@ public class StorageConfig {
       }
     }
     return o;
+  }
+
+  // Read optional LevelDB option override for default/defaultM/defaultL keys.
+  private static DbOptionOverride readDbOption(Config section, String key) {
+    if (!section.hasPath(key)) {
+      return null;
+    }
+    return readLevelDbOptions(section.getObject(key));
+  }
+
+  // Parse storage.properties list manually: ConfigBeanFactory requires every bean field to be
+  // present in each list item, but name+path-only entries (all LevelDB opts commented out) are
+  // valid — missing fields fall back to PropertyConfig Java defaults.
+  private static List<PropertyConfig> readProperties(Config section) {
+    if (!section.hasPath("properties")) {
+      return new ArrayList<>();
+    }
+    List<? extends ConfigObject> items = section.getObjectList("properties");
+    List<PropertyConfig> result = new ArrayList<>(items.size());
+    for (ConfigObject obj : items) {
+      if (!obj.containsKey("name")) {
+        throw new IllegalArgumentException(
+            "[storage.properties] 'name' is required in each properties entry.");
+      }
+      PropertyConfig p = new PropertyConfig();
+      p.setName(obj.get("name").unwrapped().toString());
+      if (obj.containsKey("path")) {
+        p.setPath(obj.get("path").unwrapped().toString());
+      }
+      DbOptionOverride opts = readLevelDbOptions(obj);
+      if (opts.getCreateIfMissing() != null) {
+        p.setCreateIfMissing(opts.getCreateIfMissing());
+      }
+      if (opts.getParanoidChecks() != null) {
+        p.setParanoidChecks(opts.getParanoidChecks());
+      }
+      if (opts.getVerifyChecksums() != null) {
+        p.setVerifyChecksums(opts.getVerifyChecksums());
+      }
+      if (opts.getCompressionType() != null) {
+        p.setCompressionType(opts.getCompressionType());
+      }
+      if (opts.getBlockSize() != null) {
+        p.setBlockSize(opts.getBlockSize());
+      }
+      if (opts.getWriteBufferSize() != null) {
+        p.setWriteBufferSize(opts.getWriteBufferSize());
+      }
+      if (opts.getCacheSize() != null) {
+        p.setCacheSize(opts.getCacheSize());
+      }
+      if (opts.getMaxOpenFiles() != null) {
+        p.setMaxOpenFiles(opts.getMaxOpenFiles());
+      }
+      result.add(p);
+    }
+    return result;
   }
 
   private static void throwIllegalArgumentException(String param, Class<?> type, String actual) {

--- a/common/src/main/java/org/tron/core/config/args/StorageConfig.java
+++ b/common/src/main/java/org/tron/core/config/args/StorageConfig.java
@@ -164,10 +164,7 @@ public class StorageConfig {
 
     private String name = "";
     private String path = "";
-    private boolean createIfMissing = true;
-    private boolean paranoidChecks = true;
-    private boolean verifyChecksums = true;
-    private int compressionType = 1;
+    // following are only used for LevelDB
     private int blockSize = 4096;
     private int writeBufferSize = 10485760;
     private long cacheSize = 10485760;
@@ -200,10 +197,6 @@ public class StorageConfig {
   @Setter
   public static class DbOptionOverride {
 
-    private Boolean createIfMissing;
-    private Boolean paranoidChecks;
-    private Boolean verifyChecksums;
-    private Integer compressionType;
     private Integer blockSize;
     private Integer writeBufferSize;
     private Long cacheSize;
@@ -214,26 +207,6 @@ public class StorageConfig {
   // DbOptionOverride uses boxed types so null means "not specified by user".
   private static DbOptionOverride readLevelDbOptions(ConfigObject conf) {
     DbOptionOverride o = new DbOptionOverride();
-    if (conf.containsKey("createIfMissing")) {
-      o.setCreateIfMissing(
-          Boolean.parseBoolean(conf.get("createIfMissing").unwrapped().toString()));
-    }
-    if (conf.containsKey("paranoidChecks")) {
-      o.setParanoidChecks(
-          Boolean.parseBoolean(conf.get("paranoidChecks").unwrapped().toString()));
-    }
-    if (conf.containsKey("verifyChecksums")) {
-      o.setVerifyChecksums(
-          Boolean.parseBoolean(conf.get("verifyChecksums").unwrapped().toString()));
-    }
-    if (conf.containsKey("compressionType")) {
-      String param = conf.get("compressionType").unwrapped().toString();
-      try {
-        o.setCompressionType(Integer.parseInt(param));
-      } catch (NumberFormatException e) {
-        throwIllegalArgumentException("compressionType", Integer.class, param);
-      }
-    }
     if (conf.containsKey("blockSize")) {
       String param = conf.get("blockSize").unwrapped().toString();
       try {
@@ -297,18 +270,6 @@ public class StorageConfig {
         p.setPath(obj.get("path").unwrapped().toString());
       }
       DbOptionOverride opts = readLevelDbOptions(obj);
-      if (opts.getCreateIfMissing() != null) {
-        p.setCreateIfMissing(opts.getCreateIfMissing());
-      }
-      if (opts.getParanoidChecks() != null) {
-        p.setParanoidChecks(opts.getParanoidChecks());
-      }
-      if (opts.getVerifyChecksums() != null) {
-        p.setVerifyChecksums(opts.getVerifyChecksums());
-      }
-      if (opts.getCompressionType() != null) {
-        p.setCompressionType(opts.getCompressionType());
-      }
       if (opts.getBlockSize() != null) {
         p.setBlockSize(opts.getBlockSize());
       }

--- a/common/src/main/java/org/tron/core/config/args/StorageConfig.java
+++ b/common/src/main/java/org/tron/core/config/args/StorageConfig.java
@@ -261,8 +261,7 @@ public class StorageConfig {
     List<PropertyConfig> result = new ArrayList<>(items.size());
     for (ConfigObject obj : items) {
       if (!obj.containsKey("name")) {
-        throw new IllegalArgumentException(
-            "[storage.properties] 'name' is required in each properties entry.");
+        throw new IllegalArgumentException("[storage.properties] database name must be set.");
       }
       PropertyConfig p = new PropertyConfig();
       p.setName(obj.get("name").unwrapped().toString());

--- a/common/src/main/java/org/tron/core/config/args/StorageConfig.java
+++ b/common/src/main/java/org/tron/core/config/args/StorageConfig.java
@@ -158,17 +158,14 @@ public class StorageConfig {
     }
   }
 
+  // A named database entry: name/path plus the optional LevelDB option overrides
+  // inherited from DbOptionOverride (boxed types, null = "inherit per-tier defaults").
   @Getter
   @Setter
-  public static class PropertyConfig {
+  public static class PropertyConfig extends DbOptionOverride {
 
     private String name = "";
     private String path = "";
-    // following are only used for LevelDB
-    private int blockSize = 4096;
-    private int writeBufferSize = 10485760;
-    private long cacheSize = 10485760;
-    private int maxOpenFiles = 100;
   }
 
   // Defaults come from reference.conf (loaded globally via Configuration.java)
@@ -204,9 +201,9 @@ public class StorageConfig {
   }
 
   // Shared LevelDB option parser used by both readDbOption and readProperties.
-  // DbOptionOverride uses boxed types so null means "not specified by user".
-  private static DbOptionOverride readLevelDbOptions(ConfigObject conf) {
-    DbOptionOverride o = new DbOptionOverride();
+  // Fills the given target (boxed fields, null means "not specified by user") so the
+  // same parser can populate a plain DbOptionOverride or a PropertyConfig (which extends it).
+  private static void readLevelDbOptions(ConfigObject conf, DbOptionOverride o) {
     if (conf.containsKey("blockSize")) {
       String param = conf.get("blockSize").unwrapped().toString();
       try {
@@ -239,7 +236,6 @@ public class StorageConfig {
         throwIllegalArgumentException("maxOpenFiles", Integer.class, param);
       }
     }
-    return o;
   }
 
   // Read optional LevelDB option override for default/defaultM/defaultL keys.
@@ -247,7 +243,9 @@ public class StorageConfig {
     if (!section.hasPath(key)) {
       return null;
     }
-    return readLevelDbOptions(section.getObject(key));
+    DbOptionOverride o = new DbOptionOverride();
+    readLevelDbOptions(section.getObject(key), o);
+    return o;
   }
 
   // Parse storage.properties list manually: ConfigBeanFactory requires every bean field to be
@@ -260,27 +258,16 @@ public class StorageConfig {
     List<? extends ConfigObject> items = section.getObjectList("properties");
     List<PropertyConfig> result = new ArrayList<>(items.size());
     for (ConfigObject obj : items) {
-      if (!obj.containsKey("name")) {
-        throw new IllegalArgumentException("[storage.properties] database name must be set.");
-      }
       PropertyConfig p = new PropertyConfig();
-      p.setName(obj.get("name").unwrapped().toString());
+      if (obj.containsKey("name")) {
+        p.setName(obj.get("name").unwrapped().toString());
+      }
       if (obj.containsKey("path")) {
         p.setPath(obj.get("path").unwrapped().toString());
       }
-      DbOptionOverride opts = readLevelDbOptions(obj);
-      if (opts.getBlockSize() != null) {
-        p.setBlockSize(opts.getBlockSize());
-      }
-      if (opts.getWriteBufferSize() != null) {
-        p.setWriteBufferSize(opts.getWriteBufferSize());
-      }
-      if (opts.getCacheSize() != null) {
-        p.setCacheSize(opts.getCacheSize());
-      }
-      if (opts.getMaxOpenFiles() != null) {
-        p.setMaxOpenFiles(opts.getMaxOpenFiles());
-      }
+      // Boxed nullable fields: unset options stay null so they inherit the per-tier
+      // defaults applied by newDefaultDbOptions instead of resetting them.
+      readLevelDbOptions(obj, p);
       result.add(p);
     }
     return result;

--- a/common/src/main/resources/reference.conf
+++ b/common/src/main/resources/reference.conf
@@ -44,17 +44,24 @@ net {
 }
 
 storage {
-  # Database engine: "LEVELDB" or "ROCKSDB" (ARM only supports ROCKSDB)
+  # Database engine: "LEVELDB" or "ROCKSDB" (ARM only supports ROCKSDB), case-insensitive
   db.engine = "LEVELDB"
+
+  # Controls the database write strategy.
+  # true  - Synchronous writes. Higher durability, lower performance.
+  # false - Asynchronous writes. Higher performance, but recent writes may be
+  #         lost if the machine crashes before data is flushed to disk.
+  # Asynchronous writes can significantly improve FullNode block sync performance.
   db.sync = false
+
   db.directory = "database"
 
   # Whether to write transaction result in transactionRetStore
   transHistory.switch = "on"
 
   # Per-database LevelDB option overrides. Default: empty (all databases use global defaults).
-  # setting can improve leveldb performance .... start, deprecated for RocksDB
-  # node: if this will increase process fds, you may check your ulimit if 'too many open files' error occurs
+  # setting can improve LevelDB performance .... start
+  # node: this will increase process fds, you may check your ulimit if 'too many open files' error occurs
   # see https://github.com/tronprotocol/tips/blob/master/tip-343.md for detail
   # if you find block sync has lower performance, you can try this settings
   # default = {
@@ -63,13 +70,15 @@ storage {
   #   cacheSize = 33554432,       // 32 MB = 32 * 1024 * 1024 B
   #   maxOpenFiles = 100
   # }
+  # Customize parameters for bulk read databases: "code", "contract"
   # defaultM = {
   #   maxOpenFiles = 500
   # }
+  # Customize parameters for frequently read databases: "account", "delegation", "storage-row"
   # defaultL = {
   #   maxOpenFiles = 1000
   # }
-  # setting can improve leveldb performance .... end, deprecated for RocksDB
+  # setting can improve LevelDB performance .... end
 
   # Per-database storage configuration overrides. Otherwise databases use global defaults and store
   # data in "output-directory" or the directory specified by the "-d" / "--output-directory" option.

--- a/common/src/main/resources/reference.conf
+++ b/common/src/main/resources/reference.conf
@@ -53,11 +53,14 @@ storage {
   transHistory.switch = "on"
 
   # Per-database LevelDB option overrides. Default: empty (all databases use global defaults).
-  # setting can improve leveldb performance .... start, deprecated for arm
+  # setting can improve leveldb performance .... start, deprecated for RocksDB
   # node: if this will increase process fds, you may check your ulimit if 'too many open files' error occurs
   # see https://github.com/tronprotocol/tips/blob/master/tip-343.md for detail
   # if you find block sync has lower performance, you can try this settings
   # default = {
+  #   blockSize = 4096,           // 4  KB =         4 * 1024 B
+  #   writeBufferSize = 16777216, // 16 MB = 16 * 1024 * 1024 B
+  #   cacheSize = 33554432,       // 32 MB = 32 * 1024 * 1024 B
   #   maxOpenFiles = 100
   # }
   # defaultM = {
@@ -66,7 +69,7 @@ storage {
   # defaultL = {
   #   maxOpenFiles = 1000
   # }
-  # setting can improve leveldb performance .... end, deprecated for arm
+  # setting can improve leveldb performance .... end, deprecated for RocksDB
 
   # Per-database storage configuration overrides. Otherwise databases use global defaults and store
   # data in "output-directory" or the directory specified by the "-d" / "--output-directory" option.

--- a/common/src/main/resources/reference.conf
+++ b/common/src/main/resources/reference.conf
@@ -72,21 +72,17 @@ storage {
   # data in "output-directory" or the directory specified by the "-d" / "--output-directory" option.
   # Attention: name is a required field that must be set!
   # The name and path properties take effect for both LevelDB and RocksDB storage engines,
-  # while additional properties (createIfMissing, paranoidChecks, compressionType, etc.)
+  # while additional 4 properties (blockSize, writeBufferSize, cacheSize, maxOpenFiles)
   # only take effect when using LevelDB.
   # Example:
   # properties = [
   #   {
   #     name = "account",
   #     path = "storage_directory_test",
-  #     createIfMissing = true,     // deprecated for arm start
-  #     paranoidChecks = true,
-  #     verifyChecksums = true,
-  #     compressionType = 1,        // compressed with snappy
   #     blockSize = 4096,           // 4  KB =         4 * 1024 B
   #     writeBufferSize = 10485760, // 10 MB = 10 * 1024 * 1024 B
   #     cacheSize = 10485760,       // 10 MB = 10 * 1024 * 1024 B
-  #     maxOpenFiles = 100          // deprecated for arm end
+  #     maxOpenFiles = 100
   #   },
   # ]
   properties = []

--- a/common/src/main/resources/reference.conf
+++ b/common/src/main/resources/reference.conf
@@ -59,26 +59,37 @@ storage {
   # Whether to write transaction result in transactionRetStore
   transHistory.switch = "on"
 
-  # Per-database LevelDB option overrides. Default: empty (all databases use global defaults).
-  # setting can improve LevelDB performance .... start
-  # node: this will increase process fds, you may check your ulimit if 'too many open files' error occurs
-  # see https://github.com/tronprotocol/tips/blob/master/tip-343.md for detail
-  # if you find block sync has lower performance, you can try this settings
+  # Per-database LevelDB option overrides.Default: empty. All databases use global LevelDB settings.
+  # These settings can be tuned to improve database performance during block synchronization.
+  # Note:
+  # - Increasing `maxOpenFiles` may significantly increase file descriptor usage.
+  # - If "Too many open files" errors occur, check the system `ulimit` configuration.
+  # - See TIP-343 for tuning recommendations:
+  #   https://github.com/tronprotocol/tips/blob/master/tip-343.md
+  # The following presets are provided as default. If block synchronization
+  # performance is unsatisfactory, consider adjusting the settings accordingly.
+  #
+  # Global default settings:
   # default = {
-  #   blockSize = 4096,           // 4  KB =         4 * 1024 B
-  #   writeBufferSize = 16777216, // 16 MB = 16 * 1024 * 1024 B
-  #   cacheSize = 33554432,       // 32 MB = 32 * 1024 * 1024 B
+  #   blockSize = 4096,           // 4 KB
+  #   writeBufferSize = 16777216, // 16 MB
+  #   cacheSize = 33554432,       // 32 MB
   #   maxOpenFiles = 100
   # }
-  # Customize parameters for bulk read databases: "code", "contract"
+  # Default for bulk-read databases: code, contract
   # defaultM = {
-  #   maxOpenFiles = 500
+  #   blockSize = 4096,           // 4 KB
+  #   writeBufferSize = 67108864, // 64 MB
+  #   cacheSize = 33554432,       // 32 MB
+  #   maxOpenFiles = 100          // recommend 500 for production
   # }
-  # Customize parameters for frequently read databases: "account", "delegation", "storage-row"
+  # Default for frequently accessed databases: account, delegation, storage-row
   # defaultL = {
-  #   maxOpenFiles = 1000
+  #   blockSize = 4096,           // 4 KB
+  #   writeBufferSize = 67108864, // 64 MB
+  #   cacheSize = 33554432,       // 32 MB
+  #   maxOpenFiles = 100          // recommend 1000 for production
   # }
-  # setting can improve LevelDB performance .... end
 
   # Per-database storage configuration overrides. Otherwise databases use global defaults and store
   # data in "output-directory" or the directory specified by the "-d" / "--output-directory" option.

--- a/common/src/test/java/org/tron/core/config/args/StorageConfigTest.java
+++ b/common/src/test/java/org/tron/core/config/args/StorageConfigTest.java
@@ -2,12 +2,15 @@ package org.tron.core.config.args;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
+import java.util.List;
 import org.junit.Test;
 import org.tron.common.math.StrictMathWrapper;
+import org.tron.core.config.args.StorageConfig.PropertyConfig;
 
 public class StorageConfigTest {
 
@@ -133,5 +136,94 @@ public class StorageConfigTest {
     StorageConfig sc = StorageConfig.fromConfig(
         withRef("storage.txCache.estimatedTransactions = 5000"));
     assertEquals(5000, sc.getTxCache().getEstimatedTransactions());
+  }
+
+  // ---- readProperties() ----
+
+  private static List<PropertyConfig> props(String storageProperties) {
+    return StorageConfig.fromConfig(withRef(storageProperties)).getProperties();
+  }
+
+  @Test
+  public void testPropertiesDefaultEmpty() {
+    // reference.conf sets storage.properties = []
+    assertTrue(StorageConfig.fromConfig(withRef()).getProperties().isEmpty());
+    assertTrue(props("storage.properties = []").isEmpty());
+  }
+
+  @Test
+  public void testPropertiesNameAndPathOnly() {
+    // All LevelDB options omitted: name/path set, the four boxed fields stay null so
+    // they inherit the per-tier defaults applied later by newDefaultDbOptions.
+    List<PropertyConfig> list = props(
+        "storage.properties = [ { name = account, path = some_path } ]");
+    assertEquals(1, list.size());
+    PropertyConfig p = list.get(0);
+    assertEquals("account", p.getName());
+    assertEquals("some_path", p.getPath());
+    assertNull(p.getBlockSize());
+    assertNull(p.getWriteBufferSize());
+    assertNull(p.getCacheSize());
+    assertNull(p.getMaxOpenFiles());
+  }
+
+  @Test
+  public void testPropertiesNameOnlyKeepsEmptyPath() {
+    PropertyConfig p = props("storage.properties = [ { name = account } ]").get(0);
+    assertEquals("account", p.getName());
+    assertEquals("", p.getPath());
+  }
+
+  @Test
+  public void testPropertiesFullOverrideParsed() {
+    PropertyConfig p = props(
+        "storage.properties = [ { name = foo, path = bar,"
+        + " blockSize = 2, writeBufferSize = 3, cacheSize = 4, maxOpenFiles = 5 } ]").get(0);
+    assertEquals(Integer.valueOf(2), p.getBlockSize());
+    assertEquals(Integer.valueOf(3), p.getWriteBufferSize());
+    assertEquals(Long.valueOf(4L), p.getCacheSize());
+    assertEquals(Integer.valueOf(5), p.getMaxOpenFiles());
+  }
+
+  @Test
+  public void testPropertiesPartialOverrideLeavesOthersNull() {
+    // Only blockSize is set; the other three stay null (inherit defaults).
+    PropertyConfig p = props(
+        "storage.properties = [ { name = foo, path = bar, blockSize = 8192 } ]").get(0);
+    assertEquals(Integer.valueOf(8192), p.getBlockSize());
+    assertNull(p.getWriteBufferSize());
+    assertNull(p.getCacheSize());
+    assertNull(p.getMaxOpenFiles());
+  }
+
+  @Test
+  public void testPropertiesMultipleEntriesInOrder() {
+    List<PropertyConfig> list = props(
+        "storage.properties = ["
+        + " { name = first, path = p1 },"
+        + " { name = second, path = p2, maxOpenFiles = 7 } ]");
+    assertEquals(2, list.size());
+    assertEquals("first", list.get(0).getName());
+    assertNull(list.get(0).getMaxOpenFiles());
+    assertEquals("second", list.get(1).getName());
+    assertEquals(Integer.valueOf(7), list.get(1).getMaxOpenFiles());
+  }
+
+  @Test
+  public void testPropertiesMissingNameKeepsEmpty() {
+    // readProperties does not require name (validation is deferred to Storage); name stays "".
+    PropertyConfig p = props("storage.properties = [ { path = bar } ]").get(0);
+    assertEquals("", p.getName());
+    assertEquals("bar", p.getPath());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testPropertiesInvalidIntegerRejected() {
+    props("storage.properties = [ { name = foo, blockSize = not_a_number } ]");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testPropertiesInvalidLongRejected() {
+    props("storage.properties = [ { name = foo, cacheSize = not_a_number } ]");
   }
 }

--- a/framework/src/test/java/org/tron/core/config/args/StorageTest.java
+++ b/framework/src/test/java/org/tron/core/config/args/StorageTest.java
@@ -49,7 +49,10 @@ public class StorageTest {
         + "    blockSize = 4096, writeBufferSize = 10485760, cacheSize = 10485760,\n"
         + "    maxOpenFiles = 100 },\n"
         + "  { name = test_name, path = test_path,\n"
-        + "    blockSize = 2, writeBufferSize = 3, cacheSize = 4, maxOpenFiles = 5 }\n"
+        + "    blockSize = 2, writeBufferSize = 3, cacheSize = 4, maxOpenFiles = 5 },\n"
+        // name/path-only entries: LevelDB options omitted, must inherit per-tier defaults
+        + "  { name = delegation, path = test_path },\n"
+        + "  { name = code, path = test_path }\n"
         + "]"
     ).withFallback(ConfigFactory.load(TestConstants.TEST_CONF));
     StorageConfig sc = StorageConfig.fromConfig(cfg);
@@ -106,6 +109,26 @@ public class StorageTest {
     options = StorageUtils.getOptionsByDbName("trans");
     Assert.assertEquals(16 * 1024 * 1024, options.writeBufferSize());
     Assert.assertEquals(50, options.maxOpenFiles());
+  }
+
+  /**
+   * A properties entry that only sets name/path (all LevelDB options omitted) must inherit
+   * the per-tier defaults from newDefaultDbOptions instead of resetting them to the
+   * PropertyConfig defaults. Both "delegation" (DB_L) and "code" (DB_M) are listed with
+   * name/path only, so they must keep their tier writeBufferSize/maxOpenFiles.
+   */
+  @Test
+  public void nameAndPathOnlyInheritsTierDefaults() {
+    Options ldb = StorageUtils.getOptionsByDbName("delegation");
+    Assert.assertEquals(64 * 1024 * 1024, ldb.writeBufferSize());
+    Assert.assertEquals(1000, ldb.maxOpenFiles());
+    // unset cacheSize/blockSize inherit the base defaults, not PropertyConfig's old 10 MB
+    Assert.assertEquals(32 * 1024 * 1024L, ldb.cacheSize());
+    Assert.assertEquals(4 * 1024, ldb.blockSize());
+
+    Options mdb = StorageUtils.getOptionsByDbName("code");
+    Assert.assertEquals(64 * 1024 * 1024, mdb.writeBufferSize());
+    Assert.assertEquals(500, mdb.maxOpenFiles());
   }
 
 }

--- a/framework/src/test/java/org/tron/core/config/args/StorageTest.java
+++ b/framework/src/test/java/org/tron/core/config/args/StorageTest.java
@@ -44,17 +44,13 @@ public class StorageTest {
         + "storage.defaultL.maxOpenFiles = 1000\n"
         + "storage.properties = [\n"
         + "  { name = account, path = storage_directory_test,\n"
-        + "    createIfMissing = true, paranoidChecks = true, verifyChecksums = true,\n"
-        + "    compressionType = 1, blockSize = 4096,\n"
-        + "    writeBufferSize = 10485760, cacheSize = 10485760, maxOpenFiles = 100 },\n"
+        + "    blockSize = 4096, writeBufferSize = 10485760, cacheSize = 10485760,\n"
+        + "    maxOpenFiles = 100 },\n"
         + "  { name = \"account-index\", path = storage_directory_test,\n"
-        + "    createIfMissing = true, paranoidChecks = true, verifyChecksums = true,\n"
-        + "    compressionType = 1, blockSize = 4096,\n"
-        + "    writeBufferSize = 10485760, cacheSize = 10485760, maxOpenFiles = 100 },\n"
+        + "    blockSize = 4096, writeBufferSize = 10485760, cacheSize = 10485760,\n"
+        + "    maxOpenFiles = 100 },\n"
         + "  { name = test_name, path = test_path,\n"
-        + "    createIfMissing = false, paranoidChecks = false, verifyChecksums = false,\n"
-        + "    compressionType = 1, blockSize = 2,\n"
-        + "    writeBufferSize = 3, cacheSize = 4, maxOpenFiles = 5 }\n"
+        + "    blockSize = 2, writeBufferSize = 3, cacheSize = 4, maxOpenFiles = 5 }\n"
         + "]"
     ).withFallback(ConfigFactory.load(TestConstants.TEST_CONF));
     StorageConfig sc = StorageConfig.fromConfig(cfg);
@@ -83,30 +79,18 @@ public class StorageTest {
   @Test
   public void getOptions() {
     Options options = StorageUtils.getOptionsByDbName("account");
-    Assert.assertTrue(options.createIfMissing());
-    Assert.assertTrue(options.paranoidChecks());
-    Assert.assertTrue(options.verifyChecksums());
-    Assert.assertEquals(CompressionType.SNAPPY, options.compressionType());
     Assert.assertEquals(4096, options.blockSize());
     Assert.assertEquals(10485760, options.writeBufferSize());
     Assert.assertEquals(10485760L, options.cacheSize());
     Assert.assertEquals(100, options.maxOpenFiles());
 
     options = StorageUtils.getOptionsByDbName("test_name");
-    Assert.assertFalse(options.createIfMissing());
-    Assert.assertFalse(options.paranoidChecks());
-    Assert.assertFalse(options.verifyChecksums());
-    Assert.assertEquals(CompressionType.SNAPPY, options.compressionType());
     Assert.assertEquals(2, options.blockSize());
     Assert.assertEquals(3, options.writeBufferSize());
     Assert.assertEquals(4L, options.cacheSize());
     Assert.assertEquals(5, options.maxOpenFiles());
 
     options = StorageUtils.getOptionsByDbName("some_name_not_exists");
-    Assert.assertTrue(options.createIfMissing());
-    Assert.assertTrue(options.paranoidChecks());
-    Assert.assertTrue(options.verifyChecksums());
-    Assert.assertEquals(CompressionType.SNAPPY, options.compressionType());
     Assert.assertEquals(4 * 1024, options.blockSize());
     Assert.assertEquals(16 * 1024 * 1024, options.writeBufferSize());
     Assert.assertEquals(32 * 1024 * 1024L, options.cacheSize());

--- a/framework/src/test/java/org/tron/core/config/args/StorageTest.java
+++ b/framework/src/test/java/org/tron/core/config/args/StorageTest.java
@@ -18,7 +18,6 @@ package org.tron.core.config.args;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import java.io.File;
-import org.iq80.leveldb.CompressionType;
 import org.iq80.leveldb.Options;
 import org.junit.AfterClass;
 import org.junit.Assert;

--- a/framework/src/test/resources/config-test.conf
+++ b/framework/src/test/resources/config-test.conf
@@ -23,6 +23,7 @@ storage {
   #   {
   #     name = "account",
   #     path = "storage_directory_test",
+  #     # following are only used for LevelDB
   #     blockSize = 4096,           // 4  KB =         4 * 1024 B
   #     writeBufferSize = 10485760, // 10 MB = 10 * 1024 * 1024 B
   #     cacheSize = 10485760,       // 10 MB = 10 * 1024 * 1024 B

--- a/framework/src/test/resources/config-test.conf
+++ b/framework/src/test/resources/config-test.conf
@@ -23,14 +23,10 @@ storage {
   #   {
   #     name = "account",
   #     path = "storage_directory_test",
-  #     createIfMissing = true,     // deprecated for arm start
-  #     paranoidChecks = true,
-  #     verifyChecksums = true,
-  #     compressionType = 1,        // compressed with snappy
   #     blockSize = 4096,           // 4  KB =         4 * 1024 B
   #     writeBufferSize = 10485760, // 10 MB = 10 * 1024 * 1024 B
   #     cacheSize = 10485760,       // 10 MB = 10 * 1024 * 1024 B
-  #     maxOpenFiles = 100          // deprecated for arm end
+  #     maxOpenFiles = 100
   #   },
   ]
 


### PR DESCRIPTION
**What does this PR do?**

**`StorageConfig` / `Storage`** — fix `ConfigException$ValidationFailed` when starting with a config file (e.g. `config-nile.conf`) whose `storage.properties` entries only set `name` and `path` (all LevelDB options commented out); clean up dead config fields in the same pass.
- **Bug fix**: `ConfigBeanFactory.create()` iterates every setter on `PropertyConfig` and requires a matching key in each list item; absent keys throw `ValidationFailed` even though `PropertyConfig` has Java-side defaults for all optional fields. Fix: add `@Setter(NONE)` to the `properties` field so `ConfigBeanFactory` skips it, then parse the list manually in `fromConfig()` using `containsKey()` guards — the same pattern already used for `defaultDbOption`/`defaultMDbOption`/`defaultLDbOption`.
- **Dead field removal**: `createIfMissing`, `paranoidChecks`, `verifyChecksums`, and `compressionType` are removed from both `PropertyConfig` and `DbOptionOverride`. These values are fixed constants in `DbOptionalsUtils` (`true`/`true`/`true`/SNAPPY) and are never changed by anyone; exposing them as config fields gave the false impression they were tunable. The corresponding setter calls are also removed from `applyPropertyOptions` and `applyDbOptionOverride` in `Storage`.
- **Refactor**: extract `readLevelDbOptions(ConfigObject)` as a shared parser for the remaining 4 LevelDB fields (`blockSize`, `writeBufferSize`, `cacheSize`, `maxOpenFiles`); `readDbOption` is reduced to 3 lines; `readProperties` reuses it and applies only non-null values to `PropertyConfig`.
- **Validation**: each `properties` entry must have a `name` field; missing `name` now throws `IllegalArgumentException` with a clear message.

**Why are these changes required?**

Nodes started with a minimal config (e.g. `config-nile.conf`) that sets only `name` and `path` per properties entry were broken by the `ConfigBeanFactory` validation; the refactored manual parser restores the original lenient behaviour while keeping error-handling consistent across all numeric fields. The four removed fields (`createIfMissing`, `paranoidChecks`, `verifyChecksums`, `compressionType`) are global LevelDB defaults fixed in `DbOptionalsUtils` — they were never user-tunable in practice and their presence in the config bean was misleading.

**This PR has been tested by:**
- Unit Tests
  - `StorageTest`: updated to reflect the removed fields; all three test methods pass.
- Manual Testing

**Follow up**

**Extra details**