### PR TITLE
fix(ci): build multinode test image from the PR's own distribution

### DIFF
--- a/.github/workflows/integration-test-multinode.yml
+++ b/.github/workflows/integration-test-multinode.yml
@@ -40,16 +40,30 @@ jobs:
           key: ${{ runner.os }}-gradle-multinode-${{ hashFiles('**/*.gradle', '**/gradle-wrapper.properties') }}
           restore-keys: ${{ runner.os }}-gradle-multinode-
 
-      - name: Build FullNode.jar
+      - name: Build all java-tron module jars
         run: ./gradlew clean build -x test --no-daemon
 
-      - name: Build local java-tron Docker image (wraps PR-built FullNode.jar)
+      - name: Build local java-tron Docker image (wraps PR-built jars)
         run: |
+          # Build the image from the PR's own distribution: the dist zip's
+          # lib/ contains every runtime jar this build produces (all module
+          # jars plus third-party dependencies from one dependency
+          # resolution). Swapping only FullNode.jar keeps the base image's
+          # stale jars on the classpath, and the node then dies during Spring
+          # startup with NoSuchMethodError while the container stays "Up",
+          # surfacing only as "container tron-mn-node1 is unhealthy".
+          # Using the dist also auto-adapts to modules being added, renamed,
+          # or dependency-version bumps by the PR itself.
           mkdir -p /tmp/tron-image
-          cp build/libs/FullNode.jar /tmp/tron-image/
+          unzip -q framework/build/distributions/java-tron-1.0.0.zip \
+            'java-tron-1.0.0/lib/*' -d /tmp/tron-image
+          mv /tmp/tron-image/java-tron-1.0.0/lib /tmp/tron-image/lib
+          rmdir /tmp/tron-image/java-tron-1.0.0
+          cp framework/build/libs/FullNode.jar /tmp/tron-image/lib/
           cat > /tmp/tron-image/Dockerfile <<'EOF'
           FROM tronprotocol/java-tron:latest
-          COPY FullNode.jar /java-tron/lib/FullNode.jar
+          RUN rm -rf /java-tron/lib
+          COPY lib/ /java-tron/lib/
           EOF
           docker build -t java-tron-local:pr /tmp/tron-image
 
@@ -101,6 +115,11 @@ jobs:
           mkdir -p integration-reports/node-logs
           for c in tron-mn-node1 tron-mn-node2 tron-mn-node3 tron-mn-mongodb; do
             docker logs "$c" > "integration-reports/node-logs/${c}.log" 2>&1 || true
+            # docker logs only captures stdout (Logback init noise); java-tron
+            # writes its real application log to /java-tron/logs/tron.log inside
+            # the container. Copy it out — without it a node startup failure
+            # is undiagnosable from CI artifacts.
+            docker cp "$c":/java-tron/logs/. "integration-reports/node-logs/${c}-applogs/" 2>/dev/null || true
           done
 
       - name: Tear down compose stack


### PR DESCRIPTION
**What does this PR do?**

- Fixes the multinode integration-test CI failure `dependency failed to start: container tron-mn-node1 is unhealthy`.
- The "Build local java-tron Docker image" step in `.github/workflows/integration-test-multinode.yml` now builds the image's `/java-tron/lib` from the PR's own distribution zip (`framework/build/distributions/java-tron-1.0.0.zip`) instead of only copying FullNode.jar into the base image
- Renames the build step "Build FullNode.jar" to "Build all java-tron module jars" to match what `./gradlew clean build -x test` actually does
- The "Collect witness node logs" step now also copies `/java-tron/logs/` (the real application log, tron.log) out of each container into the CI artifacts

**Why are these changes required?**

The image-build step only replaced FullNode.jar inside `tronprotocol/java-tron:latest`, leaving the base image's stale module jars on the classpath. When a PR adds a cross-module API (for example framework code calling a new method in common), the node dies during Spring startup with `java.lang.NoSuchMethodError: org.tron.common.parameter.CommonParameter.isAdminRpcEnable()Z` while the JVM process survives, so the container stays `Up` but port 50051 is never bound; the healthcheck then exhausts its 180s window and the stack fails with `container tron-mn-node1 is unhealthy`. Earlier PRs never hit this because they introduced no new cross-module method signatures.

Building from the PR's own dist zip makes every jar (module jars and third-party dependencies) come from a single dependency resolution, and it auto-adapts to modules being added or renamed and to dependency-version bumps by the PR itself.

Additionally, `docker logs` only captures container stdout (Logback initialization noise); java-tron writes its real application log to `/java-tron/logs/tron.log` inside the container, which CI never collected, making this class of failure undiagnosable from CI artifacts.

**This PR has been tested by:**

- Manual Testing: reproduced the exact CI failure on an x86_64 host with the CI's docker-in-docker invocation (node1 unhealthy after the 180s healthcheck window, NoSuchMethodError in tron.log), then re-ran with an image built from the PR's full distribution: all three nodes became healthy in seconds, `RpcApiService started, listening on 50051` appeared in tron.log, and the test suite proceeded normally

**Follow up**

**Extra details**
