### PR TITLE
feat(api): sanitize HTTP API error responses

### DIFF
--- a/framework/src/main/java/org/tron/core/services/http/GetBlockServlet.java
+++ b/framework/src/main/java/org/tron/core/services/http/GetBlockServlet.java
@@ -77,9 +77,7 @@ public class GetBlockServlet extends RateLimiterServlet {
         response.getWriter().println("{}");
       }
     } catch (IllegalArgumentException e) {
-      JSONObject jsonObject = new JSONObject();
-      jsonObject.put("Error", e.getMessage());
-      response.getWriter().println(jsonObject.toJSONString());
+      Util.writeAuditedError(e.getMessage(), response);
     }
   }
 

--- a/framework/src/main/java/org/tron/core/services/http/GetBrokerageServlet.java
+++ b/framework/src/main/java/org/tron/core/services/http/GetBrokerageServlet.java
@@ -1,6 +1,5 @@
 package org.tron.core.services.http;
 
-import java.io.IOException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
@@ -27,12 +26,7 @@ public class GetBrokerageServlet extends RateLimiterServlet {
       }
       response.getWriter().println("{\"brokerage\": " + value + "}");
     } catch (DecoderException | IllegalArgumentException e) {
-      try {
-        response.getWriter()
-            .println("{\"Error\": " + "\"INVALID address, " + e.getMessage() + "\"}");
-      } catch (IOException ioe) {
-        logger.debug("IOException: {}", ioe.getMessage());
-      }
+      Util.writeAuditedError(Util.INVALID_ADDRESS_MSG, response);
     } catch (Exception e) {
       Util.processError(e, response);
     }

--- a/framework/src/main/java/org/tron/core/services/http/GetBurnTrxServlet.java
+++ b/framework/src/main/java/org/tron/core/services/http/GetBurnTrxServlet.java
@@ -1,6 +1,5 @@
 package org.tron.core.services.http;
 
-import java.io.IOException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
@@ -24,12 +23,7 @@ public class GetBurnTrxServlet extends RateLimiterServlet {
           : "{\"burnTrxAmount\": " + value + "}";
       response.getWriter().println(out);
     } catch (Exception e) {
-      logger.error("", e);
-      try {
-        response.getWriter().println(Util.printErrorMsg(e));
-      } catch (IOException ioe) {
-        logger.debug("IOException: {}", ioe.getMessage());
-      }
+      Util.processError(e, response);
     }
   }
 

--- a/framework/src/main/java/org/tron/core/services/http/GetBurnTrxServlet.java
+++ b/framework/src/main/java/org/tron/core/services/http/GetBurnTrxServlet.java
@@ -23,7 +23,7 @@ public class GetBurnTrxServlet extends RateLimiterServlet {
           : "{\"burnTrxAmount\": " + value + "}";
       response.getWriter().println(out);
     } catch (Exception e) {
-      Util.processError(e, response);
+      Util.processServerError(e, response);
     }
   }
 

--- a/framework/src/main/java/org/tron/core/services/http/GetNodeInfoServlet.java
+++ b/framework/src/main/java/org/tron/core/services/http/GetNodeInfoServlet.java
@@ -1,6 +1,5 @@
 package org.tron.core.services.http;
 
-import java.io.IOException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
@@ -24,12 +23,7 @@ public class GetNodeInfoServlet extends RateLimiterServlet {
       response.getWriter().println(JSON.toJSONString(nodeInfo));
 
     } catch (Exception e) {
-      logger.error("", e);
-      try {
-        response.getWriter().println(Util.printErrorMsg(e));
-      } catch (IOException ioe) {
-        logger.debug("IOException: {}", ioe.getMessage());
-      }
+      Util.processError(e, response);
     }
   }
 

--- a/framework/src/main/java/org/tron/core/services/http/GetNodeInfoServlet.java
+++ b/framework/src/main/java/org/tron/core/services/http/GetNodeInfoServlet.java
@@ -23,7 +23,7 @@ public class GetNodeInfoServlet extends RateLimiterServlet {
       response.getWriter().println(JSON.toJSONString(nodeInfo));
 
     } catch (Exception e) {
-      Util.processError(e, response);
+      Util.processServerError(e, response);
     }
   }
 

--- a/framework/src/main/java/org/tron/core/services/http/GetPendingSizeServlet.java
+++ b/framework/src/main/java/org/tron/core/services/http/GetPendingSizeServlet.java
@@ -1,6 +1,5 @@
 package org.tron.core.services.http;
 
