### PR TITLE
feat(version): update a new version. version name:GreatVoyage-v4.8.1-6-g52d7d9d23e

### DIFF
--- a/framework/src/main/java/org/tron/program/Version.java
+++ b/framework/src/main/java/org/tron/program/Version.java
@@ -2,8 +2,8 @@ package org.tron.program;
 
 public class Version {
 
-  public static final String VERSION_NAME = "GreatVoyage-v4.8.0.1-1-g44a4bc8263";
-  public static final String VERSION_CODE = "18636";
+  public static final String VERSION_NAME = "GreatVoyage-v4.8.1-6-g52d7d9d23e";
+  public static final String VERSION_CODE = "18643";
   private static final String VERSION = "4.8.1.1";
 
   public static String getVersion() {


### PR DESCRIPTION
Bump VERSION_NAME from GreatVoyage-v4.8.0.1-1-g44a4bc8263 to GreatVoyage-v4.8.1-6-g52d7d9d23e and VERSION_CODE from 18636 to 18643, including the six commits accumulated since the v4.8.1 tag:create2/ModExp precompile check optimizations with their VM tests, the git.properties NPE fix, and the new PR pipeline and system-test CI workflows.
