### PR TITLE
feat(event): run native queue and event plugin simultaneously

### DIFF
--- a/common/src/main/resources/reference.conf
+++ b/common/src/main/resources/reference.conf
@@ -758,6 +758,7 @@ event.subscribe = {
   enable = false
 
   native = {
+    # start the native ZMQ queue; if `path` is also set, the event plugin runs alongside it
     useNativeQueue = true
     bindport = 5555
     sendqueuelength = 1000

--- a/framework/src/main/java/org/tron/common/logsfilter/EventPluginLoader.java
+++ b/framework/src/main/java/org/tron/common/logsfilter/EventPluginLoader.java
@@ -78,6 +78,9 @@ public class EventPluginLoader {
   @Getter
   private boolean useNativeQueue = false;
 
+  @Getter
+  private boolean useEventPlugin = false;
+
   public static EventPluginLoader getInstance() {
     if (Objects.isNull(instance)) {
       synchronized (EventPluginLoader.class) {
@@ -234,12 +237,25 @@ public class EventPluginLoader {
     this.triggerConfigList = config.getTriggerConfigList();
 
     useNativeQueue = config.isUseNativeQueue();
+    useEventPlugin = StringUtils.hasText(config.getPluginPath());
 
-    if (config.isUseNativeQueue()) {
-      return launchNativeQueue(config);
+    if (!useNativeQueue && !useEventPlugin) {
+      logger.error("no event output configured: native queue is off and plugin path is empty");
+      return false;
     }
 
-    return launchEventPlugin(config);
+    // Launch the plugin first so eventListeners are populated before any topic is
+    // registered. launchNativeQueue() also iterates the trigger config and (when the
+    // plugin is active) calls setPluginTopic(), which needs eventListeners to exist.
+    if (useEventPlugin && !launchEventPlugin(config)) {
+      return false;
+    }
+
+    if (useNativeQueue && !launchNativeQueue(config)) {
+      return false;
+    }
+
+    return true;
   }
 
   private void setPluginConfig() {
@@ -271,7 +287,7 @@ public class EventPluginLoader {
         blockLogTriggerSolidified = false;
       }
 
-      if (!useNativeQueue) {
+      if (useEventPlugin) {
         setPluginTopic(Trigger.BLOCK_TRIGGER, triggerConfig.getTopic());
       }
 
@@ -291,7 +307,7 @@ public class EventPluginLoader {
         transactionLogTriggerSolidified = false;
       }
 
-      if (!useNativeQueue) {
+      if (useEventPlugin) {
         setPluginTopic(Trigger.TRANSACTION_TRIGGER, triggerConfig.getTopic());
       }
 
@@ -303,7 +319,7 @@ public class EventPluginLoader {
         contractEventTriggerEnable = false;
       }
 
-      if (!useNativeQueue) {
+      if (useEventPlugin) {
         setPluginTopic(Trigger.CONTRACTEVENT_TRIGGER, triggerConfig.getTopic());
       }
 
@@ -319,7 +335,7 @@ public class EventPluginLoader {
         contractLogTriggerRedundancy = false;
       }
 
-      if (!useNativeQueue) {
+      if (useEventPlugin) {
         setPluginTopic(Trigger.CONTRACTLOG_TRIGGER, triggerConfig.getTopic());
       }
     } else if (EventPluginConfig.SOLIDITY_TRIGGER_NAME
@@ -329,7 +345,7 @@ public class EventPluginLoader {
       } else {
         solidityTriggerEnable = false;
       }
-      if (!useNativeQueue) {
+      if (useEventPlugin) {
         setPluginTopic(Trigger.SOLIDITY_TRIGGER, triggerConfig.getTopic());
       }
     } else if (EventPluginConfig.SOLIDITY_EVENT_NAME
@@ -340,7 +356,7 @@ public class EventPluginLoader {
         solidityEventTriggerEnable = false;
       }
 
-      if (!useNativeQueue) {
+      if (useEventPlugin) {
         setPluginTopic(Trigger.SOLIDITY_EVENT_TRIGGER, triggerConfig.getTopic());
       }
     } else if (EventPluginConfig.SOLIDITY_LOG_NAME
@@ -354,7 +370,7 @@ public class EventPluginLoader {
         solidityLogTriggerEnable = false;
         solidityLogTriggerRedundancy = false;
       }
-      if (!useNativeQueue) {
+      if (useEventPlugin) {
         setPluginTopic(Trigger.SOLIDITY_LOG_TRIGGER, triggerConfig.getTopic());
       }
     }
@@ -364,7 +380,8 @@ public class EventPluginLoader {
     if (useNativeQueue) {
       NativeMessageQueue.getInstance()
           .publishTrigger(toJsonString(trigger), trigger.getTriggerName());
-    } else {
+    }
+    if (useEventPlugin) {
       eventListeners.forEach(listener ->
           listener.handleSolidityTrigger(toJsonString(trigger)));
     }
@@ -427,6 +444,9 @@ public class EventPluginLoader {
   }
 
   private void setPluginTopic(int eventType, String topic) {
+    if (Objects.isNull(eventListeners)) {
+      return;
+    }
     eventListeners.forEach(listener -> listener.setTopic(eventType, topic));
   }
 
@@ -485,7 +505,8 @@ public class EventPluginLoader {
     if (useNativeQueue) {
       NativeMessageQueue.getInstance()
           .publishTrigger(toJsonString(trigger), trigger.getTriggerName());
-    } else {
+    }
+    if (useEventPlugin) {
       eventListeners.forEach(listener ->
           listener.handleBlockEvent(toJsonString(trigger)));
     }
@@ -495,7 +516,8 @@ public class EventPluginLoader {
     if (useNativeQueue) {
       NativeMessageQueue.getInstance()
           .publishTrigger(toJsonString(trigger), trigger.getTriggerName());
-    } else {
+    }
+    if (useEventPlugin) {
       eventListeners.forEach(listener ->
           listener.handleSolidityLogTrigger(toJsonString(trigger)));
     }
@@ -505,7 +527,8 @@ public class EventPluginLoader {
     if (useNativeQueue) {
       NativeMessageQueue.getInstance()
           .publishTrigger(toJsonString(trigger), trigger.getTriggerName());
-    } else {
+    }
+    if (useEventPlugin) {
       eventListeners.forEach(listener ->
           listener.handleSolidityEventTrigger(toJsonString(trigger)));
     }
@@ -515,7 +538,8 @@ public class EventPluginLoader {
     if (useNativeQueue) {
       NativeMessageQueue.getInstance()
           .publishTrigger(toJsonString(trigger), trigger.getTriggerName());
-    } else {
+    }
+    if (useEventPlugin) {
       eventListeners.forEach(listener -> listener.handleTransactionTrigger(toJsonString(trigger)));
     }
   }
@@ -524,7 +548,8 @@ public class EventPluginLoader {
     if (useNativeQueue) {
       NativeMessageQueue.getInstance()
           .publishTrigger(toJsonString(trigger), trigger.getTriggerName());
-    } else {
+    }
+    if (useEventPlugin) {
       eventListeners.forEach(listener ->
           listener.handleContractLogTrigger(toJsonString(trigger)));
     }
@@ -534,14 +559,17 @@ public class EventPluginLoader {
     if (useNativeQueue) {
       NativeMessageQueue.getInstance()
           .publishTrigger(toJsonString(trigger), trigger.getTriggerName());
-    } else {
+    }
+    if (useEventPlugin) {
       eventListeners.forEach(listener ->
           listener.handleContractEventTrigger(toJsonString(trigger)));
     }
   }
 
   public boolean isBusy() {
-    if (useNativeQueue) {
+    // Back-pressure only applies to the plugin's async queue. The native ZMQ queue
+    // has its own bounded send queue, so when the plugin is not active we never block.
+    if (!useEventPlugin) {
       return false;
     }
     int queueSize = 0;

--- a/framework/src/main/java/org/tron/core/config/args/Args.java
+++ b/framework/src/main/java/org/tron/core/config/args/Args.java
@@ -372,16 +372,17 @@ public class Args extends CommonParameter {
     epc.setBindPort(nq.getBindport());
     epc.setSendQueueLength(nq.getSendqueuelength());
 
-    if (!nq.isUseNativeQueue()) {
-      if (StringUtils.isNotEmpty(ec.getPath())) {
-        epc.setPluginPath(ec.getPath().trim());
-      }
-      if (StringUtils.isNotEmpty(ec.getServer())) {
-        epc.setServerAddress(ec.getServer().trim());
-      }
-      if (StringUtils.isNotEmpty(ec.getDbconfig())) {
-        epc.setDbConfig(ec.getDbconfig().trim());
-      }
+    // Plugin settings are always copied so the event plugin (e.g. MongoDB) can run
+    // alongside the native ZMQ queue. The native queue and the plugin are activated
+    // independently in EventPluginLoader (useNativeQueue + non-empty pluginPath).
+    if (StringUtils.isNotEmpty(ec.getPath())) {
+      epc.setPluginPath(ec.getPath().trim());
+    }
+    if (StringUtils.isNotEmpty(ec.getServer())) {
+      epc.setServerAddress(ec.getServer().trim());
+    }
+    if (StringUtils.isNotEmpty(ec.getDbconfig())) {
+      epc.setDbConfig(ec.getDbconfig().trim());
     }
 
     // topics

--- a/framework/src/main/java/org/tron/core/services/event/HistoryEventService.java
+++ b/framework/src/main/java/org/tron/core/services/event/HistoryEventService.java
@@ -67,11 +67,15 @@ public class HistoryEventService {
         if (thread.isInterrupted() || isClosed) {
           throw new InterruptedException();
         }
-        if (instance.isUseNativeQueue()) {
-          Thread.sleep(20);
-        } else if (instance.isBusy()) {
+        // isBusy() returns false unless the event plugin is active, so native-only
+        // mode keeps its original 20ms pacing. In combined mode we still honor the
+        // plugin's back-pressure so its async queue is not flooded during sync.
+        if (instance.isBusy()) {
           Thread.sleep(100);
           continue;
+        }
+        if (instance.isUseNativeQueue()) {
+          Thread.sleep(20);
         }
         BlockEvent blockEvent = blockEventGet.getBlockEvent(tmp);
         realtimeEventService.flush(blockEvent, false);

--- a/framework/src/main/resources/config.conf
+++ b/framework/src/main/resources/config.conf
@@ -803,7 +803,7 @@ committee = {
 event.subscribe = {
   enable = false // enable event subscribe, replaces deprecated CLI flag --es
   native = {
-    useNativeQueue = true // if true, use native message queue, else use event plugin.
+    useNativeQueue = true // start the native ZMQ queue. If `path` below is also set, the event plugin runs alongside it (both receive every trigger).
     bindport = 5555 // bind port
     sendqueuelength = 1000 //max length of send queue
   }

--- a/framework/src/test/java/org/tron/core/event/EventPluginLoaderTest.java
+++ b/framework/src/test/java/org/tron/core/event/EventPluginLoaderTest.java
@@ -17,11 +17,17 @@ public class EventPluginLoaderTest {
   public void testIsBusy() {
 
     EventPluginLoader eventPluginLoader = EventPluginLoader.getInstance();
+
+    // When the event plugin is not active, the node is never "busy" regardless of the
+    // native queue: back-pressure only throttles the plugin's async queue.
+    ReflectUtils.setFieldValue(eventPluginLoader, "useEventPlugin", false);
     ReflectUtils.setFieldValue(eventPluginLoader, "useNativeQueue", true);
     boolean flag = eventPluginLoader.isBusy();
     Assert.assertFalse(flag);
 
-    ReflectUtils.setFieldValue(eventPluginLoader, "useNativeQueue", false);
+    // When the plugin is active (with or without the native queue), busy-ness is driven
+    // by the plugin queue size.
+    ReflectUtils.setFieldValue(eventPluginLoader, "useEventPlugin", true);
 
     IPluginEventListener p1 = mock(IPluginEventListener.class);
     List<IPluginEventListener> list = new ArrayList<>();


### PR DESCRIPTION
## What does this PR do?

Makes the native ZMQ message queue and the event plugin (e.g. the MongoDB plugin) two independent event sinks, so a node can publish triggers to both at the same time.

Previously they were mutually exclusive: when `useNativeQueue = true`, the plugin's `path`/`server`/`dbconfig` were never loaded and only the native queue started; the plugin only ran when `useNativeQueue = false`.

Key changes:
- `Args`: always copy `path`/`server`/`dbconfig` into `EventPluginConfig`, regardless of `useNativeQueue`.
- `EventPluginLoader`: add a separate `useEventPlugin` flag (derived from a non-empty plugin path). `start()` launches the plugin first — so the plugin's listeners exist before any topic is registered — and then the native queue. Each `post*Trigger` is dispatched to every active sink; `setPluginTopic` is null-guarded for the now-possible double trigger-config pass; `isBusy()` is gated on the plugin being active instead of on the native queue being off.
- `HistoryEventService`: honor the plugin's back-pressure (`isBusy`) during historical sync even when the native queue is enabled, so the plugin queue is not flooded. Native-only pacing is unchanged.
- `config.conf` / `reference.conf`: document that `useNativeQueue` and a plugin `path` can be combined.

## Why are these changes required?

Operators often want both transports at once: low-latency ZMQ delivery for real-time consumers AND durable persistence in MongoDB for querying and indexing. Today they must pick one. With a single `event.subscribe` block (native queue on + a plugin path set), both now receive every trigger.

Example configuration enabling both:

    event.subscribe = {
      enable = true
      native   = { useNativeQueue = true, bindport = 5555, sendqueuelength = 1000 }
      path     = "/home/trx/event-plugin/plugin-mongodb-1.0.0.zip"
      server   = "127.0.0.1:27017"
      dbconfig = "db|log|pass"
      ...
    }

## This PR has been tested by:
- Unit Tests
  - Built on JDK 8 (jdk1.8.0_271) (from GreatVoyage-v4.8.1.1 tag): `:common` and `:framework` `compileJava` succeed.
  - `EventPluginLoaderTest#testIsBusy` — updated for the new `useEventPlugin` semantics — PASSED.
  - `HistoryEventServiceTest#test` — covers the reordered back-pressure path — PASSED.
- Manual Testing
  - Verified in a Docker deployment: a mainnet full node running with `useNativeQueue = true` and a MongoDB plugin path set starts cleanly, writes events to the MongoDB collections, and binds the native ZMQ queue on port 5555 simultaneously.

## Follow up

A future enhancement could add an explicit `useEventPlugin` config key instead of inferring plugin activation from a non-empty `path`.

## Extra details

In combined mode the trigger-config pass runs once per launcher; this is idempotent (boolean flags and `setTopic` overwrite with the same values). Every trigger is now serialized and dispatched to both sinks, a modest overhead versus single-sink mode. Behavior is unchanged for the two existing single-sink configurations (native-only, or plugin-only).