### PR TITLE
ci: optimize pull request checks

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -197,7 +197,7 @@ jobs:
             debian11-x86_64-gradle-
 
       - name: Build
-        run: ./gradlew clean build --no-daemon --no-build-cache
+        run: ./gradlew clean build --no-daemon
 
       - name: Toolkit jar smoke test
         run: |
@@ -209,7 +209,7 @@ jobs:
           java -jar "$JAR" keystore --help
 
       - name: Test with RocksDB engine
-        run: ./gradlew :framework:testWithRocksDb --no-daemon --no-build-cache
+        run: ./gradlew :framework:testWithRocksDb --no-daemon
 
       - name: Generate module coverage reports
         run: ./gradlew jacocoTestReport --no-daemon
@@ -265,11 +265,11 @@ jobs:
         # this PR.  The only output we need from this job is the jacoco XML for
         # coverage diffing, so we must not let a stale test failure block it.
         continue-on-error: true
-        run: ./gradlew clean build --no-daemon --no-build-cache
+        run: ./gradlew clean build --no-daemon
 
       - name: Test with RocksDB engine (base)
         continue-on-error: true
-        run: ./gradlew :framework:testWithRocksDb --no-daemon --no-build-cache
+        run: ./gradlew :framework:testWithRocksDb --no-daemon
 
       - name: Generate module coverage reports (base)
         run: ./gradlew jacocoTestReport --no-daemon

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -43,8 +43,8 @@ jobs:
               errors.push(`PR title is too long (${title.length}/72 characters).`);
             }
 
