### PR TITLE
feat: refine contract deployment transaction validation

### DIFF
--- a/actuator/src/main/java/org/tron/core/actuator/VMActuator.java
+++ b/actuator/src/main/java/org/tron/core/actuator/VMActuator.java
@@ -25,6 +25,7 @@ import org.tron.common.runtime.InternalTransaction.ExecutorType;
 import org.tron.common.runtime.InternalTransaction.TrxType;
 import org.tron.common.runtime.ProgramResult;
 import org.tron.common.runtime.vm.DataWord;
+import org.tron.common.utils.ForkController;
 import org.tron.common.utils.StorageUtils;
 import org.tron.common.utils.StringUtil;
 import org.tron.common.utils.WalletUtil;
@@ -33,6 +34,7 @@ import org.tron.core.capsule.AccountCapsule;
 import org.tron.core.capsule.BlockCapsule;
 import org.tron.core.capsule.ContractCapsule;
 import org.tron.core.capsule.ReceiptCapsule;
+import org.tron.core.config.Parameter;
 import org.tron.core.db.EnergyProcessor;
 import org.tron.core.db.TransactionContext;
 import org.tron.core.exception.ContractExeException;
@@ -217,6 +219,9 @@ public class VMActuator implements Actuator2 {
           } else {
             result.spendEnergy(saveCodeEnergy);
             if (VMConfig.allowTvmConstantinople()) {
+              CreateSmartContract createContract =
+                  ContractCapsule.getSmartContractFromTransaction(trx);
+              checkContractHashFields(createContract.getNewContract());
               rootRepository.saveCode(program.getContractAddress().getNoLeadZeroesData(), code);
             }
           }
