### PR TITLE
fix(api): hide jetty internals in oversized request 413 response

### DIFF
--- a/framework/src/main/java/org/tron/common/application/HttpService.java
+++ b/framework/src/main/java/org/tron/common/application/HttpService.java
@@ -16,12 +16,22 @@
 package org.tron.common.application;
 
 import com.google.common.annotations.VisibleForTesting;
+import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.server.ConnectionLimit;
+import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.ErrorHandler;
 import org.eclipse.jetty.server.handler.SizeLimitHandler;
 import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.util.BufferUtil;
 import org.tron.core.config.args.Args;
 
 @Slf4j(topic = "rpc")
@@ -72,6 +82,7 @@ public abstract class HttpService extends AbstractService {
     if (maxHttpConnectNumber > 0) {
       this.apiServer.addBean(new ConnectionLimit(maxHttpConnectNumber, this.apiServer));
     }
+    this.apiServer.setErrorHandler(new OversizedRequestErrorHandler());
   }
 
   protected ServletContextHandler initContextHandler() {
@@ -87,5 +98,31 @@ public abstract class HttpService extends AbstractService {
 
   protected void addFilter(ServletContextHandler context) {
 
+  }
+
+  /**
+   * For oversized requests (the 413 thrown by SizeLimitHandler during dispatch) logs the
+   * detail server-side and returns the short, uniform bad-message page, instead of the
+   * default error page that leaks the exception stack and internal request sizes. All
+   * other errors keep Jetty's default handling.
+   */
+  private static final class OversizedRequestErrorHandler extends ErrorHandler {
+
+    @Override
+    public void handle(String target, Request baseRequest, HttpServletRequest request,
+        HttpServletResponse response) throws IOException, ServletException {
+      if (response.getStatus() == HttpStatus.PAYLOAD_TOO_LARGE_413) {
+        Throwable cause = (Throwable) request.getAttribute(RequestDispatcher.ERROR_EXCEPTION);
+        logger.info("Reject oversized request, uri: {}, detail: {}",
+            request.getRequestURI(), cause == null ? "413" : cause.getMessage());
+        baseRequest.setHandled(true);
+        ByteBuffer body = badMessageError(HttpStatus.PAYLOAD_TOO_LARGE_413,
+            HttpStatus.getMessage(HttpStatus.PAYLOAD_TOO_LARGE_413),
+            baseRequest.getResponse().getHttpFields());
+        response.getOutputStream().write(BufferUtil.toArray(body));
+        return;
+      }
+      super.handle(target, baseRequest, request, response);
+    }
   }
 }

--- a/framework/src/test/java/org/tron/common/jetty/SizeLimitHandlerTest.java
+++ b/framework/src/test/java/org/tron/common/jetty/SizeLimitHandlerTest.java
@@ -1,8 +1,12 @@
 package org.tron.common.jetty;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.net.Socket;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import javax.servlet.http.HttpServlet;
@@ -33,7 +37,7 @@ import org.tron.json.JSONObject;
 
 /**
  * Tests {@link org.eclipse.jetty.server.handler.SizeLimitHandler} body-size
- * enforcement configured in {@link HttpService#initContextHandler()}.
+ * enforcement configured in {@link HttpService}.
  *
  * Covers: accept/reject by size, UTF-8 byte counting, independent limits
  * across HttpService instances, chunked transfer, and zero-limit behavior.
@@ -152,10 +156,69 @@ public class SizeLimitHandlerTest {
     Assert.assertEquals(200, post(httpServerUri, new StringEntity("small body")));
   }
 
+  /**
+   * An oversized request must return 413 carrying the short, uniform bad-message
+   * page produced by the custom ErrorHandler in {@link HttpService} -
+   * not the default Jetty error page that leaks the exception stack, class name
+   * and the internal request size.
+   */
   @Test
   public void testHttpBodyExceedsLimit() throws Exception {
-    Assert.assertEquals(413,
-        post(httpServerUri, new StringEntity(repeat('a', HTTP_MAX_BODY_SIZE + 1))));
+    HttpPost req = new HttpPost(httpServerUri);
+    req.setEntity(new StringEntity(repeat('a', HTTP_MAX_BODY_SIZE + 1)));
+    HttpResponse resp = client.execute(req);
+
+    String body = EntityUtils.toString(resp.getEntity());
+
+    // return value: 413
+    Assert.assertEquals(413, resp.getStatusLine().getStatusCode());
+
+    // returned page: short uniform bad-message page with the generic reason
+    Assert.assertTrue("should render the short bad-message page",
+        body.contains("Bad Message 413"));
+    Assert.assertTrue("reason should be the generic status message",
+        body.contains("Payload Too Large"));
+
+    // must NOT leak Jetty internals
+    Assert.assertFalse("must not leak exception class / stack frames",
+        body.contains("org.eclipse.jetty"));
+  }
+
+  /**
+   * A malformed Content-Length is rejected by the HTTP parser (onBadMessage ->
+   * ErrorHandler.badMessageError()), a different path from the 413 dispatch handler.
+   * Confirms the custom ErrorHandler leaves other 4xx untouched: still the default
+   * 400 bad-message page, not rerouted through the 413 branch.
+   */
+  @Test
+  public void testBadContentLengthReturnsDefault400() throws Exception {
+    String raw = "POST / HTTP/1.1\r\n"
+        + "Host: localhost\r\n"
+        + "Content-Length: +450\r\n"
+        + "\r\n";
+    String resp = sendRaw(httpServerUri, raw);
+
+    Assert.assertTrue("expected 400, got: " + firstLine(resp), resp.startsWith("HTTP/1.1 400"));
+    Assert.assertTrue("should be the default bad-message page", resp.contains("Bad Message 400"));
+    Assert.assertFalse("must not be rerouted through the 413 branch",
+        resp.contains("Payload Too Large"));
+  }
+
+  /**
+   * A request-line URI longer than the request header buffer is rejected by the HTTP
+   * parser (414), again via badMessageError(), not the 413 dispatch handler. Confirms it
+   * is unaffected by the custom ErrorHandler.
+   */
+  @Test
+  public void testOversizedUriReturnsDefault414() throws Exception {
+    String raw = "GET /" + repeat('a', 9000) + " HTTP/1.1\r\n"  // request line > default 8KB
+        + "Host: localhost\r\n"
+        + "\r\n";
+    String resp = sendRaw(httpServerUri, raw);
+
+    Assert.assertTrue("expected 414, got: " + firstLine(resp), resp.startsWith("HTTP/1.1 414"));
+    Assert.assertFalse("must not be rerouted through the 413 branch",
+        resp.contains("Payload Too Large"));
   }
 
   @Test
@@ -323,5 +386,27 @@ public class SizeLimitHandlerTest {
   /** Returns a string of {@code n} repetitions of {@code c}. */
   private static String repeat(char c, int n) {
     return new String(new char[n]).replace('\0', c);
+  }
+
+  /** Sends a raw HTTP request over a socket and returns the full response (until EOF). */
+  private static String sendRaw(URI uri, String rawRequest) throws Exception {
+    try (Socket socket = new Socket(uri.getHost(), uri.getPort())) {
+      socket.getOutputStream().write(rawRequest.getBytes(StandardCharsets.US_ASCII));
+      socket.getOutputStream().flush();
+      ByteArrayOutputStream out = new ByteArrayOutputStream();
+      InputStream in = socket.getInputStream();
+      byte[] buf = new byte[4096];
+      int n;
+      while ((n = in.read(buf)) != -1) {
+        out.write(buf, 0, n);
+      }
+      return new String(out.toByteArray(), StandardCharsets.UTF_8);
+    }
+  }
+
+  /** First line (status line) of a raw HTTP response. */
+  private static String firstLine(String resp) {
+    int idx = resp.indexOf("\r\n");
+    return idx < 0 ? resp : resp.substring(0, idx);
   }
 }


### PR DESCRIPTION
**What does this PR do?**

Installs a custom Jetty `ErrorHandler` (private `OversizedRequestErrorHandler` in `HttpService`) so that for an oversized request — the `413` thrown by `SizeLimitHandler` during dispatch — the node logs the detail server-side and returns the short, uniform bad-message page. Previously the default Jetty error page exposed the full exception stack, the Jetty version and the internal request size in the `413` response body.

The handler special-cases `413` only; all other errors fall through to `super` (Jetty's default handling).

**Why are these changes required?**

The `413` response body leaked Jetty internals (CWE-209 information disclosure / server fingerprinting): exact Jetty version, internal class names and line numbers, thread-pool internals, the JDK build, and the rejected request size, e.g.:

```
org.eclipse.jetty.http.BadMessageException: 413: Request body is too large: 664657339>4194304
    at org.eclipse.jetty.server.handler.SizeLimitHandler.checkRequestLimit(SizeLimitHandler.java:63)
    ...
    at java.lang.Thread.run(Thread.java:750)
```

Only the `413` path is affected, because `SizeLimitHandler` throws during dispatch (`Server.handle`) and is rendered via `ErrorHandler.handle()` -> `writeErrorPageStacks`. Parser-stage errors (`400` / `414` / `431`) already render via `badMessageError()` without a stack, so they are intentionally left untouched.

**This PR has been tested by:**
- Unit Tests
  - `SizeLimitHandlerTest#testHttpBodyExceedsLimit`: `413` body renders the short bad-message page and leaks no Jetty stack / class / size.
  - `SizeLimitHandlerTest#testBadContentLengthReturnsDefault400`, `testOversizedUriReturnsDefault414`: other 4xx stay on Jetty's default path (not rerouted through the `413` branch).
- Manual Testing
  - `curl` with an oversized body returns `413` with the short page; the response no longer contains the exception stack, class name or internal size.

**Follow up**

**Extra details**

Jetty `9.4.58`. The fix lives in the base class `HttpService#initServer()` so it applies to every HTTP service (FullNode HTTP, Solidity, PBFT, JSON-RPC). The `reason` returned to the client is the generic `HttpStatus.getMessage(413)` ("Payload Too Large"); the full detail (including the rejected size) is kept only in the server log.

