### PR TITLE
fix(jsonrpc): harden RPC/HTTP parameter validation

### DIFF
--- a/chainbase/src/main/java/org/tron/common/utils/Commons.java
+++ b/chainbase/src/main/java/org/tron/common/utils/Commons.java
@@ -48,11 +48,11 @@ public class Commons {
    */
   public static byte[] decodeFromBase58Check(String addressBase58) {
     if (StringUtils.isEmpty(addressBase58)) {
-      logger.warn("Warning: Address is empty !!");
+      logger.debug("address is empty !!");
       return null;
     }
     if (addressBase58.length() != BASE58_ADDRESS_LENGTH) {
-      logger.warn("Warning: invalid Base58 address length !!");
+      logger.debug("invalid Base58 address length");
       return null;
     }
     byte[] address = decode58Check(addressBase58);

--- a/chainbase/src/main/java/org/tron/common/utils/Commons.java
+++ b/chainbase/src/main/java/org/tron/common/utils/Commons.java
@@ -21,6 +21,8 @@ public class Commons {
 
   public static final int ASSET_ISSUE_COUNT_LIMIT_MAX = 1000;
 
+  public static final int BASE58_ADDRESS_LENGTH = 34;
+
   public static byte[] decode58Check(String input) {
     byte[] decodeCheck = Base58.decode(input);
     if (decodeCheck.length <= 4) {
@@ -41,9 +43,17 @@ public class Commons {
     return null;
   }
 
+  /**
+   * Decode a Base58Check address string to its 21-byte form.
+   */
   public static byte[] decodeFromBase58Check(String addressBase58) {
     if (StringUtils.isEmpty(addressBase58)) {
       logger.warn("Warning: Address is empty !!");
+      return null;
+    }
+    if (addressBase58.length() != BASE58_ADDRESS_LENGTH) {
+      logger.warn("Warning: invalid Base58 address length: {} ,expected {} !!",
+          addressBase58.length(), BASE58_ADDRESS_LENGTH);
       return null;
     }
     byte[] address = decode58Check(addressBase58);

--- a/chainbase/src/main/java/org/tron/common/utils/Commons.java
+++ b/chainbase/src/main/java/org/tron/common/utils/Commons.java
@@ -52,8 +52,7 @@ public class Commons {
       return null;
     }
     if (addressBase58.length() != BASE58_ADDRESS_LENGTH) {
-      logger.warn("Warning: invalid Base58 address length: {} ,expected {} !!",
-          addressBase58.length(), BASE58_ADDRESS_LENGTH);
+      logger.warn("Warning: invalid Base58 address length !!");
       return null;
     }
     byte[] address = decode58Check(addressBase58);

--- a/framework/src/main/java/org/tron/core/services/http/JsonFormat.java
+++ b/framework/src/main/java/org/tron/core/services/http/JsonFormat.java
@@ -1313,12 +1313,11 @@ public class JsonFormat {
         throws InvalidEscapeSequence {
       //Address base58 -> ByteString
       if (HttpSelfFormatFieldName.isAddressFormat(fliedName)) {
-        byte[] addressBytes;
+        byte[] addressBytes = null;
         try {
           addressBytes = Commons.decodeFromBase58Check(input);
         } catch (IllegalArgumentException e) {
-          // Base58.decode throw
-          addressBytes = null;
+          // Base58.decode throws on illegal chars -> leave addressBytes null (treated as invalid)
         }
         if (addressBytes == null) {
           // empty / wrong-length / bad-checksum / illegal chars -> all invalid addresses; throw a

--- a/framework/src/main/java/org/tron/core/services/http/JsonFormat.java
+++ b/framework/src/main/java/org/tron/core/services/http/JsonFormat.java
@@ -1313,7 +1313,19 @@ public class JsonFormat {
         throws InvalidEscapeSequence {
       //Address base58 -> ByteString
       if (HttpSelfFormatFieldName.isAddressFormat(fliedName)) {
-        return ByteString.copyFrom(Commons.decodeFromBase58Check(input));
+        byte[] addressBytes;
+        try {
+          addressBytes = Commons.decodeFromBase58Check(input);
+        } catch (IllegalArgumentException e) {
+          // Base58.decode throw
+          addressBytes = null;
+        }
+        if (addressBytes == null) {
+          // empty / wrong-length / bad-checksum / illegal chars -> all invalid addresses; throw a
+          // clear error instead of letting ByteString.copyFrom(null) throw a bare NPE.
+          throw new InvalidEscapeSequence("invalid address for field: " + fliedName);
+        }
+        return ByteString.copyFrom(addressBytes);
       }
 
       //Normal String -> ByteString

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/JsonRpcApiUtil.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/JsonRpcApiUtil.java
@@ -424,7 +424,7 @@ public class JsonRpcApiUtil {
   }
 
   /** Matches a 32-byte hash hex string: optional 0x prefix + 64 hex chars (also caps length). */
-  public static final String HASH_REGEX = "(0x)?[0-9a-fA-F]{64}$";
+  public static final String HASH_REGEX = "^(0x)?[0-9a-fA-F]{64}$";
 
   /**
    * Convert a hash hex string (optional 0x prefix) to a byte array, validating
@@ -446,7 +446,7 @@ public class JsonRpcApiUtil {
   /**
    * Matches a 32-byte topic hex string: optional 0x prefix + 63 or 64 hex chars.
    */
-  public static final String TOPIC_REGEX = "(0x)?[0-9a-fA-F]{63,64}$";
+  public static final String TOPIC_REGEX = "^(0x)?[0-9a-fA-F]{63,64}$";
 
   /**
    * Convert a topic hex string (optional 0x prefix, leading zero may be omitted) to a 32-byte

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/JsonRpcApiUtil.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/JsonRpcApiUtil.java
@@ -61,6 +61,7 @@ public class JsonRpcApiUtil {
   public static final String TAG_PENDING_SUPPORT_ERROR = "TAG pending not supported";
   public static final String TAG_SAFE_SUPPORT_ERROR = "TAG safe not supported";
   public static final String BLOCK_NUM_ERROR = "invalid block number";
+  public static final String TX_INDEX_ERROR = "invalid index value";
 
   private static final SecureRandom random = new SecureRandom();
 
@@ -399,21 +400,21 @@ public class JsonRpcApiUtil {
     // ADDRESS_SIZE (42) is the hex length of a 21-byte address; +2 leaves room for the optional
     // "0x" prefix, so a 0x-prefixed 21-byte address (0x41..., 44 chars) is still accepted.
     if (hexAddress == null || hexAddress.length() > DecodeUtil.ADDRESS_SIZE + 2) {
-      throw new JsonRpcInvalidParamsException("invalid address hash value");
+      throw new JsonRpcInvalidParamsException("invalid address");
     }
     byte[] addressByte;
     try {
       addressByte = ByteArray.fromHexString(hexAddress);
       if (addressByte.length != DecodeUtil.ADDRESS_SIZE / 2
           && addressByte.length != DecodeUtil.ADDRESS_SIZE / 2 - 1) {
-        throw new JsonRpcInvalidParamsException("invalid address hash value");
+        throw new JsonRpcInvalidParamsException("invalid address");
       }
 
       if (addressByte.length == DecodeUtil.ADDRESS_SIZE / 2 - 1) {
         addressByte = ByteUtil.merge(new byte[] {DecodeUtil.addressPreFixByte}, addressByte);
       } else if (addressByte[0] != ByteArray.fromHexString(DecodeUtil.addressPreFixString)[0]) {
         // addressByte.length == DecodeUtil.ADDRESS_SIZE / 2
-        throw new JsonRpcInvalidParamsException("invalid address hash value");
+        throw new JsonRpcInvalidParamsException("invalid address");
       }
     } catch (Exception e) {
       throw new JsonRpcInvalidParamsException(e.getMessage());
@@ -429,7 +430,7 @@ public class JsonRpcApiUtil {
    * format and length via {@link #HASH_REGEX} first.
    */
   public static byte[] hashToByteArray(String hash) throws JsonRpcInvalidParamsException {
-    if (!Pattern.matches(HASH_REGEX, hash)) {
+    if (hash == null || !Pattern.matches(HASH_REGEX, hash)) {
       throw new JsonRpcInvalidParamsException("invalid hash value");
     }
     byte[] bHash;
@@ -445,22 +446,21 @@ public class JsonRpcApiUtil {
    * convert 40 hex string of address to byte array, padding 0 ahead if length is odd.
    */
   public static byte[] addressToByteArray(String hexAddress) throws JsonRpcInvalidParamsException {
-    byte[] addressByte = ByteArray.fromHexString(hexAddress);
+    if (hexAddress == null) {
+      throw new JsonRpcInvalidParamsException("address is null");
+    } else if (hexAddress.length() > DecodeUtil.ADDRESS_SIZE) {
+      throw new JsonRpcInvalidParamsException("invalid address: " + hexAddress);
+    }
+    byte[] addressByte;
+    try {
+      addressByte = ByteArray.fromHexString(hexAddress);
+    } catch (Exception e) {
+      throw new JsonRpcInvalidParamsException("invalid address: " + hexAddress);
+    }
     if (addressByte.length != DecodeUtil.ADDRESS_SIZE / 2 - 1) {
       throw new JsonRpcInvalidParamsException("invalid address: " + hexAddress);
     }
     return new DataWord(addressByte).getLast20Bytes();
-  }
-
-  /**
-   * check if topic is hex string of size 64, padding 0 ahead if length is odd.
-   */
-  public static byte[] topicToByteArray(String hexTopic) throws JsonRpcInvalidParamsException {
-    byte[] topicByte = ByteArray.fromHexString(hexTopic);
-    if (topicByte.length != 32) {
-      throw new JsonRpcInvalidParamsException("invalid topic: " + hexTopic);
-    }
-    return topicByte;
   }
 
   public static boolean paramStringIsNull(String string) {
@@ -525,7 +525,10 @@ public class JsonRpcApiUtil {
         throw new JsonRpcInvalidParamsException("invalid param value: invalid hex number");
       }
     }
-
+    // QUANTITY is unsigned; reject a signed ("0x-..") value instead of returning a negative.
+    if (callValue < 0) {
+      throw new JsonRpcInvalidParamsException("invalid param value: negative");
+    }
     return callValue;
   }
 
@@ -674,6 +677,39 @@ public class JsonRpcApiUtil {
       throw new JsonRpcInvalidParamsException("Incorrect hex syntax");
     }
     return parseBlockNumber(blockNumOrTag);
+  }
+
+  /**
+   * Max hex digits of a 32-bit int (0x7FFFFFFF). A transaction index fits a signed int, so the
+   * longest valid input is "0x" + 8 hex digits; the +2 in the guard covers the prefix.
+   */
+  private static final int MAX_TX_INDEX_HEX_LEN = 8;
+
+  /**
+   * Parse a 0x-prefixed hex transaction index at the JSON-RPC boundary.
+   */
+  public static int parseTxIndex(String index) throws JsonRpcInvalidParamsException {
+    if (index == null || index.length() > MAX_TX_INDEX_HEX_LEN + 2) {
+      throw new JsonRpcInvalidParamsException(TX_INDEX_ERROR);
+    }
+    try {
+      return ByteArray.jsonHexToInt(index);
+    } catch (Exception e) {
+      throw new JsonRpcInvalidParamsException(TX_INDEX_ERROR);
+    }
+  }
+
+  /**
+   * Compute feeLimit = gas * energyFee with overflow protection. A gas value large enough to
+   * overflow a signed 64-bit feeLimit is rejected as invalid-params instead of silently wrapping
+   * to a bogus (possibly negative) value.
+   */
+  public static long calcFeeLimit(long gas, long energyFee) throws JsonRpcInvalidParamsException {
+    try {
+      return Math.multiplyExact(gas, energyFee);
+    } catch (ArithmeticException e) {
+      throw new JsonRpcInvalidParamsException("invalid gas: fee limit overflow");
+    }
   }
 
   public static String generateFilterId() {

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/JsonRpcApiUtil.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/JsonRpcApiUtil.java
@@ -674,7 +674,7 @@ public class JsonRpcApiUtil {
     if (isBlockTag(blockNumOrTag)) {
       return parseBlockTag(blockNumOrTag, wallet);
     }
-    if (!blockNumOrTag.startsWith("0x")) {
+    if (blockNumOrTag == null || !blockNumOrTag.startsWith("0x")) {
       throw new JsonRpcInvalidParamsException("Incorrect hex syntax");
     }
     return parseBlockNumber(blockNumOrTag);

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/JsonRpcApiUtil.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/JsonRpcApiUtil.java
@@ -8,6 +8,7 @@ import java.math.BigInteger;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.bouncycastle.util.encoders.Hex;
@@ -395,6 +396,11 @@ public class JsonRpcApiUtil {
    */
   public static byte[] addressCompatibleToByteArray(String hexAddress)
       throws JsonRpcInvalidParamsException {
+    // ADDRESS_SIZE (42) is the hex length of a 21-byte address; +2 leaves room for the optional
+    // "0x" prefix, so a 0x-prefixed 21-byte address (0x41..., 44 chars) is still accepted.
+    if (hexAddress == null || hexAddress.length() > DecodeUtil.ADDRESS_SIZE + 2) {
+      throw new JsonRpcInvalidParamsException("invalid address hash value");
+    }
     byte[] addressByte;
     try {
       addressByte = ByteArray.fromHexString(hexAddress);
@@ -413,6 +419,26 @@ public class JsonRpcApiUtil {
       throw new JsonRpcInvalidParamsException(e.getMessage());
     }
     return addressByte;
+  }
+
+  /** Matches a 32-byte hash hex string: optional 0x prefix + 64 hex chars (also caps length). */
+  public static final String HASH_REGEX = "(0x)?[a-zA-Z0-9]{64}$";
+
+  /**
+   * Convert a hash hex string (optional 0x prefix) to a byte array, validating
+   * format and length via {@link #HASH_REGEX} first.
+   */
+  public static byte[] hashToByteArray(String hash) throws JsonRpcInvalidParamsException {
+    if (!Pattern.matches(HASH_REGEX, hash)) {
+      throw new JsonRpcInvalidParamsException("invalid hash value");
+    }
+    byte[] bHash;
+    try {
+      bHash = ByteArray.fromHexString(hash);
+    } catch (Exception e) {
+      throw new JsonRpcInvalidParamsException(e.getMessage());
+    }
+    return bHash;
   }
 
   /**
@@ -603,10 +629,11 @@ public class JsonRpcApiUtil {
   /**
    * Max allowed length for a JSON-RPC block number hex/decimal input.
    * API-level DoS guard: rejects pathological inputs before BigInteger parsing,
-   * whose cost grows quadratically with length. Covers hex (0x + 64 chars for
-   * uint256) and decimal (78 chars for uint256) representations with headroom.
+   * whose cost grows quadratically with length. A block number fits a signed long,
+   * so the longest valid input is 19 chars (decimal Long.MAX_VALUE) or 18 (0x + 16
+   * hex); 20 leaves a small margin.
    */
-  private static final int MAX_BLOCK_NUM_HEX_LEN = 100;
+  private static final int MAX_BLOCK_NUM_HEX_LEN = 20;
 
   /**
    * Parse a JSON-RPC block number (hex "0x..." or decimal) into a long,
@@ -636,16 +663,17 @@ public class JsonRpcApiUtil {
   }
 
   /**
-   * Parse a block tag or hex number. Uses strict jsonHexToLong (requires 0x prefix) for hex.
-   * Callers needing flexible hex parsing (0x -> hex, bare number -> decimal) should use
-   * isBlockTag/parseBlockTag and handle hex separately with hexToBigInteger.
+   * Parse a block tag, or a 0x-prefixed hex block number.
    */
   public static long parseBlockNumber(String blockNumOrTag, Wallet wallet)
       throws JsonRpcInvalidParamsException {
     if (isBlockTag(blockNumOrTag)) {
       return parseBlockTag(blockNumOrTag, wallet);
     }
-    return ByteArray.jsonHexToLong(blockNumOrTag);
+    if (!blockNumOrTag.startsWith("0x")) {
+      throw new JsonRpcInvalidParamsException("Incorrect hex syntax");
+    }
+    return parseBlockNumber(blockNumOrTag);
   }
 
   public static String generateFilterId() {

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/JsonRpcApiUtil.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/JsonRpcApiUtil.java
@@ -444,6 +444,26 @@ public class JsonRpcApiUtil {
   }
 
   /**
+   * Matches a 32-byte topic hex string: optional 0x prefix + 63 or 64 hex chars.
+   */
+  public static final String TOPIC_REGEX = "(0x)?[0-9a-fA-F]{63,64}$";
+
+  /**
+   * Convert a topic hex string (optional 0x prefix, leading zero may be omitted) to a 32-byte
+   * array, validating format and length via {@link #TOPIC_REGEX} first.
+   */
+  public static byte[] topicToByteArray(String hexTopic) throws JsonRpcInvalidParamsException {
+    if (hexTopic == null || !Pattern.matches(TOPIC_REGEX, hexTopic)) {
+      throw new JsonRpcInvalidParamsException("invalid topic: " + hexTopic);
+    }
+    try {
+      return ByteArray.fromHexString(hexTopic);
+    } catch (Exception e) {
+      throw new JsonRpcInvalidParamsException("invalid topic: " + hexTopic);
+    }
+  }
+
+  /**
    * convert 40 hex string of address to byte array, padding 0 ahead if length is odd.
    */
   public static byte[] addressToByteArray(String hexAddress) throws JsonRpcInvalidParamsException {

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/JsonRpcApiUtil.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/JsonRpcApiUtil.java
@@ -14,6 +14,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.bouncycastle.util.encoders.Hex;
 import org.tron.api.GrpcAPI.AssetIssueList;
 import org.tron.common.crypto.Hash;
+import org.tron.common.math.StrictMathWrapper;
 import org.tron.common.parameter.CommonParameter;
 import org.tron.common.runtime.vm.DataWord;
 import org.tron.common.utils.ByteArray;
@@ -706,7 +707,7 @@ public class JsonRpcApiUtil {
    */
   public static long calcFeeLimit(long gas, long energyFee) throws JsonRpcInvalidParamsException {
     try {
-      return Math.multiplyExact(gas, energyFee);
+      return StrictMathWrapper.multiplyExact(gas, energyFee);
     } catch (ArithmeticException e) {
       throw new JsonRpcInvalidParamsException("invalid gas: fee limit overflow");
     }

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/JsonRpcApiUtil.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/JsonRpcApiUtil.java
@@ -422,7 +422,7 @@ public class JsonRpcApiUtil {
   }
 
   /** Matches a 32-byte hash hex string: optional 0x prefix + 64 hex chars (also caps length). */
-  public static final String HASH_REGEX = "(0x)?[a-zA-Z0-9]{64}$";
+  public static final String HASH_REGEX = "(0x)?[0-9a-fA-F]{64}$";
 
   /**
    * Convert a hash hex string (optional 0x prefix) to a byte array, validating

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/TronJsonRpcImpl.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/TronJsonRpcImpl.java
@@ -7,12 +7,14 @@ import static org.tron.core.services.jsonrpc.JsonRpcApiUtil.FINALIZED_STR;
 import static org.tron.core.services.jsonrpc.JsonRpcApiUtil.HASH_REGEX;
 import static org.tron.core.services.jsonrpc.JsonRpcApiUtil.LATEST_STR;
 import static org.tron.core.services.jsonrpc.JsonRpcApiUtil.addressCompatibleToByteArray;
+import static org.tron.core.services.jsonrpc.JsonRpcApiUtil.calcFeeLimit;
 import static org.tron.core.services.jsonrpc.JsonRpcApiUtil.generateFilterId;
 import static org.tron.core.services.jsonrpc.JsonRpcApiUtil.getEnergyUsageTotal;
 import static org.tron.core.services.jsonrpc.JsonRpcApiUtil.getTransactionIndex;
 import static org.tron.core.services.jsonrpc.JsonRpcApiUtil.getTxID;
 import static org.tron.core.services.jsonrpc.JsonRpcApiUtil.hashToByteArray;
 import static org.tron.core.services.jsonrpc.JsonRpcApiUtil.parseBlockNumber;
+import static org.tron.core.services.jsonrpc.JsonRpcApiUtil.parseTxIndex;
 import static org.tron.core.services.jsonrpc.JsonRpcApiUtil.triggerCallContract;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -814,14 +816,9 @@ public class TronJsonRpcImpl implements TronJsonRpc, Closeable {
 
   private TransactionResult getTransactionByBlockAndIndex(Block block, String index)
       throws JsonRpcInvalidParamsException {
-    int txIndex;
-    try {
-      txIndex = ByteArray.jsonHexToInt(index);
-    } catch (Exception e) {
-      throw new JsonRpcInvalidParamsException("invalid index value");
-    }
+    int txIndex = parseTxIndex(index);
 
-    if (txIndex >= block.getTransactionsCount()) {
+    if (txIndex < 0 || txIndex >= block.getTransactionsCount()) {
       return null;
     }
 
@@ -1143,7 +1140,11 @@ public class TronJsonRpcImpl implements TronJsonRpc, Closeable {
       ABI.Builder abiBuilder = ABI.newBuilder();
       if (StringUtils.isNotEmpty(args.getAbi())) {
         String abiStr = "{" + "\"entrys\":" + args.getAbi() + "}";
-        JsonFormat.merge(abiStr, abiBuilder, args.isVisible());
+        try {
+          JsonFormat.merge(abiStr, abiBuilder, args.isVisible());
+        } catch (StackOverflowError e) {
+          throw new JsonRpcInvalidParamsException("invalid abi");
+        }
       }
 
       SmartContract.Builder smartBuilder = SmartContract.newBuilder();
@@ -1169,7 +1170,7 @@ public class TronJsonRpcImpl implements TronJsonRpc, Closeable {
           .createTransactionCapsule(build.build(), ContractType.CreateSmartContract).getInstance();
       Transaction.Builder txBuilder = tx.toBuilder();
       Transaction.raw.Builder rawBuilder = tx.getRawData().toBuilder();
-      rawBuilder.setFeeLimit(args.parseGas() * wallet.getEnergyFee());
+      rawBuilder.setFeeLimit(calcFeeLimit(args.parseGas(), wallet.getEnergyFee()));
 
       txBuilder.setRawData(rawBuilder);
       tx = setTransactionPermissionId(args.getPermissionId(), txBuilder.build());
@@ -1218,7 +1219,7 @@ public class TronJsonRpcImpl implements TronJsonRpc, Closeable {
 
       Transaction.Builder txBuilder = tx.toBuilder();
       Transaction.raw.Builder rawBuilder = tx.getRawData().toBuilder();
-      rawBuilder.setFeeLimit(args.parseGas() * wallet.getEnergyFee());
+      rawBuilder.setFeeLimit(calcFeeLimit(args.parseGas(), wallet.getEnergyFee()));
       txBuilder.setRawData(rawBuilder);
 
       Transaction trx = wallet

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/TronJsonRpcImpl.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/TronJsonRpcImpl.java
@@ -3,14 +3,15 @@ package org.tron.core.services.jsonrpc;
 import static org.tron.core.Wallet.CONTRACT_VALIDATE_ERROR;
 import static org.tron.core.services.http.Util.setTransactionExtraData;
 import static org.tron.core.services.http.Util.setTransactionPermissionId;
-import static org.tron.core.services.jsonrpc.JsonRpcApiUtil.BLOCK_NUM_ERROR;
 import static org.tron.core.services.jsonrpc.JsonRpcApiUtil.FINALIZED_STR;
+import static org.tron.core.services.jsonrpc.JsonRpcApiUtil.HASH_REGEX;
 import static org.tron.core.services.jsonrpc.JsonRpcApiUtil.LATEST_STR;
 import static org.tron.core.services.jsonrpc.JsonRpcApiUtil.addressCompatibleToByteArray;
 import static org.tron.core.services.jsonrpc.JsonRpcApiUtil.generateFilterId;
 import static org.tron.core.services.jsonrpc.JsonRpcApiUtil.getEnergyUsageTotal;
 import static org.tron.core.services.jsonrpc.JsonRpcApiUtil.getTransactionIndex;
 import static org.tron.core.services.jsonrpc.JsonRpcApiUtil.getTxID;
+import static org.tron.core.services.jsonrpc.JsonRpcApiUtil.hashToByteArray;
 import static org.tron.core.services.jsonrpc.JsonRpcApiUtil.parseBlockNumber;
 import static org.tron.core.services.jsonrpc.JsonRpcApiUtil.triggerCallContract;
 
@@ -157,7 +158,11 @@ public class TronJsonRpcImpl implements TronJsonRpc, Closeable {
   private final Map<String, BlockFilterAndResult> blockFilter2ResultSolidity =
       new ConcurrentHashMap<>();
 
-  public static final String HASH_REGEX = "(0x)?[a-zA-Z0-9]{64}$";
+  // Storage key is a 32-byte word: 64 hex chars + optional "0x" prefix = 66 max.
+  // Reject oversized input before fromHexString / new DataWord, which would otherwise
+  // throw a RuntimeException whose message embeds the whole hex (amplifying log output)
+  // and surface as a -32603 Internal error instead of -32602 invalid params.
+  public static final int MAX_STORAGE_KEY_HEX_LEN = 66;
 
   public static final String INVALID_BLOCK_RANGE = "invalid block range params";
 
@@ -364,20 +369,6 @@ public class TronJsonRpcImpl implements TronJsonRpc, Closeable {
       throws JsonRpcInvalidParamsException {
     final Block b = getBlockByNumOrTag(blockNumOrTag);
     return (b == null ? null : getBlockResult(b, fullTransactionObjects));
-  }
-
-  private byte[] hashToByteArray(String hash) throws JsonRpcInvalidParamsException {
-    if (!Pattern.matches(HASH_REGEX, hash)) {
-      throw new JsonRpcInvalidParamsException("invalid hash value");
-    }
-
-    byte[] bHash;
-    try {
-      bHash = ByteArray.fromHexString(hash);
-    } catch (Exception e) {
-      throw new JsonRpcInvalidParamsException(e.getMessage());
-    }
-    return bHash;
   }
 
   /**
@@ -612,7 +603,18 @@ public class TronJsonRpcImpl implements TronJsonRpc, Closeable {
       throws JsonRpcInvalidParamsException {
     requireLatestBlockTag(blockNumOrTag);
 
+    if (storageIdx == null || storageIdx.length() > MAX_STORAGE_KEY_HEX_LEN) {
+      throw new JsonRpcInvalidParamsException("invalid storage key value");
+    }
+
     byte[] addressByte = addressCompatibleToByteArray(address);
+
+    DataWord index;
+    try {
+      index = new DataWord(ByteArray.fromHexString(storageIdx));
+    } catch (Exception e) {
+      throw new JsonRpcInvalidParamsException("invalid storage key value");
+    }
 
     // get contract from contractStore
     BytesMessage.Builder build = BytesMessage.newBuilder();
@@ -627,7 +629,7 @@ public class TronJsonRpcImpl implements TronJsonRpc, Closeable {
     storage.setContractVersion(smartContract.getVersion());
     storage.generateAddrHash(smartContract.getTrxHash().toByteArray());
 
-    DataWord value = storage.getValue(new DataWord(ByteArray.fromHexString(storageIdx)));
+    DataWord value = storage.getValue(index);
     return ByteArray.toJsonHex(value == null ? new byte[32] : value.getData());
   }
 

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/TronJsonRpcImpl.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/TronJsonRpcImpl.java
@@ -933,9 +933,10 @@ public class TronJsonRpcImpl implements TronJsonRpc, Closeable {
 
     Block block = null;
 
-    if (Pattern.matches(HASH_REGEX, blockNumOrHashOrTag)) {
+    if (blockNumOrHashOrTag != null && Pattern.matches(HASH_REGEX, blockNumOrHashOrTag)) {
       block = getBlockByJsonHash(blockNumOrHashOrTag);
     } else {
+      // null falls through to getBlockByNumOrTag -> parseBlockNumber -> -32602 (not an NPE)
       block = getBlockByNumOrTag(blockNumOrHashOrTag);
     }
 

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/filters/LogFilter.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/filters/LogFilter.java
@@ -1,7 +1,7 @@
 package org.tron.core.services.jsonrpc.filters;
 
 import static org.tron.core.services.jsonrpc.JsonRpcApiUtil.addressToByteArray;
-import static org.tron.core.services.jsonrpc.JsonRpcApiUtil.hashToByteArray;
+import static org.tron.core.services.jsonrpc.JsonRpcApiUtil.topicToByteArray;
 
 import com.google.protobuf.ByteString;
 import java.util.ArrayList;
@@ -57,6 +57,10 @@ public class LogFilter {
       List<byte[]> addr = new ArrayList<>();
       int i = 0;
       for (Object s : (ArrayList) fr.getAddress()) {
+        if (!(s instanceof String)) {
+          throw new JsonRpcInvalidParamsException(
+              String.format("invalid address at index %d: %s", i, s));
+        }
         try {
           addr.add(addressToByteArray((String) s));
           i++;
@@ -81,7 +85,7 @@ public class LogFilter {
           withTopic((byte[][]) null);
         } else if (topic instanceof String) {
           try {
-            withTopic(new DataWord(hashToByteArray((String) topic)).getData());
+            withTopic(new DataWord(topicToByteArray((String) topic)).getData());
           } catch (JsonRpcInvalidParamsException e) {
             throw new JsonRpcInvalidParamsException("invalid topic(s): " + topic);
           }
@@ -93,8 +97,11 @@ public class LogFilter {
 
           List<byte[]> t = new ArrayList<>();
           for (Object s : ((ArrayList) topic)) {
+            if (!(s instanceof String)) {
+              throw new JsonRpcInvalidParamsException("invalid topic(s): " + s);
+            }
             try {
-              t.add(new DataWord(hashToByteArray((String) s)).getData());
+              t.add(new DataWord(topicToByteArray((String) s)).getData());
             } catch (JsonRpcInvalidParamsException e) {
               throw new JsonRpcInvalidParamsException("invalid topic(s): " + s);
             }

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/filters/LogFilter.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/filters/LogFilter.java
@@ -1,7 +1,7 @@
 package org.tron.core.services.jsonrpc.filters;
 
 import static org.tron.core.services.jsonrpc.JsonRpcApiUtil.addressToByteArray;
-import static org.tron.core.services.jsonrpc.JsonRpcApiUtil.topicToByteArray;
+import static org.tron.core.services.jsonrpc.JsonRpcApiUtil.hashToByteArray;
 
 import com.google.protobuf.ByteString;
 import java.util.ArrayList;
@@ -81,7 +81,7 @@ public class LogFilter {
           withTopic((byte[][]) null);
         } else if (topic instanceof String) {
           try {
-            withTopic(new DataWord(topicToByteArray((String) topic)).getData());
+            withTopic(new DataWord(hashToByteArray((String) topic)).getData());
           } catch (JsonRpcInvalidParamsException e) {
             throw new JsonRpcInvalidParamsException("invalid topic(s): " + topic);
           }
@@ -94,7 +94,7 @@ public class LogFilter {
           List<byte[]> t = new ArrayList<>();
           for (Object s : ((ArrayList) topic)) {
             try {
-              t.add(new DataWord(topicToByteArray((String) s)).getData());
+              t.add(new DataWord(hashToByteArray((String) s)).getData());
             } catch (JsonRpcInvalidParamsException e) {
               throw new JsonRpcInvalidParamsException("invalid topic(s): " + s);
             }

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/filters/LogFilterWrapper.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/filters/LogFilterWrapper.java
@@ -6,7 +6,6 @@ import static org.tron.core.services.jsonrpc.JsonRpcApiUtil.LATEST_STR;
 import com.google.protobuf.ByteString;
 import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
-import org.tron.common.utils.ByteArray;
 import org.tron.core.Wallet;
 import org.tron.core.config.args.Args;
 import org.tron.core.exception.jsonrpc.JsonRpcInvalidParamsException;
@@ -35,14 +34,14 @@ public class LogFilterWrapper {
     long fromBlockSrc;
     long toBlockSrc;
     if (fr.getBlockHash() != null) {
-      String blockHash = ByteArray.fromHex(fr.getBlockHash());
       if (fr.getFromBlock() != null || fr.getToBlock() != null) {
         throw new JsonRpcInvalidParamsException(
             "cannot specify both BlockHash and FromBlock/ToBlock, choose one or the other");
       }
+      byte[] blockHashBytes = JsonRpcApiUtil.hashToByteArray(fr.getBlockHash());
       Block block = null;
       if (wallet != null) {
-        block = wallet.getBlockById(ByteString.copyFrom(ByteArray.fromHexString(blockHash)));
+        block = wallet.getBlockById(ByteString.copyFrom(blockHashBytes));
       }
       if (block == null) {
         throw new JsonRpcInvalidParamsException("invalid blockHash");

--- a/framework/src/test/java/org/tron/core/jsonrpc/JsonRpcTest.java
+++ b/framework/src/test/java/org/tron/core/jsonrpc/JsonRpcTest.java
@@ -201,11 +201,24 @@ public class JsonRpcTest {
   @Test
   public void testLogFilter() {
 
-    //topic must be 64 hex string
+    //topic must be 63 or 64 hex string, full 64-char form here
     try {
       new LogFilter(new FilterRequest(null, null, null,
           new String[] {"0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"},
           null));
+    } catch (JsonRpcInvalidParamsException e) {
+      Assert.fail();
+    }
+
+    //63-char form: leading zero stripped by some clients, padded back to the same topic
+    String paddedAddressTopic =
+        "000000000000000000000000f0cc5a2a84cd0f68ed1667070934542d673acbd8";
+    try {
+      LogFilter full = new LogFilter(new FilterRequest(null, null, null,
+          new String[] {null, "0x" + paddedAddressTopic}, null));
+      LogFilter stripped = new LogFilter(new FilterRequest(null, null, null,
+          new String[] {null, "0x" + paddedAddressTopic.substring(1)}, null));
+      Assert.assertArrayEquals(full.getTopics().get(1)[0], stripped.getTopics().get(1)[0]);
     } catch (JsonRpcInvalidParamsException e) {
       Assert.fail();
     }
@@ -224,6 +237,20 @@ public class JsonRpcTest {
     } catch (JsonRpcInvalidParamsException e) {
       Assert.assertTrue(e.getMessage().contains("invalid topic"));
     }
+
+    // non-string element in address array -> -32602, not a leaked ClassCastException
+    JsonRpcInvalidParamsException badAddrElement = Assert.assertThrows(
+        JsonRpcInvalidParamsException.class,
+        () -> new LogFilter(new FilterRequest(null, null,
+            new ArrayList<>(Collections.singletonList(1)), null, null)));
+    Assert.assertEquals("invalid address at index 0: 1", badAddrElement.getMessage());
+
+    // non-string element in nested topic array -> -32602, not a leaked ClassCastException
+    JsonRpcInvalidParamsException badTopicElement = Assert.assertThrows(
+        JsonRpcInvalidParamsException.class,
+        () -> new LogFilter(new FilterRequest(null, null, null,
+            new Object[] {new ArrayList<>(Collections.singletonList(1))}, null)));
+    Assert.assertEquals("invalid topic(s): 1", badTopicElement.getMessage());
 
     // topic size should be <= 4
     try {

--- a/framework/src/test/java/org/tron/core/jsonrpc/JsonRpcTest.java
+++ b/framework/src/test/java/org/tron/core/jsonrpc/JsonRpcTest.java
@@ -143,13 +143,13 @@ public class JsonRpcTest {
     try {
       addressCompatibleToByteArray(rawAddress.substring(1));
     } catch (JsonRpcInvalidParamsException e) {
-      Assert.assertEquals("invalid address hash value", e.getMessage());
+      Assert.assertEquals("invalid address", e.getMessage());
     }
 
     try {
       addressCompatibleToByteArray(rawAddress + "00");
     } catch (JsonRpcInvalidParamsException e) {
-      Assert.assertEquals("invalid address hash value", e.getMessage());
+      Assert.assertEquals("invalid address", e.getMessage());
     }
 
   }
@@ -176,6 +176,22 @@ public class JsonRpcTest {
       Assert.assertArrayEquals(addressToByteArray(address1), addressToByteArray(address2));
     } catch (JsonRpcInvalidParamsException e) {
       Assert.fail();
+    }
+
+    // oversized input rejected before fromHexString
+    try {
+      addressToByteArray("0x" + new String(new char[64]).replace('\0', 'a'));
+      Assert.fail();
+    } catch (JsonRpcInvalidParamsException e) {
+      Assert.assertTrue(e.getMessage().contains("invalid address"));
+    }
+
+    // invalid hex char -> invalid params, not a leaked DecoderException
+    try {
+      addressToByteArray("0x548794500882809695a8a687866e76d4271a1abz");
+      Assert.fail();
+    } catch (JsonRpcInvalidParamsException e) {
+      Assert.assertTrue(e.getMessage().contains("invalid address"));
     }
   }
 

--- a/framework/src/test/java/org/tron/core/jsonrpc/JsonrpcServiceTest.java
+++ b/framework/src/test/java/org/tron/core/jsonrpc/JsonrpcServiceTest.java
@@ -1378,6 +1378,10 @@ public class JsonrpcServiceTest extends BaseTest {
         () -> tronJsonRpc.getBlockReceipts("test"));
     Assert.assertEquals("invalid block number", testReceiptsEx.getMessage());
 
+    Exception nullReceiptsEx = Assert.assertThrows(Exception.class,
+        () -> tronJsonRpc.getBlockReceipts(null));
+    Assert.assertEquals("invalid block number", nullReceiptsEx.getMessage());
+
     try {
       List<TransactionReceipt> transactionReceiptList = tronJsonRpc.getBlockReceipts("0x2");
       Assert.assertNull(transactionReceiptList);

--- a/framework/src/test/java/org/tron/core/jsonrpc/JsonrpcServiceTest.java
+++ b/framework/src/test/java/org/tron/core/jsonrpc/JsonrpcServiceTest.java
@@ -56,6 +56,7 @@ import org.tron.core.services.jsonrpc.TronJsonRpc.LogFilterElement;
 import org.tron.core.services.jsonrpc.TronJsonRpcImpl;
 import org.tron.core.services.jsonrpc.filters.LogFilterWrapper;
 import org.tron.core.services.jsonrpc.types.BlockResult;
+import org.tron.core.services.jsonrpc.types.BuildArguments;
 import org.tron.core.services.jsonrpc.types.TransactionReceipt;
 import org.tron.core.services.jsonrpc.types.TransactionResult;
 import org.tron.json.JSON;
@@ -690,6 +691,31 @@ public class JsonrpcServiceTest extends BaseTest {
     } catch (Exception e) {
       Assert.fail();
     }
+
+    // negative index is out of range too -> null (not an Internal error)
+    try {
+      TransactionResult result = tronJsonRpc.getTransactionByBlockNumberAndIndex(
+          ByteArray.toJsonHex(blockCapsule1.getNum()), "0x-1");
+      Assert.assertNull(result);
+    } catch (Exception e) {
+      Assert.fail();
+    }
+
+    // leading zeros are tolerated: "0x00" parses to index 0
+    try {
+      TransactionResult result = tronJsonRpc.getTransactionByBlockNumberAndIndex(
+          ByteArray.toJsonHex(blockCapsule1.getNum()), "0x00");
+      Assert.assertNotNull(result);
+      Assert.assertEquals(ByteArray.toJsonHex(0L), result.getTransactionIndex());
+    } catch (Exception e) {
+      Assert.fail();
+    }
+
+    // oversized index (> 8 hex digits) rejected before parsing
+    Exception oversizedEx = Assert.assertThrows(Exception.class,
+        () -> tronJsonRpc.getTransactionByBlockNumberAndIndex(
+            ByteArray.toJsonHex(blockCapsule1.getNum()), "0x123456789"));
+    Assert.assertEquals("invalid index value", oversizedEx.getMessage());
 
     // latest -> blockCapsule1 (head)
     try {
@@ -1427,6 +1453,30 @@ public class JsonrpcServiceTest extends BaseTest {
     } finally {
       fullNodeJsonRpcHttpService.stop();
     }
+  }
+
+  @Test
+  public void testBuildTransactionRejectsDeeplyNestedAbi() {
+    // A pathological ABI with deep nesting overflows the recursive JsonFormat parser.
+    // buildCreateSmartContractTransaction must surface this as invalid-params (-32602),
+    // not let a StackOverflowError escape as a generic internal error.
+    int depth = 200_000;
+    StringBuilder abi = new StringBuilder("[],\"x\":");
+    for (int i = 0; i < depth; i++) {
+      abi.append('[');
+    }
+    for (int i = 0; i < depth; i++) {
+      abi.append(']');
+    }
+
+    BuildArguments args = new BuildArguments();
+    args.setFrom("0xabd4b9367799eaa3197fecb144eb71de1e049abc");
+    args.setData("60806040");
+    args.setAbi(abi.toString());
+
+    JsonRpcInvalidParamsException e = Assert.assertThrows(JsonRpcInvalidParamsException.class,
+        () -> tronJsonRpc.buildTransaction(args));
+    Assert.assertEquals("invalid abi", e.getMessage());
   }
 
   @Test

--- a/framework/src/test/java/org/tron/core/jsonrpc/JsonrpcServiceTest.java
+++ b/framework/src/test/java/org/tron/core/jsonrpc/JsonrpcServiceTest.java
@@ -514,11 +514,9 @@ public class JsonrpcServiceTest extends BaseTest {
         () -> parseBlockNumber("abc", wallet));
     Assert.assertEquals("Incorrect hex syntax", abcEx.getMessage());
 
-    // parseBlockNumber: malformed hex -> throws
     Exception hexEx = Assert.assertThrows(Exception.class,
         () -> parseBlockNumber("0xxabc", wallet));
-    // https://bugs.openjdk.org/browse/JDK-8176425, from JDK 12, the exception message is changed
-    Assert.assertTrue(hexEx.getMessage().startsWith("For input string: \"xabc\""));
+    Assert.assertEquals("invalid block number", hexEx.getMessage());
   }
 
   @Test
@@ -579,10 +577,29 @@ public class JsonrpcServiceTest extends BaseTest {
         () -> tronJsonRpc.getStorageAt("", "", "abc"));
     Assert.assertEquals("invalid block number", e6.getMessage());
 
+    // storageIdx length oversized -> invalid storage key value
+    String addr = "0xabd4b9367799eaa3197fecb144eb71de1e049abc";
+    Exception e7 = Assert.assertThrows(Exception.class,
+        () -> tronJsonRpc.getStorageAt(addr,
+            "0x" + new String(new char[65]).replace('\0', 'a'), "latest"));
+    Assert.assertEquals("invalid storage key value", e7.getMessage());
+
+    // storageIdx is null -> invalid storage key value
+    Exception e8 = Assert.assertThrows(Exception.class,
+        () -> tronJsonRpc.getStorageAt(addr, null, "latest"));
+    Assert.assertEquals("invalid storage key value", e8.getMessage());
+
+    // storageIdx is valid length but decodes to >32 bytes (66 hex chars without 0x = 33 bytes):
+    // DataWord rejects it -> invalid storage key value (-32602), not a leaked Internal error.
+    Exception e9 = Assert.assertThrows(Exception.class,
+        () -> tronJsonRpc.getStorageAt(addr,
+            new String(new char[66]).replace('\0', 'a'), "latest"));
+    Assert.assertEquals("invalid storage key value", e9.getMessage());
+
     // latest happy path: address is an account, not a contract, so returns 32 zero bytes
     try {
       String value = tronJsonRpc.getStorageAt(
-          "0xabd4b9367799eaa3197fecb144eb71de1e049abc", "0x0", "latest");
+          addr, "0x0", "latest");
       Assert.assertEquals(ByteArray.toJsonHex(new byte[32]), value);
     } catch (Exception e) {
       Assert.fail();
@@ -1005,6 +1022,29 @@ public class JsonrpcServiceTest extends BaseTest {
     } catch (JsonRpcInvalidParamsException e) {
       Assert.fail();
     }
+
+    JsonRpcInvalidParamsException shortHashEx = Assert.assertThrows(
+        JsonRpcInvalidParamsException.class,
+        () -> new LogFilterWrapper(new FilterRequest(null, null, null,
+            null, "0x111111"),
+            100, null, false));
+    Assert.assertEquals("invalid hash value", shortHashEx.getMessage());
+
+    JsonRpcInvalidParamsException oversizedHashEx = Assert.assertThrows(
+        JsonRpcInvalidParamsException.class,
+        () -> new LogFilterWrapper(new FilterRequest(null, null, null,
+            null,
+            "0x" + new String(new char[1000]).replace('\0', 'a')),
+            100, null, false));
+    Assert.assertEquals("invalid hash value", oversizedHashEx.getMessage());
+
+    JsonRpcInvalidParamsException validHashEx = Assert.assertThrows(
+        JsonRpcInvalidParamsException.class,
+        () -> new LogFilterWrapper(new FilterRequest(null, null, null,
+            null,
+            "0x" + new String(new char[64]).replace('\0', 'a')),
+            100, null, false));
+    Assert.assertEquals("invalid blockHash", validHashEx.getMessage());
 
     // reset
     Args.getInstance().setJsonRpcMaxBlockRange(oldMaxBlockRange);

--- a/framework/src/test/java/org/tron/core/services/http/GetAccountServletTest.java
+++ b/framework/src/test/java/org/tron/core/services/http/GetAccountServletTest.java
@@ -14,6 +14,7 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.tron.common.crypto.ECKey;
 import org.tron.common.utils.ByteArray;
+import org.tron.common.utils.StringUtil;
 import org.tron.protos.Protocol.Account;
 
 public class GetAccountServletTest extends BaseHttpTest {
@@ -51,6 +52,37 @@ public class GetAccountServletTest extends BaseHttpTest {
 
     MockHttpServletResponse response = newResponse();
     servlet.doGet(request, response);
+    assertEquals(200, response.getStatus());
+    verify(wallet).getAccount(argThat(req -> req != null && req.getAddress().equals(addr)));
+    String content = response.getContentAsString();
+    assertFalse("Should not contain error", content.contains("\"Error\""));
+    assertTrue("Should contain address", content.contains("address"));
+  }
+
+  @Test
+  public void testGetAccountPostOversizedBase58Address() throws Exception {
+    String oversized = addrStr + "0";
+    String jsonParam = "{\"address\": \"" + oversized + "\", \"visible\": true}";
+    MockHttpServletRequest request = postRequest(jsonParam);
+    MockHttpServletResponse response = newResponse();
+    servlet.doPost(request, response);
+    String content = response.getContentAsString();
+    // null from decodeFromBase58Check now surfaces a clear "invalid address" error instead of a
+    // bare NullPointerException (JsonFormat checks for null before ByteString.copyFrom).
+    assertTrue("oversized address should surface a clear invalid-address error: " + content,
+        content.contains("invalid address"));
+  }
+
+  @Test
+  public void testGetAccountPostVisibleBase58Address() throws Exception {
+    // visible=true happy path: a valid 34-char Base58 address decodes back to the same 21 bytes
+    // (decodeFromBase58Check success path) and returns the account with no error.
+    String base58Addr = StringUtil.encode58Check(address);
+    String jsonParam = "{\"address\": \"" + base58Addr + "\", \"visible\": true}";
+    MockHttpServletRequest request = postRequest(jsonParam);
+
+    MockHttpServletResponse response = newResponse();
+    servlet.doPost(request, response);
     assertEquals(200, response.getStatus());
     verify(wallet).getAccount(argThat(req -> req != null && req.getAddress().equals(addr)));
     String content = response.getContentAsString();

--- a/framework/src/test/java/org/tron/core/services/http/GetRewardServletTest.java
+++ b/framework/src/test/java/org/tron/core/services/http/GetRewardServletTest.java
@@ -130,4 +130,35 @@ public class GetRewardServletTest extends BaseTest {
     }
   }
 
+  @Test
+  public void getRewardByOversizedValidCharAddressTest() {
+    // 41-char, all-valid-Base58 address: the length guard returns null -> reward 0.
+    MockHttpServletRequest request = createRequest("application/x-www-form-urlencoded");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    request.addParameter("address", "T" + new String(new char[40]).replace('\0', 'a'));
+    new GetRewardServlet().doPost(request, response);
+    try {
+      JSONObject result = JSONObject.parseObject(response.getContentAsString());
+      Assert.assertEquals(0, (int) result.get("reward"));
+      Assert.assertNull(result.get("Error"));
+    } catch (UnsupportedEncodingException e) {
+      Assert.fail(e.getMessage());
+    }
+  }
+
+  @Test
+  public void getRewardByOversizedIllegalCharAddressTest() {
+    MockHttpServletRequest request = createRequest("application/x-www-form-urlencoded");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    request.addParameter("address", "T" + new String(new char[40]).replace('\0', '0'));
+    new GetRewardServlet().doPost(request, response);
+    try {
+      JSONObject result = JSONObject.parseObject(response.getContentAsString());
+      Assert.assertEquals(0, (int) result.get("reward"));
+      Assert.assertNull(result.get("Error"));
+    } catch (UnsupportedEncodingException e) {
+      Assert.fail(e.getMessage());
+    }
+  }
+
 }

--- a/framework/src/test/java/org/tron/core/services/jsonrpc/BuildArgumentsTest.java
+++ b/framework/src/test/java/org/tron/core/services/jsonrpc/BuildArgumentsTest.java
@@ -70,6 +70,16 @@ public class BuildArgumentsTest extends BaseTest {
   }
 
   @Test
+  public void parseValueRejectsNegative() {
+    // QUANTITY is unsigned; a signed "0x-.." value must be rejected, not returned as negative.
+    BuildArguments args = new BuildArguments();
+    args.setValue("0x-1");
+    JsonRpcInvalidParamsException e = Assert.assertThrows(JsonRpcInvalidParamsException.class,
+        () -> args.parseValue());
+    Assert.assertEquals("invalid param value: negative", e.getMessage());
+  }
+
+  @Test
   public void resolveData_inputOnly_returnsInput() throws JsonRpcInvalidParamsException {
     BuildArguments args = new BuildArguments();
     args.setInput("0xdeadbeef");

--- a/framework/src/test/java/org/tron/core/services/jsonrpc/JsonRpcApiUtilTest.java
+++ b/framework/src/test/java/org/tron/core/services/jsonrpc/JsonRpcApiUtilTest.java
@@ -98,4 +98,18 @@ public class JsonRpcApiUtilTest {
         () -> JsonRpcApiUtil.addressCompatibleToByteArray(null));
     assertEquals("invalid address hash value", e.getMessage());
   }
+
+  @Test
+  public void hashToByteArrayAcceptsValidHex() throws JsonRpcInvalidParamsException {
+    String hash = "0x" + new String(new char[64]).replace('\0', 'a');
+    assertEquals(32, JsonRpcApiUtil.hashToByteArray(hash).length);
+  }
+
+  @Test
+  public void hashToByteArrayRejectsNonHexChars() {
+    String hash = "0x" + new String(new char[64]).replace('\0', 'g');
+    JsonRpcInvalidParamsException e = assertThrows(JsonRpcInvalidParamsException.class,
+        () -> JsonRpcApiUtil.hashToByteArray(hash));
+    assertEquals("invalid hash value", e.getMessage());
+  }
 }

--- a/framework/src/test/java/org/tron/core/services/jsonrpc/JsonRpcApiUtilTest.java
+++ b/framework/src/test/java/org/tron/core/services/jsonrpc/JsonRpcApiUtilTest.java
@@ -49,8 +49,8 @@ public class JsonRpcApiUtilTest {
 
   @Test
   public void parseBlockNumberRejectsOversized() {
-    // 101 chars exceeds the 100-char limit
-    String tooLong = "0x" + new String(new char[99]).replace('\0', 'a');
+    // 21 chars exceeds the 20-char limit
+    String tooLong = "0x" + new String(new char[18]).replace('\0', '0') + "1";
     JsonRpcInvalidParamsException e = assertThrows(JsonRpcInvalidParamsException.class,
         () -> JsonRpcApiUtil.parseBlockNumber(tooLong));
     assertEquals("invalid block number", e.getMessage());
@@ -74,5 +74,28 @@ public class JsonRpcApiUtilTest {
   public void parseBlockNumberRejectsEmpty() {
     assertThrows(JsonRpcInvalidParamsException.class,
         () -> JsonRpcApiUtil.parseBlockNumber(""));
+  }
+
+  @Test
+  public void addressCompatibleToByteArrayNormal()
+      throws JsonRpcInvalidParamsException {
+    String addr = "0xabd4b9367799eaa3197fecb144eb71de1e049abc";
+    assertEquals(21, JsonRpcApiUtil.addressCompatibleToByteArray(addr).length);
+  }
+
+  @Test
+  public void addressCompatibleToByteArrayRejectsOversized() {
+    // 45 chars
+    String justOver = "0x" + new String(new char[43]).replace('\0', 'a');
+    JsonRpcInvalidParamsException e1 = assertThrows(JsonRpcInvalidParamsException.class,
+        () -> JsonRpcApiUtil.addressCompatibleToByteArray(justOver));
+    assertEquals("invalid address hash value", e1.getMessage());
+  }
+
+  @Test
+  public void addressCompatibleToByteArrayRejectsNull() {
+    JsonRpcInvalidParamsException e = assertThrows(JsonRpcInvalidParamsException.class,
+        () -> JsonRpcApiUtil.addressCompatibleToByteArray(null));
+    assertEquals("invalid address hash value", e.getMessage());
   }
 }

--- a/framework/src/test/java/org/tron/core/services/jsonrpc/JsonRpcApiUtilTest.java
+++ b/framework/src/test/java/org/tron/core/services/jsonrpc/JsonRpcApiUtilTest.java
@@ -89,14 +89,14 @@ public class JsonRpcApiUtilTest {
     String justOver = "0x" + new String(new char[43]).replace('\0', 'a');
     JsonRpcInvalidParamsException e1 = assertThrows(JsonRpcInvalidParamsException.class,
         () -> JsonRpcApiUtil.addressCompatibleToByteArray(justOver));
-    assertEquals("invalid address hash value", e1.getMessage());
+    assertEquals("invalid address", e1.getMessage());
   }
 
   @Test
   public void addressCompatibleToByteArrayRejectsNull() {
     JsonRpcInvalidParamsException e = assertThrows(JsonRpcInvalidParamsException.class,
         () -> JsonRpcApiUtil.addressCompatibleToByteArray(null));
-    assertEquals("invalid address hash value", e.getMessage());
+    assertEquals("invalid address", e.getMessage());
   }
 
   @Test
@@ -111,5 +111,74 @@ public class JsonRpcApiUtilTest {
     JsonRpcInvalidParamsException e = assertThrows(JsonRpcInvalidParamsException.class,
         () -> JsonRpcApiUtil.hashToByteArray(hash));
     assertEquals("invalid hash value", e.getMessage());
+  }
+
+  @Test
+  public void parseTxIndexAcceptsHex() throws JsonRpcInvalidParamsException {
+    assertEquals(0x1a, JsonRpcApiUtil.parseTxIndex("0x1a"));
+    assertEquals(0, JsonRpcApiUtil.parseTxIndex("0x0"));
+    // 8 hex digits is the max width; 0x7fffffff is Integer.MAX_VALUE
+    assertEquals(Integer.MAX_VALUE, JsonRpcApiUtil.parseTxIndex("0x7fffffff"));
+  }
+
+  @Test
+  public void parseTxIndexRejectsMissingPrefix() {
+    JsonRpcInvalidParamsException e = assertThrows(JsonRpcInvalidParamsException.class,
+        () -> JsonRpcApiUtil.parseTxIndex("1a"));
+    assertEquals("invalid index value", e.getMessage());
+  }
+
+  @Test
+  public void parseTxIndexAcceptsLeadingZeros() throws JsonRpcInvalidParamsException {
+    // leading zeros are tolerated (only length is capped); "0x01"/"0x00" parse normally
+    assertEquals(1, JsonRpcApiUtil.parseTxIndex("0x01"));
+    assertEquals(0, JsonRpcApiUtil.parseTxIndex("0x00"));
+  }
+
+  @Test
+  public void parseTxIndexRejectsOversized() {
+    // 9 hex digits exceeds the 8-digit (0x + 8) limit -> rejected before parsing
+    String tooLong = "0x" + new String(new char[9]).replace('\0', '1');
+    JsonRpcInvalidParamsException e = assertThrows(JsonRpcInvalidParamsException.class,
+        () -> JsonRpcApiUtil.parseTxIndex(tooLong));
+    assertEquals("invalid index value", e.getMessage());
+  }
+
+  @Test
+  public void parseTxIndexRejectsEmptyAndNull() {
+    JsonRpcInvalidParamsException e1 = assertThrows(JsonRpcInvalidParamsException.class,
+        () -> JsonRpcApiUtil.parseTxIndex("0x"));
+    assertEquals("invalid index value", e1.getMessage());
+    JsonRpcInvalidParamsException e2 = assertThrows(JsonRpcInvalidParamsException.class,
+        () -> JsonRpcApiUtil.parseTxIndex(null));
+    assertEquals("invalid index value", e2.getMessage());
+  }
+
+  @Test
+  public void parseTxIndexRejectsMalformedHex() {
+    JsonRpcInvalidParamsException e = assertThrows(JsonRpcInvalidParamsException.class,
+        () -> JsonRpcApiUtil.parseTxIndex("0xGG"));
+    assertEquals("invalid index value", e.getMessage());
+  }
+
+  @Test
+  public void parseTxIndexParsesNegativeForCallerRangeCheck() throws JsonRpcInvalidParamsException {
+    // "0x-1" is syntactically accepted and parsed to a negative int; the RPC handler maps
+    // any out-of-range index (negative or >= tx count) to a null result.
+    assertEquals(-1, JsonRpcApiUtil.parseTxIndex("0x-1"));
+  }
+
+  @Test
+  public void calcFeeLimitNormal() throws JsonRpcInvalidParamsException {
+    assertEquals(8400L, JsonRpcApiUtil.calcFeeLimit(20L, 420L));
+    assertEquals(0L, JsonRpcApiUtil.calcFeeLimit(0L, 420L));
+  }
+
+  @Test
+  public void calcFeeLimitRejectsOverflow() {
+    // gas * energyFee overflows int64 -> rejected instead of silently wrapping to a bogus feeLimit
+    JsonRpcInvalidParamsException e = assertThrows(JsonRpcInvalidParamsException.class,
+        () -> JsonRpcApiUtil.calcFeeLimit(Long.MAX_VALUE, 420L));
+    assertEquals("invalid gas: fee limit overflow", e.getMessage());
   }
 }

--- a/framework/src/test/java/org/tron/core/services/jsonrpc/JsonRpcApiUtilTest.java
+++ b/framework/src/test/java/org/tron/core/services/jsonrpc/JsonRpcApiUtilTest.java
@@ -114,6 +114,41 @@ public class JsonRpcApiUtilTest {
   }
 
   @Test
+  public void topicToByteArrayAcceptsFullLengthHex() throws JsonRpcInvalidParamsException {
+    String topic = "0x" + new String(new char[64]).replace('\0', 'a');
+    assertEquals(32, JsonRpcApiUtil.topicToByteArray(topic).length);
+  }
+
+  @Test
+  public void topicToByteArrayPadsMissingLeadingZero() throws JsonRpcInvalidParamsException {
+    String stripped = "0x" + new String(new char[63]).replace('\0', 'a');
+    byte[] parsed = JsonRpcApiUtil.topicToByteArray(stripped);
+    assertEquals(32, parsed.length);
+    assertEquals(0x0a, parsed[0]);
+  }
+
+  @Test
+  public void topicToByteArrayRejectsNonHexChars() {
+    String topic = "0x" + new String(new char[64]).replace('\0', 'g');
+    JsonRpcInvalidParamsException e = assertThrows(JsonRpcInvalidParamsException.class,
+        () -> JsonRpcApiUtil.topicToByteArray(topic));
+    assertEquals("invalid topic: " + topic, e.getMessage());
+  }
+
+  @Test
+  public void topicToByteArrayRejectsWrongLength() {
+    // 62 chars (two zeros stripped) and 65 chars are both invalid
+    String tooShort = "0x" + new String(new char[62]).replace('\0', 'a');
+    assertThrows(JsonRpcInvalidParamsException.class,
+        () -> JsonRpcApiUtil.topicToByteArray(tooShort));
+    String tooLong = "0x" + new String(new char[65]).replace('\0', 'a');
+    assertThrows(JsonRpcInvalidParamsException.class,
+        () -> JsonRpcApiUtil.topicToByteArray(tooLong));
+    assertThrows(JsonRpcInvalidParamsException.class,
+        () -> JsonRpcApiUtil.topicToByteArray(null));
+  }
+
+  @Test
   public void parseTxIndexAcceptsHex() throws JsonRpcInvalidParamsException {
     assertEquals(0x1a, JsonRpcApiUtil.parseTxIndex("0x1a"));
     assertEquals(0, JsonRpcApiUtil.parseTxIndex("0x0"));


### PR DESCRIPTION
**What does this PR do?**

Adds length/format validation to several JSON-RPC and HTTP parameter paths, so malformed,
oversized, or overflowing input is rejected early — a clear `-32602` (or a `null` result for an
out-of-range index) — instead of triggering `O(n²)` work, leaking a `NullPointerException` /
`DecoderException` / Internal error, or silently producing a wrong value. Valid input is unaffected.

1. **`Commons.decodeFromBase58Check`** — reject input whose length `!= 34` before the `O(n²)` `Base58.decode`; single funnel for every HTTP address input.
2. **`JsonFormat.unescapeBytesSelfType`** — an invalid Base58 address (null / illegal char) now returns a clear `invalid address` error instead of a bare `ByteString.copyFrom(null)` NPE; covers all merge-path address fields.
3. **`JsonRpcApiUtil.addressCompatibleToByteArray`** — cap length at `ADDRESS_SIZE + 2` (the `+2` keeps `0x`-prefixed 21-byte addresses valid) before `fromHexString`.
4. **`JsonRpcApiUtil.parseBlockNumber`** — tighten `MAX_BLOCK_NUM_HEX_LEN` 100 → 20, and route the `(String, Wallet)` overload through the single-arg parser so it also gets the length cap checks.
5. **`TronJsonRpcImpl.getStorageAt`** — bound the storage key and parse it before the contract lookup; a `>32`-byte key now returns `-32602 invalid storage key value` instead of `-32001 (json4j default error)`.
6. **`LogFilterWrapper`** — validate `blockHash` via the shared `JsonRpcApiUtil.hashToByteArray` (moved here from `TronJsonRpcImpl`).
7. **`HASH_REGEX`** accepts only hex digits `[0-9a-fA-F]`, so a non-hex hash is rejected as `invalid hash value` rather than slipping through to `fromHexString`.
8. **`JsonRpcApiUtil.parseTxIndex`** — length-capped 0x-hex parse for the tx index; a malformed / oversized / int-overflow index returns `-32602`, and a **negative or out-of-range** index returns a `null` result instead of letting `block.getTransactions(-1)` throw `IndexOutOfBoundsException` (Internal error).
9. **`TronJsonRpcImpl.buildCreateSmartContractTransaction`** — a deeply nested ABI overflows the recursive `JsonFormat` parser; the `StackOverflowError` is caught narrowly around the merge and mapped to `-32602 invalid abi` instead of an `Error` escaping as an Internal error.
10. **`JsonRpcApiUtil.calcFeeLimit`** — compute `feeLimit = gas * energyFee` via `StrictMathWrapper.multiplyExact`, so an oversized `gas` returns `-32602` instead of silently wrapping to a bogus (possibly negative) `feeLimit`.
11. **`JsonRpcApiUtil.parseQuantityValue`** — reject a signed (`0x-..`) `value` / `gas`; `QUANTITY` is unsigned, so a negative parse is `-32602` rather than a negative `callValue` / `feeLimit` reaching the actuator.
12. **`LogFilter` topics** — `topicToByteArray` now validates topics via `TOPIC_REGEX` (`^(0x)?[0-9a-fA-F]{63,64}$`); an invalid-hex / wrong-length / non-string topic returns `-32602` instead of a leaked `DecoderException` / `ClassCastException`, while keeping the odd-length (63-char) leading-`0` compatibility.
13. **`JsonRpcApiUtil.addressToByteArray`** (log-filter address) — cap length before `fromHexString` and wrap the decode, so an oversized or invalid-hex address filter returns `-32602` instead of `O(n)` work or a leaked `DecoderException`;a nested non-string address element (e.g. `{"address":[1]}`) is likewise rejected as `-32602` before the `(String)` cast; the 20-byte output and strict (no `41` prefix) semantics are unchanged.
14. **`getBlockReceipts` + `parseBlockNumber(String, Wallet)`** — a `null` block param dereferenced before validation (`Pattern.matches(HASH_REGEX, null)` / `null.startsWith("0x")`) NPE'd as an Internal error; it now returns `-32602`.

**Why are these changes required?**

Several **unauthenticated** API entry points accepted unbounded / malformed input, causing two classes of problem:

- **Algorithmic-complexity DoS** — `decodeFromBase58Check` fed the whole string into the `O(n²)`
  `Base58.decode`; since the cost grows quadratically with length, a single oversized address
  payload (well within the 4 MB body cap) can tie up a request thread far out of proportion to
  its size — a cheap DoS the body cap and rate limiter don't stop. Block-number parsing likewise
  had no effective length bound before the `O(n²)` `BigInteger` constructor.
- **Leaked exceptions / unfriendly errors** — an invalid address on the merge path returned a
  bare `NullPointerException`; `eth_getStorageAt` surfaced a `RuntimeException` as
  `-32001 Data word can't exceed 32 bytes: xxx`; a negative tx index hit `getTransactions(-1)`
  (`IndexOutOfBoundsException`); a malformed log topic / address leaked a `DecoderException`; a
  deeply nested ABI exhausted the recursive `JsonFormat` parser's stack (`StackOverflowError`); a
  `null` block param NPE'd on `Pattern.matches` / `startsWith` — all escaping as Internal errors
  instead of `-32602 invalid params`.

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

Representative affected endpoints, by guarded parameter (each parameter is a single guarded
funnel, so the lists below are examples, not exhaustive):
- **JSON-RPC**
  - **block number / tag** (length 100 → 20): `eth_getBlockByNumber`,`getBlockReceipts`, …
  - **block hash** (`hashToByteArray`): `eth_getBlockByHash`, `eth_getTransactionByBlockHashAndIndex`, …
  - **tx hash** (`hashToByteArray`): `eth_getTransactionByHash`, `eth_getTransactionReceipt`
  - **storage index** (parsed as a 32-byte word): `eth_getStorageAt`
  - **address** (length capped at `ADDRESS_SIZE + 2`): `eth_call`, `eth_getBalance` …
  - **tx index** (length-capped; negative / out-of-range → `null`): `eth_getTransactionByBlockHashAndIndex`, `eth_getTransactionByBlockNumberAndIndex`
  - **log topic / log address** (strict `hashToByteArray` / length-capped `addressToByteArray`): `eth_getLogs`, `eth_newFilter`
  - **gas / value / abi** (overflow-checked feeLimit, unsigned quantity, ABI-depth guard): `buildTransaction`
  - **block param null** (`null` → `-32602`): `eth_getBlockReceipts`
- **HTTP `/wallet/*`** — all covered by the Base58 length/DoS guard, but they differ on an invalid address:
  - most endpoints pre-convert via `Util.getHexAddress` and just return `{}` (e.g. `getcontract`) — unchanged;
  - endpoints that merge a Base58 field directly (e.g. `getaccount`, `visible=true`) get the NPE → `invalid address` fix;
  - endpoints that resolve the address via `Util.getAddress(request)` (e.g. `getReward`) get null for an invalid address and degrade to `reward 0`.