### PR TITLE
perf(vm): hoist allowDynamicEnergy out of the opcode loop

### DIFF
--- a/actuator/src/main/java/org/tron/core/vm/VM.java
+++ b/actuator/src/main/java/org/tron/core/vm/VM.java
@@ -23,8 +23,10 @@ public class VM {
     try {
       long factor = DYNAMIC_ENERGY_FACTOR_DECIMAL;
       long energyUsage = 0L;
+      // hoist once per execution: avoids a per-opcode VMConfig.current() thread-local lookup
+      final boolean allowDynamicEnergy = VMConfig.allowDynamicEnergy();
 
-      if (VMConfig.allowDynamicEnergy()) {
+      if (allowDynamicEnergy) {
         factor = program.updateContextContractFactor();
       }
 
@@ -47,7 +49,7 @@ public class VM {
           String opName = Op.getNameOf(op.getOpcode());
           /* spend energy before execution */
           long energy = op.getEnergyCost(program);
-          if (VMConfig.allowDynamicEnergy()) {
+          if (allowDynamicEnergy) {
             long actualEnergy = energy;
             // CALL Ops have special calculation on energy.
             if (CALL_OPS.contains(op.getOpcode())) {
@@ -101,7 +103,7 @@ public class VM {
         }
       }
 
-      if (VMConfig.allowDynamicEnergy()) {
+      if (allowDynamicEnergy) {
         program.addContextContractUsage(energyUsage);
       }
 


### PR DESCRIPTION
## Summary

Follow-up to #6857. That PR routed every `VMConfig` getter through a thread-local `current()` (process-global snapshot + per-constant-call override). `VM.play` reads `VMConfig.allowDynamicEnergy()` **once per executed opcode**, so after #6857 each opcode now pays a `ThreadLocal.get()` on the block-processing hot path, where before it was a plain, inlinable static read.

CPU profiling (release_v4.8.2 vs master, same workload) shows new hot frames on 4.8.2 that are absent on master:

- `org.tron.core.vm.config.VMConfig.current`
- `java.lang.ThreadLocal$ThreadLocalMap.getEntryAfterMiss` — the `localSnapshot` lookup falls onto the linear-probe miss path on the block thread, which never installs a thread-local view.

The flag is VM config: it is loaded once in `VMActuator.validate` and is immutable for the whole execution. Reading it **once per execution** instead of once per opcode is therefore semantically identical and restores the pre-#6857 hot-path cost.

`vmTrace()` is intentionally left untouched — it was not migrated to the snapshot in #6857 and is still a plain static read.

## Test

- `:actuator:compileJava` green.
- `org.tron.common.runtime.vm.OperationsTest` green (exercises the `VM.play` loop including dynamic-energy / suicide / vote-witness paths).
