### PR TITLE
fix(api): incorrect field mappings in GRPC GetStatsInfo and GetNodeInfo

### DIFF
--- a/common/src/main/java/org/tron/common/entity/NodeInfo.java
+++ b/common/src/main/java/org/tron/common/entity/NodeInfo.java
@@ -146,7 +146,7 @@ public class NodeInfo {
       peerInfoBuilder.setLastBlockUpdateTime(peerInfo.getLastBlockUpdateTime());
       peerInfoBuilder.setSyncFlag(peerInfo.isSyncFlag());
       peerInfoBuilder.setHeadBlockTimeWeBothHave(peerInfo.getHeadBlockTimeWeBothHave());
-      peerInfoBuilder.setNeedSyncFromPeer(peerInfo.isSyncFlag());
+      peerInfoBuilder.setNeedSyncFromPeer(peerInfo.isNeedSyncFromPeer());
       peerInfoBuilder.setNeedSyncFromUs(peerInfo.isNeedSyncFromUs());
       peerInfoBuilder.setHost(peerInfo.getHost());
       peerInfoBuilder.setPort(peerInfo.getPort());

--- a/common/src/test/java/org/tron/common/entity/NodeInfoTest.java
+++ b/common/src/test/java/org/tron/common/entity/NodeInfoTest.java
@@ -1,0 +1,58 @@
+package org.tron.common.entity;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Assert;
+import org.junit.Test;
+import org.tron.protos.Protocol;
+
+public class NodeInfoTest {
+
+  private PeerInfo newPeerInfo(boolean syncFlag, boolean needSyncFromPeer,
+      boolean needSyncFromUs) {
+    PeerInfo peerInfo = new PeerInfo();
+    peerInfo.setSyncFlag(syncFlag);
+    peerInfo.setNeedSyncFromPeer(needSyncFromPeer);
+    peerInfo.setNeedSyncFromUs(needSyncFromUs);
+    // string fields must be non-null, otherwise the protobuf setters throw NPE
+    peerInfo.setLastSyncBlock("");
+    peerInfo.setHost("127.0.0.1");
+    peerInfo.setNodeId("");
+    peerInfo.setHeadBlockWeBothHave("");
+    peerInfo.setLocalDisconnectReason("");
+    peerInfo.setRemoteDisconnectReason("");
+    return peerInfo;
+  }
+
+  /**
+   * The protobuf conversion must map each peer flag from its own source field. A previous
+   * copy-and-paste defect populated needSyncFromPeer from isSyncFlag(); distinct values for
+   * syncFlag and needSyncFromPeer are required so that such a mismatch is detected.
+   */
+  @Test
+  public void testPeerFlagMappingIsIndependent() {
+    NodeInfo nodeInfo = new NodeInfo();
+    nodeInfo.setBlock("");
+    nodeInfo.setSolidityBlock("");
+    List<PeerInfo> peerList = new ArrayList<>();
+    // syncFlag != needSyncFromPeer so the two fields cannot be confused
+    peerList.add(newPeerInfo(false, true, false));
+    peerList.add(newPeerInfo(true, false, true));
+    nodeInfo.setPeerList(peerList);
+    nodeInfo.setCheatWitnessInfoMap(new java.util.HashMap<>());
+
+    Protocol.NodeInfo proto = nodeInfo.transferToProtoEntity();
+
+    Assert.assertEquals(2, proto.getPeerInfoListCount());
+
+    Protocol.NodeInfo.PeerInfo peer0 = proto.getPeerInfoList(0);
+    Assert.assertFalse(peer0.getSyncFlag());
+    Assert.assertTrue(peer0.getNeedSyncFromPeer());
+    Assert.assertFalse(peer0.getNeedSyncFromUs());
+
+    Protocol.NodeInfo.PeerInfo peer1 = proto.getPeerInfoList(1);
+    Assert.assertTrue(peer1.getSyncFlag());
+    Assert.assertFalse(peer1.getNeedSyncFromPeer());
+    Assert.assertTrue(peer1.getNeedSyncFromUs());
+  }
+}

--- a/framework/src/main/java/org/tron/core/metrics/net/NetMetricManager.java
+++ b/framework/src/main/java/org/tron/core/metrics/net/NetMetricManager.java
@@ -181,7 +181,7 @@ public class NetMetricManager {
     // udp
     RateInfo udpInTraffic = net.getUdpInTraffic();
     Protocol.MetricsInfo.RateInfo udpInTrafficInfo = udpInTraffic.toProtoEntity();
-    netInfo.setTcpOutTraffic(udpInTrafficInfo);
+    netInfo.setUdpInTraffic(udpInTrafficInfo);
     RateInfo udpOutTraffic = net.getUdpOutTraffic();
     Protocol.MetricsInfo.RateInfo udpOutTrafficInfo = udpOutTraffic.toProtoEntity();
     netInfo.setUdpOutTraffic(udpOutTrafficInfo);

--- a/framework/src/test/java/org/tron/core/metrics/MetricsApiServiceTest.java
+++ b/framework/src/test/java/org/tron/core/metrics/MetricsApiServiceTest.java
@@ -38,6 +38,10 @@ public class MetricsApiServiceTest extends BaseMethodTest {
 
   @Test
   public void testProcessMessage() {
+    MetricsUtil.getMeter(MetricsKey.NET_TCP_IN_TRAFFIC).mark(1000);
+    MetricsUtil.getMeter(MetricsKey.NET_TCP_OUT_TRAFFIC).mark(2000);
+    MetricsUtil.getMeter(MetricsKey.NET_UDP_IN_TRAFFIC).mark(4000);
+    MetricsUtil.getMeter(MetricsKey.NET_UDP_OUT_TRAFFIC).mark(8000);
 
     MetricsInfo m1 = metricsApiService.getMetricsInfo();
 
@@ -79,6 +83,20 @@ public class MetricsApiServiceTest extends BaseMethodTest {
     Assert.assertEquals(m1.getNet().getErrorProtoCount(), m2.getNet().getErrorProtoCount());
     Assert
         .assertEquals(m1.getNet().getValidConnectionCount(), m2.getNet().getValidConnectionCount());
+
+    long tcpIn = m1.getNet().getTcpInTraffic().getCount();
+    long tcpOut = m1.getNet().getTcpOutTraffic().getCount();
+    long udpIn = m1.getNet().getUdpInTraffic().getCount();
+    long udpOut = m1.getNet().getUdpOutTraffic().getCount();
+
+    Assert.assertNotEquals(tcpOut, udpIn);
+    Assert.assertNotEquals(tcpIn, tcpOut);
+    Assert.assertNotEquals(udpIn, udpOut);
+
+    Assert.assertEquals(tcpIn, m2.getNet().getTcpInTraffic().getCount());
+    Assert.assertEquals(tcpOut, m2.getNet().getTcpOutTraffic().getCount());
+    Assert.assertEquals(udpIn, m2.getNet().getUdpInTraffic().getCount());
+    Assert.assertEquals(udpOut, m2.getNet().getUdpOutTraffic().getCount());
   }
 
 }


### PR DESCRIPTION
**What does this PR do?**
Node and network API responses populated two fields from the wrong source values because of copy-and-paste mapping errors.
Map `needSyncFromPeer` from the corresponding peer state and assign UDP inbound traffic to the `udpInTraffic` protobuf field.

Fixes #6926

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

