### PR TITLE
perf: optimize jump table initialization and reuse

### DIFF
--- a/actuator/src/main/java/org/tron/core/actuator/VMActuator.java
+++ b/actuator/src/main/java/org/tron/core/actuator/VMActuator.java
@@ -189,7 +189,8 @@ public class VMActuator implements Actuator2 {
           throw e;
         }
 
-        VM.play(program, OperationRegistry.getTable());
+        // Prepare the table once for this execution and all nested calls.
+        VM.play(program, OperationRegistry.prepareAndGetTable(isConstantCall));
         result = program.getResult();
 
         if (VMConfig.allowEnergyAdjustment()) {

--- a/actuator/src/main/java/org/tron/core/vm/Operation.java
+++ b/actuator/src/main/java/org/tron/core/vm/Operation.java
@@ -52,4 +52,12 @@ public class Operation {
   public boolean isEnabled() {
     return enabled.getAsBoolean();
   }
+
+  public Operation adjustCost(Function<Program, Long> newCost) {
+    return new Operation(opcode, require, ret, newCost, action, enabled);
+  }
+
+  public Operation adjustAction(Consumer<Program> newAction) {
+    return new Operation(opcode, require, ret, cost, newAction, enabled);
+  }
 }

--- a/actuator/src/main/java/org/tron/core/vm/OperationRegistry.java
+++ b/actuator/src/main/java/org/tron/core/vm/OperationRegistry.java
@@ -7,12 +7,45 @@ import org.tron.core.vm.config.VMConfig;
 
 public class OperationRegistry {
 
+  private static final Operation DEFAULT_MLOAD = new Operation(
+      Op.MLOAD, 1, 1, EnergyCost::getMloadCost, OperationActions::mLoadAction);
+
+  private static final Operation DEFAULT_MSTORE = new Operation(
+      Op.MSTORE, 2, 0, EnergyCost::getMStoreCost, OperationActions::mStoreAction);
+
+  private static final Operation DEFAULT_MSTORE8 = new Operation(
+      Op.MSTORE8, 2, 0, EnergyCost::getMStore8Cost, OperationActions::mStore8Action);
+
+  private static final Operation ADJUSTED_MLOAD =
+      DEFAULT_MLOAD.adjustCost(EnergyCost::getMloadCost2);
+
+  private static final Operation ADJUSTED_MSTORE =
+      DEFAULT_MSTORE.adjustCost(EnergyCost::getMStoreCost2);
+
+  private static final Operation ADJUSTED_MSTORE8 =
+      DEFAULT_MSTORE8.adjustCost(EnergyCost::getMStore8Cost2);
+
+  private static final Operation DEFAULT_VOTEWITNESS = new Operation(
+      Op.VOTEWITNESS, 4, 1, EnergyCost::getVoteWitnessCost,
+      OperationActions::voteWitnessAction, VMConfig::allowTvmVote);
+
+  private static final Operation ADJUSTED_VOTEWITNESS =
+      DEFAULT_VOTEWITNESS.adjustCost(EnergyCost::getVoteWitnessCost2);
+
+  private static final Operation OSAKA_VOTEWITNESS =
+      DEFAULT_VOTEWITNESS.adjustCost(EnergyCost::getVoteWitnessCost3);
+
+  private static final Operation DEFAULT_SUICIDE = new Operation(
+      Op.SUICIDE, 1, 0, EnergyCost::getSuicideCost, OperationActions::suicideAction);
+
+  private static final Operation ADJUSTED_SUICIDE =
+      DEFAULT_SUICIDE.adjustCost(EnergyCost::getSuicideCost2);
+
+  private static final Operation RESTRICTED_SUICIDE =
+      DEFAULT_SUICIDE.adjustCost(EnergyCost::getSuicideCost3)
+          .adjustAction(OperationActions::suicideAction2);
+
   public enum Version {
-    TRON_V1_0,
-    TRON_V1_1,
-    TRON_V1_2,
-    TRON_V1_3,
-    TRON_V1_4,
     TRON_V1_5,
     // add more
     // TRON_V2,
@@ -21,13 +54,21 @@ public class OperationRegistry {
 
   private static final Map<Version, JumpTable> tableMap = new HashMap<>();
 
+  // The newest version in use. Bump this when a newer operation set is added,
+  // together with newLatestOperationSet() below.
+  private static final Version LATEST_VERSION = Version.TRON_V1_5;
+
   static {
-    tableMap.put(Version.TRON_V1_0, newTronV10OperationSet());
-    tableMap.put(Version.TRON_V1_1, newTronV11OperationSet());
-    tableMap.put(Version.TRON_V1_2, newTronV12OperationSet());
-    tableMap.put(Version.TRON_V1_3, newTronV13OperationSet());
-    tableMap.put(Version.TRON_V1_4, newTronV14OperationSet());
-    tableMap.put(Version.TRON_V1_5, newTronV15OperationSet());
+    tableMap.put(LATEST_VERSION, newLatestOperationSet());
+  }
+
+  // Constant calls get a dedicated instance of the newest table, isolated from
+  // the shared consensus table above.
+  private static final JumpTable CONSTANT_CALL_TABLE = newLatestOperationSet();
+
+  // The single place that decides which operation set is the newest.
+  private static JumpTable newLatestOperationSet() {
+    return newTronV15OperationSet();
   }
 
   public static JumpTable newTronV10OperationSet() {
@@ -74,28 +115,22 @@ public class OperationRegistry {
   // Just for warming up class to avoid out_of_time
   public static void init() {}
 
-  public static JumpTable getTable() {
-    // always get the table which has the newest version
-    JumpTable table = tableMap.get(Version.TRON_V1_5);
-
-    // next make the corresponding changes, exclude activating opcode
-    if (VMConfig.allowHigherLimitForMaxCpuTimeOfOneTx()) {
-      adjustMemOperations(table);
-    }
-
-    if (VMConfig.allowEnergyAdjustment()) {
-      adjustForFairEnergy(table);
-    }
-
-    if (VMConfig.allowTvmSelfdestructRestriction()) {
-      adjustSelfdestruct(table);
-    }
-
-    if (VMConfig.allowTvmOsaka()) {
-      adjustVoteWitnessCost(table);
-    }
-
+  public static JumpTable prepareAndGetTable(boolean isConstantCall) {
+    JumpTable table = getTable(isConstantCall);
+    // Apply configuration-dependent changes once at the top level.
+    adjustTable(table);
     return table;
+  }
+
+  public static JumpTable getTable(boolean isConstantCall) {
+    return isConstantCall ? CONSTANT_CALL_TABLE : tableMap.get(LATEST_VERSION);
+  }
+
+  private static void adjustTable(JumpTable table) {
+    // Make the corresponding changes, excluding opcode activation.
+    adjustMemOperations(table);
+    adjustVoteWitness(table);
+    adjustSelfdestruct(table);
   }
 
   public static JumpTable newBaseOperationSet() {
@@ -331,20 +366,11 @@ public class OperationRegistry {
         EnergyCost::getBaseTierCost,
         OperationActions::popAction));
 
-    table.set(new Operation(
-        Op.MLOAD, 1, 1,
-        EnergyCost::getMloadCost,
-        OperationActions::mLoadAction));
+    table.set(DEFAULT_MLOAD);
 
-    table.set(new Operation(
-        Op.MSTORE, 2, 0,
-        EnergyCost::getMStoreCost,
-        OperationActions::mStoreAction));
+    table.set(DEFAULT_MSTORE);
 
-    table.set(new Operation(
-        Op.MSTORE8, 2, 0,
-        EnergyCost::getMStore8Cost,
-        OperationActions::mStore8Action));
+    table.set(DEFAULT_MSTORE8);
 
     table.set(new Operation(
         Op.SLOAD, 1, 1,
@@ -449,10 +475,7 @@ public class OperationRegistry {
         EnergyCost::getRevertCost,
         OperationActions::revertAction));
 
-    table.set(new Operation(
-        Op.SUICIDE, 1, 0,
-        EnergyCost::getSuicideCost,
-        OperationActions::suicideAction));
+    table.set(DEFAULT_SUICIDE);
 
     return table;
   }
@@ -570,11 +593,7 @@ public class OperationRegistry {
   public static void appendVoteOperations(JumpTable table) {
     BooleanSupplier proposal = VMConfig::allowTvmVote;
 
-    table.set(new Operation(
-        Op.VOTEWITNESS, 4, 1,
-        EnergyCost::getVoteWitnessCost,
-        OperationActions::voteWitnessAction,
-        proposal));
+    table.set(DEFAULT_VOTEWITNESS);
 
     table.set(new Operation(
         Op.WITHDRAWREWARD, 0, 1,
@@ -591,23 +610,6 @@ public class OperationRegistry {
         EnergyCost::getBaseTierCost,
         OperationActions::baseFeeAction,
         proposal));
-  }
-
-  public static void adjustMemOperations(JumpTable table) {
-    table.set(new Operation(
-        Op.MLOAD, 1, 1,
-        EnergyCost::getMloadCost2,
-        OperationActions::mLoadAction));
-
-    table.set(new Operation(
-        Op.MSTORE, 2, 0,
-        EnergyCost::getMStoreCost2,
-        OperationActions::mStoreAction));
-
-    table.set(new Operation(
-        Op.MSTORE8, 2, 0,
-        EnergyCost::getMStore8Cost2,
-        OperationActions::mStore8Action));
   }
 
   public static void appendFreezeV2Operations(JumpTable table) {
@@ -664,19 +666,6 @@ public class OperationRegistry {
         proposal));
   }
 
-  public static void adjustForFairEnergy(JumpTable table) {
-    table.set(new Operation(
-        Op.VOTEWITNESS, 4, 1,
-        EnergyCost::getVoteWitnessCost2,
-        OperationActions::voteWitnessAction,
-        VMConfig::allowTvmVote));
-
-    table.set(new Operation(
-        Op.SUICIDE, 1, 0,
-        EnergyCost::getSuicideCost2,
-        OperationActions::suicideAction));
-  }
-
   public static void appendCancunOperations(JumpTable table) {
     BooleanSupplier proposal = VMConfig::allowTvmCancun;
     BooleanSupplier tvmBlobProposal = VMConfig::allowTvmBlob;
@@ -722,18 +711,30 @@ public class OperationRegistry {
         proposal));
   }
 
-  public static void adjustSelfdestruct(JumpTable table) {
-    table.set(new Operation(
-        Op.SUICIDE, 1, 0,
-        EnergyCost::getSuicideCost3,
-        OperationActions::suicideAction2));
+  public static void adjustMemOperations(JumpTable table) {
+    boolean adjusted = VMConfig.allowHigherLimitForMaxCpuTimeOfOneTx();
+    table.set(adjusted ? ADJUSTED_MLOAD : DEFAULT_MLOAD);
+    table.set(adjusted ? ADJUSTED_MSTORE : DEFAULT_MSTORE);
+    table.set(adjusted ? ADJUSTED_MSTORE8 : DEFAULT_MSTORE8);
   }
 
-  public static void adjustVoteWitnessCost(JumpTable table) {
-    table.set(new Operation(
-        Op.VOTEWITNESS, 4, 1,
-        EnergyCost::getVoteWitnessCost3,
-        OperationActions::voteWitnessAction,
-        VMConfig::allowTvmVote));
+  public static void adjustVoteWitness(JumpTable table) {
+    if (VMConfig.allowTvmOsaka()) {
+      table.set(OSAKA_VOTEWITNESS);
+    } else if (VMConfig.allowEnergyAdjustment()) {
+      table.set(ADJUSTED_VOTEWITNESS);
+    } else {
+      table.set(DEFAULT_VOTEWITNESS);
+    }
+  }
+
+  public static void adjustSelfdestruct(JumpTable table) {
+    if (VMConfig.allowTvmSelfdestructRestriction()) {
+      table.set(RESTRICTED_SUICIDE);
+    } else if (VMConfig.allowEnergyAdjustment()) {
+      table.set(ADJUSTED_SUICIDE);
+    } else {
+      table.set(DEFAULT_SUICIDE);
+    }
   }
 }

--- a/actuator/src/main/java/org/tron/core/vm/program/Program.java
+++ b/actuator/src/main/java/org/tron/core/vm/program/Program.java
@@ -914,7 +914,8 @@ public class Program {
       if (VMConfig.allowTvmCompatibleEvm()) {
         program.setContractVersion(getContractVersion());
       }
-      VM.play(program, OperationRegistry.getTable());
+      // Reuse the table prepared by the top-level execution.
+      VM.play(program, OperationRegistry.getTable(isConstantCall()));
       createResult = program.getResult();
       getTrace().merge(program.getTrace());
       // always commit nonce
@@ -1146,7 +1147,8 @@ public class Program {
         program.setContractVersion(invoke.getDeposit()
             .getContract(codeAddress).getContractVersion());
       }
-      VM.play(program, OperationRegistry.getTable());
+      // Reuse the table prepared by the top-level execution.
+      VM.play(program, OperationRegistry.getTable(isConstantCall()));
       callResult = program.getResult();
 
       getTrace().merge(program.getTrace());

--- a/framework/src/test/java/org/tron/common/runtime/VMActuatorMockTest.java
+++ b/framework/src/test/java/org/tron/common/runtime/VMActuatorMockTest.java
@@ -1,6 +1,8 @@
 package org.tron.common.runtime;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.same;
 
 import java.lang.reflect.Field;
 import java.util.Collections;
@@ -13,17 +15,68 @@ import org.tron.common.runtime.vm.DataWord;
 import org.tron.common.runtime.vm.LogInfo;
 import org.tron.core.actuator.VMActuator;
 import org.tron.core.db.TransactionContext;
+import org.tron.core.vm.JumpTable;
 import org.tron.core.vm.OperationRegistry;
 import org.tron.core.vm.VM;
 import org.tron.core.vm.config.VMConfig;
 import org.tron.core.vm.program.Program;
+import org.tron.core.vm.repository.Repository;
 
 public class VMActuatorMockTest {
 
   @BeforeClass
   public static void init() {
-    // warm up the registry so VM.play(..., OperationRegistry.getTable()) arg eval is safe
+    // Warm up the registry before VM execution timing starts.
     OperationRegistry.init();
+  }
+
+  @Test
+  public void constantCallUsesDedicatedJumpTable() throws Exception {
+    try (MockedStatic<VM> vmMock = Mockito.mockStatic(VM.class)) {
+      Program program = Mockito.mock(Program.class);
+      Mockito.when(program.getResult()).thenReturn(new ProgramResult());
+
+      VMActuator actuator = new VMActuator(true);
+      Field f = VMActuator.class.getDeclaredField("program");
+      f.setAccessible(true);
+      f.set(actuator, program);
+
+      TransactionContext context = Mockito.mock(TransactionContext.class);
+      Mockito.when(context.getProgramResult()).thenReturn(new ProgramResult());
+
+      actuator.execute(context);
+
+      JumpTable transactionTable = OperationRegistry.getTable(false);
+      JumpTable constantCallTable = OperationRegistry.getTable(true);
+      vmMock.verify(() -> VM.play(any(), same(constantCallTable)));
+      vmMock.verify(() -> VM.play(any(), argThat(table -> table != transactionTable)));
+    }
+  }
+
+  @Test
+  public void nonConstantCallUsesSharedJumpTable() throws Exception {
+    try (MockedStatic<VM> vmMock = Mockito.mockStatic(VM.class)) {
+      Program program = Mockito.mock(Program.class);
+      Mockito.when(program.getResult()).thenReturn(new ProgramResult());
+
+      VMActuator actuator = new VMActuator(false);
+      Field f = VMActuator.class.getDeclaredField("program");
+      f.setAccessible(true);
+      f.set(actuator, program);
+
+      Field repositoryField = VMActuator.class.getDeclaredField("rootRepository");
+      repositoryField.setAccessible(true);
+      repositoryField.set(actuator, Mockito.mock(Repository.class));
+
+      TransactionContext context = Mockito.mock(TransactionContext.class);
+      Mockito.when(context.getProgramResult()).thenReturn(new ProgramResult());
+
+      actuator.execute(context);
+
+      // The non-constant call must receive the shared consensus table itself.
+      JumpTable shared = OperationRegistry.getTable(false);
+      vmMock.verify(() -> VM.play(any(), same(shared)));
+    }
   }
 
   private void runCatchPathTest(Throwable thrownByVm, boolean osakaOn, int expectedSize)

--- a/framework/src/test/java/org/tron/common/runtime/vm/OperationsTest.java
+++ b/framework/src/test/java/org/tron/common/runtime/vm/OperationsTest.java
@@ -51,7 +51,7 @@ public class OperationsTest extends BaseTest {
 
   private ProgramInvokeMockImpl invoke;
   private Program program;
-  private final JumpTable jumpTable = OperationRegistry.getTable();
+  private final JumpTable jumpTable = OperationRegistry.prepareAndGetTable(false);
   @Autowired
   private Wallet wallet;
 

--- a/framework/src/test/java/org/tron/common/runtime/vm/VoteWitnessCost3Test.java
+++ b/framework/src/test/java/org/tron/common/runtime/vm/VoteWitnessCost3Test.java
@@ -217,7 +217,7 @@ public class VoteWitnessCost3Test extends BaseTest {
   @Test
   public void testOperationRegistryWithoutOsaka() {
     VMConfig.initAllowTvmOsaka(0);
-    JumpTable table = OperationRegistry.getTable();
+    JumpTable table = OperationRegistry.prepareAndGetTable(false);
     Operation voteOp = table.get(Op.VOTEWITNESS);
     assertTrue(voteOp.isEnabled());
 
@@ -233,7 +233,7 @@ public class VoteWitnessCost3Test extends BaseTest {
   public void testOperationRegistryWithOsaka() {
     VMConfig.initAllowTvmOsaka(1);
     try {
-      JumpTable table = OperationRegistry.getTable();
+      JumpTable table = OperationRegistry.prepareAndGetTable(false);
       Operation voteOp = table.get(Op.VOTEWITNESS);
       assertTrue(voteOp.isEnabled());
 

--- a/framework/src/test/java/org/tron/core/vm/OperationRegistryTest.java
+++ b/framework/src/test/java/org/tron/core/vm/OperationRegistryTest.java
@@ -1,0 +1,142 @@
+package org.tron.core.vm;
+
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+
+import org.junit.Test;
+import org.tron.core.vm.config.VMConfig;
+
+public class OperationRegistryTest {
+
+  @Test
+  public void constantAndTransactionExecutionsUseDedicatedTables() {
+    JumpTable transactionTable = OperationRegistry.prepareAndGetTable(false);
+    JumpTable constantCallTable = OperationRegistry.prepareAndGetTable(true);
+
+    assertNotSame(transactionTable, constantCallTable);
+    assertSame(transactionTable, OperationRegistry.getTable(false));
+    assertSame(constantCallTable, OperationRegistry.getTable(true));
+  }
+
+  @Test
+  public void transactionExecutionsReuseTable() {
+    JumpTable first = OperationRegistry.prepareAndGetTable(false);
+    JumpTable second = OperationRegistry.prepareAndGetTable(false);
+
+    assertSame(first, second);
+  }
+
+  @Test
+  public void constantExecutionsReuseTable() {
+    JumpTable first = OperationRegistry.prepareAndGetTable(true);
+    JumpTable second = OperationRegistry.prepareAndGetTable(true);
+
+    assertSame(first, second);
+  }
+
+  @Test
+  public void constantAdjustmentsDoNotMutateTransactionTable() {
+    boolean previousHigherLimit = VMConfig.allowHigherLimitForMaxCpuTimeOfOneTx();
+    JumpTable transactionTable = OperationRegistry.getTable(false);
+    JumpTable constantCallTable = OperationRegistry.getTable(true);
+    try {
+      VMConfig.initAllowHigherLimitForMaxCpuTimeOfOneTx(0);
+      OperationRegistry.adjustMemOperations(transactionTable);
+      OperationRegistry.adjustMemOperations(constantCallTable);
+      Operation transactionMload = transactionTable.get(Op.MLOAD);
+      Operation constantMload = constantCallTable.get(Op.MLOAD);
+
+      VMConfig.initAllowHigherLimitForMaxCpuTimeOfOneTx(1);
+      OperationRegistry.adjustMemOperations(constantCallTable);
+
+      assertSame(transactionMload, transactionTable.get(Op.MLOAD));
+      assertNotSame(constantMload, constantCallTable.get(Op.MLOAD));
+    } finally {
+      VMConfig.initAllowHigherLimitForMaxCpuTimeOfOneTx(previousHigherLimit ? 1 : 0);
+      OperationRegistry.adjustMemOperations(transactionTable);
+      OperationRegistry.adjustMemOperations(constantCallTable);
+    }
+  }
+
+  @Test
+  public void adjustedOperationsReuseCachedVariants() {
+    boolean previousHigherLimit = VMConfig.allowHigherLimitForMaxCpuTimeOfOneTx();
+    boolean previousEnergyAdjustment = VMConfig.allowEnergyAdjustment();
+    boolean previousOsaka = VMConfig.allowTvmOsaka();
+    boolean previousSelfdestructRestriction = VMConfig.allowTvmSelfdestructRestriction();
+    JumpTable table = OperationRegistry.newTronV15OperationSet();
+
+    Operation defaultMload = table.get(Op.MLOAD);
+    Operation defaultMstore = table.get(Op.MSTORE);
+    Operation defaultMstore8 = table.get(Op.MSTORE8);
+    Operation defaultVoteWitness = table.get(Op.VOTEWITNESS);
+    Operation defaultSuicide = table.get(Op.SUICIDE);
+
+    try {
+      VMConfig.initAllowHigherLimitForMaxCpuTimeOfOneTx(1);
+      VMConfig.initAllowEnergyAdjustment(1);
+      VMConfig.initAllowTvmOsaka(0);
+      VMConfig.initAllowTvmSelfdestructRestriction(0);
+      adjustOperations(table);
+
+      Operation adjustedMload = table.get(Op.MLOAD);
+      Operation adjustedMstore = table.get(Op.MSTORE);
+      Operation adjustedMstore8 = table.get(Op.MSTORE8);
+      Operation adjustedVoteWitness = table.get(Op.VOTEWITNESS);
+      Operation adjustedSuicide = table.get(Op.SUICIDE);
+
+      assertNotSame(defaultMload, adjustedMload);
+      assertNotSame(defaultMstore, adjustedMstore);
+      assertNotSame(defaultMstore8, adjustedMstore8);
+      assertNotSame(defaultVoteWitness, adjustedVoteWitness);
+      assertNotSame(defaultSuicide, adjustedSuicide);
+
+      adjustOperations(table);
+      assertSame(adjustedMload, table.get(Op.MLOAD));
+      assertSame(adjustedMstore, table.get(Op.MSTORE));
+      assertSame(adjustedMstore8, table.get(Op.MSTORE8));
+      assertSame(adjustedVoteWitness, table.get(Op.VOTEWITNESS));
+      assertSame(adjustedSuicide, table.get(Op.SUICIDE));
+
+      VMConfig.initAllowTvmOsaka(1);
+      VMConfig.initAllowTvmSelfdestructRestriction(1);
+      adjustOperations(table);
+
+      Operation osakaVoteWitness = table.get(Op.VOTEWITNESS);
+      Operation restrictedSuicide = table.get(Op.SUICIDE);
+      assertNotSame(adjustedVoteWitness, osakaVoteWitness);
+      assertNotSame(adjustedSuicide, restrictedSuicide);
+
+      adjustOperations(table);
+      assertSame(adjustedMload, table.get(Op.MLOAD));
+      assertSame(adjustedMstore, table.get(Op.MSTORE));
+      assertSame(adjustedMstore8, table.get(Op.MSTORE8));
+      assertSame(osakaVoteWitness, table.get(Op.VOTEWITNESS));
+      assertSame(restrictedSuicide, table.get(Op.SUICIDE));
+
+      VMConfig.initAllowHigherLimitForMaxCpuTimeOfOneTx(0);
+      VMConfig.initAllowEnergyAdjustment(0);
+      VMConfig.initAllowTvmOsaka(0);
+      VMConfig.initAllowTvmSelfdestructRestriction(0);
+      adjustOperations(table);
+
+      assertSame(defaultMload, table.get(Op.MLOAD));
+      assertSame(defaultMstore, table.get(Op.MSTORE));
+      assertSame(defaultMstore8, table.get(Op.MSTORE8));
+      assertSame(defaultVoteWitness, table.get(Op.VOTEWITNESS));
+      assertSame(defaultSuicide, table.get(Op.SUICIDE));
+    } finally {
+      VMConfig.initAllowHigherLimitForMaxCpuTimeOfOneTx(previousHigherLimit ? 1 : 0);
+      VMConfig.initAllowEnergyAdjustment(previousEnergyAdjustment ? 1 : 0);
+      VMConfig.initAllowTvmOsaka(previousOsaka ? 1 : 0);
+      VMConfig.initAllowTvmSelfdestructRestriction(
+          previousSelfdestructRestriction ? 1 : 0);
+    }
+  }
+
+  private static void adjustOperations(JumpTable table) {
+    OperationRegistry.adjustMemOperations(table);
+    OperationRegistry.adjustVoteWitness(table);
+    OperationRegistry.adjustSelfdestruct(table);
+  }
+}


### PR DESCRIPTION
## What does this PR do?

- Removes unused historical version entries and eagerly initialized table mappings while retaining the existing operation-set builders.
- Centralizes the newest operation set selection through `LATEST_VERSION` and `newLatestOperationSet()`.
- Creates dedicated instances of the latest jump table for transactions and constant calls.
- Reuses both tables across executions.
- Applies configuration-dependent adjustments once per top-level execution.
- Reuses the prepared table for nested contract calls and contract creation.

## Why is this needed?

The previous implementation initialized jump tables for multiple historical versions even though only the latest version was selected for execution.

Transactions and constant calls also shared the same table, which allowed adjustments made for constant calls to affect transaction execution. In addition, configuration-dependent adjustments could be applied repeatedly during nested calls and contract creation.

This change centralizes the selection of the latest operation set and separates transaction and constant-call tables. It reduces startup initialization and repeated adjustment overhead while keeping the two execution paths isolated.

## Tests

- Added coverage for transaction and constant-call table isolation.
- Added coverage for table reuse across executions.
- Verified that constant-call adjustments do not affect the transaction table.
- Verified transaction, constant-call, nested-call, and contract-creation execution paths.
- Verified existing instruction and configuration-dependent behavior.