### PR TITLE
refactor(framework): decouple Manager from TronJsonRpcImpl

### DIFF
--- a/framework/src/main/java/org/tron/common/application/ApplicationImpl.java
+++ b/framework/src/main/java/org/tron/common/application/ApplicationImpl.java
@@ -1,5 +1,6 @@
 package org.tron.common.application;
 
+import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,6 +11,7 @@ import org.tron.core.consensus.ConsensusService;
 import org.tron.core.db.Manager;
 import org.tron.core.net.TronNetService;
 import org.tron.core.services.event.EventService;
+import org.tron.core.services.jsonrpc.TronJsonRpcImpl;
 import org.tron.program.SolidityNode;
 
 @Slf4j(topic = "app")
@@ -37,6 +39,9 @@ public class ApplicationImpl implements Application {
   @Autowired(required = false)
   private SolidityNode solidityNode;
 
+  @Autowired
+  private TronJsonRpcImpl tronJsonRpc;
+
   private final CountDownLatch shutdown = new CountDownLatch(1);
 
   /**
@@ -61,6 +66,13 @@ public class ApplicationImpl implements Application {
     eventService.close();
     if (solidityNode != null) {
       solidityNode.close();
+    }
+    // producers are stopped; stop the json-rpc filter consumer before the DB closes
+    // (idempotent — Spring bean destruction may call close() again)
+    try {
+      tronJsonRpc.close();
+    } catch (IOException e) {
+      logger.warn("Closing TronJsonRpcImpl failed.", e);
     }
     dbManager.close();
     shutdown.countDown();

--- a/framework/src/main/java/org/tron/common/application/ApplicationImpl.java
+++ b/framework/src/main/java/org/tron/common/application/ApplicationImpl.java
@@ -1,6 +1,5 @@
 package org.tron.common.application;
 
-import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -71,7 +70,7 @@ public class ApplicationImpl implements Application {
     // (idempotent — Spring bean destruction may call close() again)
     try {
       tronJsonRpc.close();
-    } catch (IOException e) {
+    } catch (Exception e) {
       logger.warn("Closing TronJsonRpcImpl failed.", e);
     }
     dbManager.close();

--- a/framework/src/main/java/org/tron/common/logsfilter/queue/FilterCapsuleQueue.java
+++ b/framework/src/main/java/org/tron/common/logsfilter/queue/FilterCapsuleQueue.java
@@ -1,5 +1,6 @@
 package org.tron.common.logsfilter.queue;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -24,14 +25,7 @@ public class FilterCapsuleQueue {
     return queue.poll(timeout, unit);
   }
 
-  public int size() {
-    return queue.size();
-  }
-
-  public void clear() {
-    queue.clear();
-  }
-
+  @VisibleForTesting
   public Stream<FilterTriggerCapsule> stream() {
     return queue.stream();
   }

--- a/framework/src/main/java/org/tron/common/logsfilter/queue/FilterCapsuleQueue.java
+++ b/framework/src/main/java/org/tron/common/logsfilter/queue/FilterCapsuleQueue.java
@@ -1,0 +1,38 @@
+package org.tron.common.logsfilter.queue;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+import org.springframework.stereotype.Component;
+import org.tron.common.logsfilter.capsule.FilterTriggerCapsule;
+
+/**
+ * Queue between the block-processing producer (Manager) and the json-rpc filter
+ * consumer (TronJsonRpcImpl), so that neither side references the other.
+ */
+@Component
+public class FilterCapsuleQueue {
+
+  private final BlockingQueue<FilterTriggerCapsule> queue = new LinkedBlockingQueue<>();
+
+  public boolean offer(FilterTriggerCapsule capsule) {
+    return queue.offer(capsule);
+  }
+
+  public FilterTriggerCapsule poll(long timeout, TimeUnit unit) throws InterruptedException {
+    return queue.poll(timeout, unit);
+  }
+
+  public int size() {
+    return queue.size();
+  }
+
+  public void clear() {
+    queue.clear();
+  }
+
+  public Stream<FilterTriggerCapsule> stream() {
+    return queue.stream();
+  }
+}

--- a/framework/src/main/java/org/tron/core/db/Manager.java
+++ b/framework/src/main/java/org/tron/core/db/Manager.java
@@ -2304,9 +2304,7 @@ public class Manager {
   private void postBlockFilter(final BlockCapsule blockCapsule, boolean solidified) {
     BlockFilterCapsule blockFilterCapsule =
         new BlockFilterCapsule(blockCapsule, solidified);
-    if (!filterCapsuleQueue.offer(blockFilterCapsule)) {
-      logger.info("Too many filters, block filter lost: {}.", blockCapsule.getBlockId());
-    }
+    filterCapsuleQueue.offer(blockFilterCapsule);
   }
 
   private void postLogsFilter(final BlockCapsule blockCapsule, boolean solidified,
@@ -2319,9 +2317,7 @@ public class Manager {
           blockCapsule.getBlockId().toString(), blockCapsule.getBloom(), transactionInfoList,
           solidified, removed);
 
-      if (!filterCapsuleQueue.offer(logsFilterCapsule)) {
-        logger.info("Too many filters, logs filter lost: {}.", blockNumber);
-      }
+      filterCapsuleQueue.offer(logsFilterCapsule);
     }
   }
 

--- a/framework/src/main/java/org/tron/core/db/Manager.java
+++ b/framework/src/main/java/org/tron/core/db/Manager.java
@@ -48,7 +48,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.bouncycastle.util.encoders.Hex;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 import org.tron.api.GrpcAPI;
 import org.tron.api.GrpcAPI.TransactionInfoList;
@@ -62,11 +61,11 @@ import org.tron.common.logsfilter.FilterQuery;
 import org.tron.common.logsfilter.capsule.BlockFilterCapsule;
 import org.tron.common.logsfilter.capsule.BlockLogTriggerCapsule;
 import org.tron.common.logsfilter.capsule.ContractTriggerCapsule;
-import org.tron.common.logsfilter.capsule.FilterTriggerCapsule;
 import org.tron.common.logsfilter.capsule.LogsFilterCapsule;
 import org.tron.common.logsfilter.capsule.SolidityTriggerCapsule;
 import org.tron.common.logsfilter.capsule.TransactionLogTriggerCapsule;
 import org.tron.common.logsfilter.capsule.TriggerCapsule;
+import org.tron.common.logsfilter.queue.FilterCapsuleQueue;
 import org.tron.common.logsfilter.trigger.ContractEventTrigger;
 import org.tron.common.logsfilter.trigger.ContractLogTrigger;
 import org.tron.common.logsfilter.trigger.ContractTrigger;
@@ -143,7 +142,6 @@ import org.tron.core.metrics.MetricsUtil;
 import org.tron.core.service.MortgageService;
 import org.tron.core.service.RewardViCalService;
 import org.tron.core.services.event.exception.EventException;
-import org.tron.core.services.jsonrpc.TronJsonRpcImpl;
 import org.tron.core.store.AccountAssetStore;
 import org.tron.core.store.AccountIdIndexStore;
 import org.tron.core.store.AccountIndexStore;
@@ -253,8 +251,8 @@ public class Manager {
   @Getter
   private BlockingQueue<TriggerCapsule> triggerCapsuleQueue;
   // log filter
-  private boolean isRunFilterProcessThread = true;
-  private BlockingQueue<FilterTriggerCapsule> filterCapsuleQueue;
+  @Autowired
+  private FilterCapsuleQueue filterCapsuleQueue;
 
   @Getter
   private volatile long latestSolidityNumShutDown;
@@ -273,15 +271,9 @@ public class Manager {
   private static final String rePushEsName = "repush";
   private ExecutorService triggerEs;
   private static final String triggerEsName = "event-trigger";
-  private ExecutorService filterEs;
-  private static final String filterEsName = "filter";
 
   @Autowired
   private RewardViCalService rewardViCalService;
-
-  @Lazy
-  @Autowired
-  private TronJsonRpcImpl tronJsonRpcImpl;
 
   /**
    * Cycle thread to rePush Transactions
@@ -330,26 +322,6 @@ public class Manager {
             Thread.currentThread().interrupt();
           } catch (Throwable throwable) {
             logger.error("Unknown throwable happened in process capsule loop.", throwable);
-          }
-        }
-      };
-
-  private Runnable filterProcessLoop =
-      () -> {
-        while (isRunFilterProcessThread) {
-          try {
-            FilterTriggerCapsule filterCapsule = filterCapsuleQueue.poll(1, TimeUnit.SECONDS);
-            if (filterCapsule instanceof LogsFilterCapsule) {
-              tronJsonRpcImpl.handleLogsFilter((LogsFilterCapsule) filterCapsule);
-            } else if (filterCapsule instanceof BlockFilterCapsule) {
-              tronJsonRpcImpl.handleBLockFilter((BlockFilterCapsule) filterCapsule);
-            }
-          } catch (InterruptedException e) {
-            logger.error("FilterProcessLoop get InterruptedException, error is {}.",
-                    e.getMessage());
-            Thread.currentThread().interrupt();
-          } catch (Throwable throwable) {
-            logger.error("Unknown throwable happened in filterProcessLoop. ", throwable);
           }
         }
       };
@@ -476,11 +448,6 @@ public class Manager {
     ExecutorServiceManager.shutdownAndAwaitTermination(triggerEs, triggerEsName);
   }
 
-  public void stopFilterProcessThread() {
-    isRunFilterProcessThread = false;
-    ExecutorServiceManager.shutdownAndAwaitTermination(filterEs, filterEsName);
-  }
-
   public void stopValidateSignThread() {
     ExecutorServiceManager.shutdownAndAwaitTermination(validateSignService, "validate-sign");
   }
@@ -510,7 +477,6 @@ public class Manager {
       this.rePushTransactions = new LinkedBlockingQueue<>();
     }
     this.triggerCapsuleQueue = new LinkedBlockingQueue<>();
-    this.filterCapsuleQueue = new LinkedBlockingQueue<>();
     chainBaseManager.setMerkleContainer(getMerkleContainer());
     chainBaseManager.setMortgageService(mortgageService);
     this.initGenesis();
@@ -582,12 +548,6 @@ public class Manager {
       startEventSubscribing();
       triggerEs = ExecutorServiceManager.newSingleThreadExecutor(triggerEsName, true);
       ExecutorServiceManager.submit(triggerEs, triggerCapsuleProcessLoop);
-    }
-
-    // start json rpc filter process
-    if (CommonParameter.getInstance().isJsonRpcFilterEnabled()) {
-      filterEs = ExecutorServiceManager.newSingleThreadExecutor(filterEsName);
-      ExecutorServiceManager.submit(filterEs, filterProcessLoop);
     }
 
     //initStoreFactory
@@ -2658,7 +2618,6 @@ public class Manager {
     stopRePushThread();
     stopRePushTriggerThread();
     EventPluginLoader.getInstance().stopPlugin();
-    stopFilterProcessThread();
     stopValidateSignThread();
     chainBaseManager.shutdown();
     revokingStore.shutdown();

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/TronJsonRpcImpl.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/TronJsonRpcImpl.java
@@ -236,6 +236,7 @@ public class TronJsonRpcImpl implements TronJsonRpc, Closeable {
       } catch (InterruptedException e) {
         logger.error("FilterProcessLoop get InterruptedException, error is {}.", e.getMessage());
         Thread.currentThread().interrupt();
+        return;
       } catch (Throwable throwable) {
         logger.error("Unknown throwable happened in filterProcessLoop. ", throwable);
       }

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/TronJsonRpcImpl.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/TronJsonRpcImpl.java
@@ -36,7 +36,9 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
+import javax.annotation.PostConstruct;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -53,7 +55,9 @@ import org.tron.common.crypto.Hash;
 import org.tron.common.es.ExecutorServiceManager;
 import org.tron.common.logsfilter.ContractEventParser;
 import org.tron.common.logsfilter.capsule.BlockFilterCapsule;
+import org.tron.common.logsfilter.capsule.FilterTriggerCapsule;
 import org.tron.common.logsfilter.capsule.LogsFilterCapsule;
+import org.tron.common.logsfilter.queue.FilterCapsuleQueue;
 import org.tron.common.parameter.CommonParameter;
 import org.tron.common.runtime.vm.DataWord;
 import org.tron.common.utils.ByteArray;
@@ -193,20 +197,49 @@ public class TronJsonRpcImpl implements TronJsonRpc, Closeable {
   private final ExecutorService sectionExecutor;
   private final NodeInfoService nodeInfoService;
   private final Wallet wallet;
-  @Autowired
-  private Manager manager;
+  private final Manager manager;
   private final String esName = "query-section";
 
   @Autowired
-  public TronJsonRpcImpl(@Autowired NodeInfoService nodeInfoService, @Autowired Wallet wallet) {
+  private FilterCapsuleQueue filterCapsuleQueue;
+  private ExecutorService filterEs;
+  private static final String filterEsName = "filter";
+  private final AtomicBoolean closed = new AtomicBoolean(false);
+
+  @Autowired
+  public TronJsonRpcImpl(NodeInfoService nodeInfoService, Wallet wallet, Manager manager) {
     this.nodeInfoService = nodeInfoService;
     this.wallet = wallet;
+    this.manager = manager;
     this.sectionExecutor = ExecutorServiceManager.newFixedThreadPool(esName, 5);
   }
 
-  @VisibleForTesting
-  public void setManager(Manager manager) {
-    this.manager = manager;
+  @PostConstruct
+  private void start() {
+    if (CommonParameter.getInstance().isJsonRpcFilterEnabled()) {
+      filterEs = ExecutorServiceManager.newSingleThreadExecutor(filterEsName, true);
+      ExecutorServiceManager.submit(filterEs, this::filterProcessLoop);
+    }
+  }
+
+  private void filterProcessLoop() {
+    while (!closed.get()) {
+      try {
+        FilterTriggerCapsule filterCapsule = filterCapsuleQueue.poll(1, TimeUnit.SECONDS);
+        if (filterCapsule instanceof LogsFilterCapsule) {
+          handleLogsFilter((LogsFilterCapsule) filterCapsule);
+        } else if (filterCapsule instanceof BlockFilterCapsule) {
+          handleBLockFilter((BlockFilterCapsule) filterCapsule);
+        } else if (filterCapsule != null) {
+          logger.warn("Unknown FilterTriggerCapsule: {}", filterCapsule.getClass().getName());
+        }
+      } catch (InterruptedException e) {
+        logger.error("FilterProcessLoop get InterruptedException, error is {}.", e.getMessage());
+        Thread.currentThread().interrupt();
+      } catch (Throwable throwable) {
+        logger.error("Unknown throwable happened in filterProcessLoop. ", throwable);
+      }
+    }
   }
 
   @VisibleForTesting
@@ -1614,6 +1647,12 @@ public class TronJsonRpcImpl implements TronJsonRpc, Closeable {
 
   @Override
   public void close() throws IOException {
+    if (!closed.compareAndSet(false, true)) {
+      return;
+    }
+    // The consumer loop submits to logsFilterPool (over-threshold path), so it must
+    // terminate before the pool shuts down.
+    ExecutorServiceManager.shutdownAndAwaitTermination(filterEs, filterEsName);
     ExecutorServiceManager.shutdownAndAwaitTermination(logsFilterPool, "logs-filter-pool");
     logElementCache.invalidateAll();
     blockHashCache.invalidateAll();

--- a/framework/src/test/java/org/tron/common/runtime/vm/Create2Test.java
+++ b/framework/src/test/java/org/tron/common/runtime/vm/Create2Test.java
@@ -209,8 +209,7 @@ public class Create2Test extends VMTestBase {
     NodeInfoService nodeInfoService;
     nodeInfoService = context.getBean(NodeInfoService.class);
     Wallet wallet = context.getBean(Wallet.class);
-    tronJsonRpc = new TronJsonRpcImpl(nodeInfoService, wallet);
-    tronJsonRpc.setManager(manager);
+    tronJsonRpc = new TronJsonRpcImpl(nodeInfoService, wallet, manager);
     try {
       String res =
           tronJsonRpc.getStorageAt(ByteArray.toHexString(actualContract), "0", "latest");

--- a/framework/src/test/java/org/tron/core/db/ManagerTest.java
+++ b/framework/src/test/java/org/tron/core/db/ManagerTest.java
@@ -45,10 +45,10 @@ import org.tron.common.crypto.ECKey;
 import org.tron.common.logsfilter.EventPluginLoader;
 import org.tron.common.logsfilter.capsule.BlockFilterCapsule;
 import org.tron.common.logsfilter.capsule.BlockLogTriggerCapsule;
-import org.tron.common.logsfilter.capsule.FilterTriggerCapsule;
 import org.tron.common.logsfilter.capsule.LogsFilterCapsule;
 import org.tron.common.logsfilter.capsule.TransactionLogTriggerCapsule;
 import org.tron.common.logsfilter.capsule.TriggerCapsule;
+import org.tron.common.logsfilter.queue.FilterCapsuleQueue;
 import org.tron.common.logsfilter.trigger.ContractLogTrigger;
 import org.tron.common.parameter.CommonParameter;
 import org.tron.common.runtime.RuntimeImpl;
@@ -1694,8 +1694,8 @@ public class ManagerTest extends BaseMethodTest {
   @Test
   public void switchForkShouldPostFullNodeFilterForNewBranch() throws Exception {
     CommonParameter.getInstance().jsonRpcHttpFullNodeEnable = true;
-    // filterProcessLoop only starts when isJsonRpcFilterEnabled() held at Manager.init() time; it
-    // was false then, so filterCapsuleQueue is produce-only here and fully observable.
+    // The consumer thread only starts when isJsonRpcFilterEnabled() held at context startup; it
+    // was false then, so the FilterCapsuleQueue bean is produce-only here and fully observable.
 
     // bootstrap a head with a known witness
     String key = PublicMethod.getRandomPrivateKey();
@@ -1733,8 +1733,7 @@ public class ManagerTest extends BaseMethodTest {
     dbManager.pushBlock(p);
 
     long expiration = t + 1_000_000L;
-    BlockingQueue<FilterTriggerCapsule> queue =
-        ReflectUtils.getFieldValue(dbManager, "filterCapsuleQueue");
+    FilterCapsuleQueue queue = context.getBean(FilterCapsuleQueue.class);
     queue.clear();
 
     // old branch: A carries a transfer; applied via the normal extend path
@@ -1868,7 +1867,7 @@ public class ManagerTest extends BaseMethodTest {
     return blockCapsule;
   }
 
-  private boolean hasLogsFilterCapsule(BlockingQueue<FilterTriggerCapsule> queue, BlockCapsule b,
+  private boolean hasLogsFilterCapsule(FilterCapsuleQueue queue, BlockCapsule b,
       boolean removed) {
     String blockHash = b.getBlockId().toString();
     return queue.stream()
@@ -1878,7 +1877,7 @@ public class ManagerTest extends BaseMethodTest {
             && blockHash.equals(c.getBlockHash()));
   }
 
-  private boolean hasBlockFilterCapsule(BlockingQueue<FilterTriggerCapsule> queue,
+  private boolean hasBlockFilterCapsule(FilterCapsuleQueue queue,
       BlockCapsule b) {
     String blockHash = b.getBlockId().toString();
     return queue.stream()

--- a/framework/src/test/java/org/tron/core/db/ManagerTest.java
+++ b/framework/src/test/java/org/tron/core/db/ManagerTest.java
@@ -1734,7 +1734,6 @@ public class ManagerTest extends BaseMethodTest {
 
     long expiration = t + 1_000_000L;
     FilterCapsuleQueue queue = context.getBean(FilterCapsuleQueue.class);
-    queue.clear();
 
     // old branch: A carries a transfer; applied via the normal extend path
     BlockCapsule a = blockWithTransfer(t + 6000, base + 2, p.getBlockId().getByteString(), keys,

--- a/framework/src/test/java/org/tron/core/jsonrpc/ConcurrentHashMapTest.java
+++ b/framework/src/test/java/org/tron/core/jsonrpc/ConcurrentHashMapTest.java
@@ -23,7 +23,7 @@ import org.tron.core.services.jsonrpc.filters.BlockFilterAndResult;
 @Slf4j
 public class ConcurrentHashMapTest {
   private static final String EXECUTOR_NAME = "jsonrpc-concurrent-map-test";
-  private final TronJsonRpcImpl jsonRpc = new TronJsonRpcImpl(null, null);
+  private final TronJsonRpcImpl jsonRpc = new TronJsonRpcImpl(null, null, null);
 
   private static int randomInt(int minInt, int maxInt) {
     return (int) round(random(true) * (maxInt - minInt) + minInt, true);

--- a/framework/src/test/java/org/tron/core/jsonrpc/FilterPipelineDeliveryTest.java
+++ b/framework/src/test/java/org/tron/core/jsonrpc/FilterPipelineDeliveryTest.java
@@ -1,0 +1,100 @@
+package org.tron.core.jsonrpc;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.function.BooleanSupplier;
+import javax.annotation.Resource;
+import org.junit.Assert;
+import org.junit.Test;
+import org.tron.common.BaseTest;
+import org.tron.common.TestConstants;
+import org.tron.common.logsfilter.capsule.BlockFilterCapsule;
+import org.tron.common.logsfilter.capsule.LogsFilterCapsule;
+import org.tron.common.logsfilter.queue.FilterCapsuleQueue;
+import org.tron.common.parameter.CommonParameter;
+import org.tron.common.runtime.vm.DataWord;
+import org.tron.common.runtime.vm.LogInfo;
+import org.tron.core.config.args.Args;
+import org.tron.core.services.jsonrpc.TronJsonRpc.FilterRequest;
+import org.tron.core.services.jsonrpc.TronJsonRpc.LogFilterElement;
+import org.tron.core.services.jsonrpc.TronJsonRpcImpl;
+import org.tron.core.services.jsonrpc.filters.BlockFilterAndResult;
+import org.tron.core.services.jsonrpc.filters.LogFilterAndResult;
+import org.tron.protos.Protocol.TransactionInfo;
+
+/**
+ * End-to-end coverage of the decoupled filter pipeline: capsules offered to the
+ * FilterCapsuleQueue bean are delivered to registered filters by the consumer
+ * thread that TronJsonRpcImpl starts at context startup.
+ */
+public class FilterPipelineDeliveryTest extends BaseTest {
+
+  static {
+    Args.setParam(new String[] {"--output-directory", dbPath()}, TestConstants.TEST_CONF);
+    // isJsonRpcFilterEnabled() must hold at context startup so the consumer thread starts
+    CommonParameter.getInstance().setJsonRpcHttpFullNodeEnable(true);
+  }
+
+  @Resource
+  private TronJsonRpcImpl tronJsonRpc;
+  @Resource
+  private FilterCapsuleQueue filterCapsuleQueue;
+
+  private static TransactionInfo buildTxInfoWithLog() {
+    LogInfo logInfo = new LogInfo(new byte[20],
+        Collections.singletonList(new DataWord(new byte[32])), new byte[0]);
+    return TransactionInfo.newBuilder().addLog(LogInfo.buildLog(logInfo)).build();
+  }
+
+  private static void await(BooleanSupplier condition, String message)
+      throws InterruptedException {
+    long deadline = System.currentTimeMillis() + 10_000;
+    while (System.currentTimeMillis() < deadline) {
+      if (condition.getAsBoolean()) {
+        return;
+      }
+      Thread.sleep(50);
+    }
+    Assert.fail(message);
+  }
+
+  @Test
+  public void consumerThreadStartedOnce() {
+    long count = Thread.getAllStackTraces().keySet().stream()
+        .filter(t -> "filter".equals(t.getName())).count();
+    Assert.assertEquals(1, count);
+  }
+
+  @Test
+  public void blockFilterDeliveredOnFullAndSolidityPaths() throws Exception {
+    BlockFilterAndResult full = new BlockFilterAndResult();
+    BlockFilterAndResult solidity = new BlockFilterAndResult();
+    tronJsonRpc.getBlockFilter2ResultFull().put("pipeline-block-full", full);
+    tronJsonRpc.getBlockFilter2ResultSolidity().put("pipeline-block-solidity", solidity);
+    try {
+      filterCapsuleQueue.offer(new BlockFilterCapsule("e2e-full-hash", false));
+      filterCapsuleQueue.offer(new BlockFilterCapsule("e2e-solidity-hash", true));
+      await(() -> full.getResult().size() == 1, "full-path block hash not delivered");
+      await(() -> solidity.getResult().size() == 1, "solidity-path block hash not delivered");
+    } finally {
+      tronJsonRpc.getBlockFilter2ResultFull().remove("pipeline-block-full");
+      tronJsonRpc.getBlockFilter2ResultSolidity().remove("pipeline-block-solidity");
+    }
+  }
+
+  @Test
+  public void reorgLogsDeliveredWithRemovedFlag() throws Exception {
+    LogFilterAndResult filter = new LogFilterAndResult(new FilterRequest(), 100L, null);
+    tronJsonRpc.getEventFilter2ResultFull().put("pipeline-log-removed", filter);
+    try {
+      filterCapsuleQueue.offer(new LogsFilterCapsule(150L, "0xreorg", null,
+          Collections.singletonList(buildTxInfoWithLog()), false, true));
+      await(() -> !filter.getResult().isEmpty(), "removed log not delivered");
+      List<LogFilterElement> elements = filter.popAll();
+      Assert.assertEquals(1, elements.size());
+      Assert.assertTrue(elements.get(0).isRemoved());
+    } finally {
+      tronJsonRpc.getEventFilter2ResultFull().remove("pipeline-log-removed");
+    }
+  }
+}

--- a/framework/src/test/java/org/tron/core/jsonrpc/FilterPipelineShutdownTest.java
+++ b/framework/src/test/java/org/tron/core/jsonrpc/FilterPipelineShutdownTest.java
@@ -1,0 +1,120 @@
+package org.tron.core.jsonrpc;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Resource;
+import org.junit.Assert;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+import org.tron.common.BaseTest;
+import org.tron.common.TestConstants;
+import org.tron.common.logsfilter.capsule.LogsFilterCapsule;
+import org.tron.common.logsfilter.queue.FilterCapsuleQueue;
+import org.tron.common.parameter.CommonParameter;
+import org.tron.common.runtime.vm.DataWord;
+import org.tron.common.runtime.vm.LogInfo;
+import org.tron.core.config.args.Args;
+import org.tron.core.services.jsonrpc.TronJsonRpc.FilterRequest;
+import org.tron.core.services.jsonrpc.TronJsonRpcImpl;
+import org.tron.core.services.jsonrpc.filters.LogFilterAndResult;
+import org.tron.protos.Protocol.TransactionInfo;
+
+/**
+ * Shutdown semantics of the decoupled filter pipeline. Method order matters:
+ * test1 closes the shared TronJsonRpcImpl bean, test2 asserts the second close
+ * is a guarded no-op, so they run in name order.
+ */
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class FilterPipelineShutdownTest extends BaseTest {
+
+  static {
+    Args.setParam(new String[] {"--output-directory", dbPath()}, TestConstants.TEST_CONF);
+    // isJsonRpcFilterEnabled() must hold at context startup so the consumer thread starts
+    CommonParameter.getInstance().setJsonRpcHttpFullNodeEnable(true);
+  }
+
+  @Resource
+  private TronJsonRpcImpl tronJsonRpc;
+  @Resource
+  private FilterCapsuleQueue filterCapsuleQueue;
+
+  private static TransactionInfo buildTxInfoWithLog() {
+    LogInfo logInfo = new LogInfo(new byte[20],
+        Collections.singletonList(new DataWord(new byte[32])), new byte[0]);
+    return TransactionInfo.newBuilder().addLog(LogInfo.buildLog(logInfo)).build();
+  }
+
+  /**
+   * close() while the consumer is mid-capsule on the parallel (logsFilterPool) path:
+   * the in-flight capsule must complete instead of dying on a RejectedExecutionException,
+   * which is exactly the filterEs-before-logsFilterPool ordering constraint.
+   */
+  @Test
+  public void test1CloseDuringParallelProcessingLosesNoEvent() throws Exception {
+    tronJsonRpc.setFilterParallelThreshold(0);
+    LogFilterAndResult filter = new LogFilterAndResult(new FilterRequest(), 100L, null);
+    tronJsonRpc.getEventFilter2ResultFull().put("shutdown-race", filter);
+
+    CountDownLatch entered = new CountDownLatch(1);
+    CountDownLatch release = new CountDownLatch(1);
+    LogsFilterCapsule capsule = new LogsFilterCapsule(150L, "0xrace", null,
+        Collections.singletonList(buildTxInfoWithLog()), false, false) {
+      @Override
+      public boolean isSolidified() {
+        // first call is the head of handleLogsFilter, on the consumer thread
+        entered.countDown();
+        try {
+          release.await();
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+        return false;
+      }
+    };
+    filterCapsuleQueue.offer(capsule);
+    Assert.assertTrue("consumer did not pick up the capsule",
+        entered.await(10, TimeUnit.SECONDS));
+
+    Thread closer = new Thread(() -> {
+      try {
+        tronJsonRpc.close();
+      } catch (IOException e) {
+        throw new UncheckedIOException(e);
+      }
+    }, "test-closer");
+    closer.start();
+    // close() must be parked awaiting the consumer, with logsFilterPool still open
+    Thread.sleep(500);
+    Assert.assertTrue("close() finished while a capsule was in flight", closer.isAlive());
+
+    release.countDown();
+    closer.join(150_000);
+    Assert.assertFalse("close() did not finish", closer.isAlive());
+    Assert.assertEquals("in-flight capsule was lost during close()",
+        1, filter.getResult().size());
+  }
+
+  @Test
+  public void test2RepeatedCloseIsIdempotentAndThreadStopped() throws Exception {
+    long deadline = System.currentTimeMillis() + 10_000;
+    while (System.currentTimeMillis() < deadline && filterThreadAlive()) {
+      Thread.sleep(50);
+    }
+    Assert.assertFalse("consumer thread still alive after close()", filterThreadAlive());
+
+    long t0 = System.nanoTime();
+    tronJsonRpc.close();
+    long elapsedMs = (System.nanoTime() - t0) / 1_000_000;
+    Assert.assertTrue("repeated close should be a fast no-op, took " + elapsedMs + "ms",
+        elapsedMs < 1_000);
+  }
+
+  private static boolean filterThreadAlive() {
+    return Thread.getAllStackTraces().keySet().stream()
+        .anyMatch(t -> "filter".equals(t.getName()) && t.isAlive());
+  }
+}

--- a/framework/src/test/java/org/tron/core/jsonrpc/HandleLogsFilterTest.java
+++ b/framework/src/test/java/org/tron/core/jsonrpc/HandleLogsFilterTest.java
@@ -27,7 +27,7 @@ public class HandleLogsFilterTest {
 
   @Before
   public void setUp() {
-    jsonRpc = new TronJsonRpcImpl(null, null);
+    jsonRpc = new TronJsonRpcImpl(null, null, null);
   }
 
   @After

--- a/framework/src/test/java/org/tron/core/jsonrpc/JsonRpcCallAndEstimateGasTest.java
+++ b/framework/src/test/java/org/tron/core/jsonrpc/JsonRpcCallAndEstimateGasTest.java
@@ -211,8 +211,7 @@ public class JsonRpcCallAndEstimateGasTest {
           });
     }
 
-    TronJsonRpcImpl rpc = new TronJsonRpcImpl(mockNodeInfo, mockWallet);
-    rpc.setManager(mockManager);
+    TronJsonRpcImpl rpc = new TronJsonRpcImpl(mockNodeInfo, mockWallet, mockManager);
     return rpc;
   }
 
@@ -239,8 +238,7 @@ public class JsonRpcCallAndEstimateGasTest {
               .build();
         });
 
-    TronJsonRpcImpl rpc = new TronJsonRpcImpl(mockNodeInfo, mockWallet);
-    rpc.setManager(mockManager);
+    TronJsonRpcImpl rpc = new TronJsonRpcImpl(mockNodeInfo, mockWallet, mockManager);
     return rpc;
   }
 
