### PR TITLE
fix(net): stop BackupServer.close() hanging while bind is in flight

### DIFF
--- a/framework/src/main/java/org/tron/common/backup/socket/BackupServer.java
+++ b/framework/src/main/java/org/tron/common/backup/socket/BackupServer.java
@@ -27,12 +27,12 @@ public class BackupServer implements AutoCloseable {
 
   private BackupManager backupManager;
 
-  private Channel channel;
-
   private volatile boolean shutdown = false;
 
   private final String name = "BackupServer";
-  private ExecutorService executor;
+  private volatile ExecutorService executor;
+
+  private volatile NioEventLoopGroup group;
 
   @Autowired
   public BackupServer(final BackupManager backupManager) {
@@ -41,6 +41,14 @@ public class BackupServer implements AutoCloseable {
 
   public void initServer() {
     if (port > 0 && commonParameter.getBackupMembers().size() > 0) {
+      try {
+        // Let close() reach the group before bind() completes.
+        group = new NioEventLoopGroup(1);
+      } catch (RuntimeException e) {
+        // Do not propagate selector failures to block processing.
+        logger.error("Start backup server with port {} failed.", port, e);
+        return;
+      }
       executor = ExecutorServiceManager.newSingleThreadExecutor(name);
       executor.submit(() -> {
         try {
@@ -53,7 +61,6 @@ public class BackupServer implements AutoCloseable {
   }
 
   private void start() throws Exception {
-    NioEventLoopGroup group = new NioEventLoopGroup(1);
     try {
       while (!shutdown) {
         Bootstrap b = new Bootstrap();
@@ -73,7 +80,7 @@ public class BackupServer implements AutoCloseable {
               }
             });
 
-        channel = b.bind(port).sync().channel();
+        Channel channel = b.bind(port).sync().channel();
 
         logger.info("Backup server started, bind port {}", port);
 
@@ -84,10 +91,15 @@ public class BackupServer implements AutoCloseable {
         }
         logger.warn("Restart backup server ...");
       }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      if (!shutdown) {
+        logger.error("Backup server interrupted.", e);
+      }
     } catch (Exception e) {
       logger.error("Start backup server with port {} failed.", port, e);
     } finally {
-      group.shutdownGracefully().sync();
+      group.shutdownGracefully();
     }
   }
 
@@ -96,14 +108,12 @@ public class BackupServer implements AutoCloseable {
     logger.info("Closing backup server...");
     shutdown = true;
     backupManager.stop();
-    if (channel != null) {
-      try {
-        channel.close().await(10, TimeUnit.SECONDS);
-      } catch (Exception e) {
-        logger.warn("Closing backup server failed.", e);
-      }
+    if (executor != null) {
+      executor.shutdownNow();
     }
-    ExecutorServiceManager.shutdownAndAwaitTermination(executor, name);
+    if (group != null) {
+      group.shutdownGracefully().awaitUninterruptibly(10, TimeUnit.SECONDS);
+    }
     logger.info("Backup server closed.");
   }
 }

--- a/framework/src/test/java/org/tron/common/backup/BackupManagerTest.java
+++ b/framework/src/test/java/org/tron/common/backup/BackupManagerTest.java
@@ -9,7 +9,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.BiFunction;
 import org.junit.After;
@@ -138,15 +137,8 @@ public class BackupManagerTest {
 
     Thread.sleep(parameter.getKeepAliveInterval() + 1000);//test send KeepAliveMessage
 
-    field = manager.getClass().getDeclaredField("executorService");
-    field.setAccessible(true);
-    ScheduledExecutorService executorService = (ScheduledExecutorService) field.get(manager);
-    executorService.shutdown();
-
-    Field field2 = backupServer.getClass().getDeclaredField("executor");
-    field2.setAccessible(true);
-    ExecutorService executorService2 = (ExecutorService) field2.get(backupServer);
-    executorService2.shutdown();
+    // also stops the manager's keep-alive executor
+    backupServer.close();
 
     Assert.assertEquals(BackupManager.BackupStatusEnum.INIT, manager.getStatus());
   }

--- a/framework/src/test/java/org/tron/common/backup/BackupServerTest.java
+++ b/framework/src/test/java/org/tron/common/backup/BackupServerTest.java
@@ -1,17 +1,34 @@
 package org.tron.common.backup;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mockStatic;
+
+import io.netty.channel.Channel;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.util.concurrent.SingleThreadEventExecutor;
+import java.io.IOException;
+import java.net.DatagramSocket;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.rules.Timeout;
+import org.mockito.MockedStatic;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.tron.common.TestConstants;
 import org.tron.common.backup.socket.BackupServer;
+import org.tron.common.es.ExecutorServiceManager;
 import org.tron.common.parameter.CommonParameter;
-import org.tron.common.utils.PublicMethod;
 import org.tron.core.config.args.Args;
 
 
@@ -22,17 +39,18 @@ public class BackupServerTest {
 
   @Rule
   public Timeout globalTimeout = Timeout.seconds(60);
+  private BackupManager backupManager;
   private BackupServer backupServer;
 
   @Before
   public void setUp() throws Exception {
     Args.setParam(new String[]{"-d", temporaryFolder.newFolder().toString()},
         TestConstants.TEST_CONF);
-    CommonParameter.getInstance().setBackupPort(PublicMethod.chooseRandomPort());
+    CommonParameter.getInstance().setBackupPort(freeUdpPort());
     List<String> members = new ArrayList<>();
     members.add("127.0.0.2");
     CommonParameter.getInstance().setBackupMembers(members);
-    BackupManager backupManager = new BackupManager();
+    backupManager = new BackupManager();
     backupManager.init();
     backupServer = new BackupServer(backupManager);
   }
@@ -43,10 +61,104 @@ public class BackupServerTest {
     Args.clearParam();
   }
 
-  @Test(timeout = 60_000)
-  public void test() throws InterruptedException {
+  @Test
+  public void closeAfterStarted() throws Exception {
     backupServer.initServer();
-    // wait for the server to start so channel is assigned before close() is called
-    Thread.sleep(1000);
+    assertTrue("server did not bind in time", waitUntil(() -> {
+      Channel channel = serverChannel();
+      return channel != null && channel.isActive();
+    }, 30));
+
+    Channel channel = serverChannel();
+    ExecutorService executor =
+        (ExecutorService) ReflectionTestUtils.getField(backupServer, "executor");
+    backupServer.close();
+
+    Assert.assertNotNull(channel);
+    assertFalse("server channel is still open", channel.isOpen());
+    assertTrue("event loop group did not terminate", eventLoopGroup().isTerminated());
+    Assert.assertNotNull(executor);
+    assertTrue("server executor did not terminate",
+        executor.awaitTermination(5, TimeUnit.SECONDS));
+  }
+
+  @Test
+  public void closeWhileBindIsPending() throws Exception {
+    ExecutorService executor = ExecutorServiceManager.newSingleThreadExecutor("BackupServer");
+    CountDownLatch parked = new CountDownLatch(1);
+    CountDownLatch release = new CountDownLatch(1);
+    FutureTask<Void> closed = new FutureTask<>(backupServer::close, null);
+    Thread closer = new Thread(closed, "backup-test-closer");
+    try {
+      try (MockedStatic<ExecutorServiceManager> factory =
+          mockStatic(ExecutorServiceManager.class)) {
+        factory.when(() -> ExecutorServiceManager.newSingleThreadExecutor("BackupServer"))
+            .thenAnswer(invocation -> {
+              // The group exists, but the server task has not been submitted yet.
+              eventLoopGroup().next().execute(() -> {
+                parked.countDown();
+                try {
+                  release.await();
+                } catch (InterruptedException e) {
+                  Thread.currentThread().interrupt();
+                }
+              });
+              assertTrue("event loop did not park", parked.await(5, TimeUnit.SECONDS));
+              return executor;
+            });
+        backupServer.initServer();
+      }
+
+      NioEventLoopGroup group = eventLoopGroup();
+      SingleThreadEventExecutor loop = (SingleThreadEventExecutor) group.next();
+      assertTrue("bind registration did not queue", waitUntil(() -> loop.pendingTasks() > 0, 5));
+      closer.start();
+      assertTrue("close did not shut down the group", waitUntil(group::isShuttingDown, 5));
+      // Let bind proceed only after close() has requested shutdown.
+      release.countDown();
+      closed.get(15, TimeUnit.SECONDS);
+      assertTrue("server executor did not terminate",
+          executor.awaitTermination(5, TimeUnit.SECONDS));
+      assertTrue("event loop group did not terminate", group.isTerminated());
+    } finally {
+      // Release the event loop even when a preparation or shutdown assertion fails.
+      release.countDown();
+      closer.interrupt();
+      executor.shutdownNow();
+      NioEventLoopGroup group = eventLoopGroup();
+      if (group != null) {
+        assertTrue("event loop cleanup failed",
+            group.shutdownGracefully().awaitUninterruptibly(10, TimeUnit.SECONDS));
+      }
+      closer.join(10_000);
+      assertTrue("executor cleanup failed", executor.awaitTermination(10, TimeUnit.SECONDS));
+    }
+  }
+
+  private Channel serverChannel() {
+    Object handler = ReflectionTestUtils.getField(backupManager, "messageHandler");
+    return handler == null ? null : (Channel) ReflectionTestUtils.getField(handler, "channel");
+  }
+
+  private NioEventLoopGroup eventLoopGroup() {
+    return (NioEventLoopGroup) ReflectionTestUtils.getField(backupServer, "group");
+  }
+
+  private boolean waitUntil(BooleanSupplier condition, long timeoutSeconds)
+      throws InterruptedException {
+    long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(timeoutSeconds);
+    while (!condition.getAsBoolean()) {
+      if (System.nanoTime() - deadline >= 0) {
+        return false;
+      }
+      TimeUnit.MILLISECONDS.sleep(10);
+    }
+    return true;
+  }
+
+  private int freeUdpPort() throws IOException {
+    try (DatagramSocket socket = new DatagramSocket(0)) {
+      return socket.getLocalPort();
+    }
   }
 }


### PR DESCRIPTION
**What does this PR do?**

Fix a `BackupServer` shutdown race that can cause `BackupServerTest` to time out.

Create the event loop group in `initServer()`, before the server task is submitted, so `close()` can shut it down while bind is still pending.

`close()` now interrupts the server executor and waits up to 10 seconds for the event loop group, replacing the `ExecutorServiceManager.shutdownAndAwaitTermination` call that could wait up to 120 seconds across two termination waits. The server task requests group shutdown in `finally` without blocking again.

**Why are these changes required?**

Previously, `close()` closed the channel only if it had already been published, then called `ExecutorServiceManager.shutdownAndAwaitTermination`. If bind completed after `close()` checked the channel, nothing closed the socket, the server thread stayed parked in `closeFuture().sync()`, and `close()` blocked in `awaitTermination` long enough to trip the test's 60-second timeout.

[Related CI failure](https://github.com/tronprotocol/java-tron/actions/runs/34214913406/job/102031658052?pr=6952) (attempt 2 of that workflow run; the test failed all six attempts—the initial run plus five retries), abbreviated:

```text
org.tron.common.backup.BackupServerTest > test FAILED
    org.junit.runners.model.TestTimedOutException: test timed out after 60 seconds
        ...
        at java.util.concurrent.ThreadPoolExecutor.awaitTermination(ThreadPoolExecutor.java:1475)
        at java.util.concurrent.Executors$DelegatedExecutorService.awaitTermination(Executors.java:675)
        at org.tron.common.es.ExecutorServiceManager.shutdownAndAwaitTermination(ExecutorServiceManager.java:90)
        at org.tron.common.backup.socket.BackupServer.close(BackupServer.java:106)
        at org.tron.common.backup.BackupServerTest.tearDown(BackupServerTest.java:42)
```

**This PR has been tested by:**

- `closeAfterStarted`: waits for a successfully bound channel, closes the server, and verifies that the channel closes and both the group and executor terminate.
- `closeWhileBindIsPending`: deterministically holds bind registration pending, initiates shutdown, then releases the event loop and verifies termination.
- `BackupManagerTest` now uses `backupServer.close()` for cleanup.