### PR TITLE
ci: run single-node smoke only and disable multinode

### DIFF
--- a/.github/workflows/integration-test-multinode.yml
+++ b/.github/workflows/integration-test-multinode.yml
@@ -1,14 +1,17 @@
 name: Integration Test Multinode (Full)
 
 on:
-  push:
-    branches: [ 'master', 'release_**' ]
-  pull_request:
-    branches: [ 'develop', 'release_**' ]
-    types: [ opened, synchronize, reopened ]
-    paths-ignore: [ '**/*.md', '.gitignore', '**/.gitignore', '.editorconfig',
-                    '.gitattributes', 'docs/**', 'CHANGELOG', '.github/ISSUE_TEMPLATE/**',
-                    '.github/PULL_REQUEST_TEMPLATE/**', '.github/CODEOWNERS' ]
+  # Disabled: the multinode integration suite is currently unstable (see the
+  # integration-test team). Re-enable the push/pull_request triggers below
+  # once the suite is fixed.
+  # push:
+  #   branches: [ 'master', 'release_**' ]
+  # pull_request:
+  #   branches: [ 'develop', 'release_**' ]
+  #   types: [ opened, synchronize, reopened ]
+  #   paths-ignore: [ '**/*.md', '.gitignore', '**/.gitignore', '.editorconfig',
+  #                   '.gitattributes', 'docs/**', 'CHANGELOG', '.github/ISSUE_TEMPLATE/**',
+  #                   '.github/PULL_REQUEST_TEMPLATE/**', '.github/CODEOWNERS' ]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/integration-test-single-node.yml
+++ b/.github/workflows/integration-test-single-node.yml
@@ -58,8 +58,6 @@ jobs:
             -e JAVA_HOME_17=/opt/java/openjdk \
             -v "${{ github.workspace }}/build/libs/FullNode.jar:/javatron/FullNode.jar:ro" \
             troninfra/troninfra-ci:latest \
-            # Smoke only: the full single-node suite is currently unstable
-            # (per the integration-test team), so run the smoke subset.
             --clean --smoke
 
       - name: Extract smoke test reports from container

--- a/.github/workflows/integration-test-single-node.yml
+++ b/.github/workflows/integration-test-single-node.yml
@@ -58,7 +58,9 @@ jobs:
             -e JAVA_HOME_17=/opt/java/openjdk \
             -v "${{ github.workspace }}/build/libs/FullNode.jar:/javatron/FullNode.jar:ro" \
             troninfra/troninfra-ci:latest \
-            --clean
+            # Smoke only: the full single-node suite is currently unstable
+            # (per the integration-test team), so run the smoke subset.
+            --clean --smoke
 
       - name: Extract test reports from container
         if: always()

--- a/.github/workflows/integration-test-single-node.yml
+++ b/.github/workflows/integration-test-single-node.yml
@@ -1,4 +1,4 @@
-name: Integration Test Single Node (Full)
+name: Integration Test Single Node (Smoke)
 
 on:
   push:
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   integration:
-    name: Integration Test Single Node Full (JDK 8 / x86_64)
+    name: Integration Test Single Node Smoke (JDK 8 / x86_64)
     runs-on: ubuntu-latest
     timeout-minutes: 45
 
@@ -46,7 +46,7 @@ jobs:
       - name: Pull integration-test image
         run: docker pull troninfra/troninfra-ci:latest
 
-      - name: Run integration tests
+      - name: Run integration smoke tests
         run: |
           # JAVA_HOME=JDK 8 so FullNode runs on the same JVM family as
           # production (a few assertions check `java.version` starts with
@@ -62,7 +62,7 @@ jobs:
             # (per the integration-test team), so run the smoke subset.
             --clean --smoke
 
-      - name: Extract test reports from container
+      - name: Extract smoke test reports from container
         if: always()
         run: |
           mkdir -p integration-reports
@@ -73,10 +73,10 @@ jobs:
           docker cp integration-test:/app/node/data/logs/tron.log integration-reports/ 2>/dev/null || true
           docker rm -f integration-test 2>/dev/null || true
 
-      - name: Upload test reports
+      - name: Upload smoke test reports
         if: always()
         uses: actions/upload-artifact@v6
         with:
-          name: integration-test-report
+          name: integration-smoke-test-report
           path: integration-reports/
           if-no-files-found: warn


### PR DESCRIPTION
**What does this PR do?**

- Switches the single-node integration CI to run only the smoke test subset (`--clean --smoke` instead of the full suite)
- Disables the multinode integration CI (`--all`) triggers, keeping `workflow_dispatch` for manual runs
- Renames the single-node workflow, job, steps, and report artifact from "Full" to "Smoke" to reflect the actual scope

**Why are these changes required?**

Per the QA/integration-test team:

- The smoke suite is the concise core integration test path; QA guarantees it stays valid and effective in CI. If we need additional coverage, we can request QA to add cases to the smoke suite.
- The multinode suite (`--all`) is QA's own regression suite — complex, not recommended for our CI, and not maintained by QA for CI usage. Its execution time will only grow over time, making it increasingly unsuitable as a PR gate.
- The full single-node suite is likewise unstable in CI today (its hardened assertions don't match the fixture baked into the `troninfra/troninfra-ci` image, causing stable failures unrelated to PR code).

Gating PRs on the smoke subset restores a reliable, QA-backed CI signal.

**This PR has been tested by:**
- Unit Tests
- Manual Testing (workflow YAML validated; smoke run verified green on fork PR — `smokeTest` task, 74 passed / 0 failed)

**Follow up**

- Coordinate with QA if more integration coverage is needed — new cases should be added to the smoke suite
- Multinode (`--all`) remains available via manual `workflow_dispatch`

**Extra details**

No production code changes; CI configuration only.