### PR TITLE
fix(build): skip errorprone publishing on JDK 8

### DIFF
--- a/errorprone/build.gradle
+++ b/errorprone/build.gradle
@@ -2,6 +2,8 @@ if (!JavaVersion.current().isJava11Compatible()) {
     // ErrorProne core requires JDK 11+; skip this module on JDK 8
     tasks.withType(JavaCompile).configureEach { enabled = false }
     tasks.withType(Jar).configureEach { enabled = false }
+    // No jar is produced, so the root maven-publish setup must not try to publish one
+    tasks.withType(AbstractPublishToMaven).configureEach { enabled = false }
 } else {
     dependencies {
         compileOnly "com.google.errorprone:error_prone_annotations:${errorproneVersion}"


### PR DESCRIPTION
**What does this PR do?**

Disables the `errorprone` module's Maven publish tasks on JDK 8, matching the existing compile and jar skips:

```groovy
// No jar is produced, so the root maven-publish setup must not try to publish one
tasks.withType(AbstractPublishToMaven).configureEach { enabled = false }
```

This is intentionally limited to a two-line change in `errorprone/build.gradle`.

**Why are these changes required?**

`errorprone` is a compile-time-only module. Its `error_prone_check_api` and `error_prone_core` 2.42.0 dependencies contain Java 17 bytecode, which JDK 8 cannot read. The module therefore already disables its `JavaCompile` and `Jar` tasks on JDK 8, so no jar is produced.

However, the root `build.gradle` applies `maven-publish` to every subproject and publishes `components.java`. As a result, `publishToMavenLocal` still tries to publish the missing `errorprone` jar:

```text
> Task :errorprone:jar SKIPPED
...
> Task :errorprone:publishMavenJavaPublicationToMavenLocal FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':errorprone:publishMavenJavaPublicationToMavenLocal'.
> Failed to publish publication 'mavenJava' to repository 'mavenLocal'
   > Artifact errorprone-1.0.0.jar wasn't produced by this build.
```

The original failure is visible in the [JitPack build log for GreatVoyage-v4.8.2](https://jitpack.io/com/github/tronprotocol/java-tron/GreatVoyage-v4.8.2/build.log).

The architecture gate requires JDK 8 on `x86_64`, so `publishToMavenLocal` consistently fails on that architecture. This also breaks the installation command in `jitpack.yml`. The `publish` task is unaffected, because no publishing repository is configured and it therefore resolves to an empty lifecycle task.

The failure only affects Maven publishing. Regular JDK 8 builds remain unaffected because no module applies the Error Prone plugin or depends on this jar in that configuration. The JDK 17 path is unchanged and continues to compile, package, and publish the module normally.

`generatePomFileForMavenJavaPublication` and `generateMetadataFileForMavenJavaPublication` are not `AbstractPublishToMaven` tasks, so they still run on JDK 8. They only write files into the build directory, and nothing is installed once `publishMavenJavaPublicationToMavenLocal` is disabled.

**This PR has been tested by:**

- Manual Testing

No unit test is added because this is a Gradle build-script configuration change with no Java code involved.

| Check | Result |
| --- | --- |
| `publishMavenJavaPublicationToMavenLocal` with JDK 8 on `x86_64` | `SKIPPED`; build succeeds |
| Same command with the change reverted | Fails with `Artifact errorprone-1.0.0.jar wasn't produced by this build.` |
| `errorprone` task states on JDK 17 | `compileJava`, `jar`, and the publish task remain enabled |
| Full `jitpack.yml` installation command on JDK 17 | Build succeeds and all modules are published |
| `./gradlew lint` | Passes |

**Follow up**

- The existing guard uses `isJava11Compatible()` and its comment says JDK 11+, while Error Prone 2.42.0 actually requires JDK 17. This is currently masked by the architecture gate, which permits only JDK 8 on `x86_64` or JDK 17 on `arm64`. The guard and comment should be aligned when the JDK 21 work relaxes that gate.
- Adding a JDK 8/`x86_64` CI job that runs the installation command from `jitpack.yml` would catch similar publishing regressions. No current workflow runs `publishToMavenLocal`.

**Extra details**

The regression was introduced in #6698, which added the JDK 8 compile and jar skips but did not disable the corresponding publish tasks.