### PR TITLE
fix(config): remove ineffective RocksDB table setters

### DIFF
--- a/common/src/main/java/org/tron/common/setting/RocksDbSettings.java
+++ b/common/src/main/java/org/tron/common/setting/RocksDbSettings.java
@@ -6,7 +6,6 @@ import java.util.Arrays;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.rocksdb.BlockBasedTableConfig;
-import org.rocksdb.BloomFilter;
 import org.rocksdb.ComparatorOptions;
 import org.rocksdb.InfoLogLevel;
 import org.rocksdb.LRUCache;
@@ -211,13 +210,7 @@ public class RocksDbSettings {
     options.setTargetFileSizeBase(settings.getTargetFileSizeBase());
 
     // table options
-    final BlockBasedTableConfig tableCfg;
-    options.setTableFormatConfig(tableCfg = new BlockBasedTableConfig());
-    tableCfg.setBlockSize(settings.getBlockSize());
-    tableCfg.setBlockCache(RocksDbSettings.getCache());
-    tableCfg.setCacheIndexAndFilterBlocks(true);
-    tableCfg.setPinL0FilterAndIndexBlocksInCache(true);
-    tableCfg.setFilter(new BloomFilter(10, false));
+    options.setTableFormatConfig(new BlockBasedTableConfig());
     if (Constant.MARKET_PAIR_PRICE_TO_ORDER.equals(dbName)) {
       ComparatorOptions comparatorOptions = new ComparatorOptions();
       options.setComparator(new MarketOrderPriceComparatorForRocksDB(comparatorOptions));

--- a/common/src/main/resources/reference.conf
+++ b/common/src/main/resources/reference.conf
@@ -108,7 +108,7 @@ storage {
   dbSettings = {
     levelNumber = 7             // Number of RocksDB levels.
     compactThreads = 0          // 0 = auto: max(availableProcessors, 1)
-    blocksize = 16              // n * KB
+    blocksize = 16              // n * KB. Currently retained for compatibility but not applied to native RocksDB table options.
     maxBytesForLevelBase = 256  // n * MB
     maxBytesForLevelMultiplier = 10 // Level size multiplier.
     level0FileNumCompactionTrigger = 2 // L0 files that trigger compaction.

--- a/common/src/test/java/org/tron/common/setting/RocksDbSettingsTest.java
+++ b/common/src/test/java/org/tron/common/setting/RocksDbSettingsTest.java
@@ -1,0 +1,59 @@
+/*
+ * java-tron is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * java-tron is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.tron.common.setting;
+
+import static org.junit.Assert.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.stream.Stream;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.rocksdb.Options;
+import org.rocksdb.RocksDB;
+
+public class RocksDbSettingsTest {
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Test
+  public void shouldKeepNativeBlockTableDefaults() throws Exception {
+    Path database = temporaryFolder.newFolder("rocksdb").toPath();
+
+    try (Options options = RocksDbSettings.getOptionsByDbName("test")) {
+      try (RocksDB ignored = RocksDB.open(options, database.toString())) {
+        // Opening the DB materializes the table factory and persists its native settings.
+      }
+    }
+
+    Path optionsFile;
+    try (Stream<Path> files = Files.list(database)) {
+      optionsFile = files
+          .filter(path -> path.getFileName().toString().startsWith("OPTIONS-"))
+          .max(Comparator.comparing(path -> path.getFileName().toString()))
+          .orElseThrow(() -> new AssertionError("RocksDB OPTIONS file not found"));
+    }
+    String nativeOptions = new String(Files.readAllBytes(optionsFile), StandardCharsets.UTF_8);
+
+    assertTrue(nativeOptions.contains("block_size=4096"));
+    assertTrue(nativeOptions.contains("pin_l0_filter_and_index_blocks_in_cache=false"));
+    assertTrue(nativeOptions.contains("filter_policy=nullptr"));
+  }
+}

--- a/framework/src/test/java/org/tron/core/config/ConfigurationTest.java
+++ b/framework/src/test/java/org/tron/core/config/ConfigurationTest.java
@@ -35,6 +35,7 @@ import org.tron.common.TestConstants;
 import org.tron.common.crypto.ECKey;
 import org.tron.common.utils.ByteArray;
 import org.tron.core.Wallet;
+import org.tron.core.config.args.StorageConfig;
 
 @Slf4j
 public class ConfigurationTest {
@@ -90,5 +91,21 @@ public class ConfigurationTest {
     assertTrue(config.hasPath("storage"));
     assertTrue(config.hasPath("seed.node"));
     assertTrue(config.hasPath("genesis.block"));
+  }
+
+  @Test
+  public void defaultConfigShouldPreserveEffectiveRocksDbSettings() {
+    Config config = Configuration.getByFileName("config.conf");
+    StorageConfig.DbSettingsConfig settings = StorageConfig.fromConfig(config).getDbSettings();
+
+    assertTrue(config.hasPath("storage.dbSettings.blocksize"));
+    assertEquals(64, settings.getBlocksize());
+    assertEquals(7, settings.getLevelNumber());
+    assertEquals(256, settings.getMaxBytesForLevelBase());
+    assertEquals(10, settings.getMaxBytesForLevelMultiplier(), 0.01);
+    assertEquals(4, settings.getLevel0FileNumCompactionTrigger());
+    assertEquals(256, settings.getTargetFileSizeBase());
+    assertEquals(1, settings.getTargetFileSizeMultiplier());
+    assertEquals(5000, settings.getMaxOpenFiles());
   }
 }


### PR DESCRIPTION
**What does this PR do?**

Remove RocksDB block-table setters that were applied after `setTableFormatConfig()` and therefore never reached the native table factory.

Keep the existing `storage.dbSettings.blocksize` entries and Java API for compatibility, while documenting in `reference.conf` that the value is not currently applied to native RocksDB table options.

Add regression tests for the shipped Options-level configuration and the effective native block-table behavior.

**Why are these changes required?**

`setTableFormatConfig()` materializes the native table factory from the Java configuration at call time. The later block-size, shared-cache, index/filter-cache, L0-pinning, and Bloom-filter setters only changed the Java object and did not affect the native factory.

Moving those setters before `setTableFormatConfig()` would activate several unverified settings at once. In a fixed 500-block Mainnet replay, activating the combined settings reduced throughput from 2.421 blocks/s to 1.969 and 1.680 blocks/s, while restoring the pre-change effective native behavior produced 2.418 blocks/s.

This change therefore removes the ineffective setter sequence while preserving the behavior that nodes actually used before the change.

**This PR has been tested by:**

- `./gradlew :common:test --tests org.tron.common.setting.RocksDbSettingsTest`
- `./gradlew :framework:test --tests org.tron.core.config.ConfigurationTest`
- `./gradlew :framework:checkstyleMain`
- `./gradlew :framework:checkstyleTest`

**Follow up**

Evaluate block size, Bloom filters, shared-cache capacity, ownership, lifecycle, and observability independently with representative SR and database-specific workloads before enabling another RocksDB table profile.

**Extra details**

- `blocksize` remains configurable and observable for compatibility but is not applied to the native table factory.
- The existing static shared-cache object and accessor remain for separate configuration design and validation.
- No API, protocol, database-format, or migration changes are introduced.

Closes #6939