@@ -330,6 +335,7 @@ public class VMActuator implements Actuator2 {
     if (contract == null) {
       throw new ContractValidateException("Cannot get CreateSmartContract from transaction");
     }
+
     SmartContract newSmartContract;
     if (VMConfig.allowTvmCompatibleEvm()) {
       newSmartContract = contract.getNewContract().toBuilder().setVersion(1).build();
@@ -341,11 +347,7 @@ public class VMActuator implements Actuator2 {
       throw new ContractValidateException("OwnerAddress is not equals OriginAddress");
     }
 
-    byte[] contractName = newSmartContract.getName().getBytes();
-
-    if (contractName.length > VMConstant.CONTRACT_NAME_LENGTH) {
-      throw new ContractValidateException("contractName's length cannot be greater than 32");
-    }
+    checkContractNameLength(contract.getNewContract());
 
     long percent = contract.getNewContract().getConsumeUserResourcePercent();
     if (percent < 0 || percent > VMConstant.ONE_HUNDRED) {
@@ -453,6 +455,22 @@ public class VMActuator implements Actuator2 {
           tokenValue);
     }
 
+  }
+
+  static void checkContractHashFields(SmartContract contract) {
+    if (!contract.getCodeHash().isEmpty() || !contract.getTrxHash().isEmpty()) {
+      MUtil.checkCPUTimeForContractHashFields();
+    }
+  }
+
+  static void checkContractNameLength(SmartContract contract) throws ContractValidateException {
+    int contractNameLength =
+        ForkController.instance().pass(Parameter.ForkBlockVersionEnum.VERSION_4_8_2_2)
+            ? contract.getNameBytes().size()
+            : contract.getName().getBytes().length;
+    if (contractNameLength > VMConstant.CONTRACT_NAME_LENGTH) {
+      throw new ContractValidateException("contractName's length cannot be greater than 32");
+    }
   }
 
   /**

--- a/actuator/src/main/java/org/tron/core/vm/utils/MUtil.java
+++ b/actuator/src/main/java/org/tron/core/vm/utils/MUtil.java
@@ -59,6 +59,12 @@ public class MUtil {
     return !isNullOrEmpty(str);
   }
 
+  public static void checkCPUTimeForContractHashFields() {
+    if (ForkController.instance().pass(Parameter.ForkBlockVersionEnum.VERSION_4_8_2_2)) {
+      throw new OutOfTimeException("CPU timeout for contract hash fields");
+    }
+  }
+
   public static void checkCPUTime() {
     if (ForkController.instance().pass(Parameter.ForkBlockVersionEnum.VERSION_4_7_1)) {
       throw new OutOfTimeException("CPU timeout for 0x0a executing");

--- a/common/src/main/java/org/tron/core/config/Parameter.java
+++ b/common/src/main/java/org/tron/core/config/Parameter.java
@@ -30,7 +30,8 @@ public class Parameter {
     VERSION_4_8_0_1(33, 1596780000000L, 70),
     VERSION_4_8_1(34, 1596780000000L, 80),
     VERSION_4_8_1_1(35, 1596780000000L, 70),
-    VERSION_4_8_2(36, 1596780000000L, 80);
+    VERSION_4_8_2(36, 1596780000000L, 80),
+    VERSION_4_8_2_2(37, 1596780000000L, 70);
     // if add a version, modify BLOCK_VERSION simultaneously
 
     @Getter
@@ -79,7 +80,7 @@ public class Parameter {
     public static final int SINGLE_REPEAT = 1;
     public static final int BLOCK_FILLED_SLOTS_NUMBER = 128;
     public static final int MAX_FROZEN_NUMBER = 1;
-    public static final int BLOCK_VERSION = 36;
+    public static final int BLOCK_VERSION = 37;
     public static final long FROZEN_PERIOD = 86_400_000L;
     public static final long DELEGATE_PERIOD = 3 * 86_400_000L;
     public static final long TRX_PRECISION = 1000_000L;

--- a/framework/src/test/java/org/tron/core/actuator/ContractHashValidationTest.java
+++ b/framework/src/test/java/org/tron/core/actuator/ContractHashValidationTest.java
@@ -1,0 +1,67 @@
+package org.tron.core.actuator;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.protobuf.ByteString;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.tron.common.utils.ForkController;
+import org.tron.core.config.Parameter.ForkBlockVersionEnum;
+import org.tron.core.vm.program.Program.OutOfTimeException;
+import org.tron.protos.contract.SmartContractOuterClass.SmartContract;
+
+public class ContractHashValidationTest {
+
+  @Test
+  public void acceptsHashFieldsBeforeActivation() {
+    SmartContract contract = SmartContract.newBuilder()
+        .setCodeHash(ByteString.copyFromUtf8("code"))
+        .setTrxHash(ByteString.copyFromUtf8("transaction"))
+        .build();
+
+    runWithActivation(false, () -> VMActuator.checkContractHashFields(contract));
+  }
+
+  @Test
+  public void rejectsCodeHashAfterActivation() {
+    SmartContract contract = SmartContract.newBuilder()
+        .setCodeHash(ByteString.copyFromUtf8("code"))
+        .build();
+
+    OutOfTimeException exception = assertThrows(OutOfTimeException.class,
+        () -> runWithActivation(true, () -> VMActuator.checkContractHashFields(contract)));
+
+    assertEquals("CPU timeout for contract hash fields", exception.getMessage());
+  }
+
+  @Test
+  public void rejectsTransactionHashAfterActivation() {
+    SmartContract contract = SmartContract.newBuilder()
+        .setTrxHash(ByteString.copyFromUtf8("transaction"))
+        .build();
+
+    OutOfTimeException exception = assertThrows(OutOfTimeException.class,
+        () -> runWithActivation(true, () -> VMActuator.checkContractHashFields(contract)));
+
+    assertEquals("CPU timeout for contract hash fields", exception.getMessage());
+  }
+
+  @Test
+  public void acceptsEmptyHashFieldsAfterActivation() {
+    runWithActivation(true,
+        () -> VMActuator.checkContractHashFields(SmartContract.getDefaultInstance()));
+  }
+
+  private void runWithActivation(boolean activated, Runnable action) {
+    ForkController controller = mock(ForkController.class);
+    when(controller.pass(ForkBlockVersionEnum.VERSION_4_8_2_2)).thenReturn(activated);
+    try (MockedStatic<ForkController> controllerMock = Mockito.mockStatic(ForkController.class)) {
+      controllerMock.when(ForkController::instance).thenReturn(controller);
+      action.run();
+    }
+  }
+}

--- a/framework/src/test/java/org/tron/core/actuator/ContractNameValidationTest.java
+++ b/framework/src/test/java/org/tron/core/actuator/ContractNameValidationTest.java
@@ -1,0 +1,65 @@
+package org.tron.core.actuator;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.tron.common.utils.ForkController;
+import org.tron.core.config.Parameter.ForkBlockVersionEnum;
+import org.tron.core.exception.ContractValidateException;
+import org.tron.protos.contract.SmartContractOuterClass.SmartContract;
+
+public class ContractNameValidationTest {
+
+  @Test
+  public void acceptsThirtyTwoByteNameAfterActivation() throws Throwable {
+    SmartContract contract = contractWithName("12345678901234567890123456789012");
+
+    runWithActivation(true, () -> VMActuator.checkContractNameLength(contract));
+  }
+
+  @Test
+  public void rejectsThirtyThreeByteNameAfterActivation() {
+    SmartContract contract = contractWithName("123456789012345678901234567890123");
+
+    ContractValidateException exception = assertThrows(ContractValidateException.class,
+        () -> runWithActivation(true, () -> VMActuator.checkContractNameLength(contract)));
+
+    assertEquals("contractName's length cannot be greater than 32", exception.getMessage());
+  }
+
+  @Test
+  public void countsMultibyteNameUsingProtobufBytesAfterActivation() {
+    SmartContract contract = contractWithName("合合合合合合合合合合合");
+    assertEquals(33, contract.getNameBytes().size());
+
+    assertThrows(ContractValidateException.class,
+        () -> runWithActivation(true, () -> VMActuator.checkContractNameLength(contract)));
+  }
+
+  @Test
+  public void preservesNameValidationBeforeActivation() {
+    SmartContract contract = contractWithName("123456789012345678901234567890123");
+
+    assertThrows(ContractValidateException.class,
+        () -> runWithActivation(false, () -> VMActuator.checkContractNameLength(contract)));
+  }
+
+  private SmartContract contractWithName(String name) {
+    return SmartContract.newBuilder().setName(name).build();
+  }
+
+  private void runWithActivation(boolean activated, ThrowingRunnable action) throws Throwable {
+    ForkController controller = mock(ForkController.class);
+    when(controller.pass(ForkBlockVersionEnum.VERSION_4_8_2_2)).thenReturn(activated);
+    try (MockedStatic<ForkController> controllerMock = Mockito.mockStatic(ForkController.class)) {
+      controllerMock.when(ForkController::instance).thenReturn(controller);
+      action.run();
+    }
+  }
+}


### PR DESCRIPTION
## Why is this needed?

This PR refines two existing validation behaviors for contract deployment transactions.

The `code_hash` and `trx_hash` fields supplied during contract deployment are unused. They do not participate in deployment processing or affect the deployment result. Since these fields have no functional meaning as deployment inputs, transactions carrying them should be preventively prohibited at the protocol level.

Contract name length validation already exists, but its current calculation relies on `String.getBytes()`, which depends on the system default charset. The calculation should use the original protobuf byte representation so that the same deployment transaction is evaluated consistently across environments.

## Historical transaction scan

**We performed a complete scan of all historical transactions across the full chain history.**

**No historical contract deployment transaction was found with either `code_hash` or `trx_hash` set. The number of historical transactions carrying either field is zero.**

This confirms that existing contract deployments have never relied on these fields. The restriction does not invalidate any historical transaction or alter existing user behavior.

## Implementation

After activation:

- A deployment transaction containing a non-empty `code_hash` or `trx_hash` is rejected using the existing timeout semantics immediately before its contract code is persisted.
- Contract name length is calculated directly from the original protobuf bytes instead of using the system-dependent string encoding.

Before activation, the existing behavior is preserved.

Normal contract deployments do not populate the hash fields, and ordinary contract names are unaffected by the length-calculation adjustment.

## Compatibility

Both changes are controlled by `VERSION_4_8_2_2`, with an activation threshold of 70%.

This PR currently uses the same fork version introduced by #6920. If the version identifier or activation parameters in #6920 change, this PR should be updated accordingly.

## Tests

- Verified `code_hash` and `trx_hash` behavior before and after activation.
- Verified empty hash fields remain unaffected.
- Verified contract names at the 32-byte boundary.
- Verified contract names exceeding the 32-byte boundary.
- Verified multibyte names are calculated using protobuf bytes.
- Verified pre-activation compatibility.