-import java.io.IOException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
@@ -24,12 +23,7 @@ public class GetPendingSizeServlet extends RateLimiterServlet {
           : "{\"pendingSize\": " + value + "}";
       response.getWriter().println(out);
     } catch (Exception e) {
-      logger.error("", e);
-      try {
-        response.getWriter().println(Util.printErrorMsg(e));
-      } catch (IOException ioe) {
-        logger.debug("IOException: {}", ioe.getMessage());
-      }
+      Util.processError(e, response);
     }
   }
 

--- a/framework/src/main/java/org/tron/core/services/http/GetPendingSizeServlet.java
+++ b/framework/src/main/java/org/tron/core/services/http/GetPendingSizeServlet.java
@@ -23,7 +23,7 @@ public class GetPendingSizeServlet extends RateLimiterServlet {
           : "{\"pendingSize\": " + value + "}";
       response.getWriter().println(out);
     } catch (Exception e) {
-      Util.processError(e, response);
+      Util.processServerError(e, response);
     }
   }
 

--- a/framework/src/main/java/org/tron/core/services/http/GetRewardServlet.java
+++ b/framework/src/main/java/org/tron/core/services/http/GetRewardServlet.java
@@ -1,6 +1,5 @@
 package org.tron.core.services.http;
 
-import java.io.IOException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
@@ -29,19 +28,9 @@ public class GetRewardServlet extends RateLimiterServlet {
           : "{\"reward\": " + value + "}";
       response.getWriter().println(out);
     } catch (DecoderException | IllegalArgumentException e) {
-      try {
-        response.getWriter()
-            .println("{\"Error\": " + "\"INVALID address, " + e.getMessage() + "\"}");
-      } catch (IOException ioe) {
-        logger.debug("IOException: {}", ioe.getMessage());
-      }
+      Util.writeAuditedError(Util.INVALID_ADDRESS_MSG, response);
     } catch (Exception e) {
-      logger.error("", e);
-      try {
-        response.getWriter().println(Util.printErrorMsg(e));
-      } catch (IOException ioe) {
-        logger.debug("IOException: {}", ioe.getMessage());
-      }
+      Util.processError(e, response);
     }
   }
 

--- a/framework/src/main/java/org/tron/core/services/http/GetRewardServlet.java
+++ b/framework/src/main/java/org/tron/core/services/http/GetRewardServlet.java
@@ -30,7 +30,7 @@ public class GetRewardServlet extends RateLimiterServlet {
     } catch (DecoderException | IllegalArgumentException e) {
       Util.writeAuditedError(Util.INVALID_ADDRESS_MSG, response);
     } catch (Exception e) {
-      Util.processError(e, response);
+      Util.processServerError(e, response);
     }
   }
 

--- a/framework/src/main/java/org/tron/core/services/http/GetTransactionInfoByBlockNumServlet.java
+++ b/framework/src/main/java/org/tron/core/services/http/GetTransactionInfoByBlockNumServlet.java
@@ -1,6 +1,5 @@
 package org.tron.core.services.http;
 
-import java.io.IOException;
 import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -52,12 +51,7 @@ public class GetTransactionInfoByBlockNumServlet extends RateLimiterServlet {
         response.getWriter().println("{}");
       }
     } catch (Exception e) {
-      logger.debug("Exception: {}", e.getMessage());
-      try {
-        response.getWriter().println(Util.printErrorMsg(e));
-      } catch (IOException ioe) {
-        logger.debug("IOException: {}", ioe.getMessage());
-      }
+      Util.processError(e, response);
     }
   }
 
@@ -75,12 +69,7 @@ public class GetTransactionInfoByBlockNumServlet extends RateLimiterServlet {
         response.getWriter().println("{}");
       }
     } catch (Exception e) {
-      logger.debug("Exception: {}", e.getMessage());
-      try {
-        response.getWriter().println(Util.printErrorMsg(e));
-      } catch (IOException ioe) {
-        logger.debug("IOException: {}", ioe.getMessage());
-      }
+      Util.processError(e, response);
     }
   }
 }

