### PR TITLE
feat(vm): close shielded TRC20 progressively

### DIFF
--- a/actuator/src/main/java/org/tron/core/actuator/VMActuator.java
+++ b/actuator/src/main/java/org/tron/core/actuator/VMActuator.java
@@ -6,6 +6,9 @@ import static org.tron.common.math.Maths.addExact;
 import static org.tron.common.math.Maths.floorDiv;
 import static org.tron.common.math.Maths.max;
 import static org.tron.common.math.Maths.min;
+import static org.tron.core.vm.PrecompiledContracts.BURN_NOT_ALLOWED;
+import static org.tron.core.vm.PrecompiledContracts.MINT_NOT_ALLOWED;
+import static org.tron.core.vm.PrecompiledContracts.TRANSFER_NOT_ALLOWED;
 import static org.tron.protos.contract.Common.ResourceCode.ENERGY;
 
 import com.google.protobuf.ByteString;
@@ -231,7 +234,12 @@ public class VMActuator implements Actuator2 {
           return;
         }
 
-        if (result.getException() != null || result.isRevert()) {
+        String errorString = result.getRuntimeError();
+        boolean shieldedProofNotAllowed = MINT_NOT_ALLOWED.equals(errorString)
+            || TRANSFER_NOT_ALLOWED.equals(errorString)
+            || BURN_NOT_ALLOWED.equals(errorString);
+
+        if (result.getException() != null || result.isRevert() || shieldedProofNotAllowed) {
           result.getDeleteAccounts().clear();
           result.getLogInfoList().clear();
           //result.resetFutureRefund();
@@ -243,6 +251,9 @@ public class VMActuator implements Actuator2 {
             }
             result.setRuntimeError(result.getException().getMessage());
             throw result.getException();
+          } else if (shieldedProofNotAllowed) {
+            // Runtime error already set by the precompile; just mark the revert (no energy burn).
+            result.setRevert();
           } else {
             result.setRuntimeError("REVERT opcode executed");
           }
@@ -254,7 +265,6 @@ public class VMActuator implements Actuator2 {
                 .parseLogInfos(program.getResult().getLogInfoList(), rootRepository);
             program.getResult().setTriggerList(triggers);
           }
-
         }
       } else {
         rootRepository.commit();

--- a/actuator/src/main/java/org/tron/core/utils/ProposalUtil.java
+++ b/actuator/src/main/java/org/tron/core/utils/ProposalUtil.java
@@ -13,6 +13,7 @@ import org.tron.core.config.Parameter.ForkBlockVersionConsts;
 import org.tron.core.config.Parameter.ForkBlockVersionEnum;
 import org.tron.core.exception.ContractValidateException;
 import org.tron.core.store.DynamicPropertiesStore;
+import org.tron.core.vm.PrecompiledContracts;
 
 public class ProposalUtil {
 
@@ -941,6 +942,17 @@ public class ProposalUtil {
         }
         break;
       }
+      case CLOSE_SHIELDED_TRC20_TRANSACTION: {
+        if (!forkController.pass(ForkBlockVersionEnum.VERSION_4_8_2)) {
+          throw new ContractValidateException(
+              "Bad chain parameter id [CLOSE_SHIELDED_TRC20_TRANSACTION]");
+        }
+        if (value < 0 || value > 3) {
+          throw new ContractValidateException(
+              "This value[CLOSE_SHIELDED_TRC20_TRANSACTION] is only allowed to be in the range 0-3");
+        }
+        break;
+      }
       default:
         break;
     }
