### PR TITLE
docs: clarify outdated code comments

### DIFF
--- a/common/src/main/java/org/tron/common/logsfilter/TriggerConfig.java
+++ b/common/src/main/java/org/tron/common/logsfilter/TriggerConfig.java
@@ -33,7 +33,7 @@ public class TriggerConfig {
     triggerName = "";
     enabled = false;
     topic = "";
-    redundancy = false; // event will also write to log
+    redundancy = false; // if true, event triggers will also be emitted as log triggers
     ethCompatible = false; // add eth compatible fields, just for transaction now
     solidified = false; // just write solidified data, just for block and transaction now
   }

--- a/framework/src/main/java/org/tron/core/services/interfaceOnSolidity/http/solidity/HttpApiOnSolidityService.java
+++ b/framework/src/main/java/org/tron/core/services/interfaceOnSolidity/http/solidity/HttpApiOnSolidityService.java
@@ -265,7 +265,6 @@ public class HttpApiOnSolidityService extends HttpService {
     context.addServlet(new ServletHolder(getMarketPairListOnSolidityServlet),
         "/walletsolidity/getmarketpairlist");
 
-    // only for SolidityNode
     context.addServlet(new ServletHolder(getTransactionByIdOnSolidityServlet),
         "/walletsolidity/gettransactionbyid");
     context.addServlet(new ServletHolder(getTransactionInfoByIdOnSolidityServlet),

--- a/framework/src/main/resources/logback.xml
+++ b/framework/src/main/resources/logback.xml
@@ -31,7 +31,7 @@
       class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
       <!-- rollover daily -->
       <fileNamePattern>./logs/tron-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
-      <!-- each file should be at most 500MB, keep 30 days worth of history, but at most 50GB -->
+      <!-- each file should be at most 500MB, keep 7 days worth of history, but at most 50GB -->
       <maxFileSize>500MB</maxFileSize>
       <maxHistory>7</maxHistory>
       <totalSizeCap>50GB</totalSizeCap>

--- a/protocol/src/main/protos/core/contract/account_contract.proto
+++ b/protocol/src/main/protos/core/contract/account_contract.proto
@@ -29,7 +29,7 @@ message AccountCreateContract {
   AccountType type = 3;
 }
 
-// Update account name. Account name is not unique now.
+// Update account name. ALLOW_UPDATE_ACCOUNT_NAME is not enabled on Mainnet, so account names are currently unique.
 message AccountUpdateContract {
   bytes account_name = 1;
   bytes owner_address = 2;
@@ -47,4 +47,3 @@ message AccountPermissionUpdateContract {
   Permission witness = 3; //Can be empty
   repeated Permission actives = 4; //Empty is invalidate
 }
-


### PR DESCRIPTION
**What does this PR do?**

Clarify several outdated or ambiguous comments across event triggers, Solidity HTTP APIs, log retention, and account-name rules.

**Why are these changes required?**

The existing comments no longer match the configured behavior or current Mainnet rules. Updating them makes the code easier to understand without changing runtime behavior.

**This PR has been tested by:**

- `./gradlew :framework:checkstyleMain :protocol:protoLint`
- `git diff --check`

**Follow up**

None.

**Extra details**

This is a documentation-only change with no runtime impact.