--- a/framework/src/main/java/org/tron/core/services/http/RateLimiterServlet.java
+++ b/framework/src/main/java/org/tron/core/services/http/RateLimiterServlet.java
@@ -131,8 +131,7 @@ public abstract class RateLimiterServlet extends HttpServlet {
         super.service(req, resp);
         Metrics.histogramObserve(requestTimer);
       } else {
-        resp.getWriter()
-            .println(Util.printErrorMsg(new IllegalAccessException("lack of computing resources")));
+        Util.writeAuditedError(Util.RATE_LIMITER_ERROR_MSG, resp);
       }
     } catch (ServletException | IOException | BadMessageException e) {
       throw e;

--- a/framework/src/main/java/org/tron/core/services/http/Util.java
+++ b/framework/src/main/java/org/tron/core/services/http/Util.java
@@ -555,6 +555,14 @@ public class Util {
     writeAuditedError(clientMessage(e), response);
   }
 
+  // For catch blocks that cover server-side work only, so the failure stays visible at the
+  // default log level. The Exception entry point above keeps debug because its callers also
+  // cover request parsing, which an unauthenticated client can fail cheaply and repeatedly.
+  static void processServerError(Exception e, HttpServletResponse response) {
+    logger.error("HTTP request failed", e);
+    writeAuditedError(clientMessage(e), response);
+  }
+
   // Bypasses clientMessage: callers must pass audited fixed or pre-existing client texts only.
   static void writeAuditedError(String msg, HttpServletResponse response) {
     try {

--- a/framework/src/main/java/org/tron/core/services/http/Util.java
+++ b/framework/src/main/java/org/tron/core/services/http/Util.java
@@ -48,6 +48,8 @@ import org.tron.core.capsule.BlockCapsule;
 import org.tron.core.capsule.TransactionCapsule;
 import org.tron.core.config.args.Args;
 import org.tron.core.db.TransactionTrace;
+import org.tron.core.exception.ContractValidateException;
+import org.tron.core.exception.MaintenanceUnavailableException;
 import org.tron.core.services.http.JsonFormat.ParseException;
 import org.tron.json.JSON;
 import org.tron.json.JSONArray;
@@ -64,6 +66,10 @@ import org.tron.protos.contract.SmartContractOuterClass.CreateSmartContract;
 
 @Slf4j(topic = "API")
 public class Util {
+
+  private static final String INTERNAL_SERVER_ERROR = "internal server error";
+  public static final String RATE_LIMITER_ERROR_MSG = "lack of computing resources";
+  static final String INVALID_ADDRESS_MSG = "INVALID address";
 
   public static final String EVENTS_DEPRECATED_MSG =
       "'events' field is deprecated and no longer supported";
@@ -114,10 +120,29 @@ public class Util {
     return jsonObject.toJSONString();
   }
 
-  public static String printErrorMsg(Exception e) {
+  private static String printErrorMsg(String msg) {
     JSONObject jsonObject = new JSONObject();
-    jsonObject.put("Error", e.getClass() + " : " + e.getMessage());
+    jsonObject.put("Error", msg);
     return jsonObject.toJSONString();
+  }
+
+  private static String clientMessage(Exception e) {
+    if (e == null) {
+      return INTERNAL_SERVER_ERROR;
+    }
+
+    Class<?> type = e.getClass();
+    if (type == IllegalArgumentException.class) {
+      return EVENTS_DEPRECATED_MSG.equals(e.getMessage())
+          ? EVENTS_DEPRECATED_MSG : INTERNAL_SERVER_ERROR;
+    }
+    if (type == ParseException.class
+        || type == ContractValidateException.class
+        || type == MaintenanceUnavailableException.class) {
+      String message = e.getMessage();
+      return StringUtils.isBlank(message) ? INTERNAL_SERVER_ERROR : message;
+    }
+    return INTERNAL_SERVER_ERROR;
   }
 
   public static String printBlockList(BlockList list, boolean selfType) {
@@ -526,11 +551,16 @@ public class Util {
   }
 
   public static void processError(Exception e, HttpServletResponse response) {
-    logger.debug(e.getMessage(), e);
+    logger.debug("HTTP request failed", e);
+    writeAuditedError(clientMessage(e), response);
+  }
+
+  // Bypasses clientMessage: callers must pass audited fixed or pre-existing client texts only.
+  static void writeAuditedError(String msg, HttpServletResponse response) {
     try {
-      response.getWriter().println(Util.printErrorMsg(e));
+      response.getWriter().println(Util.printErrorMsg(msg));
     } catch (IOException ioe) {
-      logger.debug("IOException: {}", ioe.getMessage());
+      logger.debug("Failed to write HTTP error response", ioe);
     }
   }
 

--- a/framework/src/main/java/org/tron/core/services/http/ValidateAddressServlet.java
+++ b/framework/src/main/java/org/tron/core/services/http/ValidateAddressServlet.java
@@ -47,7 +47,7 @@ public class ValidateAddressServlet extends RateLimiterServlet {
       }
     } catch (Exception e) {
       result = false;
-      msg = e.getMessage();
+      msg = "Invalid address";
     }
 
     JSONObject jsonAddress = new JSONObject();

--- a/framework/src/main/java/org/tron/core/services/http/solidity/GetTransactionByIdSolidityServlet.java
+++ b/framework/src/main/java/org/tron/core/services/http/solidity/GetTransactionByIdSolidityServlet.java
@@ -30,12 +30,7 @@ public class GetTransactionByIdSolidityServlet extends RateLimiterServlet {
       String input = request.getParameter("value");
       fillResponse(ByteString.copyFrom(ByteArray.fromHexString(input)), visible, response);
     } catch (Exception e) {
-      logger.debug("Exception: {}", e.getMessage());
-      try {
-        response.getWriter().println(e.getMessage());
-      } catch (IOException ioe) {
-        logger.debug("IOException: {}", ioe.getMessage());
-      }
+      Util.processError(e, response);
     }
   }
 
@@ -46,12 +41,7 @@ public class GetTransactionByIdSolidityServlet extends RateLimiterServlet {
       JsonFormat.merge(params.getParams(), build, params.isVisible());
       fillResponse(build.build().getValue(), params.isVisible(), response);
     } catch (Exception e) {
-      logger.debug("Exception: {}", e.getMessage());
-      try {
-        response.getWriter().println(e.getMessage());
-      } catch (IOException ioe) {
-        logger.debug("IOException: {}", ioe.getMessage());
-      }
+      Util.processError(e, response);
     }
   }
 

--- a/framework/src/main/java/org/tron/core/services/http/solidity/GetTransactionInfoByIdSolidityServlet.java
+++ b/framework/src/main/java/org/tron/core/services/http/solidity/GetTransactionInfoByIdSolidityServlet.java
@@ -1,7 +1,6 @@
 package org.tron.core.services.http.solidity;
 
 import com.google.protobuf.ByteString;
-import java.io.IOException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
@@ -37,12 +36,7 @@ public class GetTransactionInfoByIdSolidityServlet extends RateLimiterServlet {
         response.getWriter().println(JsonFormat.printToString(transInfo, visible));
       }
     } catch (Exception e) {
-      logger.debug("Exception: {}", e.getMessage());
-      try {
-        response.getWriter().println(e.getMessage());
-      } catch (IOException ioe) {
-        logger.debug("IOException: {}", ioe.getMessage());
-      }
+      Util.processError(e, response);
     }
   }
 
@@ -60,12 +54,7 @@ public class GetTransactionInfoByIdSolidityServlet extends RateLimiterServlet {
         response.getWriter().println(JsonFormat.printToString(transInfo, params.isVisible()));
       }
     } catch (Exception e) {
-      logger.debug("Exception: {}", e.getMessage());
-      try {
-        response.getWriter().println(e.getMessage());
-      } catch (IOException ioe) {
-        logger.debug("IOException: {}", ioe.getMessage());
-      }
+      Util.processError(e, response);
     }
   }
 

