### PR TITLE
fix(event): back-pressure realtime event loading instead of dropping

### DIFF
--- a/framework/src/main/java/org/tron/core/services/event/BlockEventLoad.java
+++ b/framework/src/main/java/org/tron/core/services/event/BlockEventLoad.java
@@ -37,7 +37,7 @@ public class BlockEventLoad {
   public void init() {
     executor.scheduleWithFixedDelay(() -> {
       try {
-        if (!instance.isBusy()) {
+        if (!instance.isBusy() && !realtimeEventService.isBusy()) {
           load();
         }
       } catch (Exception e) {

--- a/framework/src/main/java/org/tron/core/services/event/RealtimeEventService.java
+++ b/framework/src/main/java/org/tron/core/services/event/RealtimeEventService.java
@@ -59,11 +59,11 @@ public class RealtimeEventService {
     }
   }
 
+  public boolean isBusy() {
+    return queue.size() >= maxEventSize;
+  }
+
   public void add(Event event) {
-    if (queue.size() >= maxEventSize) {
-      logger.warn("Add event failed, blockId {}.", event.getBlockEvent().getBlockId().getString());
-      return;
-    }
     queue.offer(event);
   }
 

--- a/framework/src/test/java/org/tron/core/event/RealtimeEventServiceTest.java
+++ b/framework/src/test/java/org/tron/core/event/RealtimeEventServiceTest.java
@@ -115,4 +115,13 @@ public class RealtimeEventServiceTest {
       Assert.assertTrue(e instanceof NullPointerException);
     }
   }
+
+  @Test
+  public void testIsBusy() {
+    RealtimeEventService service = new RealtimeEventService();
+    Assert.assertFalse(service.isBusy());
+
+    ReflectUtils.setFieldValue(service, "maxEventSize", 0);
+    Assert.assertTrue(service.isBusy());
+  }
 }


### PR DESCRIPTION
**What does this PR do?**
When the realtime event queue was full (maxEventSize), RealtimeEventService.add silently dropped a whole block's realtime events while the solid path still delivered them from cache, causing realtime subscribers to miss events with no way to recover.

- RealtimeEventService: add isBusy() (queue.size() >= maxEventSize) and remove the silent drop in add(); just offer to the queue.
- BlockEventLoad: gate load() on realtimeEventService.isBusy() so loading pauses (non-blocking, outside the manager lock) when the realtime queue is full, instead of dropping events.

This keeps the realtime queue bounded (no OOM) and does not block block processing; loading resumes and re-derives events from db once the queue drains, so no events are lost.

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

