### PR TITLE
fix(jsonrpc): enforce maxBlockRange on eth_getFilterLogs

### DIFF
--- a/framework/src/main/java/org/tron/core/services/jsonrpc/TronJsonRpcImpl.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/TronJsonRpcImpl.java
@@ -1549,8 +1549,7 @@ public class TronJsonRpcImpl implements TronJsonRpc, Closeable {
 
   @Override
   public LogFilterElement[] getFilterLogs(String filterId) throws
-      JsonRpcInvalidParamsException,
-      ExecutionException,
+      JsonRpcInvalidParamsException, ExecutionException,
       InterruptedException, BadItemException, ItemNotFoundException,
       JsonRpcMethodNotFoundException, JsonRpcTooManyResultException {
     disableInPBFT("eth_getFilterLogs");
@@ -1571,7 +1570,7 @@ public class TronJsonRpcImpl implements TronJsonRpc, Closeable {
     long currentMaxBlockNum = wallet.getNowBlock().getBlockHeader().getRawData().getNumber();
 
     // re-check the block range against the current head: the filter was created without the cap
-    // (eth_newFilter), so enforce it here prevent an unbounded scan.
+    // (eth_newFilter), so enforce it here to prevent an unbounded scan.
     logFilterWrapper.validateBlockRange(currentMaxBlockNum);
 
     return getLogsByLogFilterWrapper(logFilterWrapper, currentMaxBlockNum);

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/TronJsonRpcImpl.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/TronJsonRpcImpl.java
@@ -1548,7 +1548,9 @@ public class TronJsonRpcImpl implements TronJsonRpc, Closeable {
   }
 
   @Override
-  public LogFilterElement[] getFilterLogs(String filterId) throws ExecutionException,
+  public LogFilterElement[] getFilterLogs(String filterId) throws
+      JsonRpcInvalidParamsException,
+      ExecutionException,
       InterruptedException, BadItemException, ItemNotFoundException,
       JsonRpcMethodNotFoundException, JsonRpcTooManyResultException {
     disableInPBFT("eth_getFilterLogs");
@@ -1567,6 +1569,10 @@ public class TronJsonRpcImpl implements TronJsonRpc, Closeable {
 
     LogFilterWrapper logFilterWrapper = eventFilter2Result.get(filterId).getLogFilterWrapper();
     long currentMaxBlockNum = wallet.getNowBlock().getBlockHeader().getRawData().getNumber();
+
+    // re-check the block range against the current head: the filter was created without the cap
+    // (eth_newFilter), so enforce it here prevent an unbounded scan.
+    logFilterWrapper.validateBlockRange(currentMaxBlockNum);
 
     return getLogsByLogFilterWrapper(logFilterWrapper, currentMaxBlockNum);
   }

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/filters/LogFilterWrapper.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/filters/LogFilterWrapper.java
@@ -98,16 +98,23 @@ public class LogFilterWrapper {
           throw new JsonRpcInvalidParamsException("please verify: fromBlock <= toBlock");
         }
       }
-
-      // till now, it needs to check block range for eth_getLogs
-      int maxBlockRange = Args.getInstance().getJsonRpcMaxBlockRange();
-      if (checkBlockRange && maxBlockRange > 0
-          && min(toBlockSrc, currentMaxBlockNum) - fromBlockSrc > maxBlockRange) {
-        throw new JsonRpcInvalidParamsException("exceed max block range: " + maxBlockRange);
-      }
     }
 
     this.fromBlock = fromBlockSrc;
     this.toBlock = toBlockSrc;
+
+    // eth_getLogs enforces the block range at construction time. eth_newFilter creates the
+    // wrapper with checkBlockRange=false (no creation-time gate); eth_getFilterLogs re-runs this
+    // check against the current head before scanning so the cap cannot be bypassed.
+    if (checkBlockRange) {
+      validateBlockRange(currentMaxBlockNum);
+    }
+  }
+
+  public void validateBlockRange(long currentMaxBlockNum) throws JsonRpcInvalidParamsException {
+    int maxBlockRange = Args.getInstance().getJsonRpcMaxBlockRange();
+    if (maxBlockRange > 0 && min(toBlock, currentMaxBlockNum) - fromBlock > maxBlockRange) {
+      throw new JsonRpcInvalidParamsException("exceed max block range: " + maxBlockRange);
+    }
   }
 }