--- a/framework/src/test/java/org/tron/core/services/http/BroadcastServletTest.java
+++ b/framework/src/test/java/org/tron/core/services/http/BroadcastServletTest.java
@@ -156,7 +156,7 @@ public class BroadcastServletTest {
     while ((text = bufferedReader.readLine()) != null) {
       sb.append(text);
     }
-    Assert.assertTrue(sb.toString().contains("null"));
+    Assert.assertTrue(sb.toString().contains("{\"Error\":\"internal server error\"}"));
     httpUrlConnection.disconnect();
   }
 }

--- a/framework/src/test/java/org/tron/core/services/http/JsonRpcRateLimiterServletTest.java
+++ b/framework/src/test/java/org/tron/core/services/http/JsonRpcRateLimiterServletTest.java
@@ -1,0 +1,129 @@
+package org.tron.core.services.http;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.googlecode.jsonrpc4j.JsonRpcServer;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collection;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.mockito.MockedStatic;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.tron.common.TestConstants;
+import org.tron.core.config.args.Args;
+import org.tron.core.services.interfaceJsonRpcOnPBFT.JsonRpcOnPBFTServlet;
+import org.tron.core.services.interfaceJsonRpcOnSolidity.JsonRpcOnSolidityServlet;
+import org.tron.core.services.interfaceOnPBFT.WalletOnPBFT;
+import org.tron.core.services.interfaceOnSolidity.WalletOnSolidity;
+import org.tron.core.services.jsonrpc.JsonRpcServlet;
+import org.tron.core.services.ratelimiter.GlobalRateLimiter;
+import org.tron.core.services.ratelimiter.RateLimiterContainer;
+import org.tron.core.services.ratelimiter.RuntimeData;
+import org.tron.core.services.ratelimiter.adapter.IRateLimiter;
+
+@RunWith(Parameterized.class)
+public class JsonRpcRateLimiterServletTest {
+
+  private final Class<? extends JsonRpcServlet> servletClass;
+  private RateLimiterServlet servlet;
+  private IRateLimiter perEndpoint;
+  private Object dispatcher;
+  private MockHttpServletRequest request;
+  private MockHttpServletResponse response;
+
+  public JsonRpcRateLimiterServletTest(Class<? extends JsonRpcServlet> servletClass) {
+    this.servletClass = servletClass;
+  }
+
+  @Parameterized.Parameters(name = "{0}")
+  public static Collection<Object[]> servlets() {
+    return Arrays.asList(new Object[][] {
+        {JsonRpcServlet.class},
+        {JsonRpcOnSolidityServlet.class},
+        {JsonRpcOnPBFTServlet.class}
+    });
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    // Initialize Args before GlobalRateLimiter's static QPS limiters are loaded.
+    Args.setParam(new String[0], TestConstants.TEST_CONF);
+    servlet = servletClass.getDeclaredConstructor().newInstance();
+    RateLimiterContainer container = new RateLimiterContainer();
+    perEndpoint = mock(IRateLimiter.class);
+    container.add("http_", servletClass.getSimpleName(), perEndpoint);
+    ReflectionTestUtils.setField(servlet, "container", container);
+
+    if (servlet instanceof JsonRpcOnSolidityServlet) {
+      dispatcher = mock(WalletOnSolidity.class);
+      ReflectionTestUtils.setField(servlet, "walletOnSolidity", dispatcher);
+    } else if (servlet instanceof JsonRpcOnPBFTServlet) {
+      dispatcher = mock(WalletOnPBFT.class);
+      ReflectionTestUtils.setField(servlet, "walletOnPBFT", dispatcher);
+    } else {
+      dispatcher = mock(JsonRpcServer.class);
+      ReflectionTestUtils.setField(servlet, "rpcServer", dispatcher);
+    }
+
+    request = new MockHttpServletRequest("POST", "/jsonrpc");
+    request.setServletPath("/jsonrpc");
+    request.setRemoteAddr("10.0.0.1");
+    request.setContentType("application/json");
+    request.setContent("{\"jsonrpc\":\"2.0\",\"method\":\"eth_blockNumber\",\"id\":1}"
+        .getBytes(StandardCharsets.UTF_8));
+    response = new MockHttpServletResponse();
+  }
+
+  @After
+  public void tearDown() {
+    Args.clearParam();
+  }
+
+  @Test
+  public void testPerEndpointRejectionReturnsSanitizedHttpError() throws Exception {
+    when(perEndpoint.acquirePermit(any(RuntimeData.class))).thenReturn(false);
+
+    try (MockedStatic<GlobalRateLimiter> global = mockStatic(GlobalRateLimiter.class)) {
+      servlet.service(request, response);
+
+      global.verify(() -> GlobalRateLimiter.acquirePermit(any()), never());
+      assertRateLimitResponse();
+    }
+  }
+
+  @Test
+  public void testGlobalRejectionReturnsSanitizedHttpError() throws Exception {
+    when(perEndpoint.acquirePermit(any(RuntimeData.class))).thenReturn(true);
+
+    try (MockedStatic<GlobalRateLimiter> global = mockStatic(GlobalRateLimiter.class)) {
+      global.when(() -> GlobalRateLimiter.acquirePermit(any())).thenReturn(false);
+
+      servlet.service(request, response);
+
+      global.verify(() -> GlobalRateLimiter.acquirePermit(any()));
+      assertRateLimitResponse();
+    }
+  }
+
+  private void assertRateLimitResponse() throws Exception {
+    assertEquals(200, response.getStatus());
+    assertEquals("application/json; charset=utf-8", response.getContentType());
+    assertEquals("{\"Error\":\"lack of computing resources\"}",
+        response.getContentAsString().trim());
+    verify(perEndpoint).acquirePermit(any(RuntimeData.class));
+    verifyNoInteractions(dispatcher);
+  }
+}

