### PR TITLE
fix(jsonrpc): don't print stacktrace in jsonrpc when request overload

### DIFF
--- a/framework/src/main/java/org/tron/core/services/filter/HttpInterceptor.java
+++ b/framework/src/main/java/org/tron/core/services/filter/HttpInterceptor.java
@@ -1,6 +1,5 @@
 package org.tron.core.services.filter;
 
-import com.google.common.base.Strings;
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
@@ -9,6 +8,8 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.eclipse.jetty.http.BadMessageException;
+import org.eclipse.jetty.http.HttpStatus;
 import org.tron.common.prometheus.MetricKeys;
 import org.tron.common.prometheus.MetricLabels;
 import org.tron.common.prometheus.Metrics;
@@ -66,6 +67,10 @@ public class HttpInterceptor implements Filter {
       }
       MetricsUtil.meterMark(MetricsKey.NET_API_QPS, 1);
       MetricsUtil.meterMark(MetricsKey.NET_API_FAIL_QPS, 1);
+      if (e instanceof BadMessageException
+          && ((BadMessageException) e).getCode() == HttpStatus.PAYLOAD_TOO_LARGE_413) {
+        throw (BadMessageException) e;
+      }
     }
   }
 
@@ -73,6 +78,5 @@ public class HttpInterceptor implements Filter {
   public void destroy() {
   }
 }
-
 
 

--- a/framework/src/main/java/org/tron/core/services/http/RateLimiterServlet.java
+++ b/framework/src/main/java/org/tron/core/services/http/RateLimiterServlet.java
@@ -15,7 +15,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.jetty.http.BadMessageException;
-import org.eclipse.jetty.http.HttpStatus;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.tron.common.parameter.RateLimiterInitialization;
 import org.tron.common.prometheus.MetricKeys;
@@ -135,18 +134,7 @@ public abstract class RateLimiterServlet extends HttpServlet {
         resp.getWriter()
             .println(Util.printErrorMsg(new IllegalAccessException("lack of computing resources")));
       }