-            // 2. Conventional format check
-            const conventionalRegex = /^(feat|fix|refactor|docs|style|test|chore|ci|perf|build|revert)(\([^)]+\))?:\s\S.*/;
+            // 2. Conventional format check (allow a missing recommended space)
+            const conventionalRegex = /^(feat|fix|refactor|docs|style|test|chore|ci|perf|build|revert)(\([^)]+\))?: ?\S.*/;
             if (title && !conventionalRegex.test(title)) {
               errors.push(
                 'PR title must follow conventional format: `type(scope): description`\n' +
@@ -60,7 +60,7 @@ jobs:
 
             // 4. Description part should not start with a capital letter
             if (title) {
-              const descMatch = title.match(/^\w+(?:\([^)]+\))?:\s*(.+)/);
+              const descMatch = title.match(/^\w+(?:\([^)]+\))?: ?(.+)/);
               if (descMatch) {
                 const desc = descMatch[1];
                 if (/^[A-Z]/.test(desc)) {

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -43,9 +43,16 @@ jobs:
               errors.push(`PR title is too long (${title.length}/72 characters).`);
             }
 
-            // 2. Conventional format check (allow a missing recommended space)
-            const conventionalRegex = /^(feat|fix|refactor|docs|style|test|chore|ci|perf|build|revert)(\([^)]+\))?: ?\S.*/;
-            if (title && !conventionalRegex.test(title)) {
+            // 2. Conventional format check (require a space after the colon)
+            const titlePrefix = '(?:feat|fix|refactor|docs|style|test|chore|ci|perf|build|revert)(?:[(][^)]+[)])?';
+            const missingSpaceAfterColonRegex = new RegExp(`^${titlePrefix}:[^ ]`);
+            const conventionalRegex = new RegExp(`^${titlePrefix}: [^ ].*`);
+            if (title && missingSpaceAfterColonRegex.test(title)) {
+              errors.push(
+                'PR title must include a space after the colon.\n' +
+                '  Example: `feat(tvm): add blob opcodes`'
+              );
+            } else if (title && !conventionalRegex.test(title)) {
               errors.push(
                 'PR title must follow conventional format: `type(scope): description`\n' +
                 '  Allowed types: ' + allowedTypes.map(t => `\`${t}\``).join(', ') + '\n' +
@@ -60,7 +67,7 @@ jobs:
 
             // 4. Description part should not start with a capital letter
             if (title) {
-              const descMatch = title.match(/^\w+(?:\([^)]+\))?: ?(.+)/);
+              const descMatch = title.match(/^\w+(?:\([^)]+\))?: (.+)/);
               if (descMatch) {
                 const desc = descMatch[1];
                 if (/^[A-Z]/.test(desc)) {

--- a/.github/workflows/pr-reviewer.yml
+++ b/.github/workflows/pr-reviewer.yml
@@ -59,13 +59,23 @@ jobs:
             const normalize = s => s.toLowerCase().replace(/[\s\-_]/g, '');
 
             // ── Extract scope from conventional commit title ──────────
-            // Format: type(scope): description
+            // Formats documented by CONTRIBUTING.md:
+            //   type(scope): description
+            //   type: description
             // Also supports: type(scope1,scope2): description
+            // Only bare "ci" currently has an equivalent reviewer scope.
             const scopeMatch = title.match(/^\w+\(([^)]+)\):/);
-            const rawScope = scopeMatch ? scopeMatch[1] : null;
+            const bareTypeMatch = title.match(/^(\w+):/);
+            const inferredScope = !scopeMatch && bareTypeMatch?.[1].toLowerCase() === 'ci'
+              ? 'ci'
+              : null;
+            const rawScope = scopeMatch ? scopeMatch[1] : inferredScope;
 
             core.info(`PR title : ${title}`);
             core.info(`Raw scope: ${rawScope || '(none)'}`);
+            if (inferredScope) {
+              core.info('Inferred scope "ci" from bare "ci" PR title type.');
+            }
 
             // ── Skip if reviewers already assigned ──────────────────
             const pr = await github.rest.pulls.get({


### PR DESCRIPTION
**What does this PR do?**

- Remove four invocation-wide `--no-build-cache` flags from Debian and Coverage Base builds and RocksDB tests.
- Require PR titles to follow `type(scope): description`, including a space immediately after the colon, and provide a dedicated error when that space is missing.
- Route a bare `ci: description` title to the existing `ci` reviewer scope; explicit scopes still take precedence and other bare types retain default reviewers.

**Why are these changes required?**

The repository already enables Gradle Build Cache. However, four x86 Gradle invocations disable task-output cache reads and writes globally. Removing those flags enables reuse for eligible compile, package, Checkstyle, and test tasks.

`CONTRIBUTING.md` requires the `type: description` or `type(scope): description` format and states that CI enforces it. Requiring the space after the colon keeps validation consistent with the documented rule, while the dedicated error makes the correction explicit.

Since `ci` is also an existing reviewer scope, a bare `ci` type can be mapped without inventing mappings for unrelated types.

**This PR has been tested by:**

- YAML AST parsing for `.github/workflows/pr-build.yml`, `.github/workflows/pr-check.yml`, and `.github/workflows/pr-reviewer.yml`
- Shell validation of 12 positive and negative PR-title cases across 1,000 rounds, totaling 12,000 assertions
- Reviewer extraction cases for explicit scopes, bare `ci`, and other bare types
- Verification that the four x86 commands no longer contain `--no-build-cache`
- `git diff --check`
- Forced local execution without task-cache reuse: `./gradlew -g /private/tmp/java-tron-gradle-home :framework:checkstyleMain :framework:checkstyleTest :plugins:checkstyleMain --no-daemon --no-build-cache`
- Local `:framework:testWithRocksDb` cache validation: an identical-input clean run restored the task `FROM-CACHE`; changing `-DrunPrecompileBenchmark=true` caused the task to execute while unrelated eligible tasks remained cached

**Follow up**

- Use task-specific `--rerun` if a future test contract requires real execution for every CI run.

**Extra details**

- Gradle Build Cache is already enabled repository-wide: `org.gradle.caching=true` is specified in the committed `gradle.properties` at the repository root (present on the base branch, not introduced by this PR). The Gradle build cache is disabled by default, and Gradle reads this file automatically, so no command-line flag or environment change is required. This PR only removes the four invocation-level `--no-build-cache` overrides that were suppressing that baseline configuration.
- `clean` removes project `build/` output but does not remove `$GRADLE_USER_HOME/caches/build-cache-1`; eligible outputs can therefore be restored after `clean`.
- This PR does not change node runtime, consensus, state, database, RPC, configuration, or protocol behavior.

