### PR TITLE
fix(net): reject unknown inventory type in P2P inv/fetch-inv handling

### DIFF
--- a/framework/src/main/java/org/tron/core/net/P2pEventHandlerImpl.java
+++ b/framework/src/main/java/org/tron/core/net/P2pEventHandlerImpl.java
@@ -215,7 +215,8 @@ public class P2pEventHandlerImpl extends P2pEventHandler {
     }
   }
 
-  private boolean checkInvRateLimit(PeerConnection peer, InventoryMessage msg) {
+  private boolean checkInvRateLimit(PeerConnection peer, InventoryMessage msg)
+      throws P2pException {
     InventoryType invType = msg.getInventoryType();
     int currentSize = msg.getInventory().getIdsCount();
     MessageStatistics stats = peer.getPeerStatistics().messageStatistics;
@@ -237,6 +238,9 @@ public class P2pEventHandlerImpl extends P2pEventHandler {
             peer.getInetAddress(), count, currentSize, maxBlockInvIn10s);
         return false;
       }
+    } else {
+      throw new P2pException(P2pException.TypeEnum.BAD_MESSAGE,
+          "unknown inventory type: " + msg.getInventory().getTypeValue());
     }
     return true;
   }

--- a/framework/src/main/java/org/tron/core/net/messagehandler/FetchInvDataMsgHandler.java
+++ b/framework/src/main/java/org/tron/core/net/messagehandler/FetchInvDataMsgHandler.java
@@ -160,9 +160,13 @@ public class FetchInvDataMsgHandler implements TronMsgHandler {
           "FetchInvData contains duplicate hashes, size: " + hashList.size());
     }
 
-    MessageTypes type = fetchInvDataMsg.getInvMessageType();
+    InventoryType invType = fetchInvDataMsg.getInventoryType();
+    if (invType != InventoryType.TRX && invType != InventoryType.BLOCK) {
+      throw new P2pException(TypeEnum.BAD_MESSAGE,
+          "unknown inventory type: " + fetchInvDataMsg.getInventory().getTypeValue());
+    }
 