-    } catch (ServletException | IOException e) {
-      throw e;
-    } catch (BadMessageException e) {
-      if (e.getCode() == HttpStatus.PAYLOAD_TOO_LARGE_413) {
-        logger.info("Reject oversized request, uri: {}, method: {}, detail: {}",
-            url, req.getMethod(), e.getMessage());
-        if (!resp.isCommitted()) {
-          resp.reset();
-          resp.setStatus(HttpStatus.PAYLOAD_TOO_LARGE_413);
-        }
-        return;
-      }
+    } catch (ServletException | IOException | BadMessageException e) {
       throw e;
     } catch (Exception unexpected) {
       logger.error("Http Api {}, Method:{}. Error：", url, req.getMethod(), unexpected);

--- a/framework/src/main/java/org/tron/core/services/http/RateLimiterServlet.java
+++ b/framework/src/main/java/org/tron/core/services/http/RateLimiterServlet.java
@@ -14,6 +14,8 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.eclipse.jetty.http.BadMessageException;
+import org.eclipse.jetty.http.HttpStatus;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.tron.common.parameter.RateLimiterInitialization;
 import org.tron.common.prometheus.MetricKeys;
@@ -134,6 +136,17 @@ public abstract class RateLimiterServlet extends HttpServlet {
             .println(Util.printErrorMsg(new IllegalAccessException("lack of computing resources")));
       }
     } catch (ServletException | IOException e) {
+      throw e;
+    } catch (BadMessageException e) {
+      if (e.getCode() == HttpStatus.PAYLOAD_TOO_LARGE_413) {
+        logger.info("Reject oversized request, uri: {}, method: {}, detail: {}",
+            url, req.getMethod(), e.getMessage());
+        if (!resp.isCommitted()) {
+          resp.reset();
+          resp.setStatus(HttpStatus.PAYLOAD_TOO_LARGE_413);
+        }
+        return;
+      }
       throw e;
     } catch (Exception unexpected) {
       logger.error("Http Api {}, Method:{}. Error：", url, req.getMethod(), unexpected);

--- a/framework/src/test/java/org/tron/core/jsonrpc/JsonrpcServiceTest.java
+++ b/framework/src/test/java/org/tron/core/jsonrpc/JsonrpcServiceTest.java
@@ -26,6 +26,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
 import org.bouncycastle.util.encoders.Hex;
+import org.eclipse.jetty.http.HttpStatus;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -1572,8 +1573,7 @@ public class JsonrpcServiceTest extends BaseTest {
    * Verifies SizeLimitHandler integration with the real JsonRpcServlet + jsonrpc4j stack.
    *
    * Covers: normal request no regression, Content-Length oversized 413,
-   * and chunked oversized handled gracefully (body truncated, 200 + empty body
-   * because jsonrpc4j absorbs the BadMessageException).
+   * and chunked oversized 413 during streaming body reads.
    */
   @Test
   public void testJsonRpcSizeLimitIntegration() {
@@ -1609,11 +1609,11 @@ public class JsonrpcServiceTest extends BaseTest {
         overPost.setEntity(new StringEntity(
             new String(new char[(int) testLimit + 1]).replace('\0', 'x')));
         resp = httpClient.execute(overPost);
-        Assert.assertEquals(413, resp.getStatusLine().getStatusCode());
+        Assert.assertEquals(HttpStatus.PAYLOAD_TOO_LARGE_413,
+            resp.getStatusLine().getStatusCode());
         resp.close();
 
-        // Chunked oversized -> BadMessageException thrown during body read,
-        // absorbed by jsonrpc4j catch(Exception) -> 200 with empty body.
+        // Chunked oversized -> BadMessageException thrown during body read.
         // Body read IS truncated at the limit - OOM protection effective.
         byte[] chunkedData = new String(new char[(int) testLimit * 2])
             .replace('\0', 'x').getBytes("UTF-8");
@@ -1621,10 +1621,8 @@ public class JsonrpcServiceTest extends BaseTest {
         chunkedPost.setEntity(new InputStreamEntity(
             new ByteArrayInputStream(chunkedData), -1));
         resp = httpClient.execute(chunkedPost);
-        Assert.assertEquals(200, resp.getStatusLine().getStatusCode());
-        body = EntityUtils.toString(resp.getEntity());
-        Assert.assertTrue("Chunked oversized should return empty body"
-            + " (jsonrpc4j absorbs BadMessageException)", body.isEmpty());
+        Assert.assertEquals(HttpStatus.PAYLOAD_TOO_LARGE_413,
+            resp.getStatusLine().getStatusCode());
         resp.close();
       }
     } catch (Exception e) {

--- a/framework/src/test/java/org/tron/core/services/filter/HttpInterceptorTest.java
+++ b/framework/src/test/java/org/tron/core/services/filter/HttpInterceptorTest.java
@@ -1,0 +1,44 @@
+package org.tron.core.services.filter;
+
+import static org.junit.Assert.assertThrows;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import org.eclipse.jetty.http.BadMessageException;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+public class HttpInterceptorTest {
+
+  private final HttpInterceptor interceptor = new HttpInterceptor();
+
+  @Test
+  public void testOversizedBadMessagePropagates() {
+    MockHttpServletRequest request = new MockHttpServletRequest("POST", "/jsonrpc");
+    request.setServletPath("/jsonrpc");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    FilterChain chain = (req, resp) -> {
+      throw new BadMessageException(HttpStatus.PAYLOAD_TOO_LARGE_413,
+          "Request body is too large");
+    };
+
+    BadMessageException e = assertThrows(BadMessageException.class,
+        () -> interceptor.doFilter(request, response, chain));
+
+    org.junit.Assert.assertEquals(HttpStatus.PAYLOAD_TOO_LARGE_413, e.getCode());
+  }
+
+  @Test
+  public void testNonOversizedExceptionIsStillSwallowed() throws Exception {
+    MockHttpServletRequest request = new MockHttpServletRequest("POST", "/jsonrpc");
+    request.setServletPath("/jsonrpc");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    FilterChain chain = (req, resp) -> {
+      throw new ServletException("expected");
+    };
+
+    interceptor.doFilter(request, response, chain);
+  }
+}

--- a/framework/src/test/java/org/tron/core/services/http/RateLimiterServletTest.java
+++ b/framework/src/test/java/org/tron/core/services/http/RateLimiterServletTest.java
@@ -16,6 +16,8 @@ import java.lang.reflect.Field;
 import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.http.BadMessageException;
+import org.eclipse.jetty.http.HttpStatus;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
@@ -66,6 +68,14 @@ public class RateLimiterServletTest {
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) {
       // intentional no-op
+    }
+  }
+
+  static class OversizedRequestServlet extends RateLimiterServlet {
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) {
+      throw new BadMessageException(HttpStatus.PAYLOAD_TOO_LARGE_413,
+          "Request body is too large");
     }
   }
 
@@ -248,6 +258,25 @@ public class RateLimiterServletTest {
       servlet.service(request, response);
 
       globalMock.verify(() -> GlobalRateLimiter.acquirePermit(any()), times(1));
+    }
+  }
+
+  @Test
+  public void testOversizedRequestBadMessageReturns413() throws Exception {
+    OversizedRequestServlet oversizedServlet = new OversizedRequestServlet();
+    Field f = RateLimiterServlet.class.getDeclaredField("container");
+    f.setAccessible(true);
+    f.set(oversizedServlet, container);
+    MockHttpServletRequest postRequest = new MockHttpServletRequest("POST", "/jsonrpc");
+    postRequest.setRemoteAddr("10.0.0.1");
+    postRequest.setServletPath("/jsonrpc");
+
+    try (MockedStatic<GlobalRateLimiter> globalMock = mockStatic(GlobalRateLimiter.class)) {
+      globalMock.when(() -> GlobalRateLimiter.acquirePermit(any())).thenReturn(true);
+
+      oversizedServlet.service(postRequest, response);
+
+      assertEquals(HttpStatus.PAYLOAD_TOO_LARGE_413, response.getStatus());
     }
   }
 }