--- a/framework/src/test/java/org/tron/core/services/http/UtilProcessErrorTest.java
+++ b/framework/src/test/java/org/tron/core/services/http/UtilProcessErrorTest.java
@@ -84,6 +84,20 @@ public class UtilProcessErrorTest {
     assertEquals("{}", response.getContentAsString().trim());
   }
 
+  @Test
+  public void serverErrorChannelSanitizesLikeTheSharedPath() throws Exception {
+    assertServerError(new NullPointerException("internal field name"), INTERNAL_SERVER_ERROR);
+    assertServerError(new ContractValidateException("balance is not sufficient"),
+        "balance is not sufficient");
+  }
+
+  private static void assertServerError(Exception error, String expected) throws Exception {
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    Util.processServerError(error, response);
+    JSONObject body = JSONObject.parseObject(response.getContentAsString());
+    assertEquals(expected, body.getString("Error"));
+  }
+
   private static void assertError(Exception error, String expected) throws Exception {
     MockHttpServletResponse response = new MockHttpServletResponse();
     Util.processError(error, response);

--- a/framework/src/test/java/org/tron/core/services/http/UtilProcessErrorTest.java
+++ b/framework/src/test/java/org/tron/core/services/http/UtilProcessErrorTest.java
@@ -1,0 +1,93 @@
+package org.tron.core.services.http;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import org.bouncycastle.util.encoders.DecoderException;
+import org.bouncycastle.util.encoders.Hex;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.tron.core.exception.ContractValidateException;
+import org.tron.core.exception.HeaderNotFound;
+import org.tron.core.exception.MaintenanceUnavailableException;
+import org.tron.core.exception.ZkProofValidateException;
+import org.tron.json.JSONException;
+import org.tron.json.JSONObject;
+
+public class UtilProcessErrorTest {
+
+  private static final String INTERNAL_SERVER_ERROR = "internal server error";
+  private static final String RATE_LIMITER_ERROR_MSG = "lack of computing resources";
+
+  @Test
+  public void exactCompatibilityTypesPreserveNonBlankMessage() throws Exception {
+    assertError(new JsonFormat.ParseException("1:2: invalid \"field\"\nvalue"),
+        "1:2: invalid \"field\"\nvalue");
+    assertError(new ContractValidateException("balance is not sufficient"),
+        "balance is not sufficient");
+    assertError(new MaintenanceUnavailableException("maintenance in progress"),
+        "maintenance in progress");
+  }
+
+  @Test
+  public void unclassifiedTypesFailClosed() throws Exception {
+    DecoderException decoder = assertThrows(DecoderException.class, () -> Hex.decode("zz"));
+    Exception[] errors = {
+        new NullPointerException("internal field name"),
+        new JSONException("server serialization detail"),
+        new InvalidProtocolBufferException("stored protobuf detail"),
+        decoder,
+        new HeaderNotFound("latest block not found"),
+        new IllegalArgumentException("No enum constant internal.Type.VALUE"),
+        new IllegalAccessException(RATE_LIMITER_ERROR_MSG),
+        new IllegalAccessException("other access failure"),
+        new ZkProofValidateException("wrapped validation detail", true)
+    };
+
+    for (Exception error : errors) {
+      assertError(error, INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  @Test
+  public void onlyExactFixedControlSignalsArePreserved() throws Exception {
+    assertError(new IllegalArgumentException(Util.EVENTS_DEPRECATED_MSG),
+        Util.EVENTS_DEPRECATED_MSG);
+    assertError(new IllegalArgumentException("other argument failure"), INTERNAL_SERVER_ERROR);
+    assertError(new NumberFormatException(Util.EVENTS_DEPRECATED_MSG), INTERNAL_SERVER_ERROR);
+  }
+
+  @Test
+  public void nullBlankAndSubclassMessagesFailClosed() throws Exception {
+    assertError(null, INTERNAL_SERVER_ERROR);
+    assertError(new JsonFormat.ParseException(null), INTERNAL_SERVER_ERROR);
+    assertError(new JsonFormat.ParseException(""), INTERNAL_SERVER_ERROR);
+    assertError(new JsonFormat.ParseException("  "), INTERNAL_SERVER_ERROR);
+    assertError(new ContractValidateException("subclass message") { }, INTERNAL_SERVER_ERROR);
+  }
+
+  @Test
+  public void auditedErrorWriterPreservesTextVerbatim() throws Exception {
+    for (String audited : new String[] {Util.INVALID_ADDRESS_MSG, Util.RATE_LIMITER_ERROR_MSG}) {
+      MockHttpServletResponse response = new MockHttpServletResponse();
+      Util.writeAuditedError(audited, response);
+      JSONObject body = JSONObject.parseObject(response.getContentAsString());
+      assertEquals(audited, body.getString("Error"));
+    }
+  }
+
+  @Test
+  public void auditedErrorWriterWithNullMessageWritesEmptyObject() throws Exception {
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    Util.writeAuditedError(null, response);
+    assertEquals("{}", response.getContentAsString().trim());
+  }
+
+  private static void assertError(Exception error, String expected) throws Exception {
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    Util.processError(error, response);
+    JSONObject body = JSONObject.parseObject(response.getContentAsString());
+    assertEquals(expected, body.getString("Error"));
+  }
+}

--- a/framework/src/test/java/org/tron/core/services/http/solidity/GetTransactionInfoByIdSolidityServletTest.java
+++ b/framework/src/test/java/org/tron/core/services/http/solidity/GetTransactionInfoByIdSolidityServletTest.java
@@ -22,14 +22,13 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.tron.common.utils.ByteArray;
-import org.tron.common.utils.Sha256Hash;
 import org.tron.core.Wallet;
 import org.tron.core.config.args.Args;
 import org.tron.json.JSONObject;
-import org.tron.protos.Protocol.Transaction;
+import org.tron.protos.Protocol.TransactionInfo;
 
 @RunWith(Parameterized.class)
-public class GetTransactionByIdSolidityServletTest {
+public class GetTransactionInfoByIdSolidityServletTest {
 
   private static final String TRANSACTION_ID =
       "309b6fa3d01353e46f57dd8a8f27611f98e392b50d035cef213f2c55225a8bd2";
@@ -39,7 +38,7 @@ public class GetTransactionByIdSolidityServletTest {
   @Parameter
   public String method;
 
-  private GetTransactionByIdSolidityServlet servlet;
+  private GetTransactionInfoByIdSolidityServlet servlet;
   private Wallet wallet;
   private long savedMaxMessageSize;
 
@@ -52,7 +51,7 @@ public class GetTransactionByIdSolidityServletTest {
   public void setUp() {
     savedMaxMessageSize = Args.getInstance().getHttpMaxMessageSize();
     Args.getInstance().setHttpMaxMessageSize(1024);
-    servlet = new GetTransactionByIdSolidityServlet();
+    servlet = new GetTransactionInfoByIdSolidityServlet();
     wallet = mock(Wallet.class);
     ReflectionTestUtils.setField(servlet, "wallet", wallet);
   }
@@ -64,13 +63,13 @@ public class GetTransactionByIdSolidityServletTest {
 
   @Test
   public void walletFailureReturnsSanitizedJson() throws Exception {
-    when(wallet.getTransactionById(TRANSACTION_ID_BYTES))
+    when(wallet.getTransactionInfoById(TRANSACTION_ID_BYTES))
         .thenThrow(new NullPointerException("internal transaction store detail"));
 
     MockHttpServletResponse response = request(TRANSACTION_ID);
 
     assertEquals("internal server error", errorMessage(response));
-    verify(wallet).getTransactionById(TRANSACTION_ID_BYTES);
+    verify(wallet).getTransactionInfoById(TRANSACTION_ID_BYTES);
   }
 
   @Test
@@ -92,39 +91,29 @@ public class GetTransactionByIdSolidityServletTest {
 
     assertEquals(200, response.getStatus());
     assertEquals("{}", response.getContentAsString().trim());
-    verify(wallet).getTransactionById(TRANSACTION_ID_BYTES);
+    verify(wallet).getTransactionInfoById(TRANSACTION_ID_BYTES);
   }
 
   @Test
-  public void successfulLookupKeepsTransaction() throws Exception {
-    ByteString signature = ByteString.copyFromUtf8("transaction signature");
-    Transaction transaction = Transaction.newBuilder()
-        .setRawData(Transaction.raw.newBuilder().setTimestamp(123).setExpiration(456))
-        .addSignature(signature).build();
-    when(wallet.getTransactionById(TRANSACTION_ID_BYTES)).thenReturn(transaction);
+  public void successfulLookupKeepsTransactionInfo() throws Exception {
+    TransactionInfo info = TransactionInfo.newBuilder()
+        .setId(TRANSACTION_ID_BYTES).setFee(7).setBlockNumber(123).build();
+    when(wallet.getTransactionInfoById(TRANSACTION_ID_BYTES)).thenReturn(info);
 
     MockHttpServletResponse response = request(TRANSACTION_ID);
 
     assertEquals(200, response.getStatus());
     JSONObject body = JSONObject.parseObject(response.getContentAsString());
-    assertEquals(4, body.size());
-    JSONObject rawData = body.getJSONObject("raw_data");
-    assertEquals(123L, rawData.getLongValue("timestamp"));
-    assertEquals(456L, rawData.getLongValue("expiration"));
-    assertEquals(0, rawData.getJSONArray("contract").size());
-    assertEquals(ByteArray.toHexString(transaction.getRawData().toByteArray()),
-        body.getString("raw_data_hex"));
-    assertEquals(Sha256Hash.of(Args.getInstance().isECKeyCryptoEngine(),
-        transaction.getRawData().toByteArray()).toString(), body.getString("txID"));
-    assertEquals(1, body.getJSONArray("signature").size());
-    assertEquals(ByteArray.toHexString(signature.toByteArray()),
-        body.getJSONArray("signature").getString(0));
-    verify(wallet).getTransactionById(TRANSACTION_ID_BYTES);
+    assertEquals(3, body.size());
+    assertEquals(TRANSACTION_ID, body.getString("id"));
+    assertEquals(7L, body.getLongValue("fee"));
+    assertEquals(123L, body.getLongValue("blockNumber"));
+    verify(wallet).getTransactionInfoById(TRANSACTION_ID_BYTES);
   }
 
   private MockHttpServletResponse request(String value) throws Exception {
     MockHttpServletRequest request = new MockHttpServletRequest(method,
-        "/walletsolidity/gettransactionbyid");
+        "/walletsolidity/gettransactioninfobyid");
     MockHttpServletResponse response = new MockHttpServletResponse();
     if ("GET".equals(method)) {
       request.setParameter("value", value);


### PR DESCRIPTION
**What does this PR do?**

Routes the standard HTTP servlet error paths through a single decision point in `Util.processError`, which determines the client-facing text:

- keeps the raw non-blank message only for the exact runtime types `JsonFormat.ParseException`, `ContractValidateException` and `MaintenanceUnavailableException`; a null, empty or whitespace-only message falls back to `internal server error`;
- keeps the events-deprecation message, and its existing HTTP 400, only for the exact `IllegalArgumentException` type carrying the audited message constant;
- writes the fixed rate-limit and `INVALID address` texts, plus the existing GetBlock validation texts, through a package-private `String` overload used at four audited call sites that bypass exception classification;
- returns `{"Error":"internal server error"}` for every other exception, with no Java exception class name.

Matching is on the exact top-level runtime type: subclasses do not inherit the compatibility exemptions, and cause chains are not unwrapped.

The two SolidityNode transaction-query endpoints also change from bare-text error bodies to standard `{"Error":...}` JSON, and `validateaddress`, `getBrokerage` and `getReward` replace leaked library text in their failure branches with the fixed messages they already use elsewhere.

The full before/after compatibility table is in #6936.

**Why are these changes required?**

Standard HTTP error responses currently return Java exception class names and unaudited `Throwable.getMessage()` values, for example `{"Error":"class java.lang.NullPointerException : ..."}`. That text gives clients nothing actionable, and it changes with JDK and dependency versions, so it is unsuitable as a long-term API contract; the failure-response format is inconsistent across the API.

**This PR has been tested by:**
- Unit Tests

**Follow up**

**Extra details**

- Scope is the `framework` HTTP servlet layer. No gRPC or JSON-RPC code is modified. The only JSON-RPC-visible change is the shared rate-limit rejection body, which all three JSON-RPC servlets inherit from `RateLimiterServlet`.
- Breaking change for failure responses only, and it needs a release-notes entry: clients that parse Java exception class names, raw exception messages, or the Solidity bare-text error bodies must read the `Error` field of the standard JSON body instead and treat unknown server errors as `internal server error`. The `INVALID address` body also loses the space after the colon, which affects clients matching that body literally.
- Successful responses, request parsing and validation rules, and existing HTTP status codes are unchanged.

Closes #6936