-    if (type == MessageTypes.TRX) {
+    if (invType == InventoryType.TRX) {
       for (Sha256Hash hash : fetchInvDataMsg.getHashList()) {
         if (peer.getAdvInvSpread().getIfPresent(new Item(hash, InventoryType.TRX)) == null) {
           throw new P2pException(TypeEnum.BAD_MESSAGE, "not spread inv: " + hash);

--- a/framework/src/main/java/org/tron/core/net/messagehandler/InventoryMsgHandler.java
+++ b/framework/src/main/java/org/tron/core/net/messagehandler/InventoryMsgHandler.java
@@ -63,6 +63,10 @@ public class InventoryMsgHandler implements TronMsgHandler {
     }
 
     InventoryType type = inventoryMessage.getInventoryType();
+    if (type != InventoryType.TRX && type != InventoryType.BLOCK) {
+      throw new P2pException(TypeEnum.BAD_MESSAGE,
+          "unknown inventory type: " + inventoryMessage.getInventory().getTypeValue());
+    }
     int size = hashList.size();
 
     if (peer.isNeedSyncFromPeer() || peer.isNeedSyncFromUs()) {

--- a/framework/src/test/java/org/tron/core/net/P2pEventHandlerImplTest.java
+++ b/framework/src/test/java/org/tron/core/net/P2pEventHandlerImplTest.java
@@ -3,6 +3,7 @@ package org.tron.core.net;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import com.google.protobuf.ByteString;
 import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
@@ -210,6 +211,35 @@ public class P2pEventHandlerImplTest extends BaseTest {
     method.invoke(handler, peer, msgBlock1.getSendBytes());
     Assert.assertEquals(100,  // count unchanged: message was dropped
         peer.getPeerStatistics().messageStatistics.tronInBlockInventoryElement.getCount(10));
+  }
+
+  @Test
+  public void testCheckInvRateLimitUnknownTypeRejected() throws Exception {
+    CommonParameter parameter = CommonParameter.getInstance();
+    parameter.setMaxTps(10);
+    parameter.setMaxBlockInvPerSecond(10);
+
+    PeerStatistics peerStatistics = new PeerStatistics();
+    PeerConnection peer = mock(PeerConnection.class);
+    Mockito.when(peer.getPeerStatistics()).thenReturn(peerStatistics);
+
+    P2pEventHandlerImpl handler = new P2pEventHandlerImpl();
+    Method method = handler.getClass()
+        .getDeclaredMethod("processMessage", PeerConnection.class, byte[].class);
+    method.setAccessible(true);
+
+    // craft an Inventory whose enum type holds an undefined value (2)
+    Protocol.Inventory inv = Protocol.Inventory.newBuilder()
+        .setTypeValue(2)
+        .addIds(ByteString.copyFrom(new byte[32]))
+        .build();
+    InventoryMessage msg = new InventoryMessage(inv.toByteArray());
+    Assert.assertEquals(InventoryType.UNRECOGNIZED, msg.getInventoryType());
+
+    method.invoke(handler, peer, msg.getSendBytes());
+
+    // checkInvRateLimit throws BAD_MESSAGE -> processException -> disconnect(BAD_PROTOCOL)
+    verify(peer).disconnect(Protocol.ReasonCode.BAD_PROTOCOL);
   }
 
   @Test

--- a/framework/src/test/java/org/tron/core/net/messagehandler/FetchInvDataMsgHandlerTest.java
+++ b/framework/src/test/java/org/tron/core/net/messagehandler/FetchInvDataMsgHandlerTest.java
@@ -157,6 +157,27 @@ public class FetchInvDataMsgHandlerTest {
   }
 
   @Test
+  public void testUnknownInventoryTypeRejected() throws Exception {
+    FetchInvDataMsgHandler handler = new FetchInvDataMsgHandler();
+    PeerConnection peer = Mockito.mock(PeerConnection.class);
+
+    // craft a FetchInvData whose enum type holds an undefined value (2)
+    Protocol.Inventory inv = Protocol.Inventory.newBuilder()
+        .setTypeValue(2)
+        .addIds(com.google.protobuf.ByteString.copyFrom(new byte[32]))
+        .build();
+    FetchInvDataMessage msg = new FetchInvDataMessage(inv.toByteArray());
+    Assert.assertEquals(Protocol.Inventory.InventoryType.UNRECOGNIZED, msg.getInventoryType());
+
+    try {
+      handler.processMessage(peer, msg);
+      Assert.fail("Expected P2pException for unknown inventory type");
+    } catch (P2pException e) {
+      Assert.assertEquals(P2pException.TypeEnum.BAD_MESSAGE, e.getType());
+    }
+  }
+
+  @Test
   public void testRateLimiter() {
     List<Sha256Hash> blockIds = new LinkedList<>();
     for (int i = 0; i <= 100; i++) {

--- a/framework/src/test/java/org/tron/core/net/messagehandler/InventoryMsgHandlerTest.java
+++ b/framework/src/test/java/org/tron/core/net/messagehandler/InventoryMsgHandlerTest.java
@@ -2,6 +2,7 @@ package org.tron.core.net.messagehandler;
 
 import static org.mockito.Mockito.mock;
 
+import com.google.protobuf.ByteString;
 import java.lang.reflect.Field;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -18,6 +19,7 @@ import org.tron.core.net.TronNetDelegate;
 import org.tron.core.net.message.adv.InventoryMessage;
 import org.tron.core.net.peer.PeerConnection;
 import org.tron.p2p.connection.Channel;
+import org.tron.protos.Protocol.Inventory;
 import org.tron.protos.Protocol.Inventory.InventoryType;
 
 public class InventoryMsgHandlerTest {
@@ -69,6 +71,30 @@ public class InventoryMsgHandlerTest {
     try {
       handler.processMessage(peer, msg);
       Assert.fail("Expected P2pException for duplicate hashes");
+    } catch (P2pException e) {
+      Assert.assertEquals(P2pException.TypeEnum.BAD_MESSAGE, e.getType());
+    }
+  }
+
+  @Test
+  public void testUnknownInventoryTypeRejected() throws Exception {
+    InventoryMsgHandler handler = new InventoryMsgHandler();
+    Args.setParam(new String[] {}, TestConstants.TEST_CONF);
+
+    // craft an Inventory whose enum type holds an undefined value (2)
+    Inventory inv = Inventory.newBuilder()
+        .setTypeValue(2)
+        .addIds(ByteString.copyFrom(new byte[32]))
+        .build();
+    InventoryMessage msg = new InventoryMessage(inv.toByteArray());
+    Assert.assertEquals(InventoryType.UNRECOGNIZED, msg.getInventoryType());
+
+    PeerConnection peer = new PeerConnection();
+    peer.setChannel(getChannel("1.0.0.5", 1000));
+
+    try {
+      handler.processMessage(peer, msg);
+      Assert.fail("Expected P2pException for unknown inventory type");
     } catch (P2pException e) {
       Assert.assertEquals(P2pException.TypeEnum.BAD_MESSAGE, e.getType());
     }


### PR DESCRIPTION
**What does this PR do?**
Validate the inventory type at the inbound entry points and reject any value other than TRX or BLOCK with P2pException(BAD_MESSAGE), before the type is used for cache insertion or outbound fetch construction:
- P2pEventHandlerImpl.checkInvRateLimit: add else branch for unknown type
- InventoryMsgHandler.check: add type allowlist check
- FetchInvDataMsgHandler.check: validate raw getInventoryType() instead of getInvMessageType() (which mapped non-BLOCK types to TRX)

Use getTypeValue() when building the error message to avoid calling getNumber() on an UNRECOGNIZED enum value. Add regression tests for all three entry points.

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

