### PR TITLE
refactor(api): remove dead WalletExtension gRPC service and config

### DIFF
--- a/common/src/main/java/org/tron/common/parameter/CommonParameter.java
+++ b/common/src/main/java/org/tron/common/parameter/CommonParameter.java
@@ -295,9 +295,6 @@ public class CommonParameter {
   public String trustNodeAddr; // clearParam: ""
   @Getter
   @Setter
-  public boolean walletExtensionApi;
-  @Getter
-  @Setter
   public boolean estimateEnergy;
   @Getter
   @Setter

--- a/common/src/main/java/org/tron/core/config/args/NodeConfig.java
+++ b/common/src/main/java/org/tron/core/config/args/NodeConfig.java
@@ -26,7 +26,6 @@ public class NodeConfig {
 
   // ---- Flat scalar fields (auto-bound by ConfigBeanFactory) ----
   private String trustNode = "";
-  private boolean walletExtensionApi = false;
   private int syncFetchBatchNum = 2000;
   private int maxPendingBlockSize = 500;
   private int validateSignThreadNum = 0; // 0 = auto (availableProcessors)
@@ -325,6 +324,12 @@ public class NodeConfig {
       logger.warn("Configuring [node.maxActiveNodesWithSameIp] is deprecated and will be removed "
           + "in a future release. Please use [node.maxConnectionsWithSameIp] instead.");
       nc.maxConnectionsWithSameIp = section.getInt("maxActiveNodesWithSameIp");
+    }
+
+    // node.walletExtensionApi (removed): the WalletExtension gRPC service no longer exists
+    if (section.hasPath("walletExtensionApi")) {
+      logger.warn("Configuring [node.walletExtensionApi] has been removed and is ignored. "
+          + "The WalletExtension gRPC service no longer exists.");
     }
 
     // Legacy key fallback: node.allowShieldedTransactionApi wins fullNodeAllowShieldedTransaction

--- a/common/src/main/resources/reference.conf
+++ b/common/src/main/resources/reference.conf
@@ -185,9 +185,6 @@ node {
   # Trust node for solidity node (example: "127.0.0.1:50051").
   trustNode = ""
 
-  # Expose extension api to public or not
-  walletExtensionApi = false
-
   listen.port = 18888   # P2P listen port.
   fetchBlock.timeout = 500 # Block fetch timeout (ms).
 

--- a/framework/src/main/java/org/tron/core/config/args/Args.java
+++ b/framework/src/main/java/org/tron/core/config/args/Args.java
@@ -598,7 +598,6 @@ public class Args extends CommonParameter {
     PARAMETER.trustNodeAddr = nc.getTrustNode();
 
     PARAMETER.validateSignThreadNum = nc.getValidateSignThreadNum();
-    PARAMETER.walletExtensionApi = nc.isWalletExtensionApi();
     PARAMETER.isOpenFullTcpDisconnect = nc.isOpenFullTcpDisconnect();
     PARAMETER.nodeDetectEnable = nc.isNodeDetectEnable();
 

--- a/framework/src/main/java/org/tron/core/services/RpcApiService.java
+++ b/framework/src/main/java/org/tron/core/services/RpcApiService.java
@@ -63,13 +63,10 @@ import org.tron.api.GrpcAPI.TransactionApprovedList;
 import org.tron.api.GrpcAPI.TransactionExtention;
 import org.tron.api.GrpcAPI.TransactionIdList;
 import org.tron.api.GrpcAPI.TransactionInfoList;
-import org.tron.api.GrpcAPI.TransactionList;
-import org.tron.api.GrpcAPI.TransactionListExtention;
 import org.tron.api.GrpcAPI.TransactionSignWeight;
 import org.tron.api.GrpcAPI.ViewingKeyMessage;
 import org.tron.api.GrpcAPI.WitnessList;
 import org.tron.api.MonitorGrpc;
-import org.tron.api.WalletExtensionGrpc;
 import org.tron.api.WalletGrpc.WalletImplBase;
 import org.tron.api.WalletSolidityGrpc.WalletSolidityImplBase;
 import org.tron.common.application.RpcService;
@@ -199,9 +196,6 @@ public class RpcApiService extends RpcService {
     CommonParameter parameter = Args.getInstance();
     if (parameter.isSolidityNode()) {
       serverBuilder.addService(walletSolidityApi);
-      if (parameter.isWalletExtensionApi()) {
-        serverBuilder.addService(new WalletExtensionApi());
-      }
     } else {
       serverBuilder.addService(walletApi);
     }
@@ -932,23 +926,6 @@ public class RpcApiService extends RpcService {
         responseObserver.onError(getRunTimeException(e));
       }
       responseObserver.onCompleted();
-    }
-  }
-
-  /**
-   * WalletExtensionApi.
-   */
-  public class WalletExtensionApi extends WalletExtensionGrpc.WalletExtensionImplBase {
-
-    private TransactionListExtention transactionList2Extention(TransactionList transactionList) {
-      if (transactionList == null) {
-        return null;
-      }
-      TransactionListExtention.Builder builder = TransactionListExtention.newBuilder();
-      for (Transaction transaction : transactionList.getTransactionList()) {
-        builder.addTransaction(transaction2Extention(transaction));
-      }
-      return builder.build();
     }
   }
 

--- a/framework/src/main/java/org/tron/core/services/http/Util.java
+++ b/framework/src/main/java/org/tron/core/services/http/Util.java
@@ -36,7 +36,6 @@ import org.tron.api.GrpcAPI.BlockList;
 import org.tron.api.GrpcAPI.TransactionApprovedList;
 import org.tron.api.GrpcAPI.TransactionExtention;
 import org.tron.api.GrpcAPI.TransactionIdList;
-import org.tron.api.GrpcAPI.TransactionList;
 import org.tron.api.GrpcAPI.TransactionSignWeight;
 import org.tron.common.crypto.Hash;
 import org.tron.common.parameter.CommonParameter;
@@ -146,17 +145,6 @@ public class Util {
           printTransactionListToJSON(blockCapsule.getTransactions(), selfType));
     }
     return jsonObject;
-  }
-
-  public static String printTransactionList(TransactionList list, boolean selfType) {
-    List<Transaction> transactions = list.getTransactionList();
-    JSONObject jsonObject = JSONObject.parseObject(JsonFormat.printToString(list, selfType));
-    JSONArray jsonArray = new JSONArray();
-    transactions.stream()
-        .forEach(transaction -> jsonArray.add(printTransactionToJSON(transaction, selfType)));
-    jsonObject.put(TRANSACTION, jsonArray);
-
-    return jsonObject.toJSONString();
   }
 
   public static String printTransactionIdList(TransactionIdList list, boolean selfType) {

--- a/framework/src/main/resources/config.conf
+++ b/framework/src/main/resources/config.conf
@@ -78,9 +78,6 @@ node.metrics = {
 node {
   trustNode = "127.0.0.1:50051"
 
-  # expose extension api to public or not
-  walletExtensionApi = true
-
   listen.port = 18888
 
   fetchBlock.timeout = 200

--- a/framework/src/test/java/org/tron/common/ParameterTest.java
+++ b/framework/src/test/java/org/tron/common/ParameterTest.java
@@ -168,8 +168,6 @@ public class ParameterTest {
     assertEquals(1, parameter.getForbidTransferToContract());
     parameter.setTrustNodeAddr("address");
     assertEquals("address", parameter.getTrustNodeAddr());
-    parameter.setWalletExtensionApi(false);
-    assertFalse(parameter.isWalletExtensionApi());
     parameter.setEstimateEnergy(false);
     assertFalse(parameter.isEstimateEnergy());
     parameter.setEstimateEnergyMaxRetry(2);

--- a/framework/src/test/java/org/tron/common/utils/client/GrpcClient.java
+++ b/framework/src/test/java/org/tron/common/utils/client/GrpcClient.java
@@ -8,7 +8,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.tron.api.GrpcAPI;
 import org.tron.api.GrpcAPI.AccountNetMessage;
-import org.tron.api.GrpcAPI.AccountPaginated;
 import org.tron.api.GrpcAPI.AssetIssueList;
 import org.tron.api.GrpcAPI.BlockLimit;
 import org.tron.api.GrpcAPI.BlockList;
@@ -17,9 +16,7 @@ import org.tron.api.GrpcAPI.EmptyMessage;
 import org.tron.api.GrpcAPI.NodeList;
 import org.tron.api.GrpcAPI.NumberMessage;
 import org.tron.api.GrpcAPI.PaginatedMessage;
-import org.tron.api.GrpcAPI.TransactionList;
 import org.tron.api.GrpcAPI.WitnessList;
-import org.tron.api.WalletExtensionGrpc;
 import org.tron.api.WalletGrpc;
 import org.tron.api.WalletSolidityGrpc;
 import org.tron.common.utils.ByteArray;
@@ -42,7 +39,6 @@ public class GrpcClient {
   private ManagedChannel channelSolidity = null;
   private WalletGrpc.WalletBlockingStub blockingStubFull = null;
   private WalletSolidityGrpc.WalletSolidityBlockingStub blockingStubSolidity = null;
-  private WalletExtensionGrpc.WalletExtensionBlockingStub blockingStubExtension = null;
 
   //  public GrpcClient(String host, int port) {
   //    channel = ManagedChannelBuilder.forAddress(host, port)
@@ -67,7 +63,6 @@ public class GrpcClient {
           .usePlaintext()
           .build();
       blockingStubSolidity = WalletSolidityGrpc.newBlockingStub(channelSolidity);
-      blockingStubExtension = WalletExtensionGrpc.newBlockingStub(channelSolidity);
     }
   }
 
@@ -283,56 +278,6 @@ public class GrpcClient {
           return blockingStubFull.totalTransaction(EmptyMessage.newBuilder().build());
       }
    }*/
-
-  /*    public Optional<AssetIssueList> getAssetIssueListByTimestamp(long time) {
-        NumberMessage.Builder timeStamp = NumberMessage.newBuilder();
-        timeStamp.setNum(time);
-        AssetIssueList assetIssueList = blockingStubSolidity
-        .getAssetIssueListByTimestamp(timeStamp.build());
-        return Optional.ofNullable(assetIssueList);
-    }*/
-  /*    public Optional<TransactionList> getTransactionsByTimestamp(
-        long start, long end, int offset , int limit) {
-        TimeMessage.Builder timeMessage = TimeMessage.newBuilder();
-        timeMessage.setBeginInMilliseconds(start);
-        timeMessage.setEndInMilliseconds(end);
-        TimePaginatedMessage.Builder timePageMessage = TimePaginatedMessage.newBuilder();
-        timePageMessage.setTimeMessage(timeMessage);
-        timePageMessage.setOffset(offset);
-        timePageMessage.setLimit(limit);
-        TransactionList transactionList = blockingStubExtension
-        .getTransactionsByTimestamp(timePageMessage.build());
-        return Optional.ofNullable(transactionList);
-    }*/
-
-  /**
-   * constructor.
-   */
-
-  public Optional<TransactionList> getTransactionsFromThis(byte[] address) {
-    ByteString addressBs = ByteString.copyFrom(address);
-    Account account = Account.newBuilder().setAddress(addressBs).build();
-    AccountPaginated.Builder builder = AccountPaginated.newBuilder().setAccount(account);
-    builder.setLimit(1000);
-    builder.setOffset(0);
-    TransactionList transactionList = blockingStubExtension
-        .getTransactionsFromThis(builder.build());
-    return Optional.ofNullable(transactionList);
-  }
-
-  /**
-   * constructor.
-   */
-
-  public Optional<TransactionList> getTransactionsToThis(byte[] address) {
-    ByteString addressBs = ByteString.copyFrom(address);
-    Account account = Account.newBuilder().setAddress(addressBs).build();
-    AccountPaginated.Builder builder = AccountPaginated.newBuilder().setAccount(account);
-    builder.setLimit(1000);
-    builder.setOffset(0);
-    TransactionList transactionList = blockingStubExtension.getTransactionsToThis(builder.build());
-    return Optional.ofNullable(transactionList);
-  }
 
   /*    public Optional<Transaction> getTransactionById(String txID){
         ByteString bsTxid = ByteString.copyFrom(ByteArray.fromHexString(txID));

--- a/framework/src/test/java/org/tron/common/utils/client/WalletClient.java
+++ b/framework/src/test/java/org/tron/common/utils/client/WalletClient.java
@@ -22,7 +22,6 @@ import org.tron.api.GrpcAPI.AccountNetMessage;
 import org.tron.api.GrpcAPI.AssetIssueList;
 import org.tron.api.GrpcAPI.BlockList;
 import org.tron.api.GrpcAPI.NodeList;
-import org.tron.api.GrpcAPI.TransactionList;
 import org.tron.api.GrpcAPI.WitnessList;
 import org.tron.common.crypto.ECKey;
 import org.tron.common.parameter.CommonParameter;
@@ -647,14 +646,6 @@ public class WalletClient {
     return rpcCli.listNodes();
   }
 
-  public static Optional<TransactionList> getTransactionsFromThis(byte[] address) {
-    return rpcCli.getTransactionsFromThis(address);
-  }
-
-  public static Optional<TransactionList> getTransactionsToThis(byte[] address) {
-    return rpcCli.getTransactionsToThis(address);
-  }
-
   public static Block getBlock(long blockNum) {
     return rpcCli.getBlock(blockNum);
   }
@@ -700,15 +691,6 @@ public class WalletClient {
     transaction = TransactionUtils.setTimestamp(transaction);
     return TransactionUtils.sign(transaction, this.ecKey);
   }
-
-  /*    public static Optional<AssetIssueList> getAssetIssueListByTimestamp(long timestamp) {
-        return rpcCli.getAssetIssueListByTimestamp(timestamp);
-  }*/
-
-  /*    public static Optional<TransactionList> getTransactionsByTimestamp(
-  long start, long end, int offset, int limit) {
-        return rpcCli.getTransactionsByTimestamp(start, end, offset, limit);
-  }*/
 
   /**
    * constructor.

--- a/framework/src/test/java/org/tron/common/utils/client/utils/HttpMethed.java
+++ b/framework/src/test/java/org/tron/common/utils/client/utils/HttpMethed.java
@@ -1911,50 +1911,6 @@ public class HttpMethed {
   }
 
   /** constructor. */
-  public static HttpResponse getTransactionsFromThisFromSolidity(
-      String httpSolidityNode, byte[] fromAddress, long offset, long limit) {
-    try {
-      Map<String, String> map1 = new HashMap<String, String>();
-      Map<String, Object> map = new HashMap<String, Object>();
-      map1.put("address", ByteArray.toHexString(fromAddress));
-      map.put("account", map1);
-      map.put("offset", offset);
-      map.put("limit", limit);
-      String requestUrl = "http://" + httpSolidityNode + "/walletextension/gettransactionsfromthis";
-      String jsonStr = new Gson().toJson(map);
-      JsonObject jsonObj = new JsonParser().parse(jsonStr).getAsJsonObject();
-      response = createConnect(requestUrl, jsonObj);
-    } catch (Exception e) {
-      e.printStackTrace();
-      httppost.releaseConnection();
-      return null;
-    }
-    return response;
-  }
-
-  /** constructor. */
-  public static HttpResponse getTransactionsToThisFromSolidity(
-      String httpSolidityNode, byte[] toAddress, long offset, long limit) {
-    try {
-      Map<String, String> map1 = new HashMap<String, String>();
-      Map<String, Object> map = new HashMap<String, Object>();
-      map1.put("address", ByteArray.toHexString(toAddress));
-      map.put("account", map1);
-      map.put("offset", offset);
-      map.put("limit", limit);
-      String requestUrl = "http://" + httpSolidityNode + "/walletextension/gettransactionstothis";
-      String jsonStr = new Gson().toJson(map);
-      JsonObject jsonObj = new JsonParser().parse(jsonStr).getAsJsonObject();
-      response = createConnect(requestUrl, jsonObj);
-    } catch (Exception e) {
-      e.printStackTrace();
-      httppost.releaseConnection();
-      return null;
-    }
-    return response;
-  }
-
-  /** constructor. */
   public static HttpResponse getAssetIssueByName(String httpNode, String name) {
     try {
       String requestUrl = "http://" + httpNode + "/wallet/getassetissuebyname";

--- a/framework/src/test/java/org/tron/core/config/args/ArgsTest.java
+++ b/framework/src/test/java/org/tron/core/config/args/ArgsTest.java
@@ -369,6 +369,18 @@ public class ArgsTest {
     Args.clearParam();
   }
 
+  /**
+   * The removed node.walletExtensionApi key must stay harmless in operator configs:
+   * binding ignores it and fromConfig logs a removal warning. Lives here rather than
+   * NodeConfigTest because module jacoco reports only aggregate framework execution data.
+   */
+  @Test
+  public void testRemovedWalletExtensionApiKeyIsIgnored() {
+    Config config = ConfigFactory.parseString("node { walletExtensionApi = true }")
+        .withFallback(ConfigFactory.defaultReference());
+    Assert.assertNotNull(NodeConfig.fromConfig(config));
+  }
+
   // ===========================================================================
   // Boundary tests for node.fetchBlock.timeout clamping.
   //

--- a/framework/src/test/java/org/tron/core/services/http/UtilMockTest.java
+++ b/framework/src/test/java/org/tron/core/services/http/UtilMockTest.java
@@ -198,16 +198,6 @@ public class UtilMockTest  {
     }
   }
 
-  @Test
-  public void testPrintTransactionList() {
-    TransactionCapsule transactionCapsule = getTransactionCapsuleExample();
-    GrpcAPI.TransactionList list = GrpcAPI.TransactionList.newBuilder()
-        .addTransaction(transactionCapsule.getInstance())
-        .build();
-    String out = Util.printTransactionList(list, true);
-    Assert.assertNotNull(out);
-  }
-
   private TransactionCapsule getTransactionCapsuleExample() {
     final String OWNER_ADDRESS = "41548794500882809695a8a687866e76d4271a1abc";
     final String RECEIVER_ADDRESS = "41abd4b9367799eaa3197fecb144eb71de1e049150";

--- a/framework/src/test/resources/config-shield.conf
+++ b/framework/src/test/resources/config-shield.conf
@@ -41,9 +41,6 @@ node {
   # trustNode = "ip:port"
   trustNode = "127.0.0.1:50051"
 
-  # expose extension api to public or not
-  walletExtensionApi = true
-
   listen.port = 6666
 
   # Number of validate sign thread, default availableProcessors / 2

--- a/protocol/src/main/protos/api/api.proto
+++ b/protocol/src/main/protos/api/api.proto
@@ -613,21 +613,6 @@ service WalletSolidity {
   }
 };
 
-service WalletExtension {
-  //Please use GetTransactionsFromThis2 instead of this function.
-  rpc GetTransactionsFromThis (AccountPaginated) returns (TransactionList) {
-  }
-  //Use this function instead of GetTransactionsFromThis.
-  rpc GetTransactionsFromThis2 (AccountPaginated) returns (TransactionListExtention) {
-  }
-  //Please use GetTransactionsToThis2 instead of this function.
-  rpc GetTransactionsToThis (AccountPaginated) returns (TransactionList) {
-  }
-  //Use this function instead of GetTransactionsToThis.
-  rpc GetTransactionsToThis2 (AccountPaginated) returns (TransactionListExtention) {
-  }
-};
-
 // the api of tron's db
 service Database {
   // for tapos
@@ -699,9 +684,6 @@ message AssetIssueList {
 message BlockList {
   repeated Block block = 1;
 }
-message TransactionList {
-  repeated Transaction transaction = 1;
-}
 message TransactionIdList {
   repeated string txId = 1;
 }
@@ -764,10 +746,6 @@ message NumberMessage {
 message BytesMessage {
   bytes value = 1;
 }
-message TimeMessage {
-  int64 beginInMilliseconds = 1;
-  int64 endInMilliseconds = 2;
-}
 message BlockReq {
   string id_or_num = 1;
   bool   detail = 2;
@@ -779,16 +757,6 @@ message BlockLimit {
 message TransactionLimit {
   bytes transactionId = 1;
   int64 limitNum = 2;
-}
-message AccountPaginated {
-  Account account = 1;
-  int64 offset = 2;
-  int64 limit = 3;
-}
-message TimePaginatedMessage {
-  TimeMessage timeMessage = 1;
-  int64 offset = 2;
-  int64 limit = 3;
 }
 //deprecated
 message AccountNetMessage {
@@ -852,10 +820,6 @@ message BlockExtention {
 
 message BlockListExtention {
   repeated BlockExtention block = 1;
-}
-
-message TransactionListExtention {
-  repeated TransactionExtention transaction = 1;
 }
 
 message BlockIncrementalMerkleTree {


### PR DESCRIPTION
**What does this PR do?**

close https://github.com/tronprotocol/java-tron/issues/6931.
Removes the dead `WalletExtension` gRPC service and everything reachable only from it:

- `api.proto`: `service WalletExtension` (`GetTransactionsFromThis/2`, `GetTransactionsToThis/2`), plus messages `AccountPaginated`, `TransactionList`, `TransactionListExtention` (referenced only by these four RPCs) and `TimeMessage` / `TimePaginatedMessage` (request types of the WalletExtension `*ByTimestamp` RPCs deleted in 2018, orphaned ever since)
- `RpcApiService`: the registration branch and the empty `WalletExtensionApi` inner class
- The `node.walletExtensionApi` config item: `CommonParameter` / `NodeConfig` fields, the `Args` binding, and the key in `reference.conf` / `config.conf` / `config-shield.conf`. Following the retirement convention for `node.*` keys, `NodeConfig.fromConfig` now logs a removal warning when the old key is still present in an operator config
- Dead code only reachable from the above: `Util.printTransactionList` (sole caller was its own mock test), the WalletExtension stub and wrappers in test utilities `GrpcClient` / `WalletClient`, `HttpMethed.getTransactions{From,To}ThisFromSolidity` (targets `/walletextension/*` HTTP paths that have no servlet), and commented-out `getTransactionsByTimestamp` / `getAssetIssueListByTimestamp` blocks

**Why are these changes required?**

`WalletExtension` has had no implementation in any release since v3.7 (2020-03): `RpcApiService$WalletExtensionApi` overrides none of the four RPCs, so every call falls through to the generated `ImplBase` default handlers and returns `UNIMPLEMENTED`. This makes `node.walletExtensionApi` behavior-irrelevant — enabled, a solidity node registers a service with zero implemented methods (advertised via gRPC reflection when `node.rpc.reflectionService` is on); disabled, callers get the same `UNIMPLEMENTED`. Removing it also resolves the default-value inconsistency between `config.conf` (`true`) and `reference.conf` (`false`).

Six years of unconditional `UNIMPLEMENTED` rules out any functional dependency, so the service is removed directly without a deprecation period, following existing practice for dead interfaces.

**This PR has been tested by:**

- Unit Tests
- Manual Test

**Follow up**

Ecosystem code that still compiles against the removed stubs/messages needs a sync: the `tronprotocol/protocol` mirror, the documentation site, and older wallet-cli/trident versions. Compile-time impact only — runtime behavior is unchanged (`UNIMPLEMENTED` before and after).

**Extra details**

None.