@@ -1018,6 +1030,7 @@ public class ProposalUtil {
     ALLOW_CANCEL_ALL_UNFREEZE_V2(77), // 0, 1
     MAX_DELEGATE_LOCK_PERIOD(78), // (86400, 10512000]
     ALLOW_OLD_REWARD_OPT(79), // 0, 1
+    CLOSE_SHIELDED_TRC20_TRANSACTION(80), // 0, {0,1,2,3}
     ALLOW_ENERGY_ADJUSTMENT(81), // 0, 1
     MAX_CREATE_ACCOUNT_TX_SIZE(82), // [500, 10000]
     ALLOW_TVM_CANCUN(83), // 0, 1

--- a/actuator/src/main/java/org/tron/core/vm/PrecompiledContracts.java
+++ b/actuator/src/main/java/org/tron/core/vm/PrecompiledContracts.java
@@ -212,6 +212,15 @@ public class PrecompiledContracts {
   private static final DataWord p256VerifyAddr = new DataWord(
       "0000000000000000000000000000000000000000000000000000000000000100");
 
+  public static final String MINT_NOT_ALLOWED = "shield trc20 mint not allowed";
+  public static final String TRANSFER_NOT_ALLOWED = "shield trc20 transfer not allowed";
+  public static final String BURN_NOT_ALLOWED = "shield trc20 burn not allowed";
+
+  // Staged values of closeShieldedTRC20Transaction(): operation (mint < transfer < burn);
+  public static final long CLOSE_SHIELDED_TRC20_MINT = 1;
+  public static final long CLOSE_SHIELDED_TRC20_TRANSFER = 2;
+  public static final long CLOSE_SHIELDED_TRC20_BURN = 3;
+
   public static PrecompiledContract getOptimizedContractForConstant(PrecompiledContract contract) {
     try {
       Constructor<?> constructor = contract.getClass().getDeclaredConstructor();
@@ -1385,6 +1394,12 @@ public class PrecompiledContracts {
 
     @Override
     public Pair<Boolean, byte[]> execute(byte[] data) {
+      // Mint closed (CLOSE_SHIELDED_TRC20_TRANSACTION level >= 1). Return success (the Boolean
+      // is the CALL success flag) so the caller's unused energy is refunded -- failing here
+      // would "spend all energy". Zero payload + a REVERT (set via runtimeError) still revert.
+      if (VMConfig.closeShieldedTRC20Transaction() >= CLOSE_SHIELDED_TRC20_MINT) {
+        return Pair.of(true, DataWord.ZERO().getData());
+      }
       if (data == null) {
         return Pair.of(true, DataWord.ZERO().getData());
       }
@@ -1463,6 +1478,12 @@ public class PrecompiledContracts {
 
     @Override
     public Pair<Boolean, byte[]> execute(byte[] data) {
+      // Transfer closed (CLOSE_SHIELDED_TRC20_TRANSACTION level >= 2). Return success (the Boolean
+      // is the CALL success flag) so the caller's unused energy is refunded -- failing here
+      // would "spend all energy". Zero payload + a REVERT (set via runtimeError) still revert.
+      if (VMConfig.closeShieldedTRC20Transaction() >= CLOSE_SHIELDED_TRC20_TRANSFER) {
+        return Pair.of(true, DataWord.ZERO().getData());
+      }
       if (data == null) {
         return Pair.of(true, DataWord.ZERO().getData());
       }
@@ -1740,6 +1761,12 @@ public class PrecompiledContracts {
 
     @Override
     public Pair<Boolean, byte[]> execute(byte[] data) {
+      // Burn closed (CLOSE_SHIELDED_TRC20_TRANSACTION level >= 3). Return success (the Boolean
+      // is the CALL success flag) so the caller's unused energy is refunded -- failing here
+      // would "spend all energy". Zero payload + a REVERT (set via runtimeError) still revert.
+      if (VMConfig.closeShieldedTRC20Transaction() >= CLOSE_SHIELDED_TRC20_BURN) {
+        return Pair.of(true, DataWord.ZERO().getData());
+      }
       if (data == null) {
         return Pair.of(true, DataWord.ZERO().getData());
       }

--- a/actuator/src/main/java/org/tron/core/vm/config/ConfigLoader.java
+++ b/actuator/src/main/java/org/tron/core/vm/config/ConfigLoader.java
@@ -24,6 +24,7 @@ public class ConfigLoader {
         VMConfig.initAllowTvmConstantinople(ds.getAllowTvmConstantinople());
         VMConfig.initAllowTvmSolidity059(ds.getAllowTvmSolidity059());
         VMConfig.initAllowShieldedTRC20Transaction(ds.getAllowShieldedTRC20Transaction());
+        VMConfig.initCloseShieldedTRC20Transaction(ds.getCloseShieldedTRC20Transaction());
         VMConfig.initAllowTvmIstanbul(ds.getAllowTvmIstanbul());
         VMConfig.initAllowTvmFreeze(ds.getAllowTvmFreeze());
         VMConfig.initAllowTvmVote(ds.getAllowTvmVote());

--- a/actuator/src/main/java/org/tron/core/vm/program/Program.java
+++ b/actuator/src/main/java/org/tron/core/vm/program/Program.java
@@ -1743,6 +1743,8 @@ public class Program {
         this.refundEnergy(msg.getEnergy().longValue() - requiredEnergy, CALL_PRE_COMPILED);
         this.stackPushOne();
         returnDataBuffer = out.getRight();
+
+        markClosedShieldedTRC20Precompile(contract);
         deposit.commit();
       } else {
         // spend all energy on failure, push zero and revert state changes
@@ -1758,6 +1760,29 @@ public class Program {
       } else {
         this.memorySave(msg.getOutDataOffs().intValue(), out.getRight());
       }
+    }
+  }
+
+  // When the shielded TRC20 kill-switch is engaged, the proof precompile returns success so the
+  // caller's unused energy is refunded (see PrecompiledContracts); we only flag the closed
+  // operation here via a runtime error, which VMActuator later turns into a REVERT.
+  private void markClosedShieldedTRC20Precompile(
+      PrecompiledContracts.PrecompiledContract contract) {
+    long phase = VMConfig.closeShieldedTRC20Transaction();
+    if (phase == 0) {
+      return;
+    }
+    if (contract instanceof PrecompiledContracts.VerifyMintProof
+        && phase >= PrecompiledContracts.CLOSE_SHIELDED_TRC20_MINT) {
+      this.result.setRuntimeError(PrecompiledContracts.MINT_NOT_ALLOWED);
+    }
+    if (contract instanceof PrecompiledContracts.VerifyTransferProof
+        && phase >= PrecompiledContracts.CLOSE_SHIELDED_TRC20_TRANSFER) {
+      this.result.setRuntimeError(PrecompiledContracts.TRANSFER_NOT_ALLOWED);
+    }
+    if (contract instanceof PrecompiledContracts.VerifyBurnProof
+        && phase >= PrecompiledContracts.CLOSE_SHIELDED_TRC20_BURN) {
+      this.result.setRuntimeError(PrecompiledContracts.BURN_NOT_ALLOWED);
     }
   }
 

--- a/chainbase/src/main/java/org/tron/core/store/DynamicPropertiesStore.java
+++ b/chainbase/src/main/java/org/tron/core/store/DynamicPropertiesStore.java
@@ -139,6 +139,8 @@ public class DynamicPropertiesStore extends TronStoreWithRevoking<BytesCapsule> 
   private static final byte[] ALLOW_SHIELDED_TRC20_TRANSACTION =
       "ALLOW_SHIELDED_TRC20_TRANSACTION"
           .getBytes();
+  private static final byte[] CLOSE_SHIELDED_TRC20_TRANSACTION =
+      "CLOSE_SHIELDED_TRC20_TRANSACTION".getBytes();
   private static final byte[] ALLOW_TVM_ISTANBUL = "ALLOW_TVM_ISTANBUL".getBytes();
   private static final byte[] ALLOW_TVM_CONSTANTINOPLE = "ALLOW_TVM_CONSTANTINOPLE".getBytes();
   private static final byte[] ALLOW_TVM_SOLIDITY_059 = "ALLOW_TVM_SOLIDITY_059".getBytes();
@@ -725,6 +727,13 @@ public class DynamicPropertiesStore extends TronStoreWithRevoking<BytesCapsule> 
     } catch (IllegalArgumentException e) {
       this.saveAllowShieldedTRC20Transaction(
           CommonParameter.getInstance().getAllowShieldedTRC20Transaction());
+    }
+
+    try {
+      this.getCloseShieldedTRC20Transaction();
+    } catch (IllegalArgumentException e) {
+      this.saveCloseShieldedTRC20Transaction(
+          CommonParameter.getInstance().getCloseShieldedTRC20Transaction());
     }
 
     try {
@@ -2054,6 +2063,20 @@ public class DynamicPropertiesStore extends TronStoreWithRevoking<BytesCapsule> 
   public long getAllowShieldedTRC20Transaction() {
     String msg = "not found ALLOW_SHIELDED_TRC20_TRANSACTION";
     return Optional.ofNullable(getUnchecked(ALLOW_SHIELDED_TRC20_TRANSACTION))
+        .map(BytesCapsule::getData)
+        .map(ByteArray::toLong)
+        .orElseThrow(
+            () -> new IllegalArgumentException(msg));
+  }
+
+  public void saveCloseShieldedTRC20Transaction(long closeShieldedTRC20Transaction) {
+    this.put(DynamicPropertiesStore.CLOSE_SHIELDED_TRC20_TRANSACTION,
+        new BytesCapsule(ByteArray.fromLong(closeShieldedTRC20Transaction)));
+  }
+
+  public long getCloseShieldedTRC20Transaction() {
+    String msg = "not found CLOSE_SHIELDED_TRC20_TRANSACTION";
+    return Optional.ofNullable(getUnchecked(CLOSE_SHIELDED_TRC20_TRANSACTION))
         .map(BytesCapsule::getData)
         .map(ByteArray::toLong)
         .orElseThrow(

--- a/common/src/main/java/org/tron/common/parameter/CommonParameter.java
+++ b/common/src/main/java/org/tron/common/parameter/CommonParameter.java
@@ -531,6 +531,9 @@ public class CommonParameter {
   public long allowShieldedTRC20Transaction;
   @Getter
   @Setter
+  public long closeShieldedTRC20Transaction;
+  @Getter
+  @Setter
   public long allowTvmIstanbul;
   @Getter
   @Setter

--- a/common/src/main/java/org/tron/core/config/args/CommitteeConfig.java
+++ b/common/src/main/java/org/tron/core/config/args/CommitteeConfig.java
@@ -28,6 +28,7 @@ public class CommitteeConfig {
   private long allowTvmSolidity059 = 0;
   private long forbidTransferToContract = 0;
   private long allowShieldedTRC20Transaction = 0;
+  private long closeShieldedTRC20Transaction = 0;
   private long allowMarketTransaction = 0;
   private long allowTransactionFeePool = 0;
   private long allowBlackHoleOptimization = 0;

--- a/common/src/main/java/org/tron/core/vm/config/VMConfig.java
+++ b/common/src/main/java/org/tron/core/vm/config/VMConfig.java
@@ -23,6 +23,8 @@ public class VMConfig {
 
   private static boolean ALLOW_SHIELDED_TRC20_TRANSACTION = false;
 
+  private static long CLOSE_SHIELDED_TRC20_TRANSACTION = 0;
+
   private static boolean ALLOW_TVM_ISTANBUL = false;
 
   private static boolean ALLOW_TVM_FREEZE = false;
@@ -98,6 +100,10 @@ public class VMConfig {
 
   public static void initAllowShieldedTRC20Transaction(long allow) {
     ALLOW_SHIELDED_TRC20_TRANSACTION = allow == 1;
+  }
+
+  public static void initCloseShieldedTRC20Transaction(long close) {
+    CLOSE_SHIELDED_TRC20_TRANSACTION = close;
   }
 
   public static void initAllowTvmIstanbul(long allow) {
@@ -206,6 +212,10 @@ public class VMConfig {
 
   public static boolean allowShieldedTRC20Transaction() {
     return ALLOW_SHIELDED_TRC20_TRANSACTION;
+  }
+
+  public static long closeShieldedTRC20Transaction() {
+    return CLOSE_SHIELDED_TRC20_TRANSACTION;
   }
 
   public static boolean allowTvmIstanbul() {

--- a/common/src/main/resources/reference.conf
+++ b/common/src/main/resources/reference.conf
@@ -830,6 +830,7 @@ committee = {
   allowTvmSolidity059 = 0             # getAllowTvmSolidity059, #32: enable Solidity 0.5.9 TVM rules
   forbidTransferToContract = 0        # getForbidTransferToContract, #35: forbid direct transfers to contracts
   allowShieldedTRC20Transaction = 0   # getAllowShieldedTRC20Transaction, #39: enable shielded TRC20 transfers
+  closeShieldedTRC20Transaction = 0   # getCloseShieldedTRC20Transaction, #80: progressively close shielded TRC20 mint(1)/transfer(2)/burn(3); range 0-3
   allowTvmIstanbul = 0                # getAllowTvmIstanbul, #41: enable Istanbul TVM rules
   allowMarketTransaction = 0          # getAllowMarketTransaction, #44: enable market transactions
   allowProtoFilterNum = 0             # getAllowProtoFilterNum, #24: enable protobuf field-number filtering

--- a/framework/src/main/java/org/tron/core/Wallet.java
+++ b/framework/src/main/java/org/tron/core/Wallet.java
@@ -1507,6 +1507,11 @@ public class Wallet {
         .setValue(dbManager.getDynamicPropertiesStore().getAllowHardenExchangeCalculation())
         .build());
 
+    builder.addChainParameter(Protocol.ChainParameters.ChainParameter.newBuilder()
+        .setKey("getCloseShieldedTRC20Transaction")
+        .setValue(dbManager.getDynamicPropertiesStore().getCloseShieldedTRC20Transaction())
+        .build());
+
     return builder.build();
   }
 

--- a/framework/src/main/java/org/tron/core/config/args/Args.java
+++ b/framework/src/main/java/org/tron/core/config/args/Args.java
@@ -453,6 +453,7 @@ public class Args extends CommonParameter {
     PARAMETER.allowTvmSolidity059 = cc.getAllowTvmSolidity059();
     PARAMETER.forbidTransferToContract = cc.getForbidTransferToContract();
     PARAMETER.allowShieldedTRC20Transaction = cc.getAllowShieldedTRC20Transaction();
+    PARAMETER.closeShieldedTRC20Transaction = cc.getCloseShieldedTRC20Transaction();
     PARAMETER.allowMarketTransaction = cc.getAllowMarketTransaction();
     PARAMETER.allowTransactionFeePool = cc.getAllowTransactionFeePool();
     PARAMETER.allowBlackHoleOptimization = cc.getAllowBlackHoleOptimization();

--- a/framework/src/main/java/org/tron/core/consensus/ProposalService.java
+++ b/framework/src/main/java/org/tron/core/consensus/ProposalService.java
@@ -360,6 +360,10 @@ public class ProposalService extends ProposalUtil {
           manager.getDynamicPropertiesStore().saveAllowOldRewardOpt(entry.getValue());
           break;
         }
+        case CLOSE_SHIELDED_TRC20_TRANSACTION: {
+          manager.getDynamicPropertiesStore().saveCloseShieldedTRC20Transaction(entry.getValue());
+          break;
+        }
         case ALLOW_ENERGY_ADJUSTMENT: {
           manager.getDynamicPropertiesStore().saveAllowEnergyAdjustment(entry.getValue());
           break;

--- a/framework/src/test/java/org/tron/common/runtime/vm/PrecompiledContractsTest.java
+++ b/framework/src/test/java/org/tron/common/runtime/vm/PrecompiledContractsTest.java
@@ -374,6 +374,44 @@ public class PrecompiledContractsTest extends BaseTest {
   }
 
   @Test
+  public void closeShieldedTRC20TransactionTest() {
+    // With the kill-switch engaged at the matching level, each shielded proof
+    // precompile short-circuits to (success, 32 zero bytes) as the very first step of
+    // execute(), before the null/size guards run. The input contents and length are
+    // therefore irrelevant here; these arrays are just non-null placeholders.
+    byte[] zero = DataWord.ZERO().getData();
+    PrecompiledContracts.VerifyMintProof mint = new PrecompiledContracts.VerifyMintProof();
+    PrecompiledContracts.VerifyTransferProof transfer =
+        new PrecompiledContracts.VerifyTransferProof();
+    PrecompiledContracts.VerifyBurnProof burn = new PrecompiledContracts.VerifyBurnProof();
+    byte[] mintData = new byte[1];
+    byte[] transferData = new byte[1];
+    byte[] burnData = new byte[1];
+    try {
+      // level 1 closes mint
+      VMConfig.initCloseShieldedTRC20Transaction(1);
+      Assert.assertEquals(1L, VMConfig.closeShieldedTRC20Transaction());
+      Pair<Boolean, byte[]> r = mint.execute(mintData);
+      Assert.assertTrue(r.getLeft());
+      Assert.assertArrayEquals(zero, r.getRight());
+
+      // level 2 also closes transfer
+      VMConfig.initCloseShieldedTRC20Transaction(2);
+      r = transfer.execute(transferData);
+      Assert.assertTrue(r.getLeft());
+      Assert.assertArrayEquals(zero, r.getRight());
+
+      // level 3 also closes burn
+      VMConfig.initCloseShieldedTRC20Transaction(3);
+      r = burn.execute(burnData);
+      Assert.assertTrue(r.getLeft());
+      Assert.assertArrayEquals(zero, r.getRight());
+    } finally {
+      VMConfig.initCloseShieldedTRC20Transaction(0);
+    }
+  }
+
+  @Test
   public void delegatableResourceTest() {
     VMConfig.initAllowTvmFreezeV2(1L);
 

--- a/framework/src/test/java/org/tron/core/actuator/utils/ProposalUtilTest.java
+++ b/framework/src/test/java/org/tron/core/actuator/utils/ProposalUtilTest.java
@@ -331,6 +331,15 @@ public class ProposalUtilTest extends BaseTest {
         "[ALLOW_STRICT_MATH] has been valid, no need to propose again",
         e34.getMessage());
 
+    // CLOSE_SHIELDED_TRC20_TRANSACTION requires VERSION_4_8_2. VERSION_4_7_7
+    // is already active here but 4_8_2 is not, so the proposal is still rejected.
+    ContractValidateException e35 = Assert.assertThrows(ContractValidateException.class,
+        () -> ProposalUtil.validator(dynamicPropertiesStore, forkUtils,
+            ProposalType.CLOSE_SHIELDED_TRC20_TRANSACTION.getCode(), 1));
+    Assert.assertEquals(
+        "Bad chain parameter id [CLOSE_SHIELDED_TRC20_TRANSACTION]",
+        e35.getMessage());
+
     testEnergyAdjustmentProposal();
 
     testConsensusLogicOptimizationProposal();
@@ -349,9 +358,39 @@ public class ProposalUtilTest extends BaseTest {
 
     testAllowHardenExchangeCalculationProposal();
 
+    testCloseShieldedTRC20TransactionProposal();
+
     forkUtils.getManager().getDynamicPropertiesStore()
         .statsByVersion(ForkBlockVersionEnum.ENERGY_LIMIT.getValue(), stats);
     forkUtils.reset();
+  }
+
+  private void testCloseShieldedTRC20TransactionProposal() {
+    // VERSION_4_8_2 has already been activated by the preceding helpers, so the
+    // validator only enforces the 0-3 value range from here on.
+    long code = ProposalType.CLOSE_SHIELDED_TRC20_TRANSACTION.getCode();
+    String rangeError =
+        "This value[CLOSE_SHIELDED_TRC20_TRANSACTION] is only allowed to be in the range 0-3";
+
+    // below range -> rejected
+    ContractValidateException e1 = Assert.assertThrows(ContractValidateException.class,
+        () -> ProposalUtil.validator(dynamicPropertiesStore, forkUtils, code, -1));
+    Assert.assertEquals(rangeError, e1.getMessage());
+
+    // above range -> rejected
+    ContractValidateException e2 = Assert.assertThrows(ContractValidateException.class,
+        () -> ProposalUtil.validator(dynamicPropertiesStore, forkUtils, code, 4));
+    Assert.assertEquals(rangeError, e2.getMessage());
+
+    // every value in [0, 3] is accepted
+    for (long value = 0; value <= 3; value++) {
+      final long v = value;
+      try {
+        ProposalUtil.validator(dynamicPropertiesStore, forkUtils, code, v);
+      } catch (ContractValidateException e) {
+        Assert.fail("value " + v + " should be valid: " + e.getMessage());
+      }
+    }
   }
 
   private void testEnergyAdjustmentProposal() {

--- a/framework/src/test/java/org/tron/core/services/ProposalServiceTest.java
+++ b/framework/src/test/java/org/tron/core/services/ProposalServiceTest.java
@@ -73,6 +73,25 @@ public class ProposalServiceTest extends BaseTest {
   }
 
   @Test
+  public void testCloseShieldedTRC20Transaction() {
+    long code = ProposalType.CLOSE_SHIELDED_TRC20_TRANSACTION.getCode();
+
+    // process persists the proposed value into the dynamic properties store
+    Proposal proposal = Proposal.newBuilder().putParameters(code, 2).build();
+    boolean result = ProposalService.process(dbManager, new ProposalCapsule(proposal));
+    Assert.assertTrue(result);
+    Assert.assertEquals(2L,
+        dbManager.getDynamicPropertiesStore().getCloseShieldedTRC20Transaction());
+
+    // a subsequent proposal overwrites the stored value
+    proposal = Proposal.newBuilder().putParameters(code, 3).build();
+    result = ProposalService.process(dbManager, new ProposalCapsule(proposal));
+    Assert.assertTrue(result);
+    Assert.assertEquals(3L,
+        dbManager.getDynamicPropertiesStore().getCloseShieldedTRC20Transaction());
+  }
+
+  @Test
   public void testUpdateEnergyFee() {
     String preHistory = dbManager.getDynamicPropertiesStore().getEnergyPriceHistory();
 

--- a/framework/src/test/java/org/tron/core/services/RpcApiServicesTest.java
+++ b/framework/src/test/java/org/tron/core/services/RpcApiServicesTest.java
@@ -207,6 +207,7 @@ public class RpcApiServicesTest {
     manager.getAccountStore().put(ownerCapsule.createDbKey(), ownerCapsule);
     manager.getDynamicPropertiesStore().saveAllowShieldedTransaction(1);
     manager.getDynamicPropertiesStore().saveAllowShieldedTRC20Transaction(1);
+    manager.getDynamicPropertiesStore().saveCloseShieldedTRC20Transaction(0);
     APP_FIXTURE.startApp();
   }
 


### PR DESCRIPTION
**What does this PR do?**

Adds a committee governance proposal `CLOSE_SHIELDED_TRC20_TRANSACTION` (id **80**, value range **0–3**) that progressively disables the shielded TRC20 precompiled contracts:

| Value | Effect |
|-------|--------|
| `0` | Off — no behavior change (default) |
| `1` | Disable **mint** (`verifyMintProof`) |
| `2` | Disable **mint + transfer** (`verifyTransferProof`) |
| `3` | Disable **mint + transfer + burn** (`verifyBurnProof`) |

When a level is engaged, the corresponding proof precompile short-circuits to `(success, 32 zero bytes)` before any verification; `Program` tags the call with a specific runtime error (`shield trc20 mint/transfer/burn not allowed`), and `VMActuator` preserves that reason and marks the call as `REVERT` (no state change) instead of overwriting it with the generic `"REVERT opcode executed"`.

The parameter is:
- persisted in `DynamicPropertiesStore` (`CLOSE_SHIELDED_TRC20_TRANSACTION`),
- applied through `ProposalService`,
- loaded into the VM via `VMConfig`/`ConfigLoader`,
- exposed in `Wallet.getChainParameters` as `getCloseShieldedTRC20Transaction`,
- configurable through `committee.closeShieldedTRC20Transaction` (see `reference.conf`),
- validation gated to fork **v4.8.2**.

**Design note — why close via "success + revert" instead of failing the precompile (energy cost)**

The proof precompile's `execute()` deliberately returns **success** `(true, 32 zero bytes)` when a level is closed, rather than throwing an exception, returning `(false, …)`, or having the contract lookup return `null`. The reason is energy accounting in `Program.callToPrecompiledAddress`:

- **Success branch** refunds the caller's unused energy: `refundEnergy(msg.getEnergy() − requiredEnergy)` — only the precompile's fixed cost (`getEnergyForData`, e.g. 150000) is consumed.
- **Failure branch** (an exception thrown from `execute()` / the contract lookup, `execute()` returning `false`, or no contract found) is the *"spend all energy on failure"* path: `refundEnergy(0)`, which burns the entire remaining energy of the call.

So if the close were implemented by making the precompile fail, every blocked mint/transfer/burn call would penalize the caller with a full-energy burn. Instead we let `execute()` return normally, then set `runtimeError` (`shield mint/transfer/burn not allowed`) on the result afterwards and let `VMActuator` turn it into a `REVERT`. This yields the same revert outcome (no state change) **while refunding the caller's unused energy**, avoiding the all-energy-consumed penalty.

**Why are these changes required?**

Governance needs a controlled, staged way to wind down shielded TRC20 support rather than an all-or-nothing switch. Closing in the order mint → transfer → burn lets the network first stop new shielded notes from being created, then stop moving them, while keeping **burn open last** so existing holders can still unshield (exit) their funds before the feature is fully closed. Default `0` keeps current behavior, so the change is inert until a proposal is approved post-4.8.2.

**This PR has been tested by:**
- Unit Tests
  - `ProposalUtilTest` — proposal 80 is rejected before fork v4.8.2 (even with earlier forks active) and validates the 0–3 range afterwards.
  - `ProposalServiceTest` — approving the proposal persists the value into the dynamic properties store.
  - `PrecompiledContractsTest` — each proof precompile short-circuits to `(success, zero)` at its matching close level.
  - `RpcApiServicesTest` — store initialization with the new key.
- `reference.conf` bean-parity, key-name, and comment-coverage gates

**Follow up**

N/A

**Extra details**

Adapted to the v4.8.2 codebase: `VMConfig` lives in `common`, and the committee parameter is wired through the `CommitteeConfig` bean + `reference.conf` (replacing the old `Constant.COMMITTEE_*` / `Args.hasPath` style). Proposal code `80` was unused on this branch (it skips 79 → 81), so no renumbering was needed.