@@ -276,8 +274,7 @@ public class JsonRpcCallAndEstimateGasTest {
           });
     }
 
-    TronJsonRpcImpl rpc = new TronJsonRpcImpl(mockNodeInfo, mockWallet);
-    rpc.setManager(mockManager);
+    TronJsonRpcImpl rpc = new TronJsonRpcImpl(mockNodeInfo, mockWallet, mockManager);
     return rpc;
   }
 }

--- a/framework/src/test/java/org/tron/core/jsonrpc/JsonrpcServiceTest.java
+++ b/framework/src/test/java/org/tron/core/jsonrpc/JsonrpcServiceTest.java
@@ -216,8 +216,7 @@ public class JsonrpcServiceTest extends BaseTest {
     dbManager.getTransactionRetStore()
         .put(ByteArray.fromLong(blockCapsule2.getNum()), transactionRetCapsule2);
 
-    tronJsonRpc = new TronJsonRpcImpl(nodeInfoService, wallet);
-    tronJsonRpc.setManager(dbManager);
+    tronJsonRpc = new TronJsonRpcImpl(nodeInfoService, wallet, dbManager);
   }
 
   @Test

--- a/framework/src/test/java/org/tron/core/jsonrpc/WalletCursorTest.java
+++ b/framework/src/test/java/org/tron/core/jsonrpc/WalletCursorTest.java
@@ -60,8 +60,7 @@ public class WalletCursorTest extends BaseTest {
 
   @Test
   public void testSource() {
-    TronJsonRpcImpl tronJsonRpc = new TronJsonRpcImpl(nodeInfoService, wallet);
-    tronJsonRpc.setManager(dbManager);
+    TronJsonRpcImpl tronJsonRpc = new TronJsonRpcImpl(nodeInfoService, wallet, dbManager);
 
     Assert.assertEquals(Cursor.HEAD, wallet.getCursor());
     Assert.assertEquals(RequestSource.FULLNODE, tronJsonRpc.getSource());
@@ -92,8 +91,7 @@ public class WalletCursorTest extends BaseTest {
 
     dbManager.setCursor(Cursor.SOLIDITY);
 
-    TronJsonRpcImpl tronJsonRpc = new TronJsonRpcImpl(nodeInfoService, wallet);
-    tronJsonRpc.setManager(dbManager);
+    TronJsonRpcImpl tronJsonRpc = new TronJsonRpcImpl(nodeInfoService, wallet, dbManager);
     try {
       tronJsonRpc.buildTransaction(buildArguments);
       tronJsonRpc.close();
@@ -115,8 +113,7 @@ public class WalletCursorTest extends BaseTest {
 
     dbManager.setCursor(Cursor.PBFT);
 
-    TronJsonRpcImpl tronJsonRpc = new TronJsonRpcImpl(nodeInfoService, wallet);
-    tronJsonRpc.setManager(dbManager);
+    TronJsonRpcImpl tronJsonRpc = new TronJsonRpcImpl(nodeInfoService, wallet, dbManager);
     try {
       tronJsonRpc.buildTransaction(buildArguments);
     } catch (Exception e) {
@@ -143,8 +140,7 @@ public class WalletCursorTest extends BaseTest {
     buildArguments.setTo("0x548794500882809695a8a687866e76d4271a1abc");
     buildArguments.setValue("0x1f4");
 
-    TronJsonRpcImpl tronJsonRpc = new TronJsonRpcImpl(nodeInfoService, wallet);
-    tronJsonRpc.setManager(dbManager);
+    TronJsonRpcImpl tronJsonRpc = new TronJsonRpcImpl(nodeInfoService, wallet, dbManager);
 
     try {
       tronJsonRpc.buildTransaction(buildArguments);
@@ -164,8 +160,7 @@ public class WalletCursorTest extends BaseTest {
     int saved = Args.getInstance().getJsonRpcMaxLogFilterNum();
     Args.getInstance().setJsonRpcMaxLogFilterNum(cap);
     FilterRequest fr = new FilterRequest();
-    TronJsonRpcImpl tronJsonRpc = new TronJsonRpcImpl(nodeInfoService, wallet);
-    tronJsonRpc.setManager(dbManager);
+    TronJsonRpcImpl tronJsonRpc = new TronJsonRpcImpl(nodeInfoService, wallet, dbManager);
     Map<String, LogFilterAndResult> map = tronJsonRpc.getEventFilter2ResultFull();
     List<String> addedKeys = new ArrayList<>();
 


### PR DESCRIPTION
**What does this PR do?**
close #6963 
Removes the `Manager → TronJsonRpcImpl` reverse dependency left by #6732, where core-layer `Manager` holds the json-rpc filter consumer through a `@Lazy` injection.

- Adds a standalone `FilterCapsuleQueue` bean; `Manager.postBlockFilter/postLogsFilter` produce into it, so Manager no longer references anything under `org.tron.core.services.jsonrpc` (repo-wide `framework/src/main` is now `@Lazy`-free).
- Moves the consumer loop into `TronJsonRpcImpl`: started by `@PostConstruct` when `isJsonRpcFilterEnabled()`, single daemon thread, stopped by `close()`.
- `TronJsonRpcImpl` constructor becomes `(NodeInfoService, Wallet, Manager)`; `setManager()` is removed and the direct-construction test sites are migrated.
- `close()` is rewritten: an `AtomicBoolean` guard makes it idempotent and serves as a visibility-safe stop flag, the loop exits on interrupt, and the consumer is awaited before `logsFilterPool` shuts down so an in-flight capsule completes on graceful shutdown.
- `ApplicationImpl.shutdown()` now closes the consumer after producers stop and before `dbManager.close()`; the later Spring-destruction `close()` is a no-op.
- The `instanceof` dispatch logs a warning for unknown `FilterTriggerCapsule` subtypes instead of silently dropping them.

Runtime behavior of the filter API is unchanged: same unbounded queue, same discard-on-shutdown semantics, one consumer shared by the FullNode/solidity/PBFT json-rpc services.

**Why are these changes required?**

Follow-up agreed in the #6732 review (see [discussion](https://github.com/tronprotocol/java-tron/pull/6732#discussion_r3193518283)). `FullNode` sets `allowCircularReferences(false)`; `@Lazy`, like `ObjectProvider` or a runtime `getBean()`, only makes Spring tolerate the cycle. The reverse core → API edge stays, obscuring the component graph, and later json-rpc cleanups keep copying the pattern. This PR removes the edge instead.

**This PR has been tested by:**

- Unit Tests
- Manual Testing
  - private chain: block production with registered filters; `eth_getFilterChanges` delivers; SIGTERM log order confirms consumer → `logs-filter-pool` → `dbManager` → context close, single shutdown episode, no errors
  - Nile and mainnet lite nodes: 5 restart cycles each with 100 filters created and polled per cycle (~2,500 queries/cycle, zero rpc errors); on mainnet the log path delivered 20k+ real contract log entries through the new queue; filters correctly report `filter not found` after restart; no `RejectedExecutionException`, no bean-cycle errors, shutdown order identical in every cycle

**Follow up**

**Extra details**