--- a/framework/src/test/java/org/tron/core/jsonrpc/JsonrpcServiceTest.java
+++ b/framework/src/test/java/org/tron/core/jsonrpc/JsonrpcServiceTest.java
@@ -1329,6 +1329,35 @@ public class JsonrpcServiceTest extends BaseTest {
   }
 
   @Test
+  public void testGetFilterLogsEnforcesBlockRange() throws Exception {
+    int oldMaxBlockRange = Args.getInstance().getJsonRpcMaxBlockRange();
+    Args.getInstance().setJsonRpcMaxBlockRange(5_000);
+    try {
+      // toBlock=0xf4240 (1_000_000) is clamped to head (LATEST_BLOCK_NUM = 10_000), so the span
+      // is min(1_000_000, 10_000) - 0 = 10_000 > 5_000 cap.
+      String wideFilterId = tronJsonRpc.newFilter(
+          new FilterRequest("0x0", "0xf4240", null, null, null));
+      Assert.assertNotNull(wideFilterId);
+
+      // eth_getFilterLogs must reject it at query time (previously bypassed -> unbounded scan).
+      JsonRpcInvalidParamsException ex = Assert.assertThrows(
+          JsonRpcInvalidParamsException.class,
+          () -> tronJsonRpc.getFilterLogs(wideFilterId));
+      Assert.assertEquals("exceed max block range: 5000", ex.getMessage());
+
+      // A within-cap filter (span 0) is still served normally - no false rejection.
+      String headHex = ByteArray.toJsonHex(blockCapsule1.getNum());
+      int expectedLogs = blockCapsule1.getTransactions().size() * 2;
+      String okFilterId = tronJsonRpc.newFilter(
+          new FilterRequest(headHex, headHex, null, null, null));
+      LogFilterElement[] okResult = tronJsonRpc.getFilterLogs(okFilterId);
+      Assert.assertEquals(expectedLogs, okResult.length);
+    } finally {
+      Args.getInstance().setJsonRpcMaxBlockRange(oldMaxBlockRange);
+    }
+  }
+
+  @Test
   public void testGetBlockReceipts() {
 
     try {


### PR DESCRIPTION
**What does this PR do?**

Applies the `jsonRpcMaxBlockRange` cap to `eth_getFilterLogs`, closing a gap where the block-range limit could be bypassed via the filter path.

`eth_getLogs` builds its `LogFilterWrapper` with `checkBlockRange=true`, so the cap is enforced. But `eth_newFilter` builds the wrapper with `checkBlockRange=false`, and `eth_getFilterLogs` reuses that stored wrapper without re-checking — so the cap was never applied when querying logs through a filter. A client could create a filter with a wide range (e.g. `fromBlock=0x0`, `toBlock` far ahead) and call `eth_getFilterLogs` to trigger an unbounded historical scan (CPU/IO pressure, potential OOM).

Changes:
- Extract the range check from the `LogFilterWrapper` constructor into a reusable  `validateBlockRange(currentMaxBlockNum)` method (logic and error message unchanged).
- `eth_getFilterLogs` now calls `validateBlockRange` against the **current head**  before scanning, mirroring `eth_getLogs`.
- Declare `JsonRpcInvalidParamsException` on the `getFilterLogs` impl (the interface and its `@JsonRpcError(code=-32602)` mapping already declared it).

Creation-time behavior is intentionally left unchanged: `eth_newFilter` still accepts wide ranges (no creation-time gate), matching geth's "creation accepts, query enforces" model and preserving forward polling via `eth_getFilterChanges` (which does not scan a range).

**Why are these changes required?**

Without this, `jsonRpcMaxBlockRange` only protects `eth_getLogs`; the `eth_newFilter` + `eth_getFilterLogs` path silently bypasses it, leaving a DoS vector on full nodes with JSON-RPC enabled.

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**