### PR TITLE
docs: clarify architecture-specific JDK requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,16 @@ TRON is building the foundational infrastructure for the decentralized internet 
 Before building java-tron, make sure you have:
 - Hardware with at least 4 CPU cores, 16 GB RAM, 10 GB free disk space for a smooth compilation process.
 - Operating system: `Linux` or `macOS` (`Windows` is not supported).
-- Git and correct JDK (version `8` or `17`) installed based on your CPU architecture.
+- Git and the JDK matching your CPU architecture (see the table below).
+
+The JDK version required to build or run java-tron is currently tied to the CPU architecture; the two versions are not interchangeable:
+
+| CPU Architecture | Required JDK |
+| :--------------- | :----------- |
+| `x86_64` / `amd64` | JDK 8 |
+| `ARM64` / `aarch64` | JDK 17 |
+
+> **Note**: `ARM64` / `aarch64` support is available starting with GreatVoyage-v4.8.1.
 
 There are two ways to install the required dependencies:
 
@@ -49,8 +58,6 @@ There are two ways to install the required dependencies:
   chmod +x install_dependencies.sh
   ./install_dependencies.sh
   ```
-  > **Note**: For production-grade stability with JDK 8 on x86_64 architecture, Oracle JDK 8 is strongly recommended (the script installs OpenJDK 8).
-
 - **Option 2: Manual installation**
 
   Follow the [Prerequisites and Installation Guide](https://tronprotocol.github.io/documentation-en/using_javatron/installing_javatron/#prerequisites-before-compiling-java-tron) for step-by-step instructions.

--- a/docs/modular-deployment-en.md
+++ b/docs/modular-deployment-en.md
@@ -4,6 +4,17 @@ After modularization, the recommended way to launch java-tron is via the shell s
 
 > **Supported platforms**: Linux and macOS. Windows is not supported.
 
+## Prerequisites
+
+The JDK version required to build and run java-tron is currently tied to the CPU architecture; the two versions are not interchangeable:
+
+| CPU Architecture | Required JDK |
+| :--------------- | :----------- |
+| `x86_64` / `amd64` | JDK 8 |
+| `ARM64` / `aarch64` | JDK 17 |
+
+> **Note**: `ARM64` / `aarch64` support is available starting with GreatVoyage-v4.8.1.
+
 ## Download
 
 ```
@@ -45,11 +56,9 @@ java-tron-1.0.0/bin/FullNode -c config.conf -w
 
 JVM options can also be specified, located in `bin/java-tron.vmoptions`:
 ```
-# demo (compatible with JDK 8 / JDK 17)
+# Heap-size customization example
 -Xms2g
 -Xmx9g
--XX:+PrintGCDetails
--Xloggc:./gc.log
--XX:+PrintGCDateStamps
--XX:ReservedCodeCacheSize=256m
 ```
+
+The generated `java-tron.vmoptions` file already contains GC options appropriate for the build architecture and its required JDK. Keep those architecture-specific options when changing the heap size; do not copy GC options between JDK 8 and JDK 17 deployments.

--- a/docs/modular-deployment-zh.md
+++ b/docs/modular-deployment-zh.md
@@ -4,6 +4,17 @@
 
 > **支持平台**：Linux 和 macOS。不支持 Windows。
 
+## 环境要求
+
+当前，构建和运行 java-tron 所需的 JDK 版本与 CPU 架构绑定，两个版本不能互换：
+
+| CPU 架构 | 所需 JDK |
+| :------- | :------- |
+| `x86_64` / `amd64` | JDK 8 |
+| `ARM64` / `aarch64` | JDK 17 |
+
+> **注意**：从 GreatVoyage-v4.8.1 开始支持 `ARM64` / `aarch64` 架构。
+
 ## 下载
 
 ```
@@ -43,11 +54,9 @@ java-tron-1.0.0/bin/FullNode -c config.conf -w
 
 java-tron 支持对 jvm 参数进行配置，配置文件为 bin 目录下的 java-tron.vmoptions 文件。
 ```
-# demo（兼容 JDK 8 / JDK 17）
+# 堆大小自定义示例
 -Xms2g
 -Xmx9g
--XX:+PrintGCDetails
--Xloggc:./gc.log
--XX:+PrintGCDateStamps
--XX:ReservedCodeCacheSize=256m
 ```
+
+生成的 `java-tron.vmoptions` 文件已包含与构建架构及其所需 JDK 匹配的 GC 参数。调整堆大小时请保留这些架构专用参数，不要在 JDK 8 和 JDK 17 部署之间复制 GC 参数。


### PR DESCRIPTION
**What does this PR do?**

- Clarifies the current JDK restrictions enforced when both building and running java-tron:
  - `x86_64` / `amd64` requires JDK 8.
  - `ARM64` / `aarch64` requires JDK 17.
- Replaces the architecture-ambiguous JVM options example with a heap-size-only example.
- Explains that generated distributions already include GC options appropriate for the build architecture and required JDK.

**Why are these changes required?**

The JDK mapping is not merely a build-toolchain recommendation. It is enforced at build time in `build.gradle` and again when a FullNode starts through `Arch.throwIfUnsupportedJavaVersion()`.

The existing documentation could be interpreted as allowing either JDK 8 or JDK 17 regardless of CPU architecture. This led to a reasonable but incorrect assumption that a node could run with JDK 17 on `x86_64`.

This PR makes the currently supported build and runtime combinations explicit and helps  prevents users from copying incompatible GC options between JDK 8 and JDK 17 deployments.

**This PR has been tested by:**
- Unit Tests: Not run (documentation-only changes).
- Manual Testing:
  - Verified the documented requirements against the build-time and FullNode startup checks.
  - Verified the architecture-specific generated JVM option files.
  - Ran `git -c core.whitespace=cr-at-eol diff --check`.

**Follow up**

- Coordinate an equivalent clarification for the related pages on developers.tron.network.
- JDK 17 support on `x86_64` remains planned for a future release.

**Extra details**

`ARM64` / `aarch64` support is available starting with GreatVoyage-v4.8.1.

Refs #6895