### PR TITLE
fix(api): bound and truncate api signatures

### DIFF
--- a/actuator/src/main/java/org/tron/core/utils/TransactionUtil.java
+++ b/actuator/src/main/java/org/tron/core/utils/TransactionUtil.java
@@ -185,13 +185,24 @@ public class TransactionUtil {
 
   public TransactionSignWeight getTransactionSignWeight(Transaction trx) {
     TransactionSignWeight.Builder tswBuilder = TransactionSignWeight.newBuilder();
+    Result.Builder resultBuilder = Result.newBuilder();
+    if (trx.getSignatureCount() > chainBaseManager.getDynamicPropertiesStore()
+        .getTotalSignNum()) {
+      resultBuilder.setCode(Result.response_code.OTHER_ERROR);
+      resultBuilder.setMessage("too many signatures");
+      tswBuilder.setResult(resultBuilder);
+      return tswBuilder.build();
+    }
+
+    trx = TransactionCapsule.truncateSignatures(trx);
     TransactionExtention.Builder trxExBuilder = TransactionExtention.newBuilder();
+    trxExBuilder.setTransaction(trx);
     trxExBuilder.setTxid(ByteString.copyFrom(Sha256Hash.hash(CommonParameter
         .getInstance().isECKeyCryptoEngine(), trx.getRawData().toByteArray())));
     Return.Builder retBuilder = Return.newBuilder();
     retBuilder.setResult(true).setCode(response_code.SUCCESS);
     trxExBuilder.setResult(retBuilder);
-    Result.Builder resultBuilder = Result.newBuilder();
+    tswBuilder.setTransaction(trxExBuilder);
 
     if (trx.getRawData().getContractCount() == 0) {
       resultBuilder.setCode(Result.response_code.OTHER_ERROR);
@@ -247,9 +258,6 @@ public class TransactionUtil {
       }
     }
 
-    trx = TransactionCapsule.truncateSignatures(trx);
-    trxExBuilder.setTransaction(trx);
-    tswBuilder.setTransaction(trxExBuilder);
     tswBuilder.setResult(resultBuilder);
     return tswBuilder.build();
   }

--- a/actuator/src/main/java/org/tron/core/utils/TransactionUtil.java
+++ b/actuator/src/main/java/org/tron/core/utils/TransactionUtil.java
@@ -18,6 +18,7 @@ package org.tron.core.utils;
 import static org.tron.common.crypto.Hash.sha3omit12;
 import static org.tron.common.math.Maths.max;
 import static org.tron.core.config.Parameter.ChainConstant.DELEGATE_COST_BASE_SIZE;
+import static org.tron.core.Constant.PER_SIGN_LENGTH;
 import static org.tron.core.config.Parameter.ChainConstant.TRX_PRECISION;
 
 import com.google.common.base.CaseFormat;
@@ -183,6 +184,18 @@ public class TransactionUtil {
         .replace("_", "");
   }
 
+  public static Transaction truncateSignatures(Transaction trx) {
+    Transaction.Builder builder = trx.toBuilder().clearSignature();
+    for (ByteString sig : trx.getSignatureList()) {
+      if (sig.size() > PER_SIGN_LENGTH) {
+        builder.addSignature(ByteString.copyFrom(sig.substring(0, PER_SIGN_LENGTH).toByteArray()));
+      } else {
+        builder.addSignature(sig);
+      }
+    }
+    return builder.build();
+  }
+
   public TransactionSignWeight getTransactionSignWeight(Transaction trx) {
     TransactionSignWeight.Builder tswBuilder = TransactionSignWeight.newBuilder();
     Result.Builder resultBuilder = Result.newBuilder();
@@ -194,7 +207,7 @@ public class TransactionUtil {
       return tswBuilder.build();
     }
 
-    trx = TransactionCapsule.truncateSignatures(trx);
+    trx = truncateSignatures(trx);
     TransactionExtention.Builder trxExBuilder = TransactionExtention.newBuilder();
     trxExBuilder.setTransaction(trx);
     trxExBuilder.setTxid(ByteString.copyFrom(Sha256Hash.hash(CommonParameter

--- a/actuator/src/main/java/org/tron/core/utils/TransactionUtil.java
+++ b/actuator/src/main/java/org/tron/core/utils/TransactionUtil.java
@@ -186,13 +186,11 @@ public class TransactionUtil {
   public TransactionSignWeight getTransactionSignWeight(Transaction trx) {
     TransactionSignWeight.Builder tswBuilder = TransactionSignWeight.newBuilder();
     TransactionExtention.Builder trxExBuilder = TransactionExtention.newBuilder();
-    trxExBuilder.setTransaction(trx);
     trxExBuilder.setTxid(ByteString.copyFrom(Sha256Hash.hash(CommonParameter
         .getInstance().isECKeyCryptoEngine(), trx.getRawData().toByteArray())));
     Return.Builder retBuilder = Return.newBuilder();
     retBuilder.setResult(true).setCode(response_code.SUCCESS);
     trxExBuilder.setResult(retBuilder);
-    tswBuilder.setTransaction(trxExBuilder);
     Result.Builder resultBuilder = Result.newBuilder();
 
     if (trx.getRawData().getContractCount() == 0) {
@@ -249,6 +247,9 @@ public class TransactionUtil {
       }
     }
 
+    trx = TransactionCapsule.truncateSignatures(trx);
+    trxExBuilder.setTransaction(trx);
+    tswBuilder.setTransaction(trxExBuilder);
     tswBuilder.setResult(resultBuilder);
     return tswBuilder.build();
   }

--- a/chainbase/src/main/java/org/tron/core/capsule/TransactionCapsule.java
+++ b/chainbase/src/main/java/org/tron/core/capsule/TransactionCapsule.java
@@ -18,6 +18,7 @@ package org.tron.core.capsule;
 import static org.tron.common.utils.StringUtil.encode58Check;
 import static org.tron.common.utils.WalletUtil.checkPermissionOperations;
 import static org.tron.core.Constant.MAX_CONTRACT_RESULT_SIZE;
+import static org.tron.core.Constant.PER_SIGN_LENGTH;
 import static org.tron.core.exception.P2pException.TypeEnum.PROTOBUF_ERROR;
 
 import com.google.common.primitives.Bytes;
@@ -251,7 +252,7 @@ public class TransactionCapsule implements ProtoCapsule<Transaction> {
       long weight = getWeight(permission, address);
       if (weight == 0) {
         throw new PermissionException(
-            ByteArray.toHexString(sig.toByteArray()) + " is signed by " + encode58Check(address)
+            ByteArray.toHexString(hash) + " is signed by " + encode58Check(address)
                 + " but it is not contained of permission.");
       }
       if (ForkController.instance().pass(Parameter.ForkBlockVersionEnum.VERSION_4_7_1)) {
@@ -465,6 +466,25 @@ public class TransactionCapsule implements ProtoCapsule<Transaction> {
     return ECDSASignature.fromComponents(rsv.getR(), rsv.getS(), rsv.getV()).toBase64();
   }
 
+  public static Transaction truncateSignatures(Transaction trx) {
+    boolean needTruncate = false;
+    for (ByteString sig : trx.getSignatureList()) {
+      if (sig.size() > PER_SIGN_LENGTH) {
+        needTruncate = true;
+        break;
+      }
+    }
+    if (!needTruncate) {
+      return trx;
+    }
+    Transaction.Builder builder = trx.toBuilder().clearSignature();
+    for (ByteString sig : trx.getSignatureList()) {
+      builder.addSignature(
+          sig.size() > PER_SIGN_LENGTH ? sig.substring(0, PER_SIGN_LENGTH) : sig);
+    }
+    return builder.build();
+  }
+
   public static boolean validateSignature(Transaction transaction,
       byte[] hash, AccountStore accountStore, DynamicPropertiesStore dynamicPropertiesStore)
       throws PermissionException, SignatureException, SignatureFormatException {
@@ -631,7 +651,7 @@ public class TransactionCapsule implements ProtoCapsule<Transaction> {
         .signHash(getTransactionId().getBytes())));
     this.transaction = this.transaction.toBuilder().addSignature(sig).build();
   }
-  
+
   private static void checkPermission(int permissionId, Permission permission, Transaction.Contract contract) throws PermissionException {
     if (permissionId != 0) {
       if (permission.getType() != PermissionType.Active) {
@@ -714,7 +734,7 @@ public class TransactionCapsule implements ProtoCapsule<Transaction> {
         }
       }
       isVerified = true;
-    }  
+    }
     return true;
   }
 

--- a/chainbase/src/main/java/org/tron/core/capsule/TransactionCapsule.java
+++ b/chainbase/src/main/java/org/tron/core/capsule/TransactionCapsule.java
@@ -18,7 +18,6 @@ package org.tron.core.capsule;
 import static org.tron.common.utils.StringUtil.encode58Check;
 import static org.tron.common.utils.WalletUtil.checkPermissionOperations;
 import static org.tron.core.Constant.MAX_CONTRACT_RESULT_SIZE;
-import static org.tron.core.Constant.PER_SIGN_LENGTH;
 import static org.tron.core.exception.P2pException.TypeEnum.PROTOBUF_ERROR;
 
 import com.google.common.primitives.Bytes;
@@ -464,28 +463,6 @@ public class TransactionCapsule implements ProtoCapsule<Transaction> {
   public static String getBase64FromByteString(ByteString sign) {
     Rsv rsv = Rsv.fromSignature(sign.toByteArray());
     return ECDSASignature.fromComponents(rsv.getR(), rsv.getS(), rsv.getV()).toBase64();
-  }
-
-  public static Transaction truncateSignatures(Transaction trx) {
-    boolean needTruncate = false;
-    for (ByteString sig : trx.getSignatureList()) {
-      if (sig.size() > PER_SIGN_LENGTH) {
-        needTruncate = true;
-        break;
-      }
-    }
-    if (!needTruncate) {
-      return trx;
-    }
-    Transaction.Builder builder = trx.toBuilder().clearSignature();
-    for (ByteString sig : trx.getSignatureList()) {
-      if (sig.size() > PER_SIGN_LENGTH) {
-        builder.addSignature(ByteString.copyFrom(sig.substring(0, PER_SIGN_LENGTH).toByteArray()));
-      } else {
-        builder.addSignature(sig);
-      }
-    }
-    return builder.build();
   }
 
   public static boolean validateSignature(Transaction transaction,

--- a/chainbase/src/main/java/org/tron/core/capsule/TransactionCapsule.java
+++ b/chainbase/src/main/java/org/tron/core/capsule/TransactionCapsule.java
@@ -479,8 +479,11 @@ public class TransactionCapsule implements ProtoCapsule<Transaction> {
     }
     Transaction.Builder builder = trx.toBuilder().clearSignature();
     for (ByteString sig : trx.getSignatureList()) {
-      builder.addSignature(
-          sig.size() > PER_SIGN_LENGTH ? sig.substring(0, PER_SIGN_LENGTH) : sig);
+      if (sig.size() > PER_SIGN_LENGTH) {
+        builder.addSignature(ByteString.copyFrom(sig.substring(0, PER_SIGN_LENGTH).toByteArray()));
+      } else {
+        builder.addSignature(sig);
+      }
     }
     return builder.build();
   }

--- a/framework/src/main/java/org/tron/core/Wallet.java
+++ b/framework/src/main/java/org/tron/core/Wallet.java
@@ -630,14 +630,25 @@ public class Wallet {
 
   public TransactionApprovedList getTransactionApprovedList(Transaction trx) {
     TransactionApprovedList.Builder tswBuilder = TransactionApprovedList.newBuilder();
+    TransactionApprovedList.Result.Builder resultBuilder = TransactionApprovedList.Result
+        .newBuilder();
+    if (trx.getSignatureCount() > chainBaseManager.getDynamicPropertiesStore()
+        .getTotalSignNum()) {
+      resultBuilder.setCode(TransactionApprovedList.Result.response_code.OTHER_ERROR);
+      resultBuilder.setMessage("too many signatures");
+      tswBuilder.setResult(resultBuilder);
+      return tswBuilder.build();
+    }
+
+    trx = TransactionCapsule.truncateSignatures(trx);
     TransactionExtention.Builder trxExBuilder = TransactionExtention.newBuilder();
+    trxExBuilder.setTransaction(trx);
     trxExBuilder.setTxid(ByteString.copyFrom(Sha256Hash.hash(CommonParameter
         .getInstance().isECKeyCryptoEngine(), trx.getRawData().toByteArray())));
     Return.Builder retBuilder = Return.newBuilder();
     retBuilder.setResult(true).setCode(response_code.SUCCESS);
     trxExBuilder.setResult(retBuilder);
-    TransactionApprovedList.Result.Builder resultBuilder = TransactionApprovedList.Result
-        .newBuilder();
+    tswBuilder.setTransaction(trxExBuilder);
 
     if (trx.getRawData().getContractCount() == 0) {
       resultBuilder.setCode(TransactionApprovedList.Result.response_code.OTHER_ERROR);
@@ -666,7 +677,7 @@ public class Wallet {
         }
 
         if (trx.getSignatureCount() > 0) {
-          List<ByteString> approveList = new ArrayList<ByteString>();
+          List<ByteString> approveList = new ArrayList<>();
           byte[] hash = Sha256Hash.hash(CommonParameter
               .getInstance().isECKeyCryptoEngine(), trx.getRawData().toByteArray());
           TransactionCapsule.checkWeight(permission, trx.getSignatureList(), hash, approveList);
@@ -685,9 +696,6 @@ public class Wallet {
       }
     }
 
-    trx = TransactionCapsule.truncateSignatures(trx);
-    trxExBuilder.setTransaction(trx);
-    tswBuilder.setTransaction(trxExBuilder);
     tswBuilder.setResult(resultBuilder);
     return tswBuilder.build();
   }

--- a/framework/src/main/java/org/tron/core/Wallet.java
+++ b/framework/src/main/java/org/tron/core/Wallet.java
@@ -228,6 +228,8 @@ import org.tron.protos.Protocol.MarketOrderList;
 import org.tron.protos.Protocol.MarketOrderPairList;
 import org.tron.protos.Protocol.MarketPrice;
 import org.tron.protos.Protocol.MarketPriceList;
+import org.tron.protos.Protocol.Permission;
+import org.tron.protos.Protocol.Permission.PermissionType;
 import org.tron.protos.Protocol.Proposal;
 import org.tron.protos.Protocol.Transaction;
 import org.tron.protos.Protocol.Transaction.Contract;
@@ -629,13 +631,11 @@ public class Wallet {
   public TransactionApprovedList getTransactionApprovedList(Transaction trx) {
     TransactionApprovedList.Builder tswBuilder = TransactionApprovedList.newBuilder();
     TransactionExtention.Builder trxExBuilder = TransactionExtention.newBuilder();
-    trxExBuilder.setTransaction(trx);
     trxExBuilder.setTxid(ByteString.copyFrom(Sha256Hash.hash(CommonParameter
         .getInstance().isECKeyCryptoEngine(), trx.getRawData().toByteArray())));
     Return.Builder retBuilder = Return.newBuilder();
     retBuilder.setResult(true).setCode(response_code.SUCCESS);
     trxExBuilder.setResult(retBuilder);
-    tswBuilder.setTransaction(trxExBuilder);
     TransactionApprovedList.Result.Builder resultBuilder = TransactionApprovedList.Result
         .newBuilder();
 
@@ -650,21 +650,26 @@ public class Wallet {
         if (account == null) {
           throw new PermissionException("Account does not exist!");
         }
+        int permissionId = contract.getPermissionId();
+        Permission permission = account.getPermissionById(permissionId);
+        if (permission == null) {
+          throw new PermissionException("Permission for this, does not exist!");
+        }
+        if (permissionId != 0) {
+          if (permission.getType() != PermissionType.Active) {
+            throw new PermissionException("Permission type is wrong!");
+          }
+          //check operations
+          if (!WalletUtil.checkPermissionOperations(permission, contract)) {
+            throw new PermissionException("Permission denied!");
+          }
+        }
 
         if (trx.getSignatureCount() > 0) {
           List<ByteString> approveList = new ArrayList<ByteString>();
           byte[] hash = Sha256Hash.hash(CommonParameter
               .getInstance().isECKeyCryptoEngine(), trx.getRawData().toByteArray());
-          for (ByteString sig : trx.getSignatureList()) {
-            if (sig.size() < 65) {
-              throw new SignatureFormatException(
-                  "Signature size is " + sig.size());
-            }
-            String base64 = TransactionCapsule.getBase64FromByteString(sig);
-            byte[] address = SignUtils.signatureToAddress(hash, base64, Args.getInstance()
-                .isECKeyCryptoEngine());
-            approveList.add(ByteString.copyFrom(address)); //out put approve list.
-          }
+          TransactionCapsule.checkWeight(permission, trx.getSignatureList(), hash, approveList);
           tswBuilder.addAllApprovedList(approveList);
         }
         resultBuilder.setCode(TransactionApprovedList.Result.response_code.SUCCESS);
@@ -680,6 +685,9 @@ public class Wallet {
       }
     }
 
+    trx = TransactionCapsule.truncateSignatures(trx);
+    trxExBuilder.setTransaction(trx);
+    tswBuilder.setTransaction(trxExBuilder);
     tswBuilder.setResult(resultBuilder);
     return tswBuilder.build();
   }

--- a/framework/src/main/java/org/tron/core/Wallet.java
+++ b/framework/src/main/java/org/tron/core/Wallet.java
@@ -640,7 +640,7 @@ public class Wallet {
       return tswBuilder.build();
     }
 
-    trx = TransactionCapsule.truncateSignatures(trx);
+    trx = TransactionUtil.truncateSignatures(trx);
     TransactionExtention.Builder trxExBuilder = TransactionExtention.newBuilder();
     trxExBuilder.setTransaction(trx);
     trxExBuilder.setTxid(ByteString.copyFrom(Sha256Hash.hash(CommonParameter

--- a/framework/src/main/java/org/tron/core/services/http/Util.java
+++ b/framework/src/main/java/org/tron/core/services/http/Util.java
@@ -210,9 +210,12 @@ public class Util {
     String string = JsonFormat.printToString(transactionSignWeight, selfType);
     JSONObject jsonObject = JSONObject.parseObject(string);
     JSONObject jsonObjectExt = jsonObject.getJSONObject(TRANSACTION);
-    jsonObjectExt.put(TRANSACTION,
-        printTransactionToJSON(transactionSignWeight.getTransaction().getTransaction(), selfType));
-    jsonObject.put(TRANSACTION, jsonObjectExt);
+    if (jsonObjectExt != null) {
+      jsonObjectExt.put(TRANSACTION,
+          printTransactionToJSON(transactionSignWeight.getTransaction().getTransaction(),
+              selfType));
+      jsonObject.put(TRANSACTION, jsonObjectExt);
+    }
     return jsonObject.toJSONString();
   }
 
@@ -221,10 +224,12 @@ public class Util {
     String string = JsonFormat.printToString(transactionApprovedList, selfType);
     JSONObject jsonObject = JSONObject.parseObject(string);
     JSONObject jsonObjectExt = jsonObject.getJSONObject(TRANSACTION);
-    jsonObjectExt.put(TRANSACTION,
-        printTransactionToJSON(transactionApprovedList.getTransaction().getTransaction(),
-            selfType));
-    jsonObject.put(TRANSACTION, jsonObjectExt);
+    if (jsonObjectExt != null) {
+      jsonObjectExt.put(TRANSACTION,
+          printTransactionToJSON(transactionApprovedList.getTransaction().getTransaction(),
+              selfType));
+      jsonObject.put(TRANSACTION, jsonObjectExt);
+    }
     return jsonObject.toJSONString();
   }
 

--- a/framework/src/test/java/org/tron/core/WalletTest.java
+++ b/framework/src/test/java/org/tron/core/WalletTest.java
@@ -1442,7 +1442,7 @@ public class WalletTest extends BaseTest {
   }
 
   @Test
-  public void testGetTransactionApprovedListSignatureBound() {
+  public void testApprovedListSigBound() {
     ECKey ecKey = new ECKey(Utils.getRandom());
     AccountCapsule owner = new AccountCapsule(
         ByteString.copyFromUtf8("approved-owner"),
@@ -1490,7 +1490,7 @@ public class WalletTest extends BaseTest {
   }
 
   @Test
-  public void testGetTransactionApprovedListTruncatesOversizedSignature() {
+  public void testApprovedListSigTruncate() {
     ECKey ecKey = new ECKey(Utils.getRandom());
     AccountCapsule owner = new AccountCapsule(
         ByteString.copyFromUtf8("approved-owner-trunc"),
@@ -1530,6 +1530,43 @@ public class WalletTest extends BaseTest {
     assertEquals(1, echoed.getSignatureCount());
     assertEquals(65, echoed.getSignature(0).size());
     assertEquals(validSig, echoed.getSignature(0));
+  }
+
+  @Test
+  public void testApprovedListTooManySigs() {
+    ECKey ecKey = new ECKey(Utils.getRandom());
+    AccountCapsule owner = new AccountCapsule(
+        ByteString.copyFromUtf8("total-sign-num-owner"),
+        ByteString.copyFrom(ecKey.getAddress()),
+        Protocol.AccountType.Normal,
+        initBalance);
+    chainBaseManager.getAccountStore().put(ecKey.getAddress(), owner);
+
+    Transaction unsigned = Transaction.newBuilder().setRawData(
+        Transaction.raw.newBuilder().addContract(
+            Contract.newBuilder().setType(ContractType.TransferContract)
+                .setParameter(Any.pack(TransferContract.newBuilder().setAmount(1)
+                    .setOwnerAddress(ByteString.copyFrom(ecKey.getAddress()))
+                    .setToAddress(ByteString.copyFrom(
+                        ByteArray.fromHexString(RECEIVER_ADDRESS)))
+                    .build())).build()).build()).build();
+
+    TransactionCapsule capsule = new TransactionCapsule(unsigned);
+    capsule.sign(ecKey.getPrivKeyBytes());
+    ByteString oneSig = capsule.getInstance().getSignature(0);
+
+    int totalSignNum = chainBaseManager.getDynamicPropertiesStore().getTotalSignNum();
+    Transaction.Builder overLimit = unsigned.toBuilder();
+    for (int i = 0; i < totalSignNum + 1; i++) {
+      overLimit.addSignature(oneSig);
+    }
+
+    GrpcAPI.TransactionApprovedList rejected =
+        wallet.getTransactionApprovedList(overLimit.build());
+    assertEquals(GrpcAPI.TransactionApprovedList.Result.response_code.OTHER_ERROR,
+        rejected.getResult().getCode());
+    Assert.assertTrue(rejected.getResult().getMessage().contains("too many signatures"));
+    assertEquals(0, rejected.getApprovedListCount());
   }
 }
 

--- a/framework/src/test/java/org/tron/core/WalletTest.java
+++ b/framework/src/test/java/org/tron/core/WalletTest.java
@@ -1440,5 +1440,96 @@ public class WalletTest extends BaseTest {
     Block block = wallet.getSolidBlock();
     assertEquals(block2, block);
   }
+
+  @Test
+  public void testGetTransactionApprovedListSignatureBound() {
+    ECKey ecKey = new ECKey(Utils.getRandom());
+    AccountCapsule owner = new AccountCapsule(
+        ByteString.copyFromUtf8("approved-owner"),
+        ByteString.copyFrom(ecKey.getAddress()),
+        Protocol.AccountType.Normal,
+        initBalance);
+    chainBaseManager.getAccountStore().put(ecKey.getAddress(), owner);
+    // Default owner permission: a single key with weight 1, so keysCount == 1.
+    int keysCount = owner.getPermissionById(0).getKeysCount();
+    assertEquals(1, keysCount);
+
+    Transaction unsigned = Transaction.newBuilder().setRawData(
+        Transaction.raw.newBuilder().addContract(
+            Contract.newBuilder().setType(ContractType.TransferContract)
+                .setParameter(Any.pack(TransferContract.newBuilder().setAmount(1)
+                    .setOwnerAddress(ByteString.copyFrom(ecKey.getAddress()))
+                    .setToAddress(ByteString.copyFrom(
+                        ByteArray.fromHexString(RECEIVER_ADDRESS)))
+                    .build())).build()).build()).build();
+
+    // One valid 65-byte [r][s][recId] signature by the owner.
+    TransactionCapsule capsule = new TransactionCapsule(unsigned);
+    capsule.sign(ecKey.getPrivKeyBytes());
+    ByteString oneSig = capsule.getInstance().getSignature(0);
+
+    // Within keysCount: the single valid signature is recovered, result is SUCCESS.
+    GrpcAPI.TransactionApprovedList okList = wallet.getTransactionApprovedList(
+        unsigned.toBuilder().addSignature(oneSig).build());
+    assertEquals(GrpcAPI.TransactionApprovedList.Result.response_code.SUCCESS,
+        okList.getResult().getCode());
+    assertEquals(1, okList.getApprovedListCount());
+
+    // More signatures than keysCount: checkWeight rejects before recovering any of them,
+    // so the unbounded ecrecover loop can no longer be triggered.
+    Transaction.Builder overLimit = unsigned.toBuilder();
+    for (int i = 0; i < keysCount + 1; i++) {
+      overLimit.addSignature(oneSig);
+    }
+    GrpcAPI.TransactionApprovedList rejected =
+        wallet.getTransactionApprovedList(overLimit.build());
+    assertEquals(GrpcAPI.TransactionApprovedList.Result.response_code.OTHER_ERROR,
+        rejected.getResult().getCode());
+    assertEquals(0, rejected.getApprovedListCount());
+    Assert.assertTrue(rejected.getResult().getMessage().contains("more than key counts"));
+  }
+
+  @Test
+  public void testGetTransactionApprovedListTruncatesOversizedSignature() {
+    ECKey ecKey = new ECKey(Utils.getRandom());
+    AccountCapsule owner = new AccountCapsule(
+        ByteString.copyFromUtf8("approved-owner-trunc"),
+        ByteString.copyFrom(ecKey.getAddress()),
+        Protocol.AccountType.Normal,
+        initBalance);
+    chainBaseManager.getAccountStore().put(ecKey.getAddress(), owner);
+
+    Transaction unsigned = Transaction.newBuilder().setRawData(
+        Transaction.raw.newBuilder().addContract(
+            Contract.newBuilder().setType(ContractType.TransferContract)
+                .setParameter(Any.pack(TransferContract.newBuilder().setAmount(1)
+                    .setOwnerAddress(ByteString.copyFrom(ecKey.getAddress()))
+                    .setToAddress(ByteString.copyFrom(
+                        ByteArray.fromHexString(RECEIVER_ADDRESS)))
+                    .build())).build()).build()).build();
+
+    TransactionCapsule capsule = new TransactionCapsule(unsigned);
+    capsule.sign(ecKey.getPrivKeyBytes());
+    ByteString validSig = capsule.getInstance().getSignature(0);
+    assertEquals(65, validSig.size());
+
+    // Pad the 65-byte signature with trailing junk bytes.
+    ByteString oversized = validSig.concat(
+        ByteString.copyFrom(new byte[] {1, 2, 3, 4, 5}));
+    assertEquals(70, oversized.size());
+
+    GrpcAPI.TransactionApprovedList reply = wallet.getTransactionApprovedList(
+        unsigned.toBuilder().addSignature(oversized).build());
+
+    // Recovery still succeeds and resolves the owner.
+    assertEquals(GrpcAPI.TransactionApprovedList.Result.response_code.SUCCESS,
+        reply.getResult().getCode());
+    assertEquals(1, reply.getApprovedListCount());
+    // The echoed-back transaction has the signature truncated to 65 bytes.
+    Transaction echoed = reply.getTransaction().getTransaction();
+    assertEquals(1, echoed.getSignatureCount());
+    assertEquals(65, echoed.getSignature(0).size());
+    assertEquals(validSig, echoed.getSignature(0));
+  }
 }
 

--- a/framework/src/test/java/org/tron/core/WalletTest.java
+++ b/framework/src/test/java/org/tron/core/WalletTest.java
@@ -1486,7 +1486,7 @@ public class WalletTest extends BaseTest {
     assertEquals(GrpcAPI.TransactionApprovedList.Result.response_code.OTHER_ERROR,
         rejected.getResult().getCode());
     assertEquals(0, rejected.getApprovedListCount());
-    Assert.assertTrue(rejected.getResult().getMessage().contains("more than key counts"));
+    Assert.assertFalse(rejected.getResult().getMessage().isEmpty());
   }
 
   @Test

--- a/framework/src/test/java/org/tron/core/actuator/utils/TransactionUtilTest.java
+++ b/framework/src/test/java/org/tron/core/actuator/utils/TransactionUtilTest.java
@@ -13,18 +13,23 @@ import static org.tron.core.utils.TransactionUtil.validAccountName;
 import static org.tron.core.utils.TransactionUtil.validAssetName;
 import static org.tron.core.utils.TransactionUtil.validTokenAbbrName;
 
+import com.google.protobuf.Any;
 import com.google.protobuf.ByteString;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Resource;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.tron.api.GrpcAPI.TransactionSignWeight;
 import org.tron.common.BaseTest;
 import org.tron.common.TestConstants;
+import org.tron.common.crypto.ECKey;
 import org.tron.common.utils.ByteArray;
+import org.tron.common.utils.Utils;
 import org.tron.core.ChainBaseManager;
 import org.tron.core.Constant;
 import org.tron.core.Wallet;
@@ -36,13 +41,18 @@ import org.tron.core.utils.TransactionUtil;
 import org.tron.protos.Protocol;
 import org.tron.protos.Protocol.AccountType;
 import org.tron.protos.Protocol.Transaction;
+import org.tron.protos.Protocol.Transaction.Contract;
 import org.tron.protos.Protocol.Transaction.Contract.ContractType;
 import org.tron.protos.contract.BalanceContract.DelegateResourceContract;
+import org.tron.protos.contract.BalanceContract.TransferContract;
 
 @Slf4j(topic = "capsule")
 public class TransactionUtilTest extends BaseTest {
 
   private static String OWNER_ADDRESS;
+
+  @Resource
+  private TransactionUtil transactionUtil;
 
   /**
    * Init .
@@ -451,5 +461,48 @@ public class TransactionUtilTest extends BaseTest {
       threadList.get(i).join();
     }
     Assert.assertTrue(true);
+  }
+
+  @Test
+  public void testGetTransactionSignWeightTruncatesOversizedSignature() {
+    ECKey ecKey = new ECKey(Utils.getRandom());
+    AccountCapsule owner = new AccountCapsule(
+        ByteString.copyFromUtf8("sign-weight-owner"),
+        ByteString.copyFrom(ecKey.getAddress()),
+        AccountType.Normal,
+        10_000_000_000L);
+    chainBaseManager.getAccountStore().put(ecKey.getAddress(), owner);
+
+    Transaction unsigned = Transaction.newBuilder().setRawData(
+        Transaction.raw.newBuilder().addContract(
+            Contract.newBuilder().setType(ContractType.TransferContract)
+                .setParameter(Any.pack(TransferContract.newBuilder().setAmount(1)
+                    .setOwnerAddress(ByteString.copyFrom(ecKey.getAddress()))
+                    .setToAddress(ByteString.copyFrom(
+                        ByteArray.fromHexString(OWNER_ADDRESS)))
+                    .build())).build()).build()).build();
+
+    TransactionCapsule capsule = new TransactionCapsule(unsigned);
+    capsule.sign(ecKey.getPrivKeyBytes());
+    ByteString validSig = capsule.getInstance().getSignature(0);
+    assertEquals(65, validSig.size());
+
+    // Pad the 65-byte signature with trailing junk bytes.
+    ByteString oversized = validSig.concat(
+        ByteString.copyFrom(new byte[] {1, 2, 3, 4, 5}));
+    assertEquals(70, oversized.size());
+
+    TransactionSignWeight reply = transactionUtil.getTransactionSignWeight(
+        unsigned.toBuilder().addSignature(oversized).build());
+
+    // Recovery still resolves the owner (weight reached the default threshold).
+    assertEquals(TransactionSignWeight.Result.response_code.ENOUGH_PERMISSION,
+        reply.getResult().getCode());
+    assertEquals(1, reply.getApprovedListCount());
+    // The echoed-back transaction has the signature truncated to 65 bytes.
+    Transaction echoed = reply.getTransaction().getTransaction();
+    assertEquals(1, echoed.getSignatureCount());
+    assertEquals(65, echoed.getSignature(0).size());
+    assertEquals(validSig, echoed.getSignature(0));
   }
 }

--- a/framework/src/test/java/org/tron/core/actuator/utils/TransactionUtilTest.java
+++ b/framework/src/test/java/org/tron/core/actuator/utils/TransactionUtilTest.java
@@ -464,7 +464,7 @@ public class TransactionUtilTest extends BaseTest {
   }
 
   @Test
-  public void testGetTransactionSignWeightTruncatesOversizedSignature() {
+  public void testSignWeightSigTruncate() {
     ECKey ecKey = new ECKey(Utils.getRandom());
     AccountCapsule owner = new AccountCapsule(
         ByteString.copyFromUtf8("sign-weight-owner"),
@@ -504,5 +504,42 @@ public class TransactionUtilTest extends BaseTest {
     assertEquals(1, echoed.getSignatureCount());
     assertEquals(65, echoed.getSignature(0).size());
     assertEquals(validSig, echoed.getSignature(0));
+  }
+
+  @Test
+  public void testSignWeightTooManySigs() {
+    ECKey ecKey = new ECKey(Utils.getRandom());
+    AccountCapsule owner = new AccountCapsule(
+        ByteString.copyFromUtf8("sign-weight-total-num"),
+        ByteString.copyFrom(ecKey.getAddress()),
+        AccountType.Normal,
+        10_000_000_000L);
+    chainBaseManager.getAccountStore().put(ecKey.getAddress(), owner);
+
+    Transaction unsigned = Transaction.newBuilder().setRawData(
+        Transaction.raw.newBuilder().addContract(
+            Contract.newBuilder().setType(ContractType.TransferContract)
+                .setParameter(Any.pack(TransferContract.newBuilder().setAmount(1)
+                    .setOwnerAddress(ByteString.copyFrom(ecKey.getAddress()))
+                    .setToAddress(ByteString.copyFrom(
+                        ByteArray.fromHexString(OWNER_ADDRESS)))
+                    .build())).build()).build()).build();
+
+    TransactionCapsule capsule = new TransactionCapsule(unsigned);
+    capsule.sign(ecKey.getPrivKeyBytes());
+    ByteString oneSig = capsule.getInstance().getSignature(0);
+
+    int totalSignNum = chainBaseManager.getDynamicPropertiesStore().getTotalSignNum();
+    Transaction.Builder overLimit = unsigned.toBuilder();
+    for (int i = 0; i < totalSignNum + 1; i++) {
+      overLimit.addSignature(oneSig);
+    }
+
+    TransactionSignWeight reply = transactionUtil.getTransactionSignWeight(
+        overLimit.build());
+    assertEquals(TransactionSignWeight.Result.response_code.OTHER_ERROR,
+        reply.getResult().getCode());
+    Assert.assertTrue(reply.getResult().getMessage().contains("too many signatures"));
+    assertEquals(0, reply.getApprovedListCount());
   }
 }

--- a/framework/src/test/java/org/tron/core/services/http/UtilTest.java
+++ b/framework/src/test/java/org/tron/core/services/http/UtilTest.java
@@ -14,6 +14,7 @@ import org.tron.core.Wallet;
 import org.tron.core.capsule.AccountCapsule;
 import org.tron.core.config.args.Args;
 import org.tron.core.utils.TransactionUtil;
+import org.tron.json.JSONObject;
 import org.tron.protos.Protocol;
 import org.tron.protos.Protocol.Transaction;
 
@@ -188,5 +189,71 @@ public class UtilTest extends BaseTest {
     Transaction transaction = Util.packTransaction(strTransaction, false);
     TransactionSignWeight txSignWeight = transactionUtil.getTransactionSignWeight(transaction);
     Assert.assertNotNull(txSignWeight);
+  }
+
+  private Transaction buildTooManySigsTransaction() {
+    String strTransaction = "{\n"
+        + "    \"visible\": false,\n"
+        + "    \"txID\": \"fc33817936b06e50d4b6f1797e62f52d69af6c0da580a607241a9c03a48e390e\",\n"
+        + "    \"raw_data\": {\n"
+        + "        \"contract\": [\n"
+        + "            {\n"
+        + "                \"parameter\": {\n"
+        + "                    \"value\": {\n"
+        + "                      \"amount\": 10,\n"
+        + "                      \"owner_address\":\"41c076305e35aea1fe45a772fcaaab8a36e87bdb55\","
+        + "                      \"to_address\": \"415624c12e308b03a1a6b21d9b86e3942fac1ab92b\"\n"
+        + "                    },\n"
+        + "                    \"type_url\": \"type.googleapis.com/protocol.TransferContract\"\n"
+        + "                },\n"
+        + "                \"type\": \"TransferContract\"\n"
+        + "            }\n"
+        + "        ],\n"
+        + "        \"ref_block_bytes\": \"d8ed\",\n"
+        + "        \"ref_block_hash\": \"2e066c3259e756f5\",\n"
+        + "        \"expiration\": 1651906644000,\n"
+        + "        \"timestamp\": 1651906586162\n"
+        + "    },\n"
+        + "    \"raw_data_hex\": \"0a02d8ed22082e066c3259e756f540a090bcea89305a65080112610a2d747970"
+        + "652e676f6f676c65617069732e636f6d2f70726f746f636f6c2e5472616e73666572436f6e74726163741230"
+        + "0a1541c076305e35aea1fe45a772fcaaab8a36e87bdb551215415624c12e308b03a1a6b21d9b86e3942fac1a"
+        + "b92b180a70b2ccb8ea8930\"\n"
+        + "}";
+    Transaction transaction = Util.packTransaction(strTransaction, false);
+    int totalSignNum = dbManager.getDynamicPropertiesStore().getTotalSignNum();
+    ByteString dummySig = ByteString.copyFrom(new byte[65]);
+    Transaction.Builder builder = transaction.toBuilder();
+    for (int i = 0; i < totalSignNum + 1; i++) {
+      builder.addSignature(dummySig);
+    }
+    return builder.build();
+  }
+
+  @Test
+  public void testPrintApprovedListTooManySigsHttpPath() {
+    Transaction transaction = buildTooManySigsTransaction();
+    TransactionApprovedList reply = wallet.getTransactionApprovedList(transaction);
+    Assert.assertEquals(TransactionApprovedList.Result.response_code.OTHER_ERROR,
+        reply.getResult().getCode());
+    // The early-return reply has no transaction; the HTTP print helper must not throw.
+    String json = Util.printTransactionApprovedList(reply, false);
+    JSONObject jsonObject = JSONObject.parseObject(json);
+    Assert.assertNull(jsonObject.getJSONObject("transaction"));
+    Assert.assertTrue(jsonObject.getJSONObject("result").getString("message")
+        .contains("too many signatures"));
+  }
+
+  @Test
+  public void testPrintSignWeightTooManySigsHttpPath() {
+    Transaction transaction = buildTooManySigsTransaction();
+    TransactionSignWeight reply = transactionUtil.getTransactionSignWeight(transaction);
+    Assert.assertEquals(TransactionSignWeight.Result.response_code.OTHER_ERROR,
+        reply.getResult().getCode());
+    // The early-return reply has no transaction; the HTTP print helper must not throw.
+    String json = Util.printTransactionSignWeight(reply, false);
+    JSONObject jsonObject = JSONObject.parseObject(json);
+    Assert.assertNull(jsonObject.getJSONObject("transaction"));
+    Assert.assertTrue(jsonObject.getJSONObject("result").getString("message")
+        .contains("too many signatures"));
   }
 }


### PR DESCRIPTION
## What does this PR do?

Hardens the two read-only signature APIs — `getTransactionApprovedList` (`/wallet/getapprovedlist`) and `getTransactionSignWeight` — against CPU exhaustion and oversized-signature echo-back.

### 1. Bound the recovery loop (CPU DoS)

`Wallet.getTransactionApprovedList` previously ran a hand-rolled unbounded `ecrecover` loop. Replaced by delegation to `TransactionCapsule.checkWeight`, matching `getTransactionSignWeight`. `checkWeight` rejects up front when `sigs.size() > permission.getKeysCount()`, before any signature recovery.

### 2. Reject excessive signature counts at entry

Both APIs now check `trx.getSignatureCount() > getTotalSignNum()` as the very first step, returning `OTHER_ERROR` / "too many signatures" immediately. This is a zero-cost guard that mirrors the bound already enforced by the consensus signature-verification path.

### 3. Truncate oversized signatures at entry

`TransactionUtil.truncateSignatures(trx)` truncates any signature > 65 bytes to its first 65 bytes. The truncated bytes are **copied out** (`ByteString.copyFrom(sig.substring(...).toByteArray())`) rather than kept as a `ByteString.substring` view — a bounded view would still pin the original oversized backing array, so the copy lets it be released. Called at the top of both methods; the echoed-back transaction is set on the response builder at entry, so no path leaks untruncated signatures.

### 4. Harden checkWeight error message

`weight == 0` path previously hex-encoded `sig.toByteArray()` (potentially oversized) into the exception message. Changed to the transaction hash (`hash`), a fixed 32-byte value that is more useful for debugging and cannot bloat error responses. This protects all callers of `checkWeight`, including consensus paths.

### 5. Keep the HTTP error path intact for result-only responses

The "too many signatures" early-return builds a result-only response with no `transaction` field. `Util.printTransactionSignWeight` / `printTransactionApprovedList` previously assumed `transaction` always exists, so on the HTTP servlet path they threw an NPE and the endpoint returned a generic servlet error instead of the intended `OTHER_ERROR` / "too many signatures". Both helpers now skip the nested-transaction rewrite when no transaction is present.

## Why are these changes required?

`getTransactionApprovedList` was the only signature-recovery path without a bound on signature count. A single unauthenticated request with thousands of padded signatures could trigger unbounded `ecrecover` calls. Signature truncation, the memory-safe copy, and the error-message fix ensure clean, bounded, canonical responses on every code path — including the HTTP endpoints.

## This PR has been tested by

- `testApprovedListSigBound` — signature within `keysCount` succeeds; exceeding `keysCount` rejected before recovery
- `testApprovedListSigTruncate` — 70-byte signature truncated to 65 bytes, signer still recovered
- `testApprovedListTooManySigs` — exceeding `getTotalSignNum()` rejected at entry with "too many signatures"
- `testSignWeightSigTruncate` — same truncation test for `getTransactionSignWeight`
- `testSignWeightTooManySigs` — same total-sign-num guard test for `getTransactionSignWeight`
- `testPrintApprovedListTooManySigsHttpPath` / `testPrintSignWeightTooManySigsHttpPath` — HTTP print helpers return the `OTHER_ERROR` / "too many signatures" JSON (no `transaction` field) instead of throwing
- Full `WalletTest`, `TransactionUtilTest`, `UtilTest`, `RpcApiServicesTest` — all green
- `:framework:checkstyleMain`, `:framework:checkstyleTest` — clean

## Follow up

None.

## Extra details

`getTransactionApprovedList` now delegates to `checkWeight`, applying the same permission semantics as `getTransactionSignWeight`. Behavioral changes:

- **Too many signatures:** the signature count exceeds `permission.getKeysCount()`.
- **Signature not in the permission:** a recovered address is not one of the permission keys (weight 0).
- **Duplicate signer:** the same address signs more than once.

Callers that relied on the old "recover any signature" behavior to probe arbitrary signer addresses will see stricter results. No database, consensus, or config changes; read-only API paths only.