--- a/framework/src/test/java/org/tron/core/services/http/RateLimiterServletTest.java
+++ b/framework/src/test/java/org/tron/core/services/http/RateLimiterServletTest.java
@@ -262,7 +262,7 @@ public class RateLimiterServletTest {
   }
 
   @Test
-  public void testOversizedRequestBadMessageReturns413() throws Exception {
+  public void testOversizedRequestBadMessagePropagates() throws Exception {
     OversizedRequestServlet oversizedServlet = new OversizedRequestServlet();
     Field f = RateLimiterServlet.class.getDeclaredField("container");
     f.setAccessible(true);
@@ -274,9 +274,10 @@ public class RateLimiterServletTest {
     try (MockedStatic<GlobalRateLimiter> globalMock = mockStatic(GlobalRateLimiter.class)) {
       globalMock.when(() -> GlobalRateLimiter.acquirePermit(any())).thenReturn(true);
 
-      oversizedServlet.service(postRequest, response);
+      BadMessageException e = assertThrows(BadMessageException.class,
+          () -> oversizedServlet.service(postRequest, response));
 
-      assertEquals(HttpStatus.PAYLOAD_TOO_LARGE_413, response.getStatus());
+      assertEquals(HttpStatus.PAYLOAD_TOO_LARGE_413, e.getCode());
     }
   }
 }


### PR DESCRIPTION
**What does this PR do?**

Let Jetty `BadMessageException` with status `HttpStatus.PAYLOAD_TOO_LARGE_413` propagate back to the existing unified `OversizedRequestErrorHandler` instead of being absorbed inside the servlet/filter chain.

The change has two parts:
- `RateLimiterServlet` no longer handles oversized-request `BadMessageException` locally; it rethrows it.
- `HttpInterceptor` still records failure metrics, but now rethrows only `BadMessageException(413)` so that oversized chunked requests can reach Jetty's existing unified error path. Other exceptions keep the previous swallow-and-meter behavior.

This keeps chunked JSON-RPC oversized requests aligned with the pre-existing unified oversized-request handling path in `HttpService`, instead of introducing a servlet-specific 413 implementation.

**Why are these changes required?**

For `Transfer-Encoding: chunked`, Jetty only discovers an oversized request while the servlet is reading the request body. In the JSON-RPC path, that expected 413 exception used to be swallowed inside the servlet/filter chain before it could reach Jetty's unified oversized-request error handler, which led to noisy ERROR stack traces and inconsistent handling.

Other HTTP endpoints can hit the same Jetty streaming exception timing. Many HTTP servlets already catch and convert errors locally, but for paths where a 413 does bubble up, this change makes them reuse the same top-level oversized-request handler instead of splitting behavior between ad hoc local handling and Jetty error handling.

**This PR has been tested by:**

- `./gradlew :framework:test --tests "org.tron.core.services.http.RateLimiterServletTest" --tests "org.tron.core.services.filter.HttpInterceptorTest" --tests "org.tron.core.jsonrpc.JsonrpcServiceTest.testJsonRpcSizeLimitIntegration"`
- `./gradlew checkstyleMain checkstyleTest`
- `git diff --check`

**Follow up**

None.

**Extra details**

- `RateLimiterServletTest` now verifies that oversized-request `BadMessageException` is propagated rather than handled in-place.
- `HttpInterceptorTest` locks down the narrower behavior change: rethrow `BadMessageException(413)`, keep swallowing non-413 exceptions.
- `JsonrpcServiceTest` still verifies that oversized chunked JSON-RPC requests return 413 end-to-